### PR TITLE
Verify matrix body storage and fragment contracts

### DIFF
--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -355,6 +355,30 @@
   (when (layout/shared-memory-layout? layout)
     (layout/validate-shared-memory! layout)))
 
+(defn- storage-layout!
+  "Validate the shape/dtype facts repeated by dense storage layouts.
+
+  Fragment layouts deliberately do not all carry a tensor shape, but every layout that does state
+  one must agree with its owner.  This prevents a target emitter from indexing according to a
+  stale layout descriptor after the storage contract changed."
+  [owner shape dtype storage-layout]
+  (layout! owner storage-layout)
+  (when (and (contains? storage-layout :shape)
+             (not= (vec shape) (vec (:shape storage-layout))))
+    (throw (ex-info (str owner " shape disagrees with its layout")
+                    {:reason :kernel-body-layout-shape
+                     :shape shape :layout storage-layout})))
+  (when (and (contains? storage-layout :rank)
+             (not= (count shape) (:rank storage-layout)))
+    (throw (ex-info (str owner " rank disagrees with its layout")
+                    {:reason :kernel-body-layout-rank
+                     :shape shape :layout storage-layout})))
+  (when (and (contains? storage-layout :dtype)
+             (not= (dtype/canon dtype) (dtype/canon (:dtype storage-layout))))
+    (throw (ex-info (str owner " dtype disagrees with its layout")
+                    {:reason :kernel-body-layout-dtype
+                     :dtype dtype :layout storage-layout}))))
+
 (defn- unique-ids! [owner values]
   (let [ids (mapv :id values)]
     (when (or (some nil? ids) (not= (count ids) (count (set ids))))
@@ -547,6 +571,14 @@
           (throw (ex-info "tile loads must produce a named dot-operand fragment"
                           {:fragment f})))
         (coordinates! "tile-load" (:coordinates operation))
+        (when-not (= (count (:shape p)) (count (:coordinates operation)))
+          (throw (ex-info "tile-load coordinates must match the buffer rank"
+                          {:reason :kernel-body-tile-load-rank
+                           :buffer p :coordinates (:coordinates operation)})))
+        (when-not (= (dtype/canon (:dtype p)) (dtype/canon (:dtype f)))
+          (throw (ex-info "tile-load fragment dtype must equal the buffer element dtype"
+                          {:reason :kernel-body-tile-load-dtype
+                           :buffer p :fragment f})))
         (mask (:mask operation))
         (when-not (contains? cache-policies (:cache operation))
           (throw (ex-info "tile load has an unsupported cache policy"
@@ -559,6 +591,15 @@
         (shape! "tile prefetch" (:shape operation))
         (layout! "tile prefetch" (:layout operation))
         (coordinates! "tile-prefetch" (:coordinates operation))
+        (when-not (= (count (:shape p)) (count (:coordinates operation)))
+          (throw (ex-info "tile-prefetch coordinates must match the buffer rank"
+                          {:reason :kernel-body-tile-prefetch-rank
+                           :buffer p :coordinates (:coordinates operation)})))
+        (when-not (= (dtype/canon (:dtype p))
+                     (dtype/canon (get-in operation [:layout :dtype])))
+          (throw (ex-info "tile-prefetch layout dtype must equal the buffer element dtype"
+                          {:reason :kernel-body-tile-prefetch-dtype
+                           :buffer p :layout (:layout operation)})))
         (when-not (and (integer? (:distance operation)) (not (neg? (:distance operation))))
           (throw (ex-info "tile-prefetch distance must be a non-negative integer"
                           {:distance (:distance operation)})))
@@ -581,7 +622,22 @@
                        (= (:parent rhs-layout) acc-layout)
                        (= (:matrix acc-layout) matrix))
           (throw (ex-info "matrix MAD fragment layouts do not agree with its instruction"
-                          {:accumulator acc :lhs lhs :rhs rhs :instruction matrix}))))
+                          {:accumulator acc :lhs lhs :rhs rhs :instruction matrix})))
+        (let [{matrix-m :m matrix-n :n matrix-k :k} matrix]
+          (when-not (= [[matrix-m matrix-n] [matrix-m matrix-k] [matrix-k matrix-n]]
+                       [(:shape acc) (:shape lhs) (:shape rhs)])
+            (throw (ex-info "matrix MAD fragment shapes do not agree with its instruction"
+                            {:reason :kernel-body-matrix-fragment-shape
+                             :accumulator acc :lhs lhs :rhs rhs :instruction matrix}))))
+        (when-not (and (= (dtype/canon (:dtype acc))
+                          (dtype/canon (:dtype acc-layout)))
+                       (= (dtype/canon (:dtype lhs))
+                          (dtype/canon (:dtype lhs-layout)))
+                       (= (dtype/canon (:dtype rhs))
+                          (dtype/canon (:dtype rhs-layout))))
+          (throw (ex-info "matrix MAD fragment dtypes do not agree with their layouts"
+                          {:reason :kernel-body-matrix-fragment-dtype
+                           :accumulator acc :lhs lhs :rhs rhs :instruction matrix}))))
 
       (record-kind? "raster.compiler.ir.kernel_body.Loop" operation)
       (do
@@ -619,6 +675,10 @@
         (when-not (= :mma-frag (get-in f [:layout :kind]))
           (throw (ex-info "tile stores require an accumulator fragment" {:fragment f})))
         (coordinates! "tile-store" (:coordinates operation))
+        (when-not (= (count (:shape p)) (count (:coordinates operation)))
+          (throw (ex-info "tile-store coordinates must match the buffer rank"
+                          {:reason :kernel-body-tile-store-rank
+                           :buffer p :coordinates (:coordinates operation)})))
         (mask (:mask operation))
         (when-let [region (:value-region operation)]
           (if (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion" region)
@@ -1889,7 +1949,7 @@
           (throw (ex-info "scalar kernel parameters cannot carry storage layout"
                           {:parameter p})))
         (do (shape! "kernel buffer parameter" (:shape p))
-            (layout! "kernel buffer parameter" (:layout p))
+            (storage-layout! "kernel buffer parameter" (:shape p) (:dtype p) (:layout p))
             (when (layout/shared-memory-layout? (:layout p))
               (throw (ex-info "shared-memory layouts are restricted to workgroup allocations"
                               {:reason :kernel-body-shared-layout-memory-space
@@ -1960,7 +2020,8 @@
                    (throw (ex-info "kernel buffer view offset references values outside its scope"
                                    {:view view :references (vec outside) :scope index-scope}))))
                (shape! "kernel buffer view" (:shape view))
-               (layout! "kernel buffer view" (:layout view))
+               (storage-layout! "kernel buffer view" (:shape view) (:dtype parent)
+                                (:layout view))
                (when (layout/shared-memory-layout? (:layout view))
                  (throw (ex-info "shared-memory layouts cannot decorate global buffer views"
                                  {:reason :kernel-body-shared-layout-memory-space
@@ -2036,7 +2097,13 @@
                        (dtype/known? (:dtype f)))
           (throw (ex-info "kernel fragment requires a known dtype" {:fragment f})))
         (shape! "kernel fragment" (:shape f))
-        (layout! "kernel fragment" (:layout f)))
+        (layout! "kernel fragment" (:layout f))
+        (when (and (contains? (:layout f) :dtype)
+                   (not= (dtype/canon (:dtype f))
+                         (dtype/canon (get-in f [:layout :dtype]))))
+          (throw (ex-info "kernel fragment dtype disagrees with its layout"
+                          {:reason :kernel-body-fragment-layout-dtype
+                           :fragment f}))))
       (doseq [[field value] [[:schedule schedule] [:launch launch] [:provenance provenance]
                              [:attributes attributes]]]
         (when-not (map? value)

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -127,10 +127,12 @@
         buffer-views (mapv (fn [view]
                              (if (instance? raster.compiler.ir.kernel_body.BufferView view)
                                view
-                               (body/->BufferView (:id view) (:buffer view)
-                                                  (:element-offset view) (:shape view)
-                                                  (or (:layout view)
-                                                      (get buffer-layouts (:buffer view))))))
+                               (let [parent-layout (get buffer-layouts (:buffer view))]
+                                 (body/->BufferView
+                                  (:id view) (:buffer view) (:element-offset view) (:shape view)
+                                  (or (:layout view)
+                                      (layout/row-major (:shape view)
+                                                        (:dtype parent-layout)))))))
                            buffer-views)
         {:keys [block-m block-n block-k sg-m sg-n num-stages]} tile
         {matrix-m :m matrix-n :n matrix-k :k subgroup :subgroup} matrix

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -54,9 +54,9 @@
 (deftest kernel-buffer-shapes-retain-symbolic-launch-arithmetic
   (let [extent (launch/ceil-div 'n 256)
         kernel (-> (minimal-body)
-                   (assoc-in [:parameters 0 :shape] [extent])
+                   (assoc-in [:parameters 0 :shape] [extent 16])
                    (assoc-in [:parameters 0 :layout]
-                             (layout/row-major [extent] :half)))]
+                             (layout/row-major [extent 16] :half)))]
     (is (= kernel (body/validate! kernel)))
     (is (= extent (get-in kernel [:parameters 0 :shape 0])))))
 
@@ -78,16 +78,39 @@
     (let [kernel (minimal-body)
           bad (assoc-in kernel [:operations 0 :operations 2 :mask] :missing)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"undeclared mask"
-                            (body/validate! bad))))))
+                            (body/validate! bad)))))
+  (testing "matrix fragment shapes are fixed by the instruction"
+    (let [bad (assoc-in (minimal-body) [:fragments 0 :shape] [8 8])]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"fragment shapes"
+                            (body/validate! bad)))))
+  (testing "tile coordinates match storage rank"
+    (let [bad (update-in (minimal-body)
+                         [:operations 0 :operations 1 :operations 0 :coordinates]
+                         pop)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"buffer rank"
+                            (body/validate! bad)))))
+  (testing "tile-load dtypes follow storage rather than target inference"
+    (let [bad (assoc-in (minimal-body) [:fragments 0 :dtype] :float)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"dtype"
+                            (body/validate! bad)))))
+  (testing "storage shape and dtype agree with their named layout"
+    (let [bad-shape (assoc-in (minimal-body) [:parameters 0 :shape] [8 16])
+          bad-dtype (assoc-in (minimal-body) [:parameters 0 :dtype] :float)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"shape disagrees"
+                            (body/validate! bad-shape)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"dtype disagrees"
+                            (body/validate! bad-dtype))))))
 
 (deftest buffer-views-retain-parent-ownership-and-explicit-offsets
   (let [kernel (minimal-body)
         kernel (-> kernel
                    (assoc-in [:parameters 0 :shape] [16 16 16])
+                   (assoc-in [:parameters 0 :layout]
+                             (layout/row-major [16 16 16] :half))
                    (assoc-in [:launch :group-count] [16]))
         view (body/->BufferView 'A-slab 'A
                                 (body/expression :mul 'group-x 16 16)
-                                [16 16] (:layout (first (:parameters kernel))))
+                                [16 16] (layout/row-major [16 16] :half))
         viewed (-> kernel
                    (assoc :views [view])
                    (assoc-in [:operations 0 :operations 1 :operations 0 :buffer] 'A-slab))]


### PR DESCRIPTION
Closes verifier gaps before cross-vendor matrix lowering: matrix fragment shapes and dtypes are checked against the selected instruction, tile memory coordinates and dtypes are checked against storage, and dense layout shape/rank/dtype facts cannot drift. Split-K and batched leading slices now receive exact rank-2 layouts instead of inheriting rank-3 parent layouts.\n\nFocused gates: kernel-body-test (23 tests, 120 assertions); contraction-schedule-test + gemm-test (24 tests, 144 assertions). Full suite is delegated to CircleCI.