### PR TITLE
Make split factors typed contraction schedules

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -414,13 +414,22 @@
      :split-k-combine {:accumulator-dtype :float :kernel-body kernel-body
                        :semantic-op :contraction})))
 
+(defn split-factor-strategy
+  "Stable strategy identity for one explicit split-K candidate."
+  [factor]
+  (when-not (and (integer? factor) (> (long factor) 1))
+    (throw (ex-info "split factor must be an integer greater than one"
+                    {:split-factor factor})))
+  (keyword (str "xmx-split-k-" factor)))
+
 (defn- xmx-graph
-  [{:keys [id a b c m n k variant tile vector-width requested-splits split-k? epilogue]
+  [{:keys [id a b c m n k variant tile vector-width requested-splits split-k? epilogue
+           strategy]
     :as spec}]
   (let [{:keys [abi arguments]} (outer-interface spec)
         {:keys [a-elements b-elements c-elements]} (extents spec)
         epilogue-buffers (epilogue-buffer-specs epilogue)
-        strategy (if split-k? :xmx-split-k :xmx-direct)
+        strategy (or strategy (if split-k? :xmx-split-k :xmx-direct))
         prefix (identifier (str id "_" (name strategy)))
         a16 [:gemm id strategy :a16]
         b16 [:gemm id strategy :b16]
@@ -643,6 +652,15 @@
          :fill-workgroups (hardware/fill-workgroups desc workgroup-size)
          :matrix (:matrix desc)}))))
 
+(defn- validate-split-factors!
+  [split-factors]
+  (when-not (and (vector? split-factors)
+                 (= (count split-factors) (count (set split-factors)))
+                 (every? #(and (integer? %) (> (long %) 1)) split-factors))
+    (throw (ex-info "split-factor candidates must be unique integers greater than one"
+                    {:split-factors split-factors})))
+  split-factors)
+
 (defn emit-matrix-alternatives
   "Emit direct and, when algebraically valid, split-K matrix graph schedules.
 
@@ -650,8 +668,8 @@
    scalar fallback or a new semantic operation.  A result transform is fused into the direct
    matrix store.  Split-K is withheld until the final combine can own that transform exactly—
    applying it independently to partial sums would be a silent algebraic error."
-  [{:keys [id a b c m n k variant tile fill-workgroups vector-width epilogue]
-    :or {vector-width 4}
+  [{:keys [id a b c m n k variant tile fill-workgroups vector-width epilogue split-factors]
+    :or {vector-width 4 split-factors []}
     :as spec}]
   (when-not (contains? #{:nn :nt :tn :tt} variant)
     (throw (ex-info "matrix alternatives require :nn, :nt, :tn, or :tt variant"
@@ -661,12 +679,21 @@
     (when (nil? value)
       (throw (ex-info "matrix alternatives are missing a required field"
                       {:field field :spec spec}))))
-  (let [spec (assoc spec :vector-width vector-width)
+  (let [split-factors (validate-split-factors! split-factors)
+        spec (assoc spec :vector-width vector-width)
         split-expression (requested-splits spec)
         xmx-spec (assoc spec :requested-splits split-expression)
         direct (xmx-graph (assoc xmx-spec :split-k? false))
         split? (not (seq epilogue))
         split (when split? (xmx-graph (assoc xmx-spec :split-k? true)))
+        explicit-splits
+        (when split?
+          (mapv (fn [factor]
+                  (xmx-graph (assoc spec
+                                    :split-k? true
+                                    :strategy (split-factor-strategy factor)
+                                    :requested-splits factor)))
+                split-factors))
         alignment-cases
         [{:expression n :op :< :value 8 :strategy :f32-scalar}
          {:expression k :op :< :value 8 :strategy :f32-scalar}
@@ -679,8 +706,13 @@
                            split? (conj {:expression split-expression :op :>= :value 2
                                          :strategy :xmx-split-k}))
                   :default :xmx-direct}]
-    {:alternatives (cond-> [direct] split (conj split))
+    {:alternatives (cond-> [direct]
+                     split (conj split)
+                     (seq explicit-splits) (into explicit-splits))
      :selector selector
+     :split-factor-schedules
+     (into {} (map (fn [factor] [(split-factor-strategy factor) factor]))
+           (if split? split-factors []))
      :result-transform-split-decline
      (when-not split? {:reason :split-k-result-transform-not-lowered})}))
 
@@ -709,12 +741,14 @@
                 (throw (ex-info
                         "standalone GEMM executable cannot manufacture its scalar fallback for a result transform"
                         {:reason :result-transform-requires-typed-contraction :id id})))
-            {:keys [alternatives selector]} (emit-matrix-alternatives spec)]
+            {:keys [alternatives selector split-factor-schedules]}
+            (emit-matrix-alternatives spec)]
         (kdispatch/make
          {:id (str id)
           :alternatives (into [scalar] alternatives)
           :default-strategy :xmx-direct
           :selector selector
           :provenance {:semantic-op :contraction :variant variant :lowering :gemm-schedule}
-          :attributes {:tile tile :precision precision :hardware-aware? true}}))
+          :attributes {:tile tile :precision precision :hardware-aware? true
+                       :split-factor-schedules split-factor-schedules}}))
       (throw (ex-info "unsupported GEMM precision" {:id id :precision precision})))))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1008,7 +1008,8 @@
                        :epilogue (:epilogue matrix-view)
                        :precision :mixed-f16-f32
                        :tile (:tile target-schedule)
-                       :fill-workgroups (:fill-workgroups target-schedule)}
+                       :fill-workgroups (:fill-workgroups target-schedule)
+                       :split-factors (or (:split-factors options) [])}
             emitted (if (:batched? matrix-view)
                       (gpu-gemm/emit-batched-matrix-alternative
                        (assoc emit-spec
@@ -1030,6 +1031,7 @@
                     :batch (:batch matrix-view)
                     :batching (:batching matrix-view)
                     :result-transform? (boolean (seq (:epilogue matrix-view)))
+                    :split-factor-schedules (:split-factor-schedules emitted)
                     :split-k-decline (:result-transform-split-decline emitted)
                     :bindings (:bindings matrix-view)
                     :dimensions (:dimensions matrix-view)
@@ -1091,12 +1093,19 @@
                      (merge
                       (if (:batched? (:schedule mixed))
                         {:xmx-batched (:schedule mixed)}
-                        {:xmx-direct (:schedule mixed)
-                         :xmx-split-k (assoc (:schedule mixed) :split-k? true)})))
+                        (merge
+                         {:xmx-direct (:schedule mixed)
+                          :xmx-split-k (assoc (:schedule mixed) :split-k? true)}
+                         (into {}
+                               (map (fn [[strategy factor]]
+                                      [strategy (assoc (:schedule mixed)
+                                                       :split-k? true
+                                                       :split-factor factor)]))
+                               (:split-factor-schedules (:schedule mixed)))))))
                    :declines (:declines routed)
                    :matrix-graph-decline (:decline mixed)
                    :tuning (typed-contraction-tuning-contract schedule dispatch-id abi
-                                                               (:precision options))
+                                                              (:precision options))
                    :selection (if (seq (:alternatives mixed))
                                 :analytic-runtime
                                 :analytic-fixed)}})))

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1333,36 +1333,6 @@
     soa-obj))
 
 ;; ================================================================
-;; GPU GEMM (non-square XMX)
-;; ================================================================
-
-(defn- emit-scheduled-split-k-gemm
-  "Legacy explicit-split-factor benchmark seam.
-
-   Ordinary direct/split selection is compiler-owned. This remains only until split count becomes
-   a finite typed-contraction schedule space rather than a runtime-specific benchmark parameter."
-  [kernel-name tile]
-  ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-split-k-kernel)
-   {:kernel-name kernel-name
-    :id [:resident-gemm kernel-name]
-    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K :kc 'KC :splits 'splits
-    :tile tile
-    :provenance {:dialect :resident-runtime}}))
-
-(declare gemm-tile)
-
-(defn- gemm-tile
-  "The GEMM tile for this device, from the ONE source (compiler.core.hardware/gemm-tile-for).
-   Launch geometry MUST be derived from the same tile the kernel was emitted with — the `/128.0`
-   literals this replaces were a second, independent spelling of block-m/block-n, so any tile change
-   would have silently mismatched kernel and grid."
-  []
-  (let [f (requiring-resolve 'raster.compiler.core.hardware/gemm-tile-for)
-        d (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for) (:device-id @state))
-               (catch Throwable _ nil))]
-    (f d)))
-
-;; ================================================================
 ;; GPU weight buffer manager (persistent FP16 across training)
 ;; ================================================================
 
@@ -2119,95 +2089,6 @@
   "Registry info for a kernel-name (source, :array-params, :written-arrays, dtype…)."
   [kernel-name]
   (get @kernel-registry kernel-name))
-
-;; ── SPLIT-K GEMM (the low-occupancy-shape schedule) ────────────────────────────
-;; A GEMM whose (M,N) tiling yields fewer workgroups than fill the machine —
-;; ceil(N/128)·ceil(M/128) — cannot be rescued by a better inner loop: the machine
-;; is idle. Splitting the K reduction across a third grid dimension multiplies the
-;; workgroup count at CONSTANT DRAM traffic (each (n-tile, k-chunk) block of B is
-;; still read exactly once), then a second kernel sums the per-chunk partials.
-;; Measured lever: the tied-embedding backward dx[13,640] = dlogits[13,262144] ·
-;; E[262144,640] launches 5 workgroups of the ~32 that fill this iGPU.
-
-(def ^:private gemm-splitk-cache (atom nil))
-(def ^:private splitk-reduce-cache (atom nil))
-
-(defn- ensure-gemm-splitk-kernel!
-  "Lazily compile + cache the split-k XMX gemm (f16 A/B in, f32 PARTIALS out).
-   Returns {:module :kernel :kernel-name}."
-  []
-  (ensure-init!)
-  (when (nil? @gemm-splitk-cache)
-    (let [kname "gemm_nonsquare_splitk"
-          tile (gemm-tile)
-          emitted (emit-scheduled-split-k-gemm kname tile)
-          cl-src (:source emitted)
-          spv (do (require 'raster.compiler.support.spirv-cache)
-                  ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                   cl-src :device (:device-id-hex @state)))
-          module (load-module! spv)
-          kernel (create-kernel module kname)]
-      (clojure.core/reset! gemm-splitk-cache
-                           {:module module :kernel kernel :kernel-name kname :tile tile
-                            :kernel-body (:kernel-body emitted)
-                            :workgroup (:workgroup-size emitted)})))
-  @gemm-splitk-cache)
-
-(defn- ensure-splitk-reduce-kernel!
-  "Lazily compile + cache the split-k partials-combine kernel."
-  []
-  (ensure-init!)
-  (when (nil? @splitk-reduce-cache)
-    (let [kname "gemm_splitk_reduce"
-          emitted ((requiring-resolve
-                    'raster.compiler.backend.gpu.gemm/emit-split-k-combine-kernel)
-                   kname)
-          src (:source emitted)
-          spv (do (require 'raster.compiler.support.spirv-cache)
-                  ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                   src :device (:device-id-hex @state)))
-          module (load-module! spv)
-          kernel (create-kernel module kname)]
-      (clojure.core/reset! splitk-reduce-cache
-                           {:module module :kernel kernel :kernel-name kname
-                            :kernel-body (:kernel-body emitted)})))
-  @splitk-reduce-cache)
-
-(defn bind-registered-gemm-splitk!
-  "Bind the SPLIT-K XMX GEMM: A[m×k]·B[k×n] → `partials` [splits, m, n] f32.
-  Grid is 3D — X = ceil(n/128), Y = ceil(m/128), Z = splits — so the launched
-  workgroup count is `splits` times the plain GEMM's. `kc` is the k-chunk each
-  z-slice reduces (must be a multiple of 32 so no interior chunk hits the k-remainder
-  path; the LAST chunk clamps to k). Pair with bind-registered-splitk-reduce!."
-  [a b partials m n k kc splits]
-  (let [{:keys [module kernel-name tile workgroup]} (ensure-gemm-splitk-kernel!)
-        {:keys [block-m block-n]} tile
-        kh (create-kernel-fresh module kernel-name)
-        m (long m) n (long n) k (long k) kc (long kc) splits (long splits)
-        args [(:segment a) (:segment b) (:segment partials)
-              {:type :int :value (int m)} {:type :int :value (int n)}
-              {:type :int :value (int k)} {:type :int :value (int kc)}
-              {:type :int :value (int splits)}]
-        bnd (bind-kernel! kh workgroup args)
-        gc ^MemorySegment (:gc-seg bnd)]
-    (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n))))) ;; X = gc-n
-    (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m))))) ;; Y = gc-m
-    (.set gc I32 8 (int splits))                             ;; Z = k-chunks
-    bnd))
-
-(defn bind-registered-splitk-reduce!
-  "Bind the split-k combine: C[i] = Σ_s partials[s·mn + i], one work-item per output
-  element of C (mn = m·n)."
-  [partials c mn splits]
-  (let [{:keys [module kernel-name]} (ensure-splitk-reduce-kernel!)
-        kh (create-kernel-fresh module kernel-name)
-        mn (long mn) splits (long splits)
-        args [(:segment partials) (:segment c)
-              {:type :int :value (int mn)} {:type :int :value (int splits)}
-              {:type :int :value (int mn)}]
-        bnd (bind-kernel! kh 256 args)]
-    (.set ^MemorySegment (:gc-seg bnd) I32 0 (int (Math/ceil (/ (double mn) 256.0))))
-    bnd))
 
 (def ^:private convert-cache (atom {}))
 

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -18,13 +18,16 @@
         (:nodes graph)))
 
 (defn- emitted
-  [variant]
-  (gemm/emit-executable
-   {:id (str "gemm-test-" (name variant))
-    :a 'a :b 'b :c 'c :m :m :n :n :k :k
-    :variant variant :precision :mixed-f16-f32
-    :tile (hardware/derive-gemm-tile {})
-    :fill-workgroups 32}))
+  ([variant] (emitted variant {}))
+  ([variant options]
+   (gemm/emit-executable
+    (merge
+     {:id (str "gemm-test-" (name variant))
+      :a 'a :b 'b :c 'c :m :m :n :n :k :k
+      :variant variant :precision :mixed-f16-f32
+      :tile (hardware/derive-gemm-tile {})
+      :fill-workgroups 32}
+     options))))
 
 (defn- arguments
   [m n k]
@@ -58,6 +61,24 @@
       (is (= :contraction (artifact/attribute operation :semantic-op)))
       (is (= [256] (get-in kernel-body [:launch :workgroup-size])))
       (is (graph-call/kernel-graph-call? call)))))
+
+(deftest explicit-split-factors-are-finite-schedule-alternatives
+  (let [scheduled (emitted :nn {:split-factors [2 8 32]})
+        by-strategy (into {} (map (juxt executable/strategy identity))
+                          (:alternatives scheduled))]
+    (is (= #{:f32-scalar :xmx-direct :xmx-split-k
+             :xmx-split-k-2 :xmx-split-k-8 :xmx-split-k-32}
+           (set (keys by-strategy))))
+    (doseq [factor [2 8 32]]
+      (let [strategy (gemm/split-factor-strategy factor)
+            graph (get by-strategy strategy)]
+        (is (= factor (get-in graph [:attributes :requested-splits])))
+        (is (= factor (get-in scheduled
+                              [:attributes :split-factor-schedules strategy])))))
+    (is (= :xmx-split-k
+           (executable/strategy
+            (dispatch/select-alternative scheduled (arguments 13 640 262144))))
+        "explicit tuning candidates do not replace the analytic default selector")))
 
 (deftest split-k-storage-and-launch-use-the-selector-expression
   (let [scheduled (emitted :nn)

--- a/test/raster/compiler/backend/gpu/typed_matrix_device_support.clj
+++ b/test/raster/compiler/backend/gpu/typed_matrix_device_support.clj
@@ -32,7 +32,7 @@
 
 (defn route
   "Compile `source` through TypedSOAC and return its target-aware contraction dispatch."
-  [device-id source array-types scalar-types & {:keys [tile precision]
+  [device-id source array-types scalar-types & {:keys [tile precision split-factors]
                                                 :or {precision :mixed-f16-f32}}]
   (let [{:keys [form]}
         (pipeline/schedule-parallel-form
@@ -46,14 +46,15 @@
            (cond-> [:dtype :float
                     :desc (hardware/descriptor-for device-id)
                     :precision precision]
-             tile (conj :tile tile)))))
+             tile (conj :tile tile)
+             split-factors (conj :split-factors split-factors)))))
 
 (defn dense-dispatch
-  [device-id & {:keys [tile]}]
+  [device-id & {:keys [tile split-factors]}]
   (route device-id dense-source
          {'A :float 'B :float 'C :float}
          {'m :int 'n :int 'k :int}
-         :tile tile))
+         :tile tile :split-factors split-factors))
 
 (defn batched-dispatch
   [device-id & {:keys [shared-column?]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1116,6 +1116,15 @@
     (is (= :mixed-f16-f32
            (get-in dispatch [:attributes :candidate-schedules :xmx-direct :precision])))
     (is (nil? (get-in dispatch [:attributes :matrix-graph-decline])))
+    (testing "explicit split factors remain compiler schedule candidates over the same typed equation"
+      (let [tunable (contract-route/route-typed-contraction-dispatch
+                     algorithm operation :dtype :float :desc descriptor
+                     :precision :mixed-f16-f32 :split-factors [2 8])]
+        (is (= #{:portable-segred :xmx-direct :xmx-split-k
+                 :xmx-split-k-2 :xmx-split-k-8}
+               (set (map kdispatch/alternative-strategy (:alternatives tunable)))))
+        (is (= 8 (get-in tunable [:attributes :candidate-schedules
+                                  :xmx-split-k-8 :split-factor])))))
     (testing "a non-DPAS target keeps the same semantic contraction on portable schedules"
       (let [portable (contract-route/route-typed-contraction-dispatch
                       algorithm operation :dtype :float

--- a/test/raster/gpu/gemm_autotune_test.clj
+++ b/test/raster/gpu/gemm_autotune_test.clj
@@ -1,90 +1,91 @@
 (ns raster.gpu.gemm-autotune-test
-  "The measurement loop end-to-end on REAL kernels: a finite emitted-candidate search driven by a
-   real device-event GEMM benchmark finds the measured-optimal split-k factor on a deep-k,
-   occupancy-bound shape — the axis with the largest proven win (~10×). This is the proof that the
-   Phase-2 machinery tunes actual kernels, not a synthetic cost.
+  "Device-event measurement of finite compiler-emitted matrix schedule spaces.
 
-   Honesty: split-k is a wired, high-headroom axis (occupancy). The dominant proj GEMM on this Arc
-   iGPU is already ~ceiling and its inner-loop levers (grf256/prefetch/dbuf) measured DEAD; the
-   small-m attention slab's gap to oneDNN is DECOMPOSITION (M=64 underfills the XMX 30×), not a
-   tuning knob. So the autotuner earns its keep on the occupancy axis (split-k), where measurement —
-   not a 'maximize splits' heuristic — finds a measured beneficial interior point.  The exact
-   factor is deliberately hardware-, driver-, and load-dependent."
+   Split factor and tile are schedule facts over an ordinary typed contraction. The tests execute
+   those alternatives through the common KernelExecutable binder; the backend runtime knows
+   neither GEMM semantics nor candidate-specific ABIs."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
-            [raster.compiler.core.hardware :as hw]
-            [raster.dl.gpu-grad-parity :as gp]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
             [raster.gpu.core :as gpu]))
 
-;; ── the real cost-fn: device-event time of the resident split-k XMX GEMM ─────────
-(defn- bench-splitk-ms
-  "Median device-event ms of the split-k GEMM (+reduce) at (m,n,k) with `splits` k-chunks."
-  [ze m n k splits]
-  (let [g!   (ns-resolve ze 'make-buffer)
-        f16  (ns-resolve ze 'buffer-of-floats-as-half)
-        rec  (ns-resolve ze 'record-graph!)   rep (ns-resolve ze 'replay-graph!)
-        rst  (ns-resolve ze 'reset-graph-events!) rts (ns-resolve ze 'read-graph-timestamps!)
-        dst  (ns-resolve ze 'destroy-graph!)
-        skg  (ns-resolve ze 'bind-registered-gemm-splitk!)
-        skr  (ns-resolve ze 'bind-registered-splitk-reduce!)
-        free (ns-resolve ze 'free-buffer!)
-        rng  (java.util.Random. 3)
-        mk   (fn [s] (let [a (float-array s)] (dotimes [i s] (aset a i (float (.nextGaussian rng)))) a))
-        kc   (* 32 (quot (quot (long k) (long splits)) 32))
-        a16  (f16 (mk (* m k)))  b16 (f16 (mk (* k n)))
-        part (g! (* splits m n) :float)  c (g! (* m n) :float)]
+(defn- bench-split-ms
+  "Measure one complete typed contraction graph, including layout conversion and final combine."
+  [session scheduled m n k splits]
+  (let [strategy (if (= 1 splits) :xmx-direct (gemm/split-factor-strategy splits))
+        graph (dispatch/alternative scheduled strategy)
+        output [:split-output splits]
+        _ (gpu/alloc! session {output [:float (* m n) nil]})
+        handle (gpu/bind-kernel-executable!
+                session [:split-candidate splits] graph
+                [:split-a :split-b output
+                 {:type :int :value m}
+                 {:type :int :value n}
+                 {:type :int :value k}]
+                {:profile? true})]
     (try
-      (let [g (rec [{:bound (skg a16 b16 part m n k kc splits) :kernel-name "gemm_nonsquare_splitk"}
-                    {:bound (skr part c (* m n) splits) :kernel-name "splitk_reduce"}]
-                   {:profile? true})]
-        (try
-          (dotimes [_ 3] (rep g) (rst g))
-          (let [s (vec (for [_ (range 11)] (do (rep g) (reduce + (map :ms (:kernels (rts g)))))))]
-            (nth (sort s) 5))
-          (finally (dst g))))
-      (finally (free a16) (free b16) (free part) (free c)))))
+      (gpu/run-kernel-graph! session handle)
+      (/ (:median-ns
+          (gpu/measure-bound-kernel-graph!
+           session handle
+           :warmup-iterations 3 :budget-ms 1000
+           :min-samples 11 :max-samples 11))
+         1.0e6)
+      (finally
+        (gpu/release-kernel-graph! session handle)))))
 
 (deftest autotune-finds-splitk-optimum
-  (if-not @gp/gpu-available?
-    (gp/gpu-skip! "GEMM autotune: split-k optimum on the resident XMX GEMM")
-    (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          m 16 n 512 k 131072                     ;; deep-k, small (m,n) grid → occupancy-bound
-          gflops (fn [ms] (/ (* 2.0 m k n) (* ms 1.0e6)))
-          measured (atom 0)
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "typed contraction autotune: split-K optimum")
+    (let [m 16 n 512 k 131072
           candidates [1 2 4 8 16 32]
-          results (mapv (fn [splits]
-                          (swap! measured inc)
-                          {:splits splits :ms (bench-splitk-ms ze m n k splits)})
-                        candidates)
-          baseline-ms (:ms (first results))
-          winner (apply min-key :ms results)
-          tuned (:splits winner)
-          tuned-ms (:ms winner)
-          speedup (/ baseline-ms tuned-ms)]
-      (println (format (str "\n=== GEMM split-k autotune (m=%d n=%d k=%d) ===\n"
-                            "  baseline splits=1 : %.2f GFLOPS\n"
-                            "  autotuned splits=%d: %.2f GFLOPS  (%.1fx, %d kernels measured)\n")
-                       m n k (gflops baseline-ms) tuned (gflops tuned-ms) speedup @measured))
-      (testing "finite candidate measurement finds a large occupancy win"
-        (is (> tuned 1) "the measured search must select a non-trivial split factor")
-        (is (> speedup 2.0) (str "tuned split-k must beat the non-split baseline by >2× (got "
-                                 (format "%.1fx" speedup) ")"))
-        (is (= (count candidates) @measured) "every emitted candidate is measured once")))))
+          measured (atom 0)
+          random (java.util.Random. 3)
+          make-input (fn [size]
+                       (let [result (float-array size)]
+                         (dotimes [index size]
+                           (aset result index (float (.nextGaussian random))))
+                         result))
+          scheduled (support/dense-dispatch :ze:0 :split-factors (vec (rest candidates)))
+          gflops (fn [ms] (/ (* 2.0 m k n) (* ms 1.0e6)))]
+      (gpu/with-gpu-session [session :ze:0]
+        (gpu/alloc! session {:split-a [:float (* m k) (make-input (* m k))]
+                             :split-b [:float (* k n) (make-input (* k n))]})
+        (let [results (mapv (fn [splits]
+                              (swap! measured inc)
+                              {:splits splits
+                               :ms (bench-split-ms session scheduled m n k splits)})
+                            candidates)
+              baseline-ms (:ms (first results))
+              winner (apply min-key :ms results)
+              tuned (:splits winner)
+              tuned-ms (:ms winner)
+              speedup (/ baseline-ms tuned-ms)]
+          (println (format (str "\n=== typed contraction split-K autotune (m=%d n=%d k=%d) ===\n"
+                                "  baseline splits=1 : %.2f GFLOPS\n"
+                                "  autotuned splits=%d: %.2f GFLOPS  (%.1fx, %d graphs measured)\n")
+                           m n k (gflops baseline-ms) tuned (gflops tuned-ms) speedup @measured))
+          (testing "finite compiler schedule measurement finds a large occupancy win"
+            (is (> tuned 1) "the measured search selects a non-trivial split factor")
+            (is (> speedup 2.0)
+                (str "split-K must beat the complete direct graph by >2× (got "
+                     (format "%.1fx" speedup) ")"))
+            (is (= (count candidates) @measured)
+                "every compiler-emitted schedule is measured once")))))))
 
-;; ── T3: the TILE axis — every finite emitted candidate is correct and device-priced ──
 (defn- run-tiled-gemm
-  "Measure one tile selected from an ordinary typed contraction.
-
-   The compiler-emitted matrix artifact is isolated so this remains a target-kernel tile ruler;
-   binding, launch geometry, profiling, and ownership still go through the generic runtime API."
+  "Measure the target matrix artifact selected from an ordinary typed contraction."
   [session m n k tile key]
   (let [scheduled (support/dense-dispatch :ze:0 :tile tile)
         artifact (support/matrix-artifact scheduled :xmx-direct)
-        c-key [:tile-output key]
-        _ (gpu/alloc! session {c-key [:float (* m n) nil]})
+        output [:tile-output key]
+        _ (gpu/alloc! session {output [:float (* m n) nil]})
         handle (gpu/bind-kernel-executable!
                 session [:tile-candidate key] artifact
-                [:tile-a :tile-b c-key
+                [:tile-a :tile-b output
                  {:type :int :value m}
                  {:type :int :value n}
                  {:type :int :value k}]
@@ -95,41 +96,41 @@
                          session handle
                          :warmup-iterations 2 :budget-ms 1000
                          :min-samples 7 :max-samples 7)]
-        [(vec (gpu/download session c-key)) (/ (:median-ns measurement) 1.0e6)])
+        [(vec (gpu/download session output)) (/ (:median-ns measurement) 1.0e6)])
       (finally
         (gpu/release-kernel-graph! session handle)))))
 
 (deftest autotune-tile-axis-all-candidates-correct
-  (if-not @gp/gpu-available?
-    (gp/gpu-skip! "GEMM autotune: tile axis (all candidates correct + measured search)")
-    (let [desc (hw/descriptor-for :ze:0)
-          cands (hw/gemm-tile-candidates desc)
-          default-tile (hw/derive-gemm-tile desc)
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "typed contraction autotune: tile candidates")
+    (let [descriptor (hardware/descriptor-for :ze:0)
+          candidates (hardware/gemm-tile-candidates descriptor)
+          default-tile (hardware/derive-gemm-tile descriptor)
           m 256 n 256 k 512
-          rng (java.util.Random. 4)
-          mk  (fn [s] (let [a (float-array s)] (dotimes [i s] (aset a i (float (* 0.05 (.nextGaussian rng))))) a))
-          a (mk (* m k))
-          b (mk (* k n))]
+          a (support/input-array (* m k) 4)
+          b (support/input-array (* k n) 5)]
       (gpu/with-gpu-session [session :ze:0]
         (gpu/alloc! session {:tile-a [:half (* m k) (support/half-array a)]
                              :tile-b [:half (* k n) (support/half-array b)]})
-        (testing "the curated candidate list is non-trivial and includes the derived default"
-          (is (> (count cands) 1) "more than one tile to search")
-          (is (some #(= % default-tile) cands) "the derived default is in the search space"))
-        (let [ref (first (run-tiled-gemm session m n k default-tile :reference))
-              results (mapv (fn [index t]
-                              (let [[c ms] (run-tiled-gemm session m n k t index)]
-                                {:tile t :bit-identical? (= ref c) :ms ms}))
-                            (range) cands)]
-          (testing "SAFETY: every candidate tile produces output bit-identical to the default"
-            (doseq [{:keys [tile bit-identical?]} results]
-              (is bit-identical? (str "tile " (select-keys tile [:block-m :block-n :block-k]) " must match default"))))
+        (testing "the finite schedule space is non-trivial and contains the analytic default"
+          (is (> (count candidates) 1))
+          (is (some #(= % default-tile) candidates)))
+        (let [reference (first (run-tiled-gemm session m n k default-tile :reference))
+              results (mapv (fn [index tile]
+                              (let [[result ms] (run-tiled-gemm session m n k tile index)]
+                                {:tile tile :bit-identical? (= reference result) :ms ms}))
+                            (range) candidates)]
+          (doseq [{:keys [tile bit-identical?]} results]
+            (is bit-identical?
+                (str "tile " (select-keys tile [:block-m :block-n :block-k])
+                     " preserves the contraction result")))
           (let [winner (:tile (apply min-key :ms results))]
-            (println (format "\n=== GEMM tile autotune (m=%d n=%d k=%d) ===" m n k))
+            (println (format "\n=== typed contraction tile autotune (m=%d n=%d k=%d) ==="
+                             m n k))
             (doseq [{:keys [tile ms]} (sort-by :ms results)]
-              (println (format "  %-22s %.3f ms%s" (str (:block-m tile) "x" (:block-n tile) " k" (:block-k tile))
+              (println (format "  %-22s %.3f ms%s"
+                               (str (:block-m tile) "x" (:block-n tile)
+                                    " k" (:block-k tile))
                                ms (if (= tile winner) "  <- winner" ""))))
-            (testing "measured search returns a feasible candidate (Arc: hand-tuned default is ~optimal)"
-              (is (some #(= % winner) cands) "winner is one of the candidates")
-              (is (= ref (first (run-tiled-gemm session m n k winner :winner)))
-                  "winner output is correct"))))))))
+            (is (some #(= % winner) candidates))
+            (is (= reference (first (run-tiled-gemm session m n k winner :winner))))))))))

--- a/test/raster/gpu/gemm_splitk_test.clj
+++ b/test/raster/gpu/gemm_splitk_test.clj
@@ -18,6 +18,7 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]))
@@ -39,60 +40,51 @@
 (deftest split-k-matches-plain-xmx-gemm
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "gemm split-k")
-    (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          record-graph! (ns-resolve ze 'record-graph!)
-          replay!       (ns-resolve ze 'replay-graph!)
-          destroy!      (ns-resolve ze 'destroy-graph!)
-          splitk!       (ns-resolve ze 'bind-registered-gemm-splitk!)
-          reduce!       (ns-resolve ze 'bind-registered-splitk-reduce!)]
-      (doseq [[m n k splits kc]
-              [[13 640 8192 8 1024]     ;; the LM-head dx shape (small k, same geometry)
-               [13 640 8192 26 320]     ;; k/splits not a multiple of kc*splits
-               [7 640 4096 4 1024]      ;; m below one 8-row DPAS tile
-               [33 200 1000 3 352]      ;; ragged m, n and k; last chunk clipped
-               [128 256 4096 8 512]]]
-        (let [A (rnd (* m k) 1) B (rnd (* k n) 2)
-              scheduled (support/dense-dispatch :ze:0)
-              direct (support/matrix-artifact scheduled :xmx-direct)]
-          (gpu/with-gpu-session [session :ze:0]
-            (gpu/alloc! session {:a16 [:half (* m k) (support/half-array A)]
-                                 :b16 [:half (* k n) (support/half-array B)]
-                                 :c-plain [:float (* m n) nil]
-                                 :c-split [:float (* m n) nil]
-                                 :parts [:float (* splits m n) nil]})
-            (let [direct-handle
-                  (gpu/bind-kernel-executable!
-                   session [:typed-direct m n k] direct
-                   [:a16 :b16 :c-plain
-                    {:type :int :value m}
-                    {:type :int :value n}
-                    {:type :int :value k}])]
+    (let [cases [[13 640 8192 8]      ;; the LM-head dx shape (small k, same geometry)
+                 [13 640 8192 26]     ;; k/splits is not integral; last chunk is clipped
+                 [7 640 4096 4]       ;; m below one 8-row DPAS tile
+                 [33 200 1000 3]      ;; ragged m, n and k
+                 [128 256 4096 8]]
+          factors (vec (distinct (map #(nth % 3) cases)))
+          scheduled (support/dense-dispatch :ze:0 :split-factors factors)
+          direct (dispatch/alternative scheduled :xmx-direct)]
+      (gpu/with-gpu-session [session :ze:0]
+        (doseq [[case-index [m n k splits]] (map-indexed vector cases)]
+          (let [a (rnd (* m k) 1)
+                b (rnd (* k n) 2)
+                a-key [:a case-index]
+                b-key [:b case-index]
+                plain-key [:plain case-index]
+                split-key [:split case-index]
+                split-graph (dispatch/alternative
+                             scheduled (gemm/split-factor-strategy splits))
+                arguments (fn [output]
+                            [a-key b-key output
+                             {:type :int :value m}
+                             {:type :int :value n}
+                             {:type :int :value k}])]
+            (gpu/alloc! session {a-key [:float (* m k) a]
+                                 b-key [:float (* k n) b]
+                                 plain-key [:float (* m n) nil]
+                                 split-key [:float (* m n) nil]})
+            (let [direct-handle (gpu/bind-kernel-executable!
+                                 session [:typed-direct case-index]
+                                 direct (arguments plain-key))
+                  split-handle (gpu/bind-kernel-executable!
+                                session [:typed-split case-index]
+                                split-graph (arguments split-key))]
               (try
                 (gpu/run-kernel-graph! session direct-handle)
-                ;; Explicit split factors remain a legacy benchmark surface until split count is
-                ;; represented as a finite compiler schedule candidate in the next increment.
-                (let [g (record-graph!
-                         [{:bound (splitk! (gpu/buffer session :a16)
-                                           (gpu/buffer session :b16)
-                                           (gpu/buffer session :parts)
-                                           m n k kc splits)
-                           :kernel-name "gemm_nonsquare_splitk"}
-                          {:bound (reduce! (gpu/buffer session :parts)
-                                           (gpu/buffer session :c-split)
-                                           (* m n) splits)
-                           :kernel-name "splitk_reduce"}])]
-                  (try
-                    (replay! g)
-                    (let [plain (gpu/download session :c-plain)
-                          split (gpu/download session :c-split)
-                          error (rel-l1 split plain)]
-                      (testing (str "m=" m " n=" n " k=" k " splits=" splits)
-                        (is (< error 1.0e-4)
-                            (str "split-k vs compiler-derived direct matrix rel-L1 " error))))
-                    (finally
-                      (destroy! g))))
+                (gpu/run-kernel-graph! session split-handle)
+                (let [plain (gpu/download session plain-key)
+                      split (gpu/download session split-key)
+                      error (rel-l1 split plain)]
+                  (testing (str "m=" m " n=" n " k=" k " splits=" splits)
+                    (is (< error 1.0e-4)
+                        (str "split-K candidate vs direct typed contraction rel-L1 " error))))
                 (finally
-                  (gpu/release-kernel-graph! session direct-handle))))))))))
+                  (gpu/release-kernel-graph! session direct-handle)
+                  (gpu/release-kernel-graph! session split-handle))))))))))
 
 (deftest unrolled-layout-convert-is-bit-exact
   ;; The f32→f16 operand cast schedules w statically unrolled, lane-owned elements per work-item.


### PR DESCRIPTION
## Summary
- expose requested split-K factors as finite ABI-compatible KernelGraph alternatives over an ordinary TypedSOAC contraction
- retain the analytic direct/split selector for normal compilation; explicit factors are emitted only when a tuning caller requests them
- record factor identity in compiler candidate schedules for generic dispatch tuning and cache identity
- migrate split correctness and autotune tests to complete compiler graphs and generic device-event measurement
- delete the final Level Zero GEMM/split-K compiler caches and bespoke binders

## Focused verification
- matrix emitter: 11 tests, 85 assertions
- TypedSOAC route: 51 tests, 415 assertions
- real Arc split correctness/conversion: 4 tests, 60 assertions
- real Arc schedule autotune: 2 tests, 16 assertions; complete-graph split=32 winner at 4.0x direct
- affected runtime/test files pass cljfmt and git diff checks