### PR TITLE
Project matrix artifacts from verified bodies

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -381,11 +381,28 @@
 (def ^:private c-reserved-words
   #{"int" "float" "double" "long" "void" "char" "short" "unsigned" "signed"
     "for" "while" "do" "if" "else" "return" "break" "continue" "switch" "case"
+    "default"
     "struct" "union" "enum" "typedef" "const" "static" "extern" "auto" "register"
     "sizeof" "goto" "volatile"
+    ;; C++ is part of the target-language intersection: CUDA and HIP kernels are compiled as C++.
+    "alignas" "alignof" "and" "and_eq" "asm" "bitand" "bitor" "catch" "class"
+    "compl" "concept" "consteval" "constexpr" "constinit" "const_cast" "co_await"
+    "co_return" "co_yield" "decltype" "delete" "dynamic_cast" "explicit" "export"
+    "char8_t" "char16_t" "char32_t" "final" "override"
+    "friend" "inline" "mutable" "namespace" "new" "noexcept" "not" "not_eq"
+    "nullptr" "operator" "or" "or_eq" "protected" "public" "reflexpr"
+    "reinterpret_cast" "requires" "static_assert" "static_cast" "template" "this"
+    "thread_local" "throw" "try" "typeid" "typename" "using" "virtual" "wchar_t"
+    "xor" "xor_eq"
+    ;; C11/C17 underscored spellings and C23 additions. Some have non-underscored C23 aliases
+    ;; already listed above; both remain unavailable in our shared target-language namespace.
+    "_Alignas" "_Alignof" "_Atomic" "_BitInt" "_Bool" "_Complex" "_Generic"
+    "_Imaginary" "_Noreturn" "_Static_assert" "_Thread_local"
+    "_Decimal32" "_Decimal64" "_Decimal128" "typeof" "typeof_unqual"
     ;; OpenCL specific (incl. scalar type keywords that are common variable names —
     ;; `half` is the OpenCL fp16 type, so a deftm binding named `half` collides)
-    "kernel" "global" "local" "constant" "private" "restrict"
+    "kernel" "global" "local" "constant" "private" "generic" "restrict"
+    "read_only" "write_only" "read_write" "pipe"
     "half" "bool" "uchar" "ushort" "uint" "ulong" "size_t" "ptrdiff_t"
     ;; GLSL specific
     "attribute" "uniform" "varying" "layout" "buffer" "shared"
@@ -398,6 +415,14 @@
     ;; Other reserved
     "sample" "patch" "coherent" "readonly" "writeonly"
     "centroid" "invariant" "main" "true" "false"})
+
+(defn- reserved-c-family-identifier?
+  [identifier]
+  (or (contains? c-reserved-words identifier)
+      ;; C and C++ reserve double-underscore names everywhere and underscore-uppercase names in
+      ;; the global namespace. CUDA/HIP implementation builtins use the same space.
+      (str/starts-with? identifier "__")
+      (boolean (re-matches #"_[A-Z].*" identifier))))
 
 (defn c-symbol
   "Convert a Clojure symbol name to a valid C identifier.
@@ -420,9 +445,17 @@
                      (<= (int \0) (int ch) (int \9))))
         s (apply str (map #(if (ascii? %) (str %) (format "_u%04x_" (int %))) source))
         s (if (and (seq s) (Character/isDigit ^char (first s))) (str "_" s) s)]
-    (if (contains? c-reserved-words s)
-      (str s "_")
-      s)))
+    (cond
+      (or (str/starts-with? s "__") (boolean (re-matches #"_[A-Z].*" s))) (str "rstr" s)
+      (contains? c-reserved-words s) (str s "_")
+      :else s)))
+
+(defn c-identifier?
+  "Whether `value` is already a portable, non-reserved C-family identifier."
+  [value]
+  (and (string? value)
+       (boolean (re-matches #"[A-Za-z_][A-Za-z0-9_]*" value))
+       (not (reserved-c-family-identifier? value))))
 
 ;; ================================================================
 ;; Identity value normalization

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -6,6 +6,7 @@
    split-K combination. All mixed-precision scratch and derived scheduling scalars are private to
    the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
   (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
@@ -187,7 +188,8 @@
 
 (defn- convert-artifact
   [kernel-name in out elements vector-width phase]
-  (let [{:keys [source kernel-body]}
+  (let [kernel-name (c-emit/c-symbol kernel-name)
+        {:keys [source kernel-body]}
         (layout-emitter/emit-cast-kernel
          {:kernel-name kernel-name :input in :output out
           :source-dtype :float :destination-dtype :half :vector-width vector-width
@@ -209,7 +211,8 @@
 
 (defn- transpose-artifact
   [kernel-name in out rows cols phase]
-  (let [{:keys [source kernel-body]}
+  (let [kernel-name (c-emit/c-symbol kernel-name)
+        {:keys [source kernel-body]}
         (layout-emitter/emit-transpose-kernel
          {:kernel-name kernel-name :input in :output out :element-dtype :half})]
     (artifact
@@ -237,7 +240,8 @@
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
            k-range launch-group-count attributes parameter-names epilogue]
     :or {result-dtype :float provenance {} target-dialect :opencl-intel}}]
-  (let [kernel-body
+  (let [kernel-name (c-emit/c-symbol kernel-name)
+        kernel-body
         (contraction-schedule/matrix-body
          {:id (or id [:gemm kernel-name])
           :row a :col b :out c
@@ -259,7 +263,9 @@
           :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})
         emitted (matrix-target/emit-matrix-kernel
                  kernel-name kernel-body target-dialect {:parameter-names parameter-names})]
-    (assoc emitted :workgroup-size (get-in kernel-body [:launch :workgroup-size]))))
+    (assoc emitted
+           :kernel-name kernel-name
+           :workgroup-size (get-in kernel-body [:launch :workgroup-size]))))
 
 (defn emit-scheduled-split-k-kernel
   "Lower a grid-Z partition of the K reduction into disjoint f32 output views."
@@ -367,7 +373,7 @@
         abi (mapv first interface)
         arguments (mapv second interface)]
     (artifact
-     kernel-name (:source scheduled)
+     (:kernel-name scheduled) (:source scheduled)
      abi arguments
      (klaunch/spec {:workgroup-size (:workgroup-size scheduled)
                     :group-count group-count})
@@ -378,7 +384,8 @@
   "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
   ([kernel-name] (emit-split-k-combine-kernel kernel-name :opencl-intel))
   ([kernel-name target-dialect]
-   (let [form '(raster.par/contract C [[i mn]] [[s splits]]
+   (let [kernel-name (c-emit/c-symbol kernel-name)
+         form '(raster.par/contract C [[i mn]] [[s splits]]
                                      (clojure.core/aget
                                       partials (clojure.core/+ (clojure.core/* s mn) i)))
         facts (contraction-facts/contraction-facts form :dtype :float)
@@ -396,11 +403,11 @@
                 {:target-dialect target-dialect
                  :parameter-names {'partials "partials" 'C "C"
                                    'mn "mn" 'splits "splits" '_nseg "_nseg"}})]
-     {:source source :kernel-body kernel-body :workgroup-size 256})))
+     {:kernel-name kernel-name :source source :kernel-body kernel-body :workgroup-size 256})))
 
 (defn- combine-artifact
   [kernel-name partials c mn splits]
-  (let [{:keys [source kernel-body]} (emit-split-k-combine-kernel kernel-name)]
+  (let [{:keys [kernel-name source kernel-body]} (emit-split-k-combine-kernel kernel-name)]
     (artifact
      kernel-name source
      [(kabi/slot 'partials :input :float :c-name "partials" :role :operand
@@ -513,7 +520,7 @@
                     :tile tile
                     :provenance {:operation-id id :phase :matrix-contract}})]
     (artifact
-     kernel-name (:source scheduled)
+     (:kernel-name scheduled) (:source scheduled)
      [(kabi/slot a :input :half :c-name "A")
       (kabi/slot b :input :half :c-name "B")
       (kabi/slot c :output :float :c-name "C")

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -25,9 +25,7 @@
   (or (symbol? value) (keyword? value)))
 
 (defn- target-name [value]
-  (-> (name value)
-      (str/replace #"[^A-Za-z0-9_]" "_")
-      (str/replace #"^[^A-Za-z_]" "_$0")))
+  (ce/c-symbol value))
 
 (declare emit-index-expression target-type)
 
@@ -115,7 +113,7 @@
   (symbol (str (name dtype) "s")))
 
 (defn- lower-scalar-region
-  [kernel-body region]
+  [kernel-body region parameter-names]
   (let [parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))
         operand-ids (set (map :sym (:operands region)))
         scalar-ids (remove operand-ids (rest (:parameters region)))
@@ -133,7 +131,7 @@
         (into {}
               (for [id (rest (:parameters region))
                     :let [parameter (get parameters id)]]
-                [id (with-meta (symbol (name id))
+                [id (with-meta (symbol (get parameter-names id))
                       {:raster.type/tag (if (= :scalar (:kind parameter))
                                           (scalar-tag (:dtype parameter))
                                           (array-tag (:dtype parameter)))})]))
@@ -152,11 +150,11 @@
                       (concat
                        (for [{:keys [sym dtype] :or {dtype :float}} (:operands region)]
                          (str ", __global const " (dtype/ctype :opencl dtype)
-                              "* restrict " (ce/c-symbol sym)))
+                              "* restrict " (get parameter-names sym)))
                        (for [id scalar-ids
                              :let [parameter (get parameters id)]]
                          (str ", " (dtype/ctype :opencl (:dtype parameter))
-                              " " (ce/c-symbol id)))))]
+                              " " (get parameter-names id)))))]
     {:epilogue (fn [accumulator-expression row col]
                  (-> emitted
                      (str/replace accumulator-token (str "(" accumulator-expression ")"))
@@ -172,7 +170,12 @@
 
   Returns nil for identity stores. This is a target lowering of typed KernelBody data: callers
   never supply source callbacks, parameter declaration strings, or helper source."
-  [kernel-body]
+  ([kernel-body]
+   (lower-store-region
+    kernel-body
+    (into {} (map (fn [parameter] [(:id parameter) (ce/c-symbol (:id parameter))]))
+          (:parameters kernel-body))))
+  ([kernel-body parameter-names]
   (let [kernel-body (body/validate! kernel-body)
         stores (filter #(record-kind? "TileStore" %)
                        (nested-operations (:operations kernel-body)))
@@ -182,8 +185,8 @@
                       {:reason :raster/bug :regions (vec regions)})))
     (when-let [region (first regions)]
       (if (record-kind? "ScalarSSARegion" region)
-        (lower-scalar-ssa-region kernel-body region)
-        (lower-scalar-region kernel-body region)))))
+        (lower-scalar-ssa-region kernel-body region parameter-names)
+        (lower-scalar-region kernel-body region parameter-names))))))
 
 (defn- require!
   [condition message data]
@@ -338,6 +341,17 @@
                    "      }\n    }\n")))
      "}\n")))
 
+(defn- matrix-parameter-names
+  [kernel-body overrides]
+  (let [{:keys [m n k]} (get-in kernel-body [:attributes :dimension-parameters])]
+    (merge
+     (into {}
+           (map (fn [{:keys [id role]}]
+                  [id (case role :lhs "A" :rhs "B" :result "C" (ce/c-symbol id))]))
+           (:parameters kernel-body))
+     {m "M" n "N" k "K"}
+     overrides)))
+
 (defn emit-matrix-kernel
   "Lower a verified f16 DPAS KernelBody directly to OpenCL C.
 
@@ -346,9 +360,10 @@
   ([kernel-name kernel-body]
    (emit-matrix-kernel kernel-name kernel-body {}))
   ([kernel-name kernel-body {:keys [parameter-names]}]
-   (emit-plan kernel-name (intel-matrix-plan kernel-body)
-              (assoc (or (lower-store-region kernel-body) {})
-                     :parameter-names parameter-names))))
+   (let [parameter-names (matrix-parameter-names kernel-body parameter-names)]
+     (emit-plan kernel-name (intel-matrix-plan kernel-body)
+                (assoc (or (lower-store-region kernel-body parameter-names) {})
+                       :parameter-names parameter-names)))))
 
 ;; ---------------------------------------------------------------------------
 ;; General scalar/control KernelBody lowering
@@ -701,15 +716,13 @@
       (str "(" local-offset ")"))))
 
 (defn- lower-scalar-ssa-region
-  [kernel-body region]
+  [kernel-body region parameter-names]
   (let [storage (into {} (map (juxt :id identity)) (:parameters kernel-body))
         accumulator (first (:parameters region))
         [row-id col-id] (:indices region)
         accumulator-token (str "__acc_" (name (gensym "")))
         row-token (str "__row_" (name (gensym "")))
         col-token (str "__col_" (name (gensym "")))
-        parameter-names (into {} (map (fn [id] [id (ce/c-symbol id)]))
-                              (rest (:parameters region)))
         initial-context
         {:names (merge parameter-names
                        {accumulator accumulator-token row-id row-token col-id col-token})
@@ -756,9 +769,10 @@
                (for [id epilogue-parameters
                      :let [parameter (get storage id)]]
                  (if (= :scalar (:kind parameter))
-                   (str ", " (dtype/ctype :opencl (:dtype parameter)) " " (ce/c-symbol id))
+                   (str ", " (dtype/ctype :opencl (:dtype parameter)) " "
+                        (get parameter-names id))
                    (str ", __global const " (dtype/ctype :opencl (:dtype parameter))
-                        "* restrict " (ce/c-symbol id)))))]
+                        "* restrict " (get parameter-names id)))))]
     (when-not emitted
       (throw (ex-info "matrix scalar SSA region has no emitted result"
                       {:reason :raster/bug :region region})))

--- a/src/raster/compiler/backend/gpu/matrix_body_plan.clj
+++ b/src/raster/compiler/backend/gpu/matrix_body_plan.clj
@@ -134,6 +134,12 @@
         lhs-param (only! "lhs parameter" (:lhs parameters-by-role))
         rhs-param (only! "rhs parameter" (:rhs parameters-by-role))
         out-param (only! "result parameter" (:result parameters-by-role))
+        stable-read-buffers (set (map :buffer (:stable-reads kernel-body)))
+        read-only-parameters (filterv #(= :input (:kind %)) parameters)
+        _ (require! (every? #(contains? stable-read-buffers (:id %)) read-only-parameters)
+                    "matrix read-only parameters require stable no-write-alias contracts"
+                    {:read-only-parameters (mapv :id read-only-parameters)
+                     :stable-reads stable-read-buffers})
         view-map (into {} (map (juxt :id identity)) views)
         operation-buffers (:operation-buffers attributes)
         lhs-storage-id (get operation-buffers :row (:id lhs-param))

--- a/src/raster/compiler/backend/gpu/matrix_target.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target.clj
@@ -6,9 +6,94 @@
    fork at which DPAS and MMA diverge; callers may not select a target template directly or pass a
    second tile/launch/ABI description beside the body."
   (:require [raster.compiler.backend.gpu.cuda-codegen :as cuda-codegen]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
-            [raster.compiler.ir.kernel-body :as kernel-body]))
+            [raster.compiler.ir.kernel-abi :as kernel-abi]
+            [raster.compiler.ir.kernel-artifact :as kernel-artifact]
+            [raster.compiler.ir.kernel-body :as kernel-body]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-launch :as kernel-launch]))
+
+(defn- target-parameter-names
+  [body overrides]
+  (let [{:keys [m n k]} (get-in body [:attributes :dimension-parameters])]
+    (merge
+     (into {}
+           (map (fn [{:keys [id role]}]
+                  [id (case role
+                        :lhs "A"
+                        :rhs "B"
+                        :result "C"
+                        (c-emit/c-symbol id))]))
+           (:parameters body))
+     {m "M" n "N" k "K"}
+     overrides)))
+
+(def ^:private matrix-local-names
+  #{"warpId" "warp_row" "warp_col" "sg_id" "sg_lid" "sg_row" "sg_col"
+    "m_base" "k" "pk" "pr" "row" "col" "k_begin" "k_end"
+    "a_wb" "a_pb" "b_wb" "b_pb"})
+
+(defn- generated-matrix-local?
+  [generated-locals c-name]
+  (or (contains? generated-locals c-name)
+      (boolean (re-matches #"(?:a|b|sa|bp|acc|n_base)[0-9]+(?:_[0-9]+)?" c-name))))
+
+(defn- matrix-generated-locals
+  [body]
+  (into matrix-local-names
+        (comp (filter #(and (= :group (:source %)) (= 2 (:axis %))))
+              (map #(c-emit/c-symbol (:id %))))
+        (:indices body)))
+
+(defn- validate-target-names!
+  [kernel-name body names]
+  (when-not (c-emit/c-identifier? kernel-name)
+    (throw (ex-info "matrix kernel entry point is not a portable C-family identifier"
+                    {:reason :matrix-target-entry-point :kernel-name kernel-name})))
+  (let [ordered-names (mapv #(get names (:id %)) (:parameters body))
+        generated-locals (matrix-generated-locals body)]
+    (doseq [[parameter c-name] (map vector (:parameters body) ordered-names)]
+      (when-not (c-emit/c-identifier? c-name)
+        (throw (ex-info "matrix ABI parameter is not a portable C-family identifier"
+                        {:reason :matrix-target-parameter-name
+                         :parameter parameter :c-name c-name})))
+      (when (generated-matrix-local? generated-locals c-name)
+        (throw (ex-info "matrix ABI parameter collides with a generated kernel local"
+                        {:reason :matrix-target-name-collision
+                         :parameter parameter :c-name c-name}))))
+    (when-not (= (count ordered-names) (count (set ordered-names)))
+      (throw (ex-info "matrix ABI parameter names are not unique after target spelling"
+                      {:reason :matrix-target-name-collision
+                       :parameters (:parameters body) :c-names ordered-names})))
+    names))
+
+(defn- projected-abi
+  [body names target-dialect]
+  (let [target-alignment (when (= :cuda target-dialect) 32)]
+    (body-abi/project-contracts
+     (mapv (fn [{:keys [id kind dtype role]}]
+             (kernel-abi/slot id kind dtype
+                              :c-name (get names id)
+                              :role role
+                              :alignment (when (and target-alignment (not= :scalar kind))
+                                           target-alignment)))
+           (:parameters body))
+     body)))
+
+(defn- body-arguments
+  [body]
+  (let [dimension-values (get-in body [:attributes :dimension-values])]
+    (mapv (fn [{:keys [id role]}]
+            (if (= :dimension role) (get dimension-values id id) id))
+          (:parameters body))))
+
+(defn- body-effects
+  [body]
+  {:kind :tensor-contraction-stage
+   :reads (mapv :id (filter #(contains? #{:input :inout} (:kind %)) (:parameters body)))
+   :writes (mapv :id (filter #(contains? #{:output :inout} (:kind %)) (:parameters body)))})
 
 (defn emit-matrix-kernel
   "Emit `body` for one C-family target dialect.
@@ -22,6 +107,15 @@
   ([kernel-name body target-dialect {:keys [parameter-names]}]
    (let [body (kernel-body/validate! body)
          dialect (c-dialect/resolve! target-dialect)
+         parameter-names (validate-target-names!
+                          kernel-name body
+                          (target-parameter-names body parameter-names))
+         default-names (target-parameter-names body nil)
+         _ (when (and (= :cuda (:id dialect)) (not= default-names parameter-names))
+             (throw (ex-info "CUDA matrix lowering does not support ABI spelling overrides"
+                             {:reason :cuda-mma-parameter-spelling-unsupported
+                              :target :cuda :requested parameter-names
+                              :required default-names})))
          source
          (case (:id dialect)
            :opencl-intel
@@ -40,4 +134,37 @@
      {:source source
       :target (c-dialect/target dialect)
       :target-dialect (:id dialect)
+      :parameter-names parameter-names
       :kernel-body body})))
+
+(defn emit-matrix-artifact
+  "Project one verified matrix body into a complete target artifact.
+
+   ABI order, memory contracts, compiler arguments and launch geometry are consequences of the
+   body. Static dimension specializations become literal artifact arguments; dynamic dimensions
+   retain their compiler identities. Target parameter names are spelling policy only."
+  ([kernel-name body target-dialect]
+   (emit-matrix-artifact kernel-name body target-dialect {}))
+  ([kernel-name body target-dialect {:keys [parameter-names provenance attributes]}]
+   (let [body (kernel-body/validate! body)
+         dimension-values (get-in body [:attributes :dimension-values])
+         emitted (emit-matrix-kernel kernel-name body target-dialect
+                                     {:parameter-names parameter-names})
+         names (:parameter-names emitted)]
+     (kernel-artifact/make
+      {:kernel-name kernel-name
+       :target (:target emitted)
+       :source (:source emitted)
+       :abi (projected-abi body names (:target-dialect emitted))
+       :arguments (body-arguments body)
+       :launch (kernel-launch/rebind-spec (:launch body) dimension-values)
+       :effects (body-effects body)
+       :provenance (merge provenance
+                          (:provenance body)
+                          {:lowering :matrix-kernel-body
+                           :target-dialect (:target-dialect emitted)})
+       :attributes (merge attributes
+                          {:kernel-body body
+                           :emission-route :kernel-body
+                           :instruction-family
+                           (get-in body [:attributes :instruction-family])})}))))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1658,13 +1658,17 @@
         ;; substitute each operand's aget index from its declared map (maps, not pattern-matching)
         idx-of (into {} (for [{:keys [sym map]} operands] [sym (am/index-expr map)]))
         expr' (descriptor/rewrite-aget-indices expr idx-of)
-        acc-token (str "__acc_" (name (gensym "")))
+        acc-symbol (symbol (str "__acc_" (name (gensym ""))))
+        ;; The target identifier policy may rename implementation-reserved source names (notably
+        ;; the double-underscore spelling used to keep this placeholder collision-free).  Splice
+        ;; the spelling that `emit-expr` actually writes, not the pre-projection source symbol.
+        acc-token (ce/c-symbol acc-symbol)
         ;; emit once with a distinctive token standing in for the accumulator, then splice the
         ;; real acc C-expression in at call time (the hook supplies it per store slot)
         emitted (binding [ce/*emit-config* ce/opencl-config
                           ce/*scalar-type* ctype
                           ce/*int-vars* (into ce/*int-vars* int-vars)]
-                  (ce/emit-expr (walk/postwalk-replace {acc (symbol acc-token)} expr')
+                  (ce/emit-expr (walk/postwalk-replace {acc acc-symbol} expr')
                                 (gensym "z__") arr-syms))
         params (apply str
                       (concat

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -107,7 +107,7 @@
 (defn- minimum? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.Minimum" x))
 
-(declare index-expr? index-cast?)
+(declare index-expr? index-cast? validate-spec! spec)
 
 (defn expression?
   "True for explicit symbolic integer-expression nodes and literal integers. Opaque compiler
@@ -147,6 +147,42 @@
     (reduce into #{} (map expression-references (:arguments expression)))
     (index-cast? expression) (expression-references (:argument expression))
     :else #{expression}))
+
+(defn rebind-expression
+  "Replace opaque compiler-value leaves in an integer expression.
+
+   `bindings` maps compiler identities to either literals or new identities. RuntimeValue wrappers
+   disappear when their replacement is an integer, so a statically specialized artifact no longer
+   asks its call binder to resolve a value absent from the public compiler-argument order. The
+   explicit arithmetic structure is otherwise preserved; this is substitution, not evaluation."
+  [expression bindings]
+  (letfn [(rebind [value]
+            (cond
+              (integer? value) value
+              (runtime-value? value)
+              (let [replacement (get bindings (:value value) (:value value))]
+                (if (integer? replacement) replacement (->RuntimeValue replacement)))
+              (ceil-div? value) (assoc value :value (rebind (:value value))
+                                            :divisor (rebind (:divisor value)))
+              (floor-div? value) (assoc value :value (rebind (:value value))
+                                             :divisor (rebind (:divisor value)))
+              (sum? value) (assoc value :terms (mapv rebind (:terms value)))
+              (product? value) (assoc value :factors (mapv rebind (:factors value)))
+              (align-up? value) (assoc value :value (rebind (:value value)))
+              (minimum? value) (assoc value :values (mapv rebind (:values value)))
+              (index-expr? value) (assoc value :arguments (mapv rebind (:arguments value)))
+              (index-cast? value) (assoc value :argument (rebind (:argument value)))
+              :else (get bindings value value)))]
+    (rebind expression)))
+
+(defn rebind-spec
+  "Substitute compiler-value leaves throughout a checked LaunchSpec."
+  [launch-spec bindings]
+  (let [{:keys [workgroup-size group-count shared-memory-bytes]}
+        (validate-spec! launch-spec)]
+    (spec {:workgroup-size (mapv #(rebind-expression % bindings) workgroup-size)
+           :group-count (mapv #(rebind-expression % bindings) group-count)
+           :shared-memory-bytes shared-memory-bytes})))
 
 (defn- dimension-vector!
   [owner field dimensions pred expected]

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -2,6 +2,22 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.c-emit :as c-emit]))
 
+(deftest portable-identifiers-cover-the-cuda-and-hip-cpp-language
+  (is (not (c-emit/c-identifier? "class")))
+  (is (not (c-emit/c-identifier? "default")))
+  (is (not (c-emit/c-identifier? "template")))
+  (is (not (c-emit/c-identifier? "char8_t")))
+  (is (not (c-emit/c-identifier? "_Atomic")))
+  (is (not (c-emit/c-identifier? "read_only")))
+  (is (not (c-emit/c-identifier? "__device__")))
+  (is (not (c-emit/c-identifier? "_Reserved")))
+  (is (= "class_" (c-emit/c-symbol 'class)))
+  (is (= "default_" (c-emit/c-symbol 'default)))
+  (is (= "rstr_Atomic" (c-emit/c-symbol '_Atomic)))
+  (is (= "read_only_" (c-emit/c-symbol 'read-only)))
+  (is (= "rstr__device__" (c-emit/c-symbol '__device__)))
+  (is (c-emit/c-identifier? "ordinary_kernel")))
+
 (deftest retained-scalar-dtypes-are-not-collapsed-to-the-kernel-element-type
   (is (= :long (c-emit/scalar-parameter-dtype 'iteration {'iteration :int64} :float)))
   (is (= :byte (c-emit/scalar-parameter-dtype 'quantized {'quantized :int8} :float)))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -271,9 +271,9 @@
 
 (deftest one-atomic-update-contract-has-thin-target-spellings
   (doseq [[target spelling]
-          [[:opencl-portable "atomic_add_float(rstr_out +"]
-           [:cuda "atomicAdd(rstr_out +"]
-           [:hip "atomicAdd(rstr_out +"]]]
+          [[:opencl-portable "atomic_add_float(rstr_out_ +"]
+           [:cuda "atomicAdd(rstr_out_ +"]
+           [:hip "atomicAdd(rstr_out_ +"]]]
     (let [source (opencl/emit-scalar-kernel
                   "atomic_add_test" (atomic-add-kernel-body)
                   {:target-dialect target})]

--- a/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
@@ -59,7 +59,10 @@
     (testing "runtime dimension identities are specialized to the storage contract"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"dimension specializations"
                             (matrix-plan/analyze
-                             (assoc-in kernel [:attributes :dimension-values 'M] 63)))))))
+                             (assoc-in kernel [:attributes :dimension-values 'M] 63)))))
+    (testing "restrict-qualified matrix inputs require stable read contracts"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stable no-write-alias"
+                            (matrix-plan/analyze (assoc kernel :stable-reads [])))))))
 
 (deftest intel-opencl-retains-its-own-instruction-legality
   (testing "neutral MMA analysis does not make an Intel DPAS emitter accept MMA"

--- a/test/raster/compiler/backend/gpu/matrix_target_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_target_test.clj
@@ -3,6 +3,10 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-artifact :as kernel-artifact]
+            [raster.compiler.ir.kernel-body :as kernel-body]
+            [raster.compiler.ir.kernel-call :as kernel-call]
+            [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
 
 (def ^:private mma
@@ -54,3 +58,98 @@
            (mapv :id (get-in emitted [:kernel-body :parameters]))))
     (is (re-find #"extern \"C\" __global__" (:source emitted)))
     (is (not (re-find #"__kernel" (:source emitted))))))
+
+(deftest verified-body-owns-the-complete-target-artifact
+  (let [body (assoc (mma-body) :provenance {:scheduled-operation :body-certificate
+                                            :dialect :matrix-schedule})
+        artifact (matrix-target/emit-matrix-artifact
+                  "matrix_artifact_cuda" body :cuda
+                  {:provenance {:lowering :caller-lie :target-dialect :hip}
+                   :attributes {:kernel-body :caller-lie :instruction-family :mfma}})
+        aligned-buffer (fn [id] {:id id :alignment 32})
+        call (kernel-call/make
+              artifact
+              [(aligned-buffer :a-buffer)
+               (aligned-buffer :b-buffer)
+               (aligned-buffer :c-buffer)
+               {:type :int :value 128}
+               {:type :int :value 128}
+               {:type :int :value 64}])]
+    (is (kernel-artifact/kernel-artifact? artifact))
+    (is (= :cuda-c (:target artifact)))
+    (is (= ['a 'b 'c 128 128 64] (:arguments artifact)))
+    (is (= [1 1] (get-in call [:geometry :group-count])))
+    (is (empty? (mapcat kernel-launch/expression-references
+                        (concat (get-in artifact [:launch :workgroup-size])
+                                (get-in artifact [:launch :group-count]))))
+        "static dimension specialization closes launch expressions")
+    (is (= [:no-write-alias :no-write-alias nil]
+           (mapv :aliasing (take 3 (:abi artifact))))
+        "stable body reads survive target ABI projection")
+    (is (= [:lhs :rhs :result :dimension :dimension :dimension]
+           (mapv :role (:abi artifact))))
+    (is (= [32 32 32]
+           (mapv :alignment (take 3 (:abi artifact))))
+        "WMMA load/store alignment is a checked call precondition")
+    (is (identical? body (get-in artifact [:attributes :kernel-body])))
+    (is (= :mma (get-in artifact [:attributes :instruction-family])))
+    (is (= :matrix-kernel-body (get-in artifact [:provenance :lowering])))
+    (is (= :cuda (get-in artifact [:provenance :target-dialect])))
+    (is (= :body-certificate (get-in artifact [:provenance :scheduled-operation])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"alignment contract"
+         (kernel-call/make
+          artifact
+          [{:id :a-buffer :alignment 16}
+           (aligned-buffer :b-buffer)
+           (aligned-buffer :c-buffer)
+           {:type :int :value 128}
+           {:type :int :value 128}
+           {:type :int :value 64}])))))
+
+(deftest target-symbols-are-validated-before-source-emission
+  (let [body (mma-body)]
+    (testing "the public entry point is already a portable identifier"
+      (try
+        (matrix-target/emit-matrix-kernel "bad-name" body :cuda)
+        (is false "invalid entry point unexpectedly reached CUDA emission")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :matrix-target-entry-point (:reason (ex-data exception)))))))
+    (testing "the CUDA C++ keyword set is part of the public-name contract"
+      (try
+        (matrix-target/emit-matrix-kernel "default" body :cuda)
+        (is false "C++ keyword unexpectedly reached CUDA emission")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :matrix-target-entry-point (:reason (ex-data exception)))))))
+    (testing "ABI spelling cannot shadow an emitter-owned local"
+      (try
+        (matrix-target/emit-matrix-kernel
+         "valid_name" body :opencl-intel {:parameter-names {'a "m_base"}})
+        (is false "generated-local collision unexpectedly reached OpenCL emission")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :matrix-target-name-collision (:reason (ex-data exception)))))))
+    (testing "CUDA currently has one exact verified spelling"
+      (try
+        (matrix-target/emit-matrix-kernel
+         "valid_name" body :cuda {:parameter-names {'a "lhs"}})
+        (is false "unsupported CUDA spelling override was accepted")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :cuda-mma-parameter-spelling-unsupported
+                 (:reason (ex-data exception)))))))
+    (testing "a dynamically emitted grid-Z local shares the ABI collision check"
+      (let [grid-body
+            (schedule/matrix-body
+             {:id :grid-z-name-collision :row 'a :col 'b :out 'c
+              :dimensions [128 128 64] :dimension-parameters ['m 'n 'k]
+              :tile (assoc (hardware/derive-gemm-tile {})
+                           :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16})
+              :result-dtype :float
+              :additional-parameters
+              [(kernel-body/->KernelParameter 'k_slice :scalar :int [] nil nil :schedule)]
+              :additional-indices [(kernel-body/->IndexBinding 'k-slice :group 2)]
+              :launch-group-count [1 1 (kernel-launch/runtime-value 'k_slice)]})]
+        (try
+          (matrix-target/emit-matrix-kernel "grid_z_collision" grid-body :opencl-intel)
+          (is false "grid-Z local unexpectedly shadowed an ABI parameter")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :matrix-target-name-collision (:reason (ex-data exception))))))))))

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -72,6 +72,19 @@
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be an integer"
                         (launch/resolve-expression {} (launch/ceil-div 'n 256)))))
 
+(deftest launch-specialization-rebinds-explicit-expression-leaves
+  (let [original (launch/spec
+                  {:workgroup-size [256 1]
+                   :group-count [(launch/ceil-div (launch/runtime-value 'n) 128)
+                                 (launch/ceil-div 'm 64)]})
+        specialized (launch/rebind-spec original {'n 256 'm 'rows})]
+    (is (= #{} (launch/expression-references
+                (first (:group-count specialized)))))
+    (is (= #{'rows} (launch/expression-references
+                     (second (:group-count specialized)))))
+    (is (= [2 3]
+           (:group-count (launch/realize specialized {'rows 129}))))))
+
 (deftest concrete-geometry-rejects-invalid-backend-launches
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"positive integer"
                         (launch/geometry {:workgroup-size [0] :group-count [1]})))


### PR DESCRIPTION
Closes the next representation seam after target selection.\n\n- projects ordered ABI directly from KernelBody parameters\n- preserves stable-read no-write-alias contracts\n- derives compiler arguments, including static dimension specialization, from body facts\n- takes launch geometry from the verified body\n- constructs and validates the concrete OpenCL/CUDA KernelArtifact at emission\n\nFocused test: 3 tests, 18 assertions, all green. Downstream graph routing is deliberately not switched yet; all graph nodes must be retargeted together in the next certified-refinement slice.