### PR TITLE
Lower aligned CUDA MMA from verified KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/cuda_codegen.clj
+++ b/src/raster/compiler/backend/gpu/cuda_codegen.clj
@@ -1,36 +1,86 @@
 (ns raster.compiler.backend.gpu.cuda-codegen
-  "CUDA-C codegen — the NVIDIA `:mma` (Tensor Core) fork of the tile-parametric GEMM. The tile
-   vocabulary is vendor-neutral (block-m/block-n/sg-m/sg-n/block-k × matrix shape, identical to the
-   Intel :dpas generator in opencl-codegen); only the emitted LANGUAGE and matrix INSTRUCTION differ.
-   This generator emits CUDA C using the WMMA fragment API (nvcuda::wmma), which the NVIDIA toolchain
-   lowers to HMMA Tensor Core instructions on cc≥7.0.
+  "CUDA-C target lowering for verified matrix KernelBody values.
 
-   T5 scope + honesty: on a machine with nvcc but NO NVIDIA GPU, this is validated to the strongest
-   available gate — it COMPILES (nvcc → SASS) and SELECTS Tensor Cores (HMMA in the SASS). NUMERICAL
-   correctness needs a real GPU (deferred, like the Intel kernel's on-device gate). The MVP emits the
-   f32-accumulator (:float output), tile-aligned path (M/N/K multiples of the tile — ragged-tile
-   boundary handling via SMEM zero-pad is the on-device follow-up). SMEM double-buffering (the true
-   num_stages knob for this family) and WGMMA (sm_90 async warp-group) are separate emitters."
-  (:require [clojure.string :as str]))
+  The first row deliberately covers direct, aligned f16×f16→f32 WMMA bodies. Unsupported body
+  structure fails before source emission; masks, views, slices, epilogues and extra ABI values are
+  never silently discarded. Shared-memory staging and WGMMA are later schedules over the same
+  typed contraction and KernelBody vocabulary."
+  (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]))
 
-(defn emit-gemm-tiled-cuda
-  "Tile-parametric CUDA WMMA GEMM (C = A·B, f16 in, f32 accumulate, row-major). Same tile map as the
-   Intel emit-gemm-tiled; `matrix` is the WMMA fragment shape {:m 16 :n 16 :k 16 :subgroup 32}. Each
-   WARP computes an sg-m×sg-n output tile as an (sg-m/16)×(sg-n/16) grid of 16×16 accumulator
-   fragments; the block is a (block-m/sg-m)×(block-n/sg-n) grid of warps. K-loop steps by 16
-   (WMMA k), unrolled block-k/16 per iteration. Emits :float (f32-accumulator) output."
-  [kernel-name & {:keys [block-m block-n sg-m sg-n block-k matrix c-dtype]
-                  :or {block-m 64 block-n 64 sg-m 32 sg-n 32 block-k 16
-                       matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32} c-dtype :float}}]
-  (let [{mi :m ni :n ki :k sg :subgroup :or {mi 16 ni 16 ki 16 sg 32}} matrix]
-    (doseq [[nm a b] [["sg-m/M_i" sg-m mi] ["sg-n/N_i" sg-n ni] ["block-m/sg-m" block-m sg-m]
-                      ["block-n/sg-n" block-n sg-n] ["block-k/K_i" block-k ki]]]
-      (when-not (zero? (rem a b))
-        (throw (ex-info (str "emit-gemm-tiled-cuda: " nm " not divisible (" a "/" b ")") {:matrix matrix}))))
-    (when (not= c-dtype :float)
-      (throw (ex-info "emit-gemm-tiled-cuda MVP emits :float (f32 accumulator); :half epilogue is a follow-up"
-                      {:c-dtype c-dtype})))
-    (let [nms (quot sg-m mi) nns (quot sg-n ni)      ;; fragments per warp (M, N)
+(defn- decline!
+  [condition reason data]
+  (when-not condition
+    (throw (ex-info "CUDA matrix lowering does not implement this verified body"
+                    (assoc data :reason reason :target :cuda)))))
+
+(defn- identity-store?
+  [store]
+  (nil? (:value-region store)))
+
+(defn- parameter-declarations
+  [parameters dimension-parameters]
+  (let [dimension-name (into {} (map (fn [[axis id]] [id (str/upper-case (name axis))]))
+                             dimension-parameters)]
+    (mapv
+     (fn [{:keys [id kind dtype role] :as parameter}]
+       (cond
+         (and (= :lhs role) (= :input kind) (= :half dtype))
+         "const half* __restrict__ A"
+
+         (and (= :rhs role) (= :input kind) (= :half dtype))
+         "const half* __restrict__ B"
+
+         (and (= :result role) (= :output kind) (= :float dtype))
+         "float* __restrict__ C"
+
+         (and (= :dimension role) (= :scalar kind) (= :int dtype)
+              (contains? dimension-name id))
+         (str "int " (get dimension-name id))
+
+         :else
+         (throw (ex-info "CUDA matrix lowering cannot render this ordered ABI parameter"
+                         {:reason :cuda-mma-extra-abi-unsupported
+                          :target :cuda :parameter parameter}))))
+     parameters)))
+
+(defn- emit-plan
+  [kernel-name {:keys [instruction dimensions dimension-values parameters
+                       mi ni ki subgroup block-m block-n sg-m sg-n
+                       block-k lhs-ids rhs-ids stores prefetch result-dtype
+                       dimension-parameters schedule-parameters group-z k-lower k-upper
+                       buffer-offsets]}]
+  (let [[M N K] dimensions]
+    (decline! (= {:family :mma :m 16 :n 16 :k 16 :subgroup 32} instruction)
+              :cuda-mma-instruction-unsupported {:instruction instruction})
+    (decline! (= :float result-dtype)
+              :cuda-mma-result-dtype-unsupported {:result-dtype result-dtype})
+    (decline! (and (every? #(and (integer? %) (pos? %)) dimensions)
+                   (zero? (mod M block-m))
+                   (zero? (mod N block-n))
+                   (zero? (mod K block-k)))
+              :cuda-mma-requires-aligned-static-dimensions
+              {:dimensions dimensions :block [block-m block-n block-k]})
+    (decline! (= [0 (:k dimension-parameters)] [k-lower k-upper])
+              :cuda-mma-k-slice-unsupported {:k-range [k-lower k-upper]})
+    (decline! (and (nil? group-z) (empty? schedule-parameters)
+                   (every? nil? (vals buffer-offsets)))
+              :cuda-mma-views-or-schedule-parameters-unsupported
+              {:group-z group-z :schedule-parameters schedule-parameters
+               :buffer-offsets buffer-offsets})
+    (decline! (every? identity-store? stores)
+              :cuda-mma-store-region-unsupported {:stores stores})
+    (let [declarations (parameter-declarations parameters dimension-parameters)
+          _ (decline! (= 6 (count declarations))
+                      :cuda-mma-extra-abi-unsupported {:parameters parameters})
+          specialized-dimensions
+          (mapv dimension-values [(:m dimension-parameters)
+                                  (:n dimension-parameters)
+                                  (:k dimension-parameters)])
+          _ (decline! (= dimensions specialized-dimensions)
+                      :cuda-mma-dimension-specialization-invalid
+                      {:dimensions dimensions :dimension-values dimension-values})
+          nms (count lhs-ids) nns (count rhs-ids)      ;; fragments per warp (M, N)
           ncols (quot block-n sg-n)                   ;; warp columns
           ksteps (quot block-k ki)
           ms (range nms) ns (range nns)
@@ -42,11 +92,12 @@
        "#include <mma.h>\n"
        "using namespace nvcuda;\n\n"
        "// Tiled WMMA GEMM (parametric): block " block-m "x" block-n ", warp-tile " sg-m "x" sg-n
-       ", K " block-k ", frag " mi "x" ni "x" ki ", warp " sg ", warps/block " warps-per-block "\n"
-       "extern \"C\" __global__ void " kernel-name "(\n"
-       "    const half* __restrict__ A, const half* __restrict__ B,\n"
-       "    float* __restrict__ C, int M, int N, int K) {\n"
-       "  int warpId = threadIdx.x / 32;\n"
+       ", K " block-k ", frag " mi "x" ni "x" ki ", warp " subgroup
+       ", warps/block " warps-per-block "\n"
+       "extern \"C\" __global__ void " kernel-name "(\n    "
+       (str/join ",\n    " declarations) ") {\n"
+       "  if (M != " M " || N != " N " || K != " K ") { asm volatile(\"trap;\"); return; }\n"
+       "  int warpId = threadIdx.x / " subgroup ";\n"
        "  int warp_row = warpId / " ncols ";\n"
        "  int warp_col = warpId % " ncols ";\n"
        "  int m_base = blockIdx.y * " block-m " + warp_row * " sg-m ";\n"
@@ -61,6 +112,17 @@
               (for [ks (range ksteps)]
                 (let [koff (* ks ki)]
                   (str
+                   "    { int pk = k + " (+ koff (* prefetch ki)) ";\n"
+                   "      if (pk < K && ((int)threadIdx.x % " subgroup ") == 0) {\n"
+                   (apply str
+                          (for [m ms]
+                            (str "        #pragma unroll\n"
+                                 "        for (int pr = 0; pr < " mi "; ++pr) {\n"
+                                 "          const half* pp = A + (m_base + " (* m mi)
+                                 " + pr) * K + pk;\n"
+                                 "          asm volatile(\"prefetch.global.L2 [%0];\" :: \"l\"(pp));\n"
+                                 "        }\n")))
+                   "      } }\n"
                    (apply str (for [m ms] (str "    wmma::load_matrix_sync(a" m ", A + (m_base + " (* m mi) ") * K + k + " koff ", K);\n")))
                    (apply str (for [n ns] (str "    wmma::load_matrix_sync(b" n ", B + (k + " koff ") * N + n_base + " (* n ni) ", N);\n")))
                    (apply str (for [m ms n ns] (str "    wmma::mma_sync(acc" m "_" n ", a" m ", b" n ", acc" m "_" n ");\n")))))))
@@ -69,3 +131,11 @@
                     (str "  wmma::store_matrix_sync(C + (m_base + " (* m mi) ") * N + n_base + " (* n ni)
                          ", acc" m "_" n ", N, wmma::mem_row_major);\n")))
        "}\n"))))
+
+(defn emit-matrix-kernel
+  "Lower the currently supported CUDA WMMA subset of a verified matrix KernelBody.
+
+  This boundary takes no tile, dimension, launch or ABI side channel. The returned source is a
+  target spelling of the analyzed body; unsupported verified bodies fail with a structured reason."
+  [kernel-name kernel-body]
+  (emit-plan kernel-name (matrix-plan/analyze kernel-body)))

--- a/src/raster/compiler/backend/gpu/matrix_body_plan.clj
+++ b/src/raster/compiler/backend/gpu/matrix_body_plan.clj
@@ -165,6 +165,7 @@
         m-parameter (:m dimension-parameters)
         n-parameter (:n dimension-parameters)
         k-parameter (:k dimension-parameters)
+        dimension-values (:dimension-values attributes)
         schedule-parameters (filterv #(= :schedule (:role %)) parameters)
         _ (require! (every? #(and (= :scalar (:kind %)) (= :int (:dtype %)))
                             schedule-parameters)
@@ -175,6 +176,12 @@
                     "matrix body dimension roles and parameter identities disagree"
                     {:dimension-parameters dimension-parameters
                      :parameters (:dimension parameters-by-role)})
+        _ (require! (= {m-parameter m-extent n-parameter n-extent k-parameter k-extent}
+                       dimension-values)
+                    "matrix dimension specializations must agree with its storage shapes"
+                    {:dimension-parameters dimension-parameters
+                     :dimension-values dimension-values
+                     :storage-dimensions [m-extent n-extent k-extent]})
         _ (require! (and (= :half (:dtype lhs-param)) (= :half (:dtype rhs-param))
                          (contains? #{:half :float} (:dtype out-param)))
                     "matrix plan requires f16 inputs and an f16 or f32 result"
@@ -381,11 +388,14 @@
            "tile-store masks do not match their fragment coordinates"
            {:stores stores :masks masks})]
     {:instruction instruction
+     :dimensions [m-extent n-extent k-extent]
      :mi mi :ni ni :ki ki :subgroup subgroup
      :block-m block-m :block-n block-n :block-k block-k :sg-m sg-m :sg-n sg-n
      :ncols ncols :lhs-ids lhs-ids :rhs-ids rhs-ids :mad-by-operands mad-by-operands
      :stores stores :prefetch prefetch-distance :result-dtype (:dtype out-param)
      :dimension-parameters dimension-parameters
+     :dimension-values dimension-values
+     :parameters parameters
      :schedule-parameters schedule-parameters
      :launch launch
      :group-z (some #(when (and (record-kind? "IndexBinding" %)

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -276,6 +276,7 @@
                     :instruction-family (:family matrix)
                     :dims [M N K]
                     :dimension-parameters {:m m-parameter :n n-parameter :k k-parameter}
+                    :dimension-values {m-parameter M n-parameter N k-parameter K}
                     :axis-symbols [i j k-sym]
                     :bindings bindings
                     :operation-buffers {:row row-buffer :col col-buffer :out out-buffer}

--- a/test/raster/compiler/backend/gpu/cuda_mma_compile_test.clj
+++ b/test/raster/compiler/backend/gpu/cuda_mma_compile_test.clj
@@ -8,7 +8,8 @@
             [clojure.java.shell :as sh]
             [clojure.java.io :as io]
             [raster.compiler.core.hardware :as hw]
-            [raster.compiler.backend.gpu.cuda-codegen :as cuda]))
+            [raster.compiler.backend.gpu.cuda-codegen :as cuda]
+            [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
 
 (defn- nvcc-available? []
   (try (zero? (:exit (sh/sh "bash" "-c" "command -v nvcc"))) (catch Exception _ false)))
@@ -26,6 +27,12 @@
           (let [s (sh/sh "cuobjdump" "-sass" (.getPath cubin))]
             {:compiled? true :sass (:out s)}))))))
 
+(defn- matrix-body
+  [id tile dimensions]
+  (schedule/matrix-body
+   {:id id :row 'a :col 'b :out 'c
+    :dimensions dimensions :tile tile :result-dtype :float}))
+
 (deftest cuda-wmma-derives-and-compiles-with-tensor-cores
   (if-not (nvcc-available?)
     (println "SKIP cuda-mma: no nvcc toolchain")
@@ -39,17 +46,53 @@
           (is (zero? (mod (:sg-n tile) 16)) "warp-tile N is a 16-fragment multiple")))
       (testing "the derived tile emits CUDA that nvcc compiles + lowers to HMMA Tensor Cores"
         (let [tile (hw/derive-gemm-tile a100)
-              src  (apply cuda/emit-gemm-tiled-cuda "gemm_mma_derived"
-                          (mapcat identity (select-keys tile [:block-m :block-n :sg-m :sg-n :block-k :matrix])))
+              dimensions [(:block-m tile) (:block-n tile) (* 2 (:block-k tile))]
+              src (cuda/emit-matrix-kernel
+                   "gemm_mma_derived" (matrix-body :gemm-mma-derived tile dimensions))
               {:keys [compiled? sass err]} (compile-cu src)]
           (is compiled? (str "nvcc must accept the emitted kernel; stderr:\n" err))
+          (is (re-find #"if \(M != [0-9]+ \|\| N != [0-9]+ \|\| K != [0-9]+\)"
+                       src)
+              "runtime dimensions are guarded by the checked body specialization")
           (is (re-find #"HMMA" (or sass "")) "SASS must contain HMMA (Tensor Core) instructions")))
       (testing "a different tile also compiles + selects Tensor Cores (parametricity holds through nvcc)"
-        (let [src (cuda/emit-gemm-tiled-cuda "gemm_mma_big"
-                                             :block-m 128 :block-n 128 :sg-m 64 :sg-n 64 :block-k 32)
+        (let [tile {:block-m 128 :block-n 128 :sg-m 64 :sg-n 64 :block-k 32
+                    :num-stages 3 :matrix (:matrix a100)}
+              src (cuda/emit-matrix-kernel
+                   "gemm_mma_big" (matrix-body :gemm-mma-big tile [128 128 64]))
               {:keys [compiled? sass err]} (compile-cu src)]
           (is compiled? (str "big tile must compile; stderr:\n" err))
           (is (re-find #"HMMA" (or sass "")) "big tile SASS has HMMA")))
-      (testing "the generator rejects a non-divisible tile (fail-loud, like the Intel emitter)"
-        (is (thrown? clojure.lang.ExceptionInfo
-                     (cuda/emit-gemm-tiled-cuda "bad" :sg-m 24)))))))
+      (testing "the emitter rejects a schedule that could overread its final K block"
+        (let [tile {:block-m 64 :block-n 64 :sg-m 32 :sg-n 32 :block-k 32
+                    :num-stages 3 :matrix (:matrix a100)}]
+          (try
+            (cuda/emit-matrix-kernel "bad_k" (matrix-body :bad-k tile [64 64 16]))
+            (is false "CUDA matrix lowering admitted K smaller than its scheduled K block")
+            (catch clojure.lang.ExceptionInfo exception
+              (is (= :cuda-mma-requires-aligned-static-dimensions
+                     (:reason (ex-data exception))))))))
+      (testing "the emitter rejects result-store semantics it cannot preserve"
+        (let [tile (hw/derive-gemm-tile a100)
+              dimensions [(:block-m tile) (:block-n tile) (:block-k tile)]
+              half-body (schedule/matrix-body
+                         {:id :half-result :row 'a :col 'b :out 'c
+                          :dimensions dimensions :tile tile :result-dtype :half})]
+          (try
+            (cuda/emit-matrix-kernel "half_result" half-body)
+            (is false "CUDA matrix lowering silently narrowed an unsupported result")
+            (catch clojure.lang.ExceptionInfo exception
+              (is (= :cuda-mma-result-dtype-unsupported
+                     (:reason (ex-data exception)))))))))))
+
+(deftest cuda-signature-follows-the-ordered-kernel-body-abi
+  (let [matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32}
+        tile {:block-m 64 :block-n 64 :sg-m 32 :sg-n 32 :block-k 32
+              :num-stages 3 :matrix matrix}
+        kernel (matrix-body :ordered-abi tile [64 64 64])
+        [a b & tail] (:parameters kernel)
+        reordered (assoc kernel :parameters (vec (concat [b a] tail)))
+        source (cuda/emit-matrix-kernel "ordered_abi" reordered)
+        signature (subs source (.indexOf source "extern \"C\"") (.indexOf source ") {"))]
+    (is (< (.indexOf signature " B") (.indexOf signature " A"))
+        "target parameter declarations preserve KernelBody ABI order")))

--- a/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
@@ -55,7 +55,11 @@
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exact row-major"
                               (matrix-plan/analyze
                                (assoc-in kernel [:parameters 0 :layout]
-                                         (layout/col-major shape :half)))))))))
+                                         (layout/col-major shape :half)))))))
+    (testing "runtime dimension identities are specialized to the storage contract"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"dimension specializations"
+                            (matrix-plan/analyze
+                             (assoc-in kernel [:attributes :dimension-values 'M] 63)))))))
 
 (deftest intel-opencl-retains-its-own-instruction-legality
   (testing "neutral MMA analysis does not make an Intel DPAS emitter accept MMA"


### PR DESCRIPTION
Replaces the public raw-tile CUDA WMMA experiment with an emitter that consumes the checked matrix plan derived solely from KernelBody. The initial row is intentionally narrow: direct static/tile-aligned f16×f16→f32 MMA 16x16x16, identity stores, no views, slices, batching, split-K, or epilogues. Unsupported body structure declines explicitly.\n\nMatrix bodies now record checked dimension specializations; CUDA traps before memory access if runtime M/N/K violate them. Source declarations preserve the actual ordered KernelBody ABI by role. Scheduled TilePrefetch operations emit CUDA L2 prefetch hints instead of disappearing.\n\nHardware-free gate: nvcc compiles to cubin and cuobjdump confirms HMMA. Focused results: CUDA/plan tests 5 tests, 20 assertions; contraction schedule + GEMM 24 tests, 144 assertions. This is a verified vertical milestone, not yet a peak shared-memory schedule.