### PR TITLE
Certify one-to-many scheduled graph refinements

### DIFF
--- a/src/raster/compiler/backend/gpu/paged_kv_append.clj
+++ b/src/raster/compiler/backend/gpu/paged_kv_append.clj
@@ -108,7 +108,7 @@
         input-buffers (mapv buffer inputs)
         output-buffers (mapv buffer outputs)
         uses (vec (concat (map #(graph/->ValueUse % :read) inputs)
-                          (map #(graph/->ValueUse % :write) outputs)))]
+                          (map #(graph/->ValueUse % :read-write) outputs)))]
     (graph/make
      {:inputs (into input-buffers output-buffers)
       :outputs output-buffers

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -824,18 +824,62 @@
   "Give an artifact-valued graph its one ordered external ABI.
 
    Node artifacts remain free to order their own physical parameters. The graph boundary groups
-   equal symbolic scalars, proves their emitted dtypes agree, and exposes every external buffer
-   exactly once."
+   equal scalar uses, proves their emitted dtypes agree, and exposes every external buffer exactly
+   once. An explicit target-neutral GraphScalar interface is authoritative: target artifacts may
+   choose a physical kernel dtype, but cannot invent, omit, reorder, or retype public scalars."
   [emitted target-dialect scalar-types]
   (let [external-buffers (vec (distinct (concat (:inputs emitted) (:outputs emitted))))
+        declared-scalars (:scalars emitted)
+        declared-scalar-ids (set (map :id declared-scalars))
+        ;; Artifacts own physical parameter order and kernel representation; the scheduled graph
+        ;; owns the logical scalar dtype. Project that logical fact into every direct use before
+        ;; KernelExecutable checks node-to-boundary agreement. Derived expressions remain private
+        ;; and are checked for closure below.
+        declared-by-id (into {} (map (juxt :id identity)) declared-scalars)
+        ;; Typed scheduled graphs carry GraphScalar declarations. Compatibility graphs that have
+        ;; not migrated yet still receive compiler-owned scalar facts from the enclosing program.
+        ;; In both cases project only direct public arguments; target-private expressions retain
+        ;; their independently checked representation.
+        logical-dtype-by-id (merge (into {} (map (fn [[id scalar-dtype]]
+                                                   [id (dt/canon scalar-dtype)]))
+                                          scalar-types)
+                                   (into {} (map (fn [[id scalar]] [id (:dtype scalar)]))
+                                         declared-by-id))
+        emitted (if (seq logical-dtype-by-id)
+                  (kgraph/map-operations
+                   emitted
+                   (fn [node]
+                     (kart/validate!
+                      (update (:operation node) :abi
+                              (fn [slots]
+                                (mapv (fn [slot argument]
+                                        (if-let [logical-dtype
+                                                 (and (= :scalar (:kind slot))
+                                                      (get logical-dtype-by-id argument))]
+                                          (assoc slot :dtype logical-dtype)
+                                          slot))
+                                      slots (get-in node [:operation :arguments])))))))
+                  emitted)
         scalar-pairs (->> (:nodes emitted)
                           (mapcat (fn [node]
                                     (map vector (get-in node [:operation :abi])
                                          (get-in node [:operation :arguments]))))
                           (filter (fn [[slot argument]]
-                                    (and (= :scalar (:kind slot)) (symbol? argument))))
+                                    (and (= :scalar (:kind slot))
+                                         (or (symbol? argument)
+                                             (contains? declared-scalar-ids argument)))))
                           vec)
         scalar-groups (group-by second scalar-pairs)
+        scalar-arguments (if (some? declared-scalars)
+                           (mapv :id declared-scalars)
+                           (vec (sort-by name (keys scalar-groups))))
+        _ (when (and (some? declared-scalars)
+                     (not (clojure.set/subset? (set (keys scalar-groups))
+                                               declared-scalar-ids)))
+            (throw (ex-info "emitted kernel graph invented a public scalar argument"
+                            {:reason :kernel-graph-scalar-interface
+                             :expected scalar-arguments
+                             :actual (vec (sort-by pr-str (keys scalar-groups)))})))
         _ (doseq [[argument pairs] scalar-groups]
             (when-not (apply = (map (comp :kernel-dtype first) pairs))
               (throw (ex-info "kernel graph scalar has inconsistent emitted ABI dtypes"
@@ -852,13 +896,23 @@
                                                :output :result
                                                :inout :inout)))
                           external-buffers)
-        scalar-arguments (vec (sort-by name (keys scalar-groups)))
         scalar-abi (mapv (fn [argument]
                            (let [slots (mapv first (get scalar-groups argument))
-                                 kernel-dtype (:kernel-dtype (first slots))
-                                 logical-dtype (or (get scalar-types argument) kernel-dtype)
+                                 declared (some #(when (= argument (:id %)) %) declared-scalars)
+                                 kernel-dtype (or (:kernel-dtype (first slots)) (:dtype declared))
+                                 logical-dtype (or (:dtype declared)
+                                                   (get scalar-types argument)
+                                                   kernel-dtype)
+                                 supplied-dtype (get scalar-types argument)
                                  role (if (some #(= :bound (:role %)) slots)
                                         :bound :parameter)]
+                             (when (and declared supplied-dtype
+                                        (not= (:dtype declared) (dt/canon supplied-dtype)))
+                               (throw (ex-info
+                                       "target scalar facts differ from the scheduled interface"
+                                       {:reason :kernel-graph-scalar-logical-dtype
+                                        :argument argument :scheduled (:dtype declared)
+                                        :target supplied-dtype})))
                              (kabi/slot argument :scalar logical-dtype
                                         :kernel-dtype kernel-dtype :role role)))
                          scalar-arguments)]

--- a/src/raster/compiler/ir/emitted_parallel_equation.clj
+++ b/src/raster/compiler/ir/emitted_parallel_equation.clj
@@ -1,13 +1,15 @@
 (ns raster.compiler.ir.emitted-parallel-equation
   "Checked target emission of one scheduled TypedSOAC equation."
   (:require [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.scheduled-graph-refinement :as refinement]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]))
 
-(defrecord EmittedParallelEquation [algorithm body graph provenance attributes])
+(defrecord EmittedParallelEquation [algorithm body refinement graph provenance attributes])
 
 (defn emitted-equation?
   [value]
@@ -31,25 +33,27 @@
     (fail! :emitted-parallel-equation-type
            "expected an EmittedParallelEquation"
            {:actual (type emitted-equation)}))
-  (let [{:keys [algorithm body graph provenance attributes]} emitted-equation
+  (let [{:keys [algorithm body refinement graph provenance attributes]} emitted-equation
         algorithm (soac/validate! algorithm)
         body (program/validate! body segop/segop-node? algorithm-boundary?)
         expected (equation-graph/make algorithm body)
-        emitted (graph/validate! graph)]
+        refinement (when refinement (refinement/validate-against! refinement expected))
+        scheduled (if refinement (refinement/scheduled-graph refinement) expected)
+        emitted (-> graph graph/validate! executable/validate!)]
     (when-not (every? (comp artifact/kernel-artifact? :operation) (:nodes emitted))
       (fail! :emitted-parallel-equation-artifact
              "emitted equation graph requires only KernelArtifact nodes" {}))
-    (when-not (graph/dataflow-equivalent? expected emitted)
+    (when-not (graph/dataflow-equivalent? scheduled emitted)
       (fail! :emitted-parallel-equation-dataflow
              "target emission changed scheduled equation dataflow"
-             {:scheduled (graph/dataflow-contract expected)
+             {:scheduled (graph/dataflow-contract scheduled)
               :emitted (graph/dataflow-contract emitted)}))
     (when-not (every? true?
                       (map (fn [scheduled-node emitted-node]
                              (= (:operation scheduled-node)
                                 (get-in emitted-node
                                         [:operation :provenance :scheduled-operation])))
-                           (:nodes expected) (:nodes emitted)))
+                           (:nodes scheduled) (:nodes emitted)))
       (fail! :emitted-parallel-equation-operation
              "target emission changed a scheduled equation operation certificate" {}))
     (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
@@ -62,7 +66,7 @@
 (defn make
   ([algorithm body emitted]
    (make algorithm body emitted {}))
-  ([algorithm body emitted {:keys [provenance attributes]
+  ([algorithm body emitted {:keys [refinement provenance attributes]
                             :or {provenance {} attributes {}}}]
    (validate!
-    (->EmittedParallelEquation algorithm body emitted provenance attributes))))
+    (->EmittedParallelEquation algorithm body refinement emitted provenance attributes))))

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -8,7 +8,8 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
-            [raster.compiler.ir.kernel-graph :as kgraph]))
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-launch :as klaunch]))
 
 (defn kernel-executable?
   [value]
@@ -31,6 +32,86 @@
     (throw (ex-info "kernel executable must be an artifact or graph"
                     {:executable executable :actual (type executable)}))))
 
+(defn- access-flags
+  [access]
+  (case access
+    :read #{:read}
+    :write #{:write}
+    :read-write #{:read :write}))
+
+(defn- flags-access
+  [flags]
+  (case flags
+    #{:read} :read
+    #{:write} :write
+    #{:read :write} :read-write))
+
+(defn- validate-node-artifact-bindings!
+  "Bind every emitted pointer slot back to the exact scheduled ValueUse it implements."
+  [graph]
+  (let [buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
+        public-scalars
+        (into {}
+              (keep (fn [[slot argument]]
+                      (when (= :scalar (:kind slot)) [argument slot])))
+              (map vector (:abi graph) (:arguments graph)))]
+    (doseq [{:keys [id operation uses]} (:nodes graph)]
+      (let [artifact (kart/validate! operation)
+            pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot)))
+                                   (mapv vector (:abi artifact) (:arguments artifact)))
+            undeclared (filterv (fn [[_ argument]] (not (contains? buffers argument)))
+                                pointer-pairs)]
+        (when (seq undeclared)
+          (throw (ex-info "kernel artifact pointer argument is not a declared graph buffer"
+                          {:reason :kernel-graph-artifact-buffer
+                           :node id :arguments (mapv second undeclared)
+                           :declared (set (keys buffers))})))
+        (doseq [[slot argument] pointer-pairs
+                :let [buffer (get buffers argument)]]
+          (when-not (= (:dtype slot) (:dtype buffer))
+            (throw (ex-info "kernel artifact pointer dtype differs from its graph buffer"
+                            {:reason :kernel-graph-artifact-buffer-dtype
+                             :node id :argument argument :slot slot :buffer buffer}))))
+        (let [actual
+              (into {}
+                    (map (fn [[argument pairs]]
+                           [argument
+                            (flags-access
+                             (reduce into #{}
+                                     (map (comp access-flags kabi/slot-access first) pairs)))]))
+                    (group-by second pointer-pairs))
+              expected (into {} (map (juxt :buffer :access)) uses)]
+          (when-not (= expected actual)
+            (throw (ex-info "kernel artifact pointer ABI differs from scheduled graph uses"
+                            {:reason :kernel-graph-artifact-uses
+                             :node id :expected expected :actual actual}))))
+        (doseq [[slot argument] (filterv (fn [[slot _]] (= :scalar (:kind slot)))
+                                         (mapv vector (:abi artifact) (:arguments artifact)))]
+          (if-let [public-slot (get public-scalars argument)]
+            (when-not (= (select-keys slot [:dtype :kernel-dtype])
+                         (select-keys public-slot [:dtype :kernel-dtype]))
+              (throw (ex-info "kernel artifact scalar dtype differs from its graph interface"
+                              {:reason :kernel-graph-artifact-scalar-dtype
+                               :node id :argument argument
+                               :artifact-slot slot :graph-slot public-slot})))
+            (let [references (klaunch/expression-references argument)]
+              (try
+                (when-not (contains? #{:int :long} (:kernel-dtype slot))
+                  (throw (ex-info "target-private scalar representation must be integral"
+                                  {:kernel-dtype (:kernel-dtype slot)})))
+                (klaunch/validate-typed-expression!
+                 argument #(some-> (get public-scalars %) :dtype))
+                (catch clojure.lang.ExceptionInfo exception
+                  (throw (ex-info "kernel artifact scalar is not closed over checked graph scalars"
+                                  {:reason :kernel-graph-artifact-scalar
+                                   :node id :argument argument :slot slot
+                                   :references references
+                                   :public-scalars (set (keys public-scalars))
+                                   :expression-error (ex-data exception)}
+                                  exception)))))))))
+    graph))
+
 (defn validate!
   "Validate an emitted executable and return it unchanged."
   [executable]
@@ -40,13 +121,15 @@
     (let [graph (kgraph/validate! executable)]
       (when-not (kgraph/has-interface? graph)
         (throw (ex-info "emitted kernel graph requires an ordered external ABI"
-                        {:graph graph})))
+                        {:reason :kernel-graph-executable-interface :graph graph})))
       (when-not (seq (:nodes graph))
-        (throw (ex-info "emitted kernel graph requires at least one kernel node" {:graph graph})))
+        (throw (ex-info "emitted kernel graph requires at least one kernel node"
+                        {:reason :kernel-graph-executable-empty :graph graph})))
+      (validate-node-artifact-bindings! graph)
       (let [targets (set (map :target (artifacts graph)))]
         (when-not (= 1 (count targets))
           (throw (ex-info "kernel graph nodes must share one target dialect"
-                          {:targets targets}))))
+                          {:reason :kernel-graph-executable-targets :targets targets}))))
       graph)
     (throw (ex-info "kernel executable must be an artifact or graph"
                     {:executable executable :actual (type executable)}))))

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -6,13 +6,16 @@
    replaces the operation with a KernelArtifact without reconstructing dataflow from marker
    conventions.  Stable GraphBuffer identities make intermediate storage part of the program."
   (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.segop :as segop]))
 
 (defrecord GraphBuffer [id dtype elements memory-space role])
+(defrecord GraphScalar [id dtype])
 (defrecord ValueUse [buffer access])
 (defrecord ScheduledKernel [id operation uses dependencies])
-(defrecord KernelGraph [inputs outputs temporaries nodes abi arguments effects provenance attributes])
+(defrecord KernelGraph
+           [inputs outputs temporaries scalars nodes abi arguments effects provenance attributes])
 
 (def ^:private buffer-roles #{:input :output :inout :temporary})
 (def ^:private access-modes #{:read :write :read-write})
@@ -22,6 +25,9 @@
 
 (defn graph-buffer? [x]
   (record-kind? "raster.compiler.ir.kernel_graph.GraphBuffer" x))
+
+(defn graph-scalar? [x]
+  (record-kind? "raster.compiler.ir.kernel_graph.GraphScalar" x))
 
 (defn value-use? [x]
   (record-kind? "raster.compiler.ir.kernel_graph.ValueUse" x))
@@ -50,6 +56,16 @@
   [id dtype elements memory-space role]
   (validate-buffer-fields! (->GraphBuffer id dtype elements memory-space role)))
 
+(defn scalar
+  "Construct one ordered, target-neutral public scalar dependency."
+  [id scalar-dtype]
+  (when-not (or (symbol? id) (keyword? id))
+    (throw (ex-info "graph scalar identity must be a symbol or keyword" {:id id})))
+  (when-not (dtype/known? scalar-dtype)
+    (throw (ex-info "graph scalar requires a known dtype"
+                    {:id id :dtype scalar-dtype})))
+  (->GraphScalar id (dtype/canon scalar-dtype)))
+
 (defn- reads? [access] (contains? #{:read :read-write} access))
 (defn- writes? [access] (contains? #{:write :read-write} access))
 
@@ -76,7 +92,7 @@
 
 (defn- validate-interface!
   [graph]
-  (let [{:keys [abi arguments]} graph]
+  (let [{:keys [abi arguments scalars]} graph]
     (when-not (= (some? abi) (some? arguments))
       (throw (ex-info "kernel graph ABI and arguments must be declared together"
                       {:abi abi :arguments arguments})))
@@ -87,9 +103,9 @@
             pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot)))
                                    (mapv vector abi arguments))
             pointer-arguments (mapv second pointer-pairs)
-            scalar-arguments (mapv second
-                                   (filterv (fn [[slot _]] (= :scalar (:kind slot)))
-                                            (mapv vector abi arguments)))]
+            scalar-pairs (filterv (fn [[slot _]] (= :scalar (:kind slot)))
+                                  (mapv vector abi arguments))
+            scalar-arguments (mapv second scalar-pairs)]
         (when-not (= (set (keys external-by-id)) (set pointer-arguments))
           (throw (ex-info "kernel graph pointer interface differs from its external buffers"
                           {:external (set (keys external-by-id))
@@ -100,6 +116,15 @@
         (when-not (= (count scalar-arguments) (count (set scalar-arguments)))
           (throw (ex-info "kernel graph scalar interface arguments must be unique"
                           {:scalar-arguments scalar-arguments})))
+        (when (some? scalars)
+          (let [expected (mapv (juxt :id :dtype) scalars)
+                actual (mapv (fn [[slot argument]]
+                               [argument (dtype/canon (:dtype slot))])
+                             scalar-pairs)]
+            (when-not (= expected actual)
+              (throw (ex-info "kernel graph ABI scalar interface differs from its schedule"
+                              {:reason :kernel-graph-scalar-interface
+                               :expected expected :actual actual})))))
         (doseq [[slot id] pointer-pairs]
           (let [{:keys [dtype role]} (get external-by-id id)
                 expected-kind (case role
@@ -125,7 +150,7 @@
   (when-not (kernel-graph? graph)
     (throw (ex-info "kernel graph must be a KernelGraph value"
                     {:graph graph :actual (type graph)})))
-  (let [{:keys [inputs outputs temporaries nodes effects provenance attributes]} graph
+  (let [{:keys [inputs outputs temporaries scalars nodes effects provenance attributes]} graph
         sections [inputs outputs temporaries]
         buffers (vec (mapcat identity sections))
         buffer-ids (mapv :id buffers)]
@@ -134,6 +159,29 @@
       (when-not (vector? values)
         (throw (ex-info "kernel graph sections must be ordered vectors"
                         {:field field :value values}))))
+    (when-not (or (nil? scalars) (vector? scalars))
+      (throw (ex-info "kernel graph scalar interface must be an ordered vector"
+                      {:field :scalars :value scalars})))
+    (when (some? scalars)
+      (doseq [value scalars]
+        (when-not (graph-scalar? value)
+          (throw (ex-info "kernel graph contains a non-scalar interface value"
+                          {:scalar value})))
+        (when-not (or (symbol? (:id value)) (keyword? (:id value)))
+          (throw (ex-info "graph scalar identity must be a symbol or keyword"
+                          {:scalar value})))
+        (when-not (and (dtype/known? (:dtype value))
+                       (= (:dtype value) (dtype/canon (:dtype value))))
+          (throw (ex-info "kernel graph scalar must use its canonical dtype"
+                          {:scalar value}))))
+      (when-not (= (count scalars) (count (distinct (map :id scalars))))
+        (throw (ex-info "kernel graph scalar identities must be unique"
+                        {:scalars scalars})))
+      (let [collisions (set/intersection (set buffer-ids) (set (map :id scalars)))]
+        (when (seq collisions)
+          (throw (ex-info "kernel graph buffer and scalar identities must be disjoint"
+                          {:reason :kernel-graph-value-identity
+                           :collisions collisions})))))
     (doseq [b buffers]
       (when-not (graph-buffer? b)
         (throw (ex-info "kernel graph contains a non-buffer value" {:buffer b})))
@@ -236,9 +284,9 @@
 
 (defn make
   "Construct and verify a scheduled KernelGraph from explicit compiler values."
-  [{:keys [inputs outputs temporaries nodes abi arguments effects provenance attributes]
+  [{:keys [inputs outputs temporaries scalars nodes abi arguments effects provenance attributes]
     :or {inputs [] outputs [] temporaries [] nodes [] effects {} provenance {} attributes {}}}]
-  (validate! (->KernelGraph inputs outputs temporaries nodes abi arguments
+  (validate! (->KernelGraph inputs outputs temporaries scalars nodes abi arguments
                             effects provenance attributes)))
 
 (defn map-operations
@@ -260,8 +308,37 @@
     {:inputs (:inputs graph)
      :outputs (:outputs graph)
      :temporaries (:temporaries graph)
+     :scalars (:scalars graph)
      :nodes (mapv #(select-keys % [:id :uses :dependencies]) (:nodes graph))
      :effects (:effects graph)}))
+
+(defn boundary-contract
+  "Project the exact public boundary of a scheduled graph.
+
+   A schedule refinement may introduce private buffers and replace one operation with several
+   scheduled stages, but it may not change the ordered external storage contract, public ABI, or
+   logical effects.  Keeping this projection separate from `dataflow-contract` makes that
+   distinction explicit instead of weakening target-emission equivalence."
+  [graph]
+  (let [graph (validate! graph)]
+    {:inputs (:inputs graph)
+     :outputs (:outputs graph)
+     :scalars (:scalars graph)
+     :abi (:abi graph)
+     :arguments (:arguments graph)
+     :effects (:effects graph)}))
+
+(defn schedule-contract
+  "Project the complete scheduled identity of a graph before target emission.
+
+   Unlike `dataflow-contract`, this includes the exact ordered operations.  It is used to bind a
+   graph-refinement witness to the semantic schedule it claims to refine; target emission still
+   uses the stricter positional one-operation-to-one-artifact check."
+  [graph]
+  (let [graph (validate! graph)]
+    {:boundary (boundary-contract graph)
+     :dataflow (dataflow-contract graph)
+     :operations (mapv :operation (:nodes graph))}))
 
 (defn dataflow-equivalent?
   "Whether two valid graphs have exactly the same target-independent dataflow contract."
@@ -283,7 +360,7 @@
    `temporaries` is a map from stable buffer identity to at least `{:elements expr}`. External
    inputs/outputs are explicit; therefore a newly introduced intermediate can never hide as an
    undeclared symbol in a later kernel."
-  [segops {:keys [inputs outputs temporaries buffer-specs dtype memory-space effects provenance
+  [segops {:keys [inputs outputs temporaries scalars buffer-specs dtype memory-space effects provenance
                   attributes]
            :or {temporaries {} buffer-specs {} memory-space :device effects {} provenance {}
                 attributes {}}}]
@@ -346,6 +423,7 @@
       (make {:inputs inputs*
              :outputs outputs*
              :temporaries temporaries*
+             :scalars scalars
              :nodes nodes
              :effects effects
              :provenance provenance

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -62,7 +62,7 @@
 (defn- cast-scalar
   [dtype value]
   (case dtype
-    :int (int value)
+    :int (Math/toIntExact (long value))
     :long (long value)
     (throw (ex-info "derived graph scalar is only defined for integer ABI slots"
                     {:dtype dtype :value value}))))

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -3,7 +3,8 @@
 
    A LaunchSpec belongs to compiler IR: its dimensions may refer to compiler values.  A
    LaunchGeometry is the concrete 1-3D value a backend submits.  Keeping the two distinct stops
-   emitters, extractors and runtimes from inventing incompatible scalar/2-D marker conventions.")
+   emitters, extractors and runtimes from inventing incompatible scalar/2-D marker conventions."
+  (:require [raster.compiler.core.dtype :as dtype]))
 
 (defrecord RuntimeValue [value])
 (defrecord CeilDiv [value divisor])
@@ -109,6 +110,16 @@
 
 (declare index-expr? index-cast? validate-spec! spec)
 
+(def ^:private index-operations
+  #{:add :sub :mul :floor-div :ceil-div :mod :min :max})
+
+(defn- valid-index-arity?
+  [op arguments]
+  (case op
+    (:floor-div :ceil-div :mod) (= 2 (count arguments))
+    (:add :sub :mul :min :max) (seq arguments)
+    false))
+
 (defn expression?
   "True for explicit symbolic integer-expression nodes and literal integers. Opaque compiler
    values such as symbols are leaves and are therefore also accepted. Sequential Clojure forms
@@ -116,18 +127,108 @@
   [x]
   (cond
     (integer? x) true
-    (runtime-value? x) (some? (:value x))
-    (ceil-div? x) (and (expression? (:value x)) (expression? (:divisor x)))
-    (floor-div? x) (and (expression? (:value x)) (expression? (:divisor x)))
+    (runtime-value? x) (let [value (:value x)]
+                         (or (integer? value) (symbol? value) (keyword? value)))
+    (ceil-div? x) (and (expression? (:value x))
+                       (expression? (:divisor x))
+                       (or (not (integer? (:divisor x))) (pos? (:divisor x))))
+    (floor-div? x) (and (expression? (:value x))
+                        (expression? (:divisor x))
+                        (or (not (integer? (:divisor x))) (pos? (:divisor x))))
     (sum? x) (and (seq (:terms x)) (every? expression? (:terms x)))
     (product? x) (and (seq (:factors x)) (every? expression? (:factors x)))
     (align-up? x) (and (expression? (:value x))
                        (integer? (:alignment x)) (pos? (:alignment x)))
     (minimum? x) (and (seq (:values x)) (every? expression? (:values x)))
-    (index-expr? x) (and (seq (:arguments x)) (every? expression? (:arguments x)))
-    (index-cast? x) (expression? (:argument x))
+    (index-expr? x) (and (contains? index-operations (:op x))
+                         (valid-index-arity? (:op x) (:arguments x))
+                         (every? expression? (:arguments x)))
+    ;; The launch evaluator represents exact mathematical integers. Wrapping, saturation, or
+    ;; floating conversion would change that algebra and therefore needs a distinct lowering.
+    (index-cast? x) (and (dtype/known? (:dtype x))
+                         (contains? #{:int :long} (dtype/canon (:dtype x)))
+                         (= :exact (:overflow x))
+                         (expression? (:argument x)))
     (sequential? x) false
+    :else (or (symbol? x) (keyword? x))))
+
+(defn- resolvable-expression?
+  "Structural launch/storage expression check that preserves opaque compiler value identities.
+
+   Unlike certified target-private scalar algebra, a graph extent identity may itself be a list,
+   for example `(extent output)`. Such a leaf is passed whole to the resolver and never evaluated.
+   Known arithmetic records still receive their complete structural checks here."
+  [x]
+  (cond
+    (integer? x) true
+    (runtime-value? x) (some? (:value x))
+    (ceil-div? x) (and (resolvable-expression? (:value x))
+                       (resolvable-expression? (:divisor x))
+                       (or (not (integer? (:divisor x))) (pos? (:divisor x))))
+    (floor-div? x) (and (resolvable-expression? (:value x))
+                        (resolvable-expression? (:divisor x))
+                        (or (not (integer? (:divisor x))) (pos? (:divisor x))))
+    (sum? x) (and (seq (:terms x)) (every? resolvable-expression? (:terms x)))
+    (product? x) (and (seq (:factors x)) (every? resolvable-expression? (:factors x)))
+    (align-up? x) (and (resolvable-expression? (:value x))
+                       (integer? (:alignment x)) (pos? (:alignment x)))
+    (minimum? x) (and (seq (:values x)) (every? resolvable-expression? (:values x)))
+    (or (index-expr? x) (index-cast? x)) (expression? x)
     :else (some? x)))
+
+(defn validate-typed-expression!
+  "Validate an integer expression against the logical dtype of each opaque leaf.
+
+   `leaf-dtype` returns the public scalar dtype for a compiler value. Generic launch arithmetic
+   promotes an int operand to long when needed. KernelBody IndexExpr is stricter: its operands must
+   already have one width, and IndexCast permits only exact identity or int-to-long widening. The
+   final artifact-slot conversion is separately range-checked when a graph call is bound."
+  [expression leaf-dtype]
+  (when-not (expression? expression)
+    (throw (ex-info "invalid checked integer expression"
+                    {:reason :kernel-launch-expression :expression expression})))
+  (letfn [(promote [types]
+            (if (some #{:long} types) :long :int))
+          (infer [value]
+            (cond
+              (integer? value)
+              (if (<= Integer/MIN_VALUE value Integer/MAX_VALUE) :int :long)
+
+              (runtime-value? value) (infer (:value value))
+              (ceil-div? value) (promote (map infer [(:value value) (:divisor value)]))
+              (floor-div? value) (promote (map infer [(:value value) (:divisor value)]))
+              (sum? value) (promote (map infer (:terms value)))
+              (product? value) (promote (map infer (:factors value)))
+              (align-up? value) (promote [(infer (:value value)) :int])
+              (minimum? value) (promote (map infer (:values value)))
+
+              (index-expr? value)
+              (let [types (set (map infer (:arguments value)))]
+                (when-not (= 1 (count types))
+                  (throw (ex-info "kernel index expression mixes widths without an exact cast"
+                                  {:reason :kernel-launch-index-dtype
+                                   :expression value :types types})))
+                (first types))
+
+              (index-cast? value)
+              (let [source (infer (:argument value))
+                    target (dtype/canon (:dtype value))]
+                (when-not (or (= source target)
+                              (and (= :int source) (= :long target)))
+                  (throw (ex-info "kernel launch index cast is not an exact widening"
+                                  {:reason :kernel-launch-index-cast
+                                   :expression value :source source :target target})))
+                target)
+
+              :else
+              (let [leaf (some-> (leaf-dtype value) dtype/canon)]
+                (when-not (contains? #{:int :long} leaf)
+                  (throw (ex-info "integer expression references a non-integral or absent scalar"
+                                  {:reason :kernel-launch-expression-leaf
+                                   :expression expression :leaf value :dtype leaf})))
+                leaf)))]
+    (infer expression)
+    expression))
 
 (defn expression-references
   "Return the opaque compiler-value leaves read by an integer expression."
@@ -205,14 +306,15 @@
    values with `runtime-value` so scheduled extents cannot smuggle source S-expressions into an
    emitted ABI."
   [x]
-  (or (and (integer? x) (pos? x))
-      (runtime-value? x)
-      (ceil-div? x)
-      (product? x)
-      (align-up? x)
-      (floor-div? x)
-      (sum? x)
-      (minimum? x)))
+  (and (resolvable-expression? x)
+       (or (and (integer? x) (pos? x))
+           (runtime-value? x)
+           (ceil-div? x)
+           (product? x)
+           (align-up? x)
+           (floor-div? x)
+           (sum? x)
+           (minimum? x))))
 
 (defn validate-spec!
   "Validate and return a symbolic launch specification."
@@ -328,6 +430,9 @@
                (ceil-div? expression)
                (let [value (resolve* (:value expression))
                      divisor (resolve* (:divisor expression))]
+                 (when (neg? value)
+                   (throw (ex-info "ceil-div resolved value must be non-negative"
+                                   {:expression expression :value value})))
                  (when-not (pos? divisor)
                    (throw (ex-info "ceil-div resolved divisor must be positive"
                                    {:expression expression :divisor divisor})))
@@ -336,6 +441,9 @@
                (floor-div? expression)
                (let [value (resolve* (:value expression))
                      divisor (resolve* (:divisor expression))]
+                 (when (neg? value)
+                   (throw (ex-info "floor-div resolved value must be non-negative"
+                                   {:expression expression :value value})))
                  (when-not (pos? divisor)
                    (throw (ex-info "floor-div resolved divisor must be positive"
                                    {:expression expression :divisor divisor})))
@@ -352,6 +460,9 @@
                (let [value (resolve* (:value expression))
                      alignment (:alignment expression)
                      quotient (quot value alignment)]
+                 (when (neg? value)
+                   (throw (ex-info "align-up resolved value must be non-negative"
+                                   {:expression expression :value value})))
                  (Math/multiplyExact
                   (long (+ quotient (if (zero? (rem value alignment)) 0 1)))
                   (long alignment)))
@@ -362,22 +473,35 @@
                ;; the same exact-overflow discipline rather than asking the runtime binder to
                ;; interpret a compiler record it does not own.
                (index-expr? expression)
-               (let [arguments (mapv resolve* (:arguments expression))]
+               (let [_ (when-not (expression? expression)
+                         (throw (ex-info "cannot resolve an invalid kernel index expression"
+                                         {:reason :kernel-launch-expression
+                                          :expression expression})))
+                     arguments (mapv resolve* (:arguments expression))]
                  (case (:op expression)
                    :add (reduce #(Math/addExact (long %1) (long %2)) arguments)
                    :sub (reduce #(Math/subtractExact (long %1) (long %2)) arguments)
                    :mul (reduce #(Math/multiplyExact (long %1) (long %2)) arguments)
                    :floor-div (let [[value divisor] arguments]
+                                (when (neg? value)
+                                  (throw (ex-info "index floor-div resolved value must be non-negative"
+                                                  {:expression expression :value value})))
                                 (when-not (pos? divisor)
                                   (throw (ex-info "index floor-div resolved divisor must be positive"
                                                   {:expression expression :divisor divisor})))
                                 (quot value divisor))
                    :ceil-div (let [[value divisor] arguments]
+                               (when (neg? value)
+                                 (throw (ex-info "index ceil-div resolved value must be non-negative"
+                                                 {:expression expression :value value})))
                                (when-not (pos? divisor)
                                  (throw (ex-info "index ceil-div resolved divisor must be positive"
                                                  {:expression expression :divisor divisor})))
                                (+ (quot value divisor) (if (zero? (rem value divisor)) 0 1)))
                    :mod (let [[value divisor] arguments]
+                          (when (neg? value)
+                            (throw (ex-info "index mod resolved value must be non-negative"
+                                            {:expression expression :value value})))
                           (when-not (pos? divisor)
                             (throw (ex-info "index mod resolved divisor must be positive"
                                             {:expression expression :divisor divisor})))
@@ -387,7 +511,12 @@
                    (throw (ex-info "launch dimension uses an unsupported index operation"
                                    {:expression expression :op (:op expression)}))))
                (index-cast? expression)
-               (resolve* (:argument expression))
+               (do
+                 (when-not (expression? expression)
+                   (throw (ex-info "cannot resolve an invalid kernel index cast"
+                                   {:reason :kernel-launch-expression
+                                    :expression expression})))
+                 (resolve* (:argument expression)))
                :else (resolve-integer! resolve-value expression expression))))]
     (resolve* dimension)))
 

--- a/src/raster/compiler/ir/scheduled_graph_refinement.clj
+++ b/src/raster/compiler/ir/scheduled_graph_refinement.clj
@@ -1,0 +1,138 @@
+(ns raster.compiler.ir.scheduled-graph-refinement
+  "A checked one-semantic-node to many-scheduled-kernels refinement.
+
+   The witness preserves the graph's exact public boundary while allowing a schedule to introduce
+   private temporaries and an ordered kernel DAG.  This IR establishes structural identity; the
+   producing schedule pass remains responsible for proving its algorithm-specific numerical or
+   effect law before constructing the witness.  Target emission subsequently remains a strict
+   one-node-to-one-artifact projection of the refined graph."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.kernel-graph :as graph]))
+
+(defrecord ScheduledGraphRefinement [source graph schedule numerics provenance attributes])
+
+(def ^:private numerical-modes #{:exact :reassociated :bounded-error})
+(def ^:private rounding-policies
+  #{:nearest-even :toward-zero :up :down :implementation-defined})
+
+(declare fail!)
+
+(defn- validate-numerics!
+  "Validate the refinement producer's numerical attestation.
+
+   This is intentionally not presented as an automatic floating-point proof. The producer derives
+   the attestation while establishing schedule legality; this boundary makes its policy explicit
+   and rejects unstructured claims so later proof/checking machinery has one stable seam."
+  [numerics]
+  (when-not (and (map? numerics)
+                 (contains? numerical-modes (:mode numerics))
+                 (keyword? (:policy numerics)))
+    (fail! :scheduled-graph-refinement-numerics
+           "scheduled graph refinement requires a supported numerical mode and named policy"
+           {:field :numerics :value numerics :supported numerical-modes}))
+  (case (:mode numerics)
+    :exact nil
+    :reassociated
+    (when-not (and (contains? rounding-policies (:rounding numerics))
+                   (dtype/known? (:accumulator-dtype numerics)))
+      (fail! :scheduled-graph-refinement-numerics
+             "reassociated refinement requires rounding and accumulator dtype evidence"
+             {:field :numerics :value numerics}))
+    :bounded-error
+    (when-not (and (contains? rounding-policies (:rounding numerics))
+                   (dtype/known? (:accumulator-dtype numerics))
+                   (map? (:error-model numerics))
+                   (keyword? (get-in numerics [:error-model :kind])))
+      (fail! :scheduled-graph-refinement-numerics
+             "bounded-error refinement requires rounding, accumulator dtype, and an error model"
+             {:field :numerics :value numerics})))
+  numerics)
+
+(defn scheduled-graph-refinement?
+  "Recognize refinement witnesses across Typed Clojure child classloaders."
+  [value]
+  (and value
+       (= "raster.compiler.ir.scheduled_graph_refinement.ScheduledGraphRefinement"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message
+                  (assoc data :reason reason :ir :scheduled-graph-refinement))))
+
+(defn validate!
+  "Validate and return a scheduled graph-refinement witness."
+  [refinement]
+  (when-not (scheduled-graph-refinement? refinement)
+    (fail! :scheduled-graph-refinement-type
+           "expected a ScheduledGraphRefinement"
+           {:actual (type refinement)}))
+  (let [{source :source refined :graph
+         :keys [schedule numerics provenance attributes]} refinement
+        source (graph/validate! source)
+        refined (graph/validate! refined)]
+    (when-not (= 1 (count (:nodes source)))
+      (fail! :scheduled-graph-refinement-source-cardinality
+             "a graph refinement currently requires exactly one semantic source node"
+             {:nodes (mapv :id (:nodes source))}))
+    (when-not (seq (:nodes refined))
+      (fail! :scheduled-graph-refinement-empty
+             "a scheduled graph refinement cannot erase its semantic source node"
+             {}))
+    (when-not (and (some? (:scalars source)) (some? (:scalars refined)))
+      (fail! :scheduled-graph-refinement-scalar-interface
+             "a graph refinement requires an explicit target-neutral scalar interface"
+             {:source-scalars (:scalars source) :refined-scalars (:scalars refined)}))
+    (when-not (= (graph/boundary-contract source)
+                 (graph/boundary-contract refined))
+      (fail! :scheduled-graph-refinement-boundary
+             "scheduled graph refinement changed the public graph boundary"
+             {:source (graph/boundary-contract source)
+              :refined (graph/boundary-contract refined)}))
+    (when-not (and (map? schedule) (keyword? (:kind schedule)))
+      (fail! :scheduled-graph-refinement-description
+             "scheduled graph refinement requires an identified schedule"
+             {:field :schedule :value schedule}))
+    (validate-numerics! numerics)
+    (doseq [[field value] [[:schedule schedule]
+                           [:numerics numerics]
+                           [:provenance provenance]
+                           [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :scheduled-graph-refinement-description
+               "scheduled graph refinement descriptions must be maps"
+               {:field field :value value})))
+    refinement))
+
+(defn make
+  "Construct a refinement from explicit source and refined graphs.
+
+   `schedule` is deliberately explicit: a caller must name the verified scheduling decision that
+   justifies the one-to-many rewrite rather than relying on matching boundaries alone."
+  [{:keys [source graph schedule numerics provenance attributes]
+    :or {provenance {} attributes {}}}]
+  (validate!
+   (->ScheduledGraphRefinement source graph schedule numerics provenance attributes)))
+
+(defn source-operation
+  "Return the exact semantic operation refined by this witness."
+  [refinement]
+  (-> refinement validate! :source :nodes first :operation))
+
+(defn scheduled-graph
+  "Return the checked many-kernel schedule graph."
+  [refinement]
+  (:graph (validate! refinement)))
+
+(defn validate-against!
+  "Require a refinement witness to name the exact rederived source schedule."
+  [refinement expected-source]
+  (let [refinement (validate! refinement)
+        expected-source (graph/validate! expected-source)]
+    (when-not (= (graph/schedule-contract expected-source)
+                 (graph/schedule-contract (:source refinement)))
+      (fail! :scheduled-graph-refinement-source
+             "scheduled graph refinement does not refine the expected source schedule"
+             {:expected (graph/schedule-contract expected-source)
+              :source (graph/schedule-contract (:source refinement))}))
+    refinement))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -76,6 +76,32 @@
        (= (:operands equation) (:inputs (soac/facts algorithm)))
        (= (:results equation) (soac/outputs algorithm))))
 
+(defn- ordered-distinct
+  [values]
+  (reduce (fn [result value]
+            (if (some #(= value %) result) result (conj result value)))
+          [] values))
+
+(defn- public-scalars
+  [scheduled operations]
+  (let [required (reduce set/union #{} (map segop/operation-scalars operations))
+        ordered (ordered-distinct
+                 (concat (filter required (:inputs scheduled))
+                         (sort-by pr-str (remove (set (:inputs scheduled)) required))))
+        values (:values scheduled)]
+    (mapv (fn [id]
+            (let [value (get values id)]
+              (when-not value
+                (fail! :scheduled-equation-scalar-value
+                       "scheduled scalar lacks an AbstractValue"
+                       {:value id}))
+              (when-not (empty? (:shape value))
+                (fail! :scheduled-equation-scalar-shape
+                       "scheduled scalar dependency must have scalar shape"
+                       {:value id :shape (:shape value)}))
+              (graph/scalar id (:dtype value))))
+          ordered)))
+
 (defn make
   "Build a verified graph from `algorithm` and its fully scheduled SegOp ParallelProgram.
 
@@ -115,6 +141,7 @@
                                        operations))
          temporary-ids (set/difference operation-values inputs outputs)
          values (:values scheduled)
+         scalars (public-scalars scheduled operations)
          buffer-specs (into {}
                             (map (fn [id] [id (storage-spec values id)]))
                             (set/union inputs outputs temporary-ids))]
@@ -123,6 +150,7 @@
       {:inputs inputs
        :outputs outputs
        :temporaries (select-keys buffer-specs temporary-ids)
+       :scalars scalars
        :buffer-specs buffer-specs
        :dtype (:dtype (first (vals buffer-specs)))
        :effects (or effects {:semantic (:effects (soac/facts algorithm))})

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -677,6 +677,13 @@
                    elements arrays))
         stable (set (get-in attributes [:attributes :stable-array-captures]))
         scalar-captures (set (remove stable captures))
+        public-scalar-ids (cond-> scalar-captures
+                            (or (symbol? (:extent attributes))
+                                (keyword? (:extent attributes)))
+                            (conj (:extent attributes)))
+        ordered-public-scalars
+        (vec (concat (filter public-scalar-ids (:inputs facts))
+                     (sort-by pr-str (remove (set (:inputs facts)) public-scalar-ids))))
         scan-dtype (or (first (:dtypes attributes)) dtype :double)
         substitutions (assoc substitutions index index)
         algebra (update (first (:algebra attributes)) :element
@@ -694,6 +701,15 @@
      :inputs (into (set arrays) (disj stable destination))
      :outputs #{destination}
      :scalars scalar-captures
+     :public-scalars
+     (mapv (fn [id]
+             (let [value (get (:values facts) id)]
+               (when-not (and value (empty? (:shape value)))
+                 (throw (ex-info "typed scan public scalar lacks a scalar AbstractValue"
+                                 {:reason :typed-soac-scan-scalar :value id
+                                  :abstract-value value})))
+               (kernel-graph/scalar id (:dtype value))))
+           ordered-public-scalars)
      :elem-type scan-dtype}))
 
 (defn lower-typed-scan
@@ -1117,6 +1133,7 @@
      {:inputs (or (:inputs description) #{})
       :outputs (or (:outputs description) #{})
       :temporaries temporaries
+      :scalars (:public-scalars description)
       :buffer-specs buffer-specs
       :dtype dtype
       :effects {:memory-order :dependency-ordered}

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -54,6 +54,20 @@
         partials (first (:inputs (second (mapv :operation (:nodes graph)))))
         temporary-specs (graph-call/temporary-specs
                          emitted {'n {:type :long :value 1025}})]
+    (is (= [(kgraph/scalar 'n :long)] (:scalars graph)))
+    (is (= (:scalars graph) (:scalars emitted)))
+    (let [slot (->> (map vector (:abi emitted) (:arguments emitted))
+                    (some (fn [[slot argument]] (when (= 'n argument) slot))))]
+      (is (= :long (:dtype slot))
+          "the scheduled graph supplies the public logical dtype")
+      (is (= :int (:kernel-dtype slot))
+          "the target graph retains the physical scalar representation used by its nodes"))
+    (doseq [artifact [phase-one phase-two]
+            :let [[slot argument] (last (map vector (:abi artifact) (:arguments artifact)))]]
+      (is (= :int (:kernel-dtype slot))
+          "the target-private bound retains its physical scalar representation")
+      (is (= #{'n} (klaunch/expression-references argument))
+          "a target-private derived bound closes over the public logical scalar"))
     (is (= 2 (count (:nodes emitted))))
     (is (every? kart/kernel-artifact? [phase-one phase-two]))
     (is (str/includes? (:source phase-two) (str (name partials) "[")))

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -282,5 +282,6 @@
                         [:equations 0 :operations 0 :graph :nodes 0 :operation :target]
                         :hip-cpp)
         failure (reason-of #(emitted-program/validate! mixed))]
-    (is (= :emitted-parallel-program-target (:reason failure)))
-    (is (= :cuda-c (:expected-target failure)))))
+    (is (= :kernel-graph-executable-targets (:reason failure))
+        "the executable graph rejects a mixed target before its enclosing program must")
+    (is (= #{:cuda-c :hip-cpp} (:targets failure)))))

--- a/test/raster/compiler/ir/emitted_parallel_equation_test.clj
+++ b/test/raster/compiler/ir/emitted_parallel_equation_test.clj
@@ -1,0 +1,251 @@
+(ns raster.compiler.ir.emitted-parallel-equation-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as kernel-body]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scheduled-graph-refinement :as refinement]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]))
+
+(def ^:private map-source
+  '(raster.par/pmap i n float (clojure.core/+ 1.0 (clojure.core/aget values i))))
+
+(defn- scheduled-fixture []
+  (let [source (list 'let* ['result map-source] 'result)
+        typed (:program (typed-route/attempt
+                         source :float {'values :float}
+                         {:scalar-types {'n :int}}))
+        lowered (:form (segop-lower/segop-lower-pass
+                        typed {:target-device :cpu:0 :dtype :float}))
+        equation (first (:equations lowered))
+        ;; Production equation emission narrows the enclosing program to this equation and retains
+        ;; its semantic operand order. The whole-program lowerer sorts independent outer inputs.
+        body (assoc lowered :inputs (:operands equation) :outputs (:results equation))
+        algorithm (-> body :equations first :algorithm)
+        source (equation-graph/make algorithm body)
+        source-node (first (:nodes source))
+        refined-nodes
+        (mapv (fn [index]
+                (graph/->ScheduledKernel
+                 [:refined index]
+                 [:refined-operation index]
+                 (:uses source-node)
+                 (mapv (fn [earlier] [:refined earlier]) (range index))))
+              (range 3))
+        refined (graph/validate! (assoc source :nodes refined-nodes))
+        witness (refinement/make
+                 {:source source :graph refined
+                  :schedule {:kind :test-three-stage
+                             :semantic-law :fixture-only}
+                  :numerics {:mode :exact :policy :fixture-only}})]
+    {:algorithm algorithm :body body :source source :refined refined :witness witness}))
+
+(defn- use-kind [access]
+  (case access :read :input :write :output :read-write :inout))
+
+(defn- test-artifact
+  ([index operation uses buffers]
+   (test-artifact index operation uses buffers :opencl-c))
+  ([index operation uses buffers target]
+   (let [kernel-name (str "refined_" index)
+         slots (mapv (fn [{:keys [buffer access]}]
+                       (abi/slot buffer (use-kind access) (:dtype (get buffers buffer))
+                                 :c-name (c-emit/c-symbol buffer)))
+                     uses)
+         parameters
+         (mapv (fn [slot]
+                 (str (if (= :opencl-c target)
+                        (if (= :input (:kind slot)) "__global const " "__global ")
+                        (if (= :input (:kind slot)) "const " ""))
+                      "float* " (:c-name slot)))
+               slots)
+         prefix (if (= :opencl-c target) "__kernel void " "extern \"C\" __global__ void ")]
+     (artifact/certify-scheduled-operation
+      (artifact/make
+       {:kernel-name kernel-name
+        :target target
+        :source (str prefix kernel-name "(" (str/join ", " parameters)
+                     ") { " (:c-name (first (filter #(not= :input (:kind %)) slots)))
+                     "[0] = 0.0f; }")
+        :abi slots :arguments (mapv :buffer uses)
+        :launch (launch/spec {:workgroup-size [1] :group-count [1]})})
+      operation))))
+
+(defn- graph-interface
+  [scheduled]
+  (let [external (vec (distinct (concat (:inputs scheduled) (:outputs scheduled))))
+        scalar-interface (:scalars scheduled)]
+    (graph/validate!
+     (assoc scheduled
+            :abi (vec
+                  (concat
+                   (map (fn [{:keys [id dtype role]}]
+                          (abi/slot id (case role
+                                         :input :input :output :output :inout :inout)
+                                    dtype :c-name (c-emit/c-symbol id)))
+                        external)
+                   (map (fn [{:keys [id dtype]}]
+                          (abi/slot id :scalar dtype :c-name (c-emit/c-symbol id)))
+                        scalar-interface)))
+            :arguments (vec (concat (map :id external) (map :id scalar-interface)))))))
+
+(defn- emit-graph
+  [scheduled]
+  (let [buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs scheduled) (:outputs scheduled) (:temporaries scheduled)))]
+    (graph-interface
+     (graph/map-operations
+      scheduled
+      (fn [{:keys [id operation uses]}]
+        (test-artifact (last id) operation uses buffers))))))
+
+(defn- append-int-scalar
+  [kernel argument]
+  (let [slot (abi/slot 'derived :scalar :int :c-name "derived")]
+    (artifact/validate!
+     (-> kernel
+         (update :abi conj slot)
+         (update :arguments conj argument)
+         (update :source #(str/replace-first % #"\) \{" ", int derived) {"))))))
+
+(defn- reason-of [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo exception
+      (:reason (ex-data exception)))))
+
+(deftest legacy-one-to-one-emission-remains-the-degenerate-case
+  (let [{:keys [algorithm body source]} (scheduled-fixture)
+        emitted (emit-graph source)]
+    (is (emitted-equation/emitted-equation?
+         (emitted-equation/make algorithm body emitted)))))
+
+(deftest emitted-equation-certifies-both-links-of-a-one-to-many-schedule
+  (let [{:keys [algorithm body refined witness]} (scheduled-fixture)
+        emitted (emit-graph refined)
+        value (emitted-equation/make algorithm body emitted {:refinement witness})]
+    (is (emitted-equation/emitted-equation? value))
+    (is (identical? witness (:refinement value)))
+    (testing "emission must retain the refined topology"
+      (let [{:keys [source]} (scheduled-fixture)
+            wrong-shape (emit-graph source)]
+        (is (= :emitted-parallel-equation-dataflow
+               (reason-of #(emitted-equation/make
+                            algorithm body wrong-shape {:refinement witness}))))))
+    (testing "every artifact certifies its exact refined operation"
+      (let [wrong-certificate
+            (assoc-in emitted [:nodes 1 :operation :provenance :scheduled-operation]
+                      :wrong-operation)]
+        (is (= :emitted-parallel-equation-operation
+               (reason-of #(emitted-equation/make
+                            algorithm body wrong-certificate {:refinement witness}))))))))
+
+(deftest emitted-graph-is-an-executable-artifact-projection
+  (let [{:keys [algorithm body refined witness]} (scheduled-fixture)
+        emitted (emit-graph refined)
+        buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs refined) (:outputs refined) (:temporaries refined)))
+        node (get-in refined [:nodes 1])]
+    (testing "a node artifact cannot invent or omit a graph buffer use"
+      (is (= :kernel-graph-artifact-buffer
+             (reason-of #(emitted-equation/make
+                          algorithm body
+                          (assoc-in emitted [:nodes 0 :operation :arguments 0] 'undeclared)
+                          {:refinement witness}))))
+      (let [output-use (filterv #(not= :read (:access %)) (:uses node))
+            output-only (test-artifact 99 (:operation node) output-use buffers)]
+        (is (= :kernel-graph-artifact-uses
+               (reason-of #(emitted-equation/make
+                            algorithm body
+                            (assoc-in emitted [:nodes 1 :operation] output-only)
+                            {:refinement witness}))))))
+    (testing "an emitted graph has one interface and one target dialect"
+      (is (= :kernel-graph-executable-interface
+             (reason-of #(emitted-equation/make
+                          algorithm body (assoc emitted :abi nil :arguments nil)
+                          {:refinement witness}))))
+      (let [{:keys [id operation uses]} node
+            hip (test-artifact (last id) operation uses buffers :hip-cpp)]
+        (is (= :kernel-graph-executable-targets
+               (reason-of #(emitted-equation/make
+                            algorithm body (assoc-in emitted [:nodes 1 :operation] hip)
+                            {:refinement witness}))))))))
+
+(deftest refinement-source-is-rederived-from-the-typed-equation
+  (let [{:keys [algorithm body source refined]} (scheduled-fixture)
+        stale-source (assoc-in source [:nodes 0 :operation] :stale-operation)
+        stale (refinement/make
+               {:source stale-source :graph refined :schedule {:kind :stale}
+                :numerics {:mode :exact :policy :structural-identity}})
+        emitted (emit-graph refined)]
+    (is (= :scheduled-graph-refinement-source
+           (reason-of #(emitted-equation/make
+                        algorithm body emitted {:refinement stale}))))))
+
+(deftest emitted-equation-cannot-invent-a-public-scalar
+  (let [{:keys [algorithm body refined witness]} (scheduled-fixture)
+        emitted (emit-graph refined)
+        forged (-> emitted
+                   (update :scalars conj (graph/scalar 'forged :int))
+                   (update :abi conj (abi/slot 'forged :scalar :int))
+                   (update :arguments conj 'forged))]
+    (is (= :emitted-parallel-equation-dataflow
+           (reason-of #(emitted-equation/make
+                        algorithm body forged {:refinement witness}))))))
+
+(deftest artifact-private-scalars-are-closed-integral-launch-expressions
+  (let [{:keys [algorithm body refined witness]} (scheduled-fixture)
+        emitted (emit-graph refined)]
+    (testing "a signed literal is a valid private scalar even though it is not a dimension"
+      (let [with-literal (update-in emitted [:nodes 0 :operation]
+                                    append-int-scalar -1)]
+        (is (emitted-equation/emitted-equation?
+             (emitted-equation/make
+              algorithm body with-literal {:refinement witness})))))
+    (testing "a derived integer may not close over a public floating-point scalar"
+      (let [alpha (graph/scalar 'alpha :float)
+            with-alpha (-> emitted
+                           (update :scalars conj alpha)
+                           (update :abi conj (abi/slot 'alpha :scalar :float))
+                           (update :arguments conj 'alpha)
+                           (update-in [:nodes 0 :operation]
+                                      append-int-scalar (launch/runtime-value 'alpha)))]
+        (is (= :kernel-graph-artifact-scalar
+               (reason-of #(emitted-equation/make
+                            algorithm body with-alpha {:refinement witness}))))))
+    (testing "malformed target-private index algebra is rejected before runtime binding"
+      (let [malformed (update-in emitted [:nodes 0 :operation]
+                                 append-int-scalar
+                                 (kernel-body/->IndexExpr :unknown ['n]))]
+        (is (= :kernel-graph-artifact-scalar
+               (reason-of #(emitted-equation/make
+                            algorithm body malformed {:refinement witness}))))))))
+
+(deftest refinement-cannot-forge-the-rederived-source-interface
+  (let [{:keys [algorithm body source refined]} (scheduled-fixture)
+        scalar (abi/slot 'forged :scalar :int)
+        forged-source (let [interfaced (graph-interface source)]
+                        (graph/validate! (-> interfaced
+                                             (update :abi conj scalar)
+                                             (update :arguments conj 'forged)
+                                             (update :scalars conj (graph/scalar 'forged :int)))))
+        forged-refined (let [interfaced (graph-interface refined)]
+                         (graph/validate! (-> interfaced
+                                              (update :abi conj scalar)
+                                              (update :arguments conj 'forged)
+                                              (update :scalars conj (graph/scalar 'forged :int)))))
+        forged (refinement/make
+                {:source forged-source :graph forged-refined
+                 :schedule {:kind :forged-interface}
+                 :numerics {:mode :exact :policy :structural-identity}})
+        emitted (emit-graph refined)]
+    (is (= :scheduled-graph-refinement-source
+           (reason-of #(emitted-equation/make
+                        algorithm body emitted {:refinement forged}))))))

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -44,6 +44,14 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicitly typed"
                           (graph-call/make graph buffers {'n 1025})))))
 
+(deftest derived-int-scalars-refuse-narrowing-overflow
+  (let [graph (emitted-graph)
+        ids (set (map :id (concat (:inputs graph) (:outputs graph) (:temporaries graph))))
+        buffers (zipmap ids (repeatedly #(Object.)))]
+    (is (thrown? ArithmeticException
+                 (graph-call/make graph buffers
+                                  {'n {:type :int :value Long/MAX_VALUE}})))))
+
 (deftest emitted-graph-projects-one-ordered-public-call-to-runtime-binding-maps
   (let [graph (emitted-graph)
         n {:type :int :value 1025}

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -97,6 +97,32 @@
     (is (identical? interfaced (graph/validate! interfaced)))
     (is (= :inout (get-in interfaced [:abi 0 :kind])))))
 
+(deftest graph-scalars-are-an-ordered-target-neutral-interface
+  (let [operation (segop/->SegMap
+                   10 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
+                   '(+ alpha (aget values i)) nil #{'values} #{'out} #{'alpha}
+                   (segop/->KernelGrid 1 32 0) :float 'out nil)
+        scalars [(graph/scalar 'n :long) (graph/scalar 'alpha :float)]
+        scheduled (graph/from-segops
+                   [operation]
+                   {:inputs #{'values} :outputs #{'out} :dtype :float :scalars scalars})]
+    (is (= scalars (:scalars scheduled)))
+    (is (not (graph/dataflow-equivalent?
+              scheduled (assoc scheduled :scalars (vec (reverse scalars))))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar identities must be unique"
+                          (graph/validate!
+                           (assoc scheduled :scalars [(graph/scalar 'n :long)
+                                                      (graph/scalar 'n :long)]))))
+    (is (= :kernel-graph-value-identity
+           (try
+             (graph/validate!
+              (assoc scheduled :scalars [(graph/scalar 'values :long)]))
+             nil
+             (catch clojure.lang.ExceptionInfo exception
+               (:reason (ex-data exception))))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"symbol or keyword"
+                          (graph/scalar 42 :int)))))
+
 (deftest ordered-output-vectors-retain-write-access
   (let [operation (segop/->SegFoldMap
                    10 (segop/make-seg-space 'segment 'nsegments)

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -43,6 +43,14 @@
                             (launch/realize spec {'groups 1.5}))))))
 
 (deftest symbolic-storage-expressions-use-the-same-checked-evaluator
+  (is (= 17 (launch/resolve-expression {'(extent output) 17} '(extent output)))
+      "stable compound extent identities are resolved as values, never evaluated as source")
+  (is (= [1]
+         (:group-count
+          (launch/realize
+           (launch/spec {:workgroup-size [32]
+                         :group-count [(launch/ceil-div '(extent output) 32)]})
+           {'(extent output) 17}))))
   (is (= 5 (launch/resolve-expression {'n 1025} (launch/ceil-div 'n 256))))
   (is (= 768
          (launch/resolve-expression
@@ -70,7 +78,12 @@
                                        (launch/ceil-div 'm 128)]})
            {'m 129 'n 257}))))
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be an integer"
-                        (launch/resolve-expression {} (launch/ceil-div 'n 256)))))
+                        (launch/resolve-expression {} (launch/ceil-div 'n 256))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be non-negative"
+                        (launch/resolve-expression {} (launch/ceil-div -1 256))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be non-negative"
+                        (launch/resolve-expression
+                         {} (body/expression :mod -1 4)))))
 
 (deftest launch-specialization-rebinds-explicit-expression-leaves
   (let [original (launch/spec
@@ -106,3 +119,21 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (launch/resolve-expression (constantly 0)
                                             (body/expression :ceil-div 'n 'zero))))))
+
+(deftest malformed-kernel-body-index-algebra-is-not-a-launch-expression
+  (is (false? (launch/expression? (launch/->CeilDiv 'n 0))))
+  (is (false? (launch/expression? (launch/->FloorDiv 'n -1))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"divisor must be positive"
+                        (launch/resolve-expression {'n 4} (launch/->CeilDiv 'n 0))))
+  (is (false? (launch/expression? (body/->IndexExpr :unknown ['n]))))
+  (is (false? (launch/expression? (body/->IndexExpr :ceil-div ['n]))))
+  (is (false? (launch/expression? (body/->IndexCast 'n :float :exact))))
+  (is (false? (launch/expression? (body/->IndexCast 'n :long :wrap))))
+  (is (launch/expression? (body/index-cast 'n :int64 :exact)))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"not an exact widening"
+       (launch/validate-typed-expression!
+        (body/index-cast 'n :int :exact) (constantly :long))))
+  (let [expression (body/index-cast 'n :int64 :exact)]
+    (is (= expression
+           (launch/validate-typed-expression! expression (constantly :int))))))

--- a/test/raster/compiler/ir/scheduled_graph_refinement_test.clj
+++ b/test/raster/compiler/ir/scheduled_graph_refinement_test.clj
@@ -1,0 +1,157 @@
+(ns raster.compiler.ir.scheduled-graph-refinement-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.scheduled-graph-refinement :as refinement]))
+
+(defn- fixtures []
+  (let [a (graph/buffer 'a :float 64 :device :input)
+        b (graph/buffer 'b :float 64 :device :input)
+        c (graph/buffer 'c :float 64 :device :output)
+        ah (graph/buffer 'a-half :half 64 :device :temporary)
+        bh (graph/buffer 'b-half :half 64 :device :temporary)
+        interface [(abi/slot 'a :input :float)
+                   (abi/slot 'b :input :float)
+                   (abi/slot 'c :output :float)
+                   (abi/slot 'n :scalar :int)]
+        arguments '[a b c n]
+        scalars [(graph/scalar 'n :int)]
+        effects {:semantic #{:numerical}}
+        source
+        (graph/make
+         {:inputs [a b] :outputs [c]
+          :nodes [(graph/->ScheduledKernel
+                   :semantic-contract :contract
+                   [(graph/->ValueUse 'a :read)
+                    (graph/->ValueUse 'b :read)
+                    (graph/->ValueUse 'c :write)] [])]
+          :scalars scalars :abi interface :arguments arguments :effects effects})
+        refined
+        (graph/make
+         {:inputs [a b] :outputs [c] :temporaries [ah bh]
+          :nodes [(graph/->ScheduledKernel
+                   :cast-a :cast-a
+                   [(graph/->ValueUse 'a :read) (graph/->ValueUse 'a-half :write)] [])
+                  (graph/->ScheduledKernel
+                   :cast-b :cast-b
+                   [(graph/->ValueUse 'b :read) (graph/->ValueUse 'b-half :write)] [])
+                  (graph/->ScheduledKernel
+                   :matrix :matrix
+                   [(graph/->ValueUse 'a-half :read)
+                    (graph/->ValueUse 'b-half :read)
+                    (graph/->ValueUse 'c :write)]
+                   [:cast-a :cast-b])]
+          :scalars scalars :abi interface :arguments arguments :effects effects})]
+    {:a a :b b :c c :source source :refined refined}))
+
+(defn- witness []
+  (let [{:keys [source refined]} (fixtures)]
+    (refinement/make
+     {:source source :graph refined
+      :schedule {:kind :mixed-precision-contraction
+                 :accumulator-dtype :float}
+      :numerics {:mode :bounded-error
+                 :policy :mixed-precision-fixture
+                 :rounding :nearest-even
+                 :accumulator-dtype :float
+                 :error-model {:kind :producer-verified-mixed-precision}}})))
+
+(defn- reason-of [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo exception
+      (:reason (ex-data exception)))))
+
+(deftest one-semantic-operation-can-refine-to-a-private-kernel-dag
+  (let [{:keys [source refined]} (fixtures)
+        value (witness)]
+    (is (refinement/scheduled-graph-refinement? value))
+    (is (= :contract (refinement/source-operation value)))
+    (is (= refined (refinement/scheduled-graph value)))
+    (is (= (graph/boundary-contract source)
+           (graph/boundary-contract refined)))
+    (is (not= (graph/dataflow-contract source)
+              (graph/dataflow-contract refined))
+        "private topology changes without weakening strict emission equivalence")))
+
+(deftest refinement-rejects-erasure-and-a-non-singleton-source
+  (let [{:keys [a b refined]} (fixtures)
+        empty-source (graph/make {:inputs [a b] :nodes []})]
+    (is (= :scheduled-graph-refinement-source-cardinality
+           (reason-of #(refinement/make
+                        {:source empty-source :graph refined :schedule {}}))))
+    (is (= :scheduled-graph-refinement-source-cardinality
+           (reason-of #(refinement/make
+                        {:source refined :graph refined :schedule {}}))))
+    (let [{:keys [source]} (fixtures)
+          empty-refined (graph/make {:inputs [a b] :nodes []})]
+      (is (= :scheduled-graph-refinement-empty
+             (reason-of #(refinement/make
+                          {:source source :graph empty-refined :schedule {}})))))))
+
+(deftest refinement-preserves-the-exact-ordered-public-boundary
+  (let [{:keys [source refined]} (fixtures)]
+    (testing "tensor extents and ordered inputs"
+      (is (= :scheduled-graph-refinement-boundary
+             (reason-of #(refinement/make
+                          {:source source
+                           :graph (graph/validate!
+                                   (assoc-in refined [:inputs 0 :elements] 32))
+                           :schedule {}}))))
+      (is (= :scheduled-graph-refinement-boundary
+             (reason-of #(refinement/make
+                          {:source source
+                           :graph (graph/validate!
+                                   (update refined :inputs (fn [values] (vec (reverse values)))))
+                           :schedule {}})))))
+    (testing "the ordered public ABI and scalar arguments"
+      (let [extra-abi (conj (:abi refined) (abi/slot 'tile :scalar :int))]
+        (is (= :scheduled-graph-refinement-boundary
+               (reason-of #(refinement/make
+                            {:source source
+                             :graph (graph/validate!
+                                     (assoc refined :abi extra-abi
+                                                    :arguments (conj (:arguments refined) 'tile)
+                                                    :scalars (conj (:scalars refined)
+                                                                   (graph/scalar 'tile :int))))
+                             :schedule {}}))))))
+    (testing "logical effects"
+      (is (= :scheduled-graph-refinement-boundary
+             (reason-of #(refinement/make
+                          {:source source
+                           :graph (assoc refined :effects {:semantic #{:io}})
+                           :schedule {}})))))))
+
+(deftest refinement-preserves-logical-scalars-without-a-target-abi
+  (let [{:keys [source refined]} (fixtures)
+        source (graph/validate! (assoc source :abi nil :arguments nil))
+        refined (graph/validate! (assoc refined :abi nil :arguments nil))]
+    (is (refinement/scheduled-graph-refinement?
+         (refinement/make {:source source :graph refined
+                           :schedule {:kind :target-neutral-fixture}
+                           :numerics {:mode :exact :policy :structural-identity}})))
+    (is (= :scheduled-graph-refinement-boundary
+           (reason-of #(refinement/make
+                        {:source source
+                         :graph (assoc refined :scalars [(graph/scalar 'n :long)])
+                         :schedule {:kind :target-neutral-fixture}
+                         :numerics {:mode :exact :policy :structural-identity}}))))))
+
+(deftest refinement-descriptions-and-source-identity-are-checked
+  (let [{:keys [source]} (fixtures)
+        value (witness)]
+    (doseq [[field bad] [[:schedule []] [:schedule {}]
+                         [:provenance nil] [:attributes :bad]]]
+      (is (= :scheduled-graph-refinement-description
+             (reason-of #(refinement/validate! (assoc value field bad))))))
+    (is (= :scheduled-graph-refinement-numerics
+           (reason-of #(refinement/validate! (assoc value :numerics {})))))
+    (is (= :scheduled-graph-refinement-numerics
+           (reason-of #(refinement/validate!
+                        (assoc value :numerics {:mode :bounded-error
+                                                :policy :missing-evidence})))))
+    (let [different-operation
+          (graph/validate! (assoc-in source [:nodes 0 :operation] :different-contract))]
+      (is (= :scheduled-graph-refinement-source
+             (reason-of #(refinement/validate-against! value different-operation)))))))

--- a/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
+++ b/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.paged-kv-append-route-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.paged-kv-append :as append]
             [raster.compiler.passes.parallel.paged-kv-append-route :as route]))
@@ -59,7 +60,10 @@
     (is (= #{'key-pages 'value-pages}
            (set (map :id (:outputs graph)))))
     (is (every? #(= :inout (:role %)) (:outputs graph)))
-    (is (graph/kernel-graph? graph))))
+    (is (every? #(= :read-write (:access %))
+                (filter (comp #{'key-pages 'value-pages} :buffer)
+                        (get-in graph [:nodes 0 :uses]))))
+    (is (identical? graph (executable/validate! graph)))))
 
 (deftest unsupported-storage-declines-before-emission
   (let [result (route/route (problem {:key-storage-dtype :float}))]

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -85,11 +85,13 @@
     (is (= [(:id first-node)] (:dependencies second-node)))
     (is (= '[u-in] (mapv :id (:inputs graph))))
     (is (= '[u-next] (mapv :id (:outputs graph))))
+    (is (= '[iteration n-in alpha-in] (mapv :id (:scalars graph)))
+        "public scalars retain the typed body input order")
     (let [emitted (opencl/generate-kernel-graph
                    graph :scalar-types {'alpha-in :float 'iteration :long})]
       (is (emitted-loop/emitted-loop? (emitted-loop/make scheduled emitted)))
       (is (every? artifact/kernel-artifact? (map :operation (:nodes emitted))))
-      (is (= '[u-in u-next alpha-in iteration n-in] (:arguments emitted)))
+      (is (= '[u-in u-next iteration n-in alpha-in] (:arguments emitted)))
       (is (= :opencl-c (get-in emitted [:provenance :target-dialect])))
       (is (= (mapv :operation (:nodes graph))
              (mapv #(get-in % [:operation :provenance :scheduled-operation])

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -668,6 +668,7 @@
     (is (= 3 (count (:nodes graph))))
     (is (= :typed-soac (get-in (first (:operations equation)) [:algorithm-dialect])))
     (is (= #{'out} (set (map :id (:outputs graph)))))
+    (is (= [['n :long]] (mapv (juxt :id :dtype) (:scalars graph))))
     (is (= 1 (count (:temporaries graph))))
     (parallel-program/validate! scheduled segop/segop-node?)))
 

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -284,11 +284,15 @@
         compiled (try {:ok (pl/compile-gpu-program probe :ze:0 :dtype :float)}
                       (catch Throwable t {:err t}))]
     (if-let [t (:err compiled)]
-      ;; Fix (b): rejected at compile. Assert it is the PRINCIPLED, named rejection —
-      ;; not an incidental failure that might mask a real regression.
-      (is (= :unsupported-gemm-alpha-beta (:why (:non-resident (ex-data t))))
-          (str "an accumulating GEMM must be rejected by NAME "
-               "(:unsupported-gemm-alpha-beta), got: " (.getMessage t)))
+      ;; Fix (b): rejected at compile. The TypedSOAC frontend now represents BLAS accumulation as
+      ;; an ordinary result transform, so the honest narrow rejection is the missing typed result
+      ;; operand rather than the retired BLAS-specific classification. Assert that exact structured
+      ;; decline—not an incidental emitter failure that might mask a real regression.
+      (let [data (ex-data t)
+            reason (or (:missing-rule data) (:why (:non-resident data)))]
+        (is (= :result-transform-operand reason)
+            (str "an accumulating GEMM must be rejected by its typed result-transform rule "
+                 "(:result-transform-operand), got: " (.getMessage t))))
       ;; Fix (a): it compiled — then it MUST be numerically correct on device.
       (if-not @gp/gpu-available?
         (gp/gpu-skip! "gemm-accumulate device verify (compiled resident)")


### PR DESCRIPTION
Adds the proof-carrying boundary for one semantic operation refining into a scheduled kernel DAG without weakening target emission.

- preserves exact buffer, ordered GraphScalar, ABI, effect, and semantic-operation identity
- requires an explicit schedule plus structured numerical attestation
- derives public scalars from typed AbstractValues before target emission
- permits only checked target-private integral expressions closed over public integral scalars
- validates exact index casts, non-negative division/modulo semantics, and overflow-checked int binding
- projects logical scalar dtype into node artifacts while retaining physical kernel dtype
- validates paged K/V append read-write effects through KernelExecutable

Focused validation: proof/emission suite 54 tests / 252 assertions; equation/control suite 34 / 250; launch/dispatch/call suite 23 / 117. Full and vendor gates are delegated to CircleCI.