### PR TITLE
Fork verified matrix bodies at one target boundary

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -8,6 +8,7 @@
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
+            [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-abi :as kabi]
@@ -231,16 +232,17 @@
   is solely a target concern. Optional views, hardware indices, and K bounds are explicit schedule
   values used by the split-K and batched wrappers below. An optional epilogue becomes a typed
   ScalarRegion on every store and is lowered as part of the body."
-  [{:keys [kernel-name id a b c m n k tile result-dtype provenance
+  [{:keys [kernel-name id a b c m n k dimension-parameters tile result-dtype provenance
+           target-dialect
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
            k-range launch-group-count attributes parameter-names epilogue]
-    :or {result-dtype :float provenance {}}}]
+    :or {result-dtype :float provenance {} target-dialect :opencl-intel}}]
   (let [kernel-body
         (contraction-schedule/matrix-body
          {:id (or id [:gemm kernel-name])
           :row a :col b :out c
           :dimensions [m n k]
-          :dimension-parameters [m n k]
+          :dimension-parameters (or dimension-parameters [m n k])
           :axis-symbols ['i 'j 'l]
           :tile tile
           :bindings {:row a :col b}
@@ -254,11 +256,10 @@
           :k-range k-range
           :launch-group-count launch-group-count
           :attributes attributes
-          :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})]
-    {:source (kernel-body-opencl/emit-matrix-kernel
-              kernel-name kernel-body {:parameter-names parameter-names})
-     :kernel-body kernel-body
-     :workgroup-size (get-in kernel-body [:launch :workgroup-size])}))
+          :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})
+        emitted (matrix-target/emit-matrix-kernel
+                 kernel-name kernel-body target-dialect {:parameter-names parameter-names})]
+    (assoc emitted :workgroup-size (get-in kernel-body [:launch :workgroup-size]))))
 
 (defn emit-scheduled-split-k-kernel
   "Lower a grid-Z partition of the K reduction into disjoint f32 output views."

--- a/src/raster/compiler/backend/gpu/matrix_target.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target.clj
@@ -1,0 +1,43 @@
+(ns raster.compiler.backend.gpu.matrix-target
+  "Target selection for verified matrix KernelBody values.
+
+   Contraction scheduling chooses the matrix instruction and records the complete execution in a
+   KernelBody. This namespace performs only the final target spelling. It is deliberately the one
+   fork at which DPAS and MMA diverge; callers may not select a target template directly or pass a
+   second tile/launch/ABI description beside the body."
+  (:require [raster.compiler.backend.gpu.cuda-codegen :as cuda-codegen]
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
+            [raster.compiler.ir.kernel-body :as kernel-body]))
+
+(defn emit-matrix-kernel
+  "Emit `body` for one C-family target dialect.
+
+   Returns the target module together with the validated body and concrete artifact target. The
+   optional parameter-name map controls spelling only on the Intel OpenCL row; CUDA derives its
+   ordered signature from KernelBody parameter roles. Unsupported target/instruction pairs fail
+   loudly in the selected target lowerer."
+  ([kernel-name body target-dialect]
+   (emit-matrix-kernel kernel-name body target-dialect {}))
+  ([kernel-name body target-dialect {:keys [parameter-names]}]
+   (let [body (kernel-body/validate! body)
+         dialect (c-dialect/resolve! target-dialect)
+         source
+         (case (:id dialect)
+           :opencl-intel
+           (kernel-body-opencl/emit-matrix-kernel
+            kernel-name body {:parameter-names parameter-names})
+
+           :cuda
+           (cuda-codegen/emit-matrix-kernel kernel-name body)
+
+           (throw (ex-info "matrix KernelBody target lowering is not implemented for this dialect"
+                           {:reason :matrix-target-dialect-not-lowered
+                            :target-dialect (:id dialect)
+                            :target (c-dialect/target dialect)
+                            :instruction-family
+                            (get-in body [:attributes :instruction-family])})))]
+     {:source source
+      :target (c-dialect/target dialect)
+      :target-dialect (:id dialect)
+      :kernel-body body})))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -9,6 +9,7 @@
    same SegOp IR but produce different target code."
   (:require [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as kernel-body-c-dialect]
+            [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -1712,7 +1713,8 @@
                    (:parameters kernel-body))
              kernel-body)))
         source (if kernel-body
-                 (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body)
+                 (:source (matrix-target/emit-matrix-kernel
+                           kernel-name kernel-body :opencl-intel))
                  (apply codegen/emit-gemm-tiled kernel-name
                         (concat [:c-dtype :half
                                  :block-m (:block-m effective-tile)

--- a/test/raster/compiler/backend/gpu/matrix_target_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_target_test.clj
@@ -1,0 +1,56 @@
+(ns raster.compiler.backend.gpu.matrix-target-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.backend.gpu.matrix-target :as matrix-target]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
+
+(def ^:private mma
+  {:family :mma :m 16 :n 16 :k 16 :subgroup 32})
+
+(defn- mma-tile []
+  (assoc (hardware/derive-gemm-tile
+          {:device-type :gpu :backend :cuda :compute-capability [8 0]
+           :subgroup-size 32 :grf-bytes-per-lane 256 :matrix mma})
+         :matrix mma))
+
+(defn- mma-body []
+  (schedule/matrix-body
+   {:id :matrix-target-test :row 'a :col 'b :out 'c
+    :dimensions [128 128 64] :dimension-parameters ['m 'n 'k]
+    :tile (mma-tile) :result-dtype :float}))
+
+(deftest target-lowering-forks-after-one-verified-body
+  (let [body (mma-body)
+        cuda (matrix-target/emit-matrix-kernel "matrix_target_cuda" body :cuda)]
+    (is (= :cuda-c (:target cuda)))
+    (is (= :cuda (:target-dialect cuda)))
+    (is (identical? body (:kernel-body cuda)))
+    (is (re-find #"wmma::mma_sync" (:source cuda)))
+    (testing "an instruction cannot leak into an unrelated target spelling"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"no builtin"
+           (matrix-target/emit-matrix-kernel "mma_as_dpas" body :opencl-intel))))
+    (testing "unimplemented families decline at the single target boundary"
+      (try
+        (matrix-target/emit-matrix-kernel "mma_as_mfma" body :hip)
+        (is false "HIP matrix target unexpectedly accepted an unimplemented MFMA row")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :matrix-target-dialect-not-lowered (:reason (ex-data exception)))))))))
+
+(deftest scheduled-matrix-entry-no-longer-implies-opencl
+  (let [emitted
+        (gemm/emit-scheduled-matrix-kernel
+         {:kernel-name "scheduled_cuda_mma"
+          :a 'a :b 'b :c 'c
+          :m 128 :n 128 :k 64
+          :dimension-parameters ['m 'n 'k]
+          :tile (mma-tile)
+          :result-dtype :float
+          :target-dialect :cuda})]
+    (is (= :cuda-c (:target emitted)))
+    (is (= :cuda (:target-dialect emitted)))
+    (is (= ['a 'b 'c 'm 'n 'k]
+           (mapv :id (get-in emitted [:kernel-body :parameters]))))
+    (is (re-find #"extern \"C\" __global__" (:source emitted)))
+    (is (not (re-find #"__kernel" (:source emitted))))))


### PR DESCRIPTION
Makes the verified matrix KernelBody the single target-lowering input.\n\n- adds one matrix target dispatcher: Intel DPAS and CUDA MMA are target spellings of the same scheduled body\n- removes the implicit OpenCL assumption from the shared scheduled-matrix entry\n- separates static semantic extents from ordered ABI dimension identities\n- routes the production Intel wrapper through the same boundary\n- fails loudly for unsupported target/instruction pairs (HIP MFMA remains a later row)\n\nFocused matrix target, GEMM, and contraction schedule tests: 26 tests, 155 assertions, all green. This does not claim peak CUDA performance yet; shared staging and measured tuning remain later schedules.