### PR TITLE
Make ScheduledKernelBody the target projection boundary

### DIFF
--- a/src/raster/compiler/backend/gpu/kernel_body_target.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_target.clj
@@ -1,0 +1,161 @@
+(ns raster.compiler.backend.gpu.kernel-body-target
+  "Single target projection for verified ScheduledKernelBody values.
+
+   The fork between scalar/control and matrix instruction spelling is selected from KernelBody
+   vocabulary, never from a source operation name.  ABI order, arguments, launch, effects,
+   numerical policy, and semantic identity all come from the checked refinement."
+  (:require [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as scalar-target]
+            [raster.compiler.backend.gpu.matrix-target :as matrix-target]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
+
+(defn- record-kind?
+  [simple-name value]
+  (and value (= simple-name (.getSimpleName (class value)))))
+
+(defn- nested-operations
+  [operation]
+  (cond
+    (record-kind? "IfRegion" operation)
+    (concat (:then-operations operation) (:else-operations operation))
+
+    (or (record-kind? "ForLoop" operation)
+        (record-kind? "PipelinedFor" operation)
+        (record-kind? "Loop" operation)
+        (record-kind? "Guard" operation))
+    (:operations operation)
+
+    :else []))
+
+(defn- operations
+  [kernel-body]
+  (letfn [(walk [values]
+            (mapcat (fn [operation]
+                      (cons operation (walk (nested-operations operation))))
+                    values))]
+    (walk (:operations kernel-body))))
+
+(defn matrix-body?
+  "A body selects matrix target spelling exactly when it contains a scheduled MatrixMad."
+  [kernel-body]
+  (boolean (some #(record-kind? "MatrixMad" %) (operations (body/validate! kernel-body)))))
+
+(defn- scalar-parameter-names
+  [kernel-body overrides]
+  (into {}
+        (map (fn [parameter]
+               [(:id parameter)
+                (or (get overrides (:id parameter)) (c-emit/c-symbol (:id parameter)))]))
+        (:parameters kernel-body)))
+
+(defn- validate-target-names!
+  [kernel-name kernel-body names]
+  (when-not (c-emit/c-identifier? kernel-name)
+    (throw (ex-info "scheduled kernel entry point is not a portable C-family identifier"
+                    {:reason :kernel-body-target-entry-point :kernel-name kernel-name})))
+  (let [ordered (mapv #(get names (:id %)) (:parameters kernel-body))]
+    (doseq [[parameter target-name] (map vector (:parameters kernel-body) ordered)]
+      (when-not (c-emit/c-identifier? target-name)
+        (throw (ex-info "scheduled kernel parameter is not a portable C-family identifier"
+                        {:reason :kernel-body-target-parameter-name
+                         :parameter parameter :target-name target-name}))))
+    (when-not (= (count ordered) (count (set ordered)))
+      (throw (ex-info "scheduled kernel parameter names are not unique"
+                      {:reason :kernel-body-target-name-collision :names ordered})))
+    names))
+
+(defn- project-abi
+  [scheduled names alignments]
+  (let [kernel-body (:body scheduled)
+        scalar-bindings (into {} (map (juxt :parameter identity))
+                              (:scalar-bindings scheduled))]
+  (body-abi/project-contracts
+   (mapv (fn [{:keys [id kind dtype role]}]
+           (let [binding (get scalar-bindings id)]
+             (abi/slot id kind (or (:dtype binding) dtype)
+                       :kernel-dtype (or (:kernel-dtype binding) dtype)
+                       :c-name (get names id) :role role
+                       :alignment (get alignments id))))
+         (:parameters kernel-body))
+   kernel-body)))
+
+(defn- scalar-target-facts
+  [kernel-body dialect target-features]
+  (let [consumed (select-keys target-features [:compute-capability :architecture])
+        physical-dialect (merge dialect consumed)
+        operation-kinds (set (map #(some-> % class .getSimpleName)
+                                  (operations kernel-body)))
+        collective? (contains? operation-kinds "Collective")
+        async? (some operation-kinds
+                     #{"AsyncWorkgroupCopy" "AsyncCommit" "AsyncWait" "PipelinedFor"})]
+    (cond-> {:target-dialect (:id dialect)}
+      collective?
+      (assoc :collective-association (c-dialect/collective-association physical-dialect))
+      async?
+      (assoc :async-copy-mode (c-dialect/async-copy-mode physical-dialect)
+             :target-features consumed))))
+
+(defn emit-artifact
+  "Emit a ScheduledKernelBody to one C-family target artifact.
+
+   Optional metadata is non-authoritative: checked body/refinement and selected-target facts win
+   on key collisions.  `parameter-names` and `target-features` affect target spelling only."
+  ([kernel-name scheduled target-dialect]
+   (emit-artifact kernel-name scheduled target-dialect {}))
+  ([kernel-name scheduled target-dialect
+    {:keys [parameter-names target-features provenance attributes]}]
+   (let [scheduled (scheduled-body/validate! scheduled)
+         kernel-body (:body scheduled)
+         matrix? (matrix-body? kernel-body)
+         dialect (c-dialect/resolve! target-dialect)
+         emitted
+         (if matrix?
+           (matrix-target/emit-matrix-kernel
+            kernel-name kernel-body target-dialect {:parameter-names parameter-names})
+           (let [names (validate-target-names!
+                        kernel-name kernel-body
+                        (scalar-parameter-names kernel-body parameter-names))]
+             {:source (scalar-target/emit-scalar-kernel
+                       kernel-name kernel-body
+                       {:target-dialect target-dialect
+                        :target-features target-features
+                        :parameter-names names})
+              :target (c-dialect/target dialect)
+              :target-dialect (:id dialect)
+              :parameter-names names
+              :parameter-alignments {}
+              :target-facts (scalar-target-facts kernel-body dialect target-features)}))
+         names (validate-target-names! kernel-name kernel-body (:parameter-names emitted))
+         projected-abi (project-abi scheduled names (:parameter-alignments emitted))]
+     (scheduled-body/validate-artifact-projection!
+      scheduled
+      (artifact/make
+       {:kernel-name kernel-name
+        :target (:target emitted)
+        :source (:source emitted)
+        :abi projected-abi
+        :arguments (:arguments scheduled)
+        :launch (scheduled-body/realized-launch scheduled)
+        :temporaries []
+        :effects (:effects scheduled)
+        :provenance (merge provenance
+                          (:provenance kernel-body)
+                          (:provenance scheduled)
+                          {:lowering :scheduled-kernel-body
+                           :target-dialect (:target-dialect emitted)
+                           :scheduled-operation scheduled
+                           :target-facts (:target-facts emitted)})
+        :attributes (merge attributes
+                          (:attributes scheduled)
+                          {:kernel-body kernel-body
+                           :scheduled-kernel-body scheduled
+                           :emission-route :kernel-body
+                           :body-family (if matrix? :matrix :scalar-control)
+                           :legality (:legality scheduled)
+                           :numerics (:numerics scheduled)
+                           :target-facts (:target-facts emitted)})})))))

--- a/src/raster/compiler/backend/gpu/matrix_target.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target.clj
@@ -9,11 +9,8 @@
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
-            [raster.compiler.ir.kernel-abi :as kernel-abi]
-            [raster.compiler.ir.kernel-artifact :as kernel-artifact]
-            [raster.compiler.ir.kernel-body :as kernel-body]
-            [raster.compiler.ir.kernel-body-abi :as body-abi]
-            [raster.compiler.ir.kernel-launch :as kernel-launch]))
+            [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
+            [raster.compiler.ir.kernel-body :as kernel-body]))
 
 (defn- target-parameter-names
   [body overrides]
@@ -69,31 +66,23 @@
                        :parameters (:parameters body) :c-names ordered-names})))
     names))
 
-(defn- projected-abi
-  [body names target-dialect]
-  (let [target-alignment (when (= :cuda target-dialect) 32)]
-    (body-abi/project-contracts
-     (mapv (fn [{:keys [id kind dtype role]}]
-             (kernel-abi/slot id kind dtype
-                              :c-name (get names id)
-                              :role role
-                              :alignment (when (and target-alignment (not= :scalar kind))
-                                           target-alignment)))
+(defn physical-requirements
+  "Return target-derived ABI requirements and identity-bearing physical lowering facts."
+  [body target-dialect plan]
+  (let [body (kernel-body/validate! body)
+        dialect (c-dialect/resolve! target-dialect)
+        pointer-alignment (when (= :cuda (:id dialect)) 32)]
+    {:parameter-alignments
+     (into {}
+           (keep (fn [{:keys [id kind]}]
+                   (when (and pointer-alignment (not= :scalar kind))
+                     [id pointer-alignment])))
            (:parameters body))
-     body)))
-
-(defn- body-arguments
-  [body]
-  (let [dimension-values (get-in body [:attributes :dimension-values])]
-    (mapv (fn [{:keys [id role]}]
-            (if (= :dimension role) (get dimension-values id id) id))
-          (:parameters body))))
-
-(defn- body-effects
-  [body]
-  {:kind :tensor-contraction-stage
-   :reads (mapv :id (filter #(contains? #{:input :inout} (:kind %)) (:parameters body)))
-   :writes (mapv :id (filter #(contains? #{:output :inout} (:kind %)) (:parameters body)))})
+     :target-facts
+     {:target-dialect (:id dialect)
+      :instruction (:instruction plan)
+      :instruction-family (get-in plan [:instruction :family])
+      :pointer-alignment pointer-alignment}}))
 
 (defn emit-matrix-kernel
   "Emit `body` for one C-family target dialect.
@@ -106,6 +95,7 @@
    (emit-matrix-kernel kernel-name body target-dialect {}))
   ([kernel-name body target-dialect {:keys [parameter-names]}]
    (let [body (kernel-body/validate! body)
+         plan (matrix-plan/analyze body)
          dialect (c-dialect/resolve! target-dialect)
          parameter-names (validate-target-names!
                           kernel-name body
@@ -131,40 +121,9 @@
                             :target (c-dialect/target dialect)
                             :instruction-family
                             (get-in body [:attributes :instruction-family])})))]
-     {:source source
+     (merge {:source source
       :target (c-dialect/target dialect)
       :target-dialect (:id dialect)
       :parameter-names parameter-names
-      :kernel-body body})))
-
-(defn emit-matrix-artifact
-  "Project one verified matrix body into a complete target artifact.
-
-   ABI order, memory contracts, compiler arguments and launch geometry are consequences of the
-   body. Static dimension specializations become literal artifact arguments; dynamic dimensions
-   retain their compiler identities. Target parameter names are spelling policy only."
-  ([kernel-name body target-dialect]
-   (emit-matrix-artifact kernel-name body target-dialect {}))
-  ([kernel-name body target-dialect {:keys [parameter-names provenance attributes]}]
-   (let [body (kernel-body/validate! body)
-         dimension-values (get-in body [:attributes :dimension-values])
-         emitted (emit-matrix-kernel kernel-name body target-dialect
-                                     {:parameter-names parameter-names})
-         names (:parameter-names emitted)]
-     (kernel-artifact/make
-      {:kernel-name kernel-name
-       :target (:target emitted)
-       :source (:source emitted)
-       :abi (projected-abi body names (:target-dialect emitted))
-       :arguments (body-arguments body)
-       :launch (kernel-launch/rebind-spec (:launch body) dimension-values)
-       :effects (body-effects body)
-       :provenance (merge provenance
-                          (:provenance body)
-                          {:lowering :matrix-kernel-body
-                           :target-dialect (:target-dialect emitted)})
-       :attributes (merge attributes
-                          {:kernel-body body
-                           :emission-route :kernel-body
-                           :instruction-family
-                           (get-in body [:attributes :instruction-family])})}))))
+      :kernel-body body}
+            (physical-requirements body (:id dialect) plan)))))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -8,6 +8,7 @@
    This is the GPU counterpart to segop_simd.clj — both consume the
    same SegOp IR but produce different target code."
   (:require [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
+            [raster.compiler.backend.gpu.kernel-body-target :as kernel-body-target]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as kernel-body-c-dialect]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
@@ -25,6 +26,7 @@
             [raster.compiler.ir.kernel-body-abi :as body-abi]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
@@ -385,50 +387,13 @@
              :or {kernel-name-prefix "segmap"
                   target-dialect :opencl-intel workgroup-size 256
                   scalar-types {} array-types {}}}]
-  (let [{:keys [kernel-body bound inputs outputs scalars]}
-        (segmap-body/lower segmap
-                           {:workgroup-size workgroup-size
-                            :scalar-types scalar-types :array-types array-types})
-        parameters (:parameters kernel-body)
+  (let [scheduled
+        (segmap-body/schedule segmap
+                              {:workgroup-size workgroup-size
+                               :scalar-types scalar-types :array-types array-types})
         kernel-name (str kernel-name-prefix "_" (gensym ""))
-        parameter-names (into {}
-                              (map (fn [parameter]
-                                     [(:id parameter) (ce/c-symbol (:id parameter))]))
-                              parameters)
-        source (kernel-body-opencl/emit-scalar-kernel
-                kernel-name kernel-body
-                {:target-dialect target-dialect :parameter-names parameter-names})
-        abi (body-abi/project-contracts
-             (mapv (fn [{:keys [id kind dtype role]}]
-                     (kabi/slot id kind dtype :c-name (get parameter-names id)
-                                :role (if (= id '_n_bound) :bound role)))
-                   parameters)
-             kernel-body)
-        arguments (mapv (fn [parameter]
-                          (if (= '_n_bound (:id parameter)) bound (:id parameter)))
-                        parameters)]
-    (kart/make
-     {:kernel-name kernel-name
-      :source source
-      :abi abi
-      :arguments arguments
-      :launch (:launch kernel-body)
-      :temporaries []
-      :effects {:kind (case (:write-conflict segmap)
-                        :reduce :reducing-scatter
-                        (if (:out-sym segmap) :elementwise-map :side-effect-map))
-                :write-conflict (or (:write-conflict segmap) :unique)
-                :conflict-contract (:conflict-contract segmap)}
-      :target (kernel-body-c-dialect/target
-               (kernel-body-c-dialect/resolve! target-dialect))
-      :provenance {:dialect :kernel-body :source-dialect :segmap
-                   :segop-id (:id segmap)}
-      :attributes {:kernel-body kernel-body
-                   :emission-route :kernel-body
-                   :array-params (vec (concat inputs outputs))
-                   :scalar-params scalars
-                   :dtype (:dtype segmap)
-                   :aliasing :no-write-alias}})))
+        ]
+    (kernel-body-target/emit-artifact kernel-name scheduled target-dialect)))
 
 (defn generate-segstencil-kernel-body
   "Schedule and emit one certified SegStencil through portable KernelBody."
@@ -749,8 +714,7 @@
                      target-dialect :opencl-intel}}]
   (let [dtype (or (:dtype operation) dtype :double)
         target (kernel-body-c-dialect/resolve! target-dialect)]
-    (kart/certify-scheduled-operation
-     (try
+    (try
        (generate-segmap-kernel-body
         operation :dtype dtype :scalar-types scalar-types :array-types array-types
         :target-dialect target-dialect :kernel-name-prefix kernel-name-prefix)
@@ -758,17 +722,19 @@
          (if (and (kernel-body-c-dialect/opencl? target)
                   (segmap-body/declined? exception))
            (try
-             (-> (if (:out-sym operation)
-                   (generate-segmap-kernel
-                    operation (:out-sym operation)
-                    :dtype dtype :scalar-types scalar-types :array-types array-types
-                    :kernel-name-prefix kernel-name-prefix)
-                   (generate-explicit-segmap-kernel
-                    operation :dtype dtype :scalar-types scalar-types :array-types array-types
-                    :kernel-name-prefix (str kernel-name-prefix "_effect")))
-                 (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
-                 (assoc-in [:attributes :kernel-body-decline]
-                           (assoc (ex-data exception) :fallback :verified-segmap-opencl)))
+             (kart/certify-scheduled-operation
+              (-> (if (:out-sym operation)
+                    (generate-segmap-kernel
+                     operation (:out-sym operation)
+                     :dtype dtype :scalar-types scalar-types :array-types array-types
+                     :kernel-name-prefix kernel-name-prefix)
+                    (generate-explicit-segmap-kernel
+                     operation :dtype dtype :scalar-types scalar-types :array-types array-types
+                     :kernel-name-prefix (str kernel-name-prefix "_effect")))
+                  (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
+                  (assoc-in [:attributes :kernel-body-decline]
+                            (assoc (ex-data exception) :fallback :verified-segmap-opencl)))
+              operation)
              (catch clojure.lang.ExceptionInfo retry
                ;; The verified OpenCL generator refused as well: report both refusals as one
                ;; structured error instead of letting the second one hide the first.
@@ -778,8 +744,7 @@
                                 :kernel-body-decline (ex-data exception)
                                 :generator-refusal (ex-data retry)}
                                retry))))
-           (throw exception))))
-     operation)))
+           (throw exception))))))
 
 (defn generate-segred-kernel
   "Emit a scheduled full reduction exclusively through target-neutral KernelBody.
@@ -849,16 +814,34 @@
                   (kgraph/map-operations
                    emitted
                    (fn [node]
-                     (kart/validate!
-                      (update (:operation node) :abi
-                              (fn [slots]
-                                (mapv (fn [slot argument]
-                                        (if-let [logical-dtype
-                                                 (and (= :scalar (:kind slot))
-                                                      (get logical-dtype-by-id argument))]
-                                          (assoc slot :dtype logical-dtype)
-                                          slot))
-                                      slots (get-in node [:operation :arguments])))))))
+                     (let [artifact (:operation node)
+                           certificate (get-in artifact
+                                               [:provenance :scheduled-operation])]
+                       (if (scheduled-body/scheduled-kernel-body? certificate)
+                         (do
+                           (doseq [[slot argument] (map vector (:abi artifact)
+                                                        (:arguments artifact))
+                                   :let [logical-dtype
+                                         (and (= :scalar (:kind slot))
+                                              (get logical-dtype-by-id argument))]
+                                   :when logical-dtype]
+                             (when-not (= logical-dtype (:dtype slot))
+                               (throw (ex-info
+                                       "scheduled-body ABI disagrees with its GraphScalar"
+                                       {:reason :kernel-graph-scalar-interface
+                                        :node (:id node) :argument argument
+                                        :expected logical-dtype :actual (:dtype slot)}))))
+                           artifact)
+                         (kart/validate!
+                          (update artifact :abi
+                                  (fn [slots]
+                                    (mapv (fn [slot argument]
+                                            (if-let [logical-dtype
+                                                     (and (= :scalar (:kind slot))
+                                                          (get logical-dtype-by-id argument))]
+                                              (assoc slot :dtype logical-dtype)
+                                              slot))
+                                          slots (:arguments artifact)))))))))
                   emitted)
         scalar-pairs (->> (:nodes emitted)
                           (mapcat (fn [node]
@@ -1040,31 +1023,33 @@
   [graph {:keys [scalar-types array-types target-dialect]
           :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
   (let [target (kernel-body-c-dialect/resolve! target-dialect)
+        scalar-types (merge scalar-types
+                            (into {} (map (juxt :id :dtype)) (:scalars graph)))
         array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
          graph
          (fn [{:keys [id operation]}]
-           (kart/certify-scheduled-operation
-            (cond
-              (instance? raster.compiler.ir.segop.SegMap operation)
-              (generate-scheduled-segmap-kernel
-               operation :dtype (:dtype operation)
-               :scalar-types scalar-types :array-types array-types
-               :target-dialect target-dialect
-               :kernel-name-prefix "graph_segmap")
+           (cond
+             (instance? raster.compiler.ir.segop.SegMap operation)
+             (generate-scheduled-segmap-kernel
+              operation :dtype (:dtype operation)
+              :scalar-types scalar-types :array-types array-types
+              :target-dialect target-dialect
+              :kernel-name-prefix "graph_segmap")
 
-              (instance? raster.compiler.ir.segop.SegStencil operation)
+             (instance? raster.compiler.ir.segop.SegStencil operation)
+             (kart/certify-scheduled-operation
               (generate-segstencil-kernel-body
                operation :scalar-types scalar-types :array-types array-types
                :target-dialect target-dialect
                :kernel-name-prefix "graph_segstencil")
+              operation)
 
-              :else
-              (throw (ex-info "OpenCL elementwise graph has an unsupported scheduled node"
-                              {:reason :kernel-graph-node-target-lowering-missing
-                               :target :opencl-c :node id :operation operation})))
-            operation)))]
+             :else
+             (throw (ex-info "OpenCL elementwise graph has an unsupported scheduled node"
+                             {:reason :kernel-graph-node-target-lowering-missing
+                              :target :opencl-c :node id :operation operation})))))]
     (finalize-emitted-graph emitted (kernel-body-c-dialect/target target) scalar-types)))
 
 (declare generate-contraction-kernel-artifact)

--- a/src/raster/compiler/ir/emitted_parallel_equation.clj
+++ b/src/raster/compiler/ir/emitted_parallel_equation.clj
@@ -5,6 +5,7 @@
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.scheduled-graph-refinement :as refinement]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]))
@@ -50,9 +51,16 @@
               :emitted (graph/dataflow-contract emitted)}))
     (when-not (every? true?
                       (map (fn [scheduled-node emitted-node]
-                             (= (:operation scheduled-node)
-                                (get-in emitted-node
-                                        [:operation :provenance :scheduled-operation])))
+                             (let [certificate (get-in emitted-node
+                                                       [:operation :provenance
+                                                        :scheduled-operation])]
+                               (if (scheduled-body/scheduled-kernel-body? certificate)
+                                 (do (scheduled-body/validate-against-node!
+                                      certificate scheduled-node scheduled)
+                                     (scheduled-body/validate-artifact-projection!
+                                      certificate (:operation emitted-node))
+                                     true)
+                                 (= (:operation scheduled-node) certificate))))
                            (:nodes scheduled) (:nodes emitted)))
       (fail! :emitted-parallel-equation-operation
              "target emission changed a scheduled equation operation certificate" {}))

--- a/src/raster/compiler/ir/emitted_structured_loop.clj
+++ b/src/raster/compiler/ir/emitted_structured_loop.clj
@@ -6,6 +6,7 @@
    are bound into a StructuredLoopCall."
   (:require [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.structured-control-schedule :as schedule]))
 
 (defrecord EmittedStructuredLoop [schedule graph provenance attributes])
@@ -40,9 +41,16 @@
               :emitted (graph/dataflow-contract emitted)}))
     (when-not (every? true?
                       (map (fn [scheduled-node emitted-node]
-                             (= (:operation scheduled-node)
-                                (get-in emitted-node
-                                        [:operation :provenance :scheduled-operation])))
+                             (let [certificate (get-in emitted-node
+                                                       [:operation :provenance
+                                                        :scheduled-operation])]
+                               (if (scheduled-body/scheduled-kernel-body? certificate)
+                                 (do (scheduled-body/validate-against-node!
+                                      certificate scheduled-node (:graph scheduled))
+                                     (scheduled-body/validate-artifact-projection!
+                                      certificate (:operation emitted-node))
+                                     true)
+                                 (= (:operation scheduled-node) certificate))))
                            (:nodes (:graph scheduled)) (:nodes emitted)))
       (fail! :emitted-structured-loop-operation
              "target emission changed a scheduled loop operation certificate" {}))

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -176,8 +176,8 @@
     (or (index-expr? x) (index-cast? x)) (expression? x)
     :else (some? x)))
 
-(defn validate-typed-expression!
-  "Validate an integer expression against the logical dtype of each opaque leaf.
+(defn typed-expression-dtype
+  "Validate an integer expression and return its inferred exact integer width.
 
    `leaf-dtype` returns the public scalar dtype for a compiler value. Generic launch arithmetic
    promotes an int operand to long when needed. KernelBody IndexExpr is stricter: its operands must
@@ -227,8 +227,13 @@
                                   {:reason :kernel-launch-expression-leaf
                                    :expression expression :leaf value :dtype leaf})))
                 leaf)))]
-    (infer expression)
-    expression))
+    (infer expression)))
+
+(defn validate-typed-expression!
+  "Validate an integer expression against the logical dtype of each opaque leaf and return it."
+  [expression leaf-dtype]
+  (typed-expression-dtype expression leaf-dtype)
+  expression)
 
 (defn expression-references
   "Return the opaque compiler-value leaves read by an integer expression."

--- a/src/raster/compiler/ir/numerical_contract.clj
+++ b/src/raster/compiler/ir/numerical_contract.clj
@@ -1,0 +1,64 @@
+(ns raster.compiler.ir.numerical-contract
+  "Shared numerical attestation for verified schedule refinements.
+
+   This value is producer evidence, not an inferred floating-point proof.  Scheduling passes state
+   whether they preserve evaluation exactly, reassociate a known accumulator, or accept a named
+   error model.  IR boundaries consume the same validator so numerical policy cannot drift between
+   graph and single-kernel refinements."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(def modes #{:exact :reassociated :bounded-error})
+(def rounding-policies
+  #{:nearest-even :toward-zero :up :down :implementation-defined})
+
+(defn- canonical-dtype?
+  [value]
+  (and (dtype/known? value) (= value (dtype/canon value))))
+
+(defn- accumulator-component?
+  [component]
+  (and (map? component)
+       (some? (:value component))
+       (canonical-dtype? (:dtype component))
+       (contains? rounding-policies (:rounding component))
+       (keyword? (:policy component))))
+
+(defn- component-accumulators?
+  [contract]
+  (let [components (:accumulators contract)]
+    (and (vector? components)
+         (seq components)
+         (every? accumulator-component? components)
+         (= (count components) (count (set (map :value components)))))))
+
+(defn validate!
+  "Validate and return a numerical contract.
+
+   `context` lets an owning IR preserve its public diagnostic identity while sharing this one
+   contract."
+  ([contract] (validate! contract {}))
+  ([contract {:keys [reason ir]
+              :or {reason :numerical-contract ir :numerical-contract}}]
+   (letfn [(fail! [message data]
+             (throw (ex-info message (assoc data :reason reason :ir ir))))]
+     (when-not (and (map? contract)
+                    (contains? modes (:mode contract))
+                    (keyword? (:policy contract)))
+       (fail! "numerical contract requires a supported mode and named policy"
+              {:value contract :supported modes}))
+     (case (:mode contract)
+       :exact nil
+       :reassociated
+       (when-not (or (and (contains? rounding-policies (:rounding contract))
+                          (canonical-dtype? (:accumulator-dtype contract)))
+                     (component-accumulators? contract))
+         (fail! "reassociated numerical contract requires one accumulator or checked components"
+                {:value contract}))
+       :bounded-error
+       (when-not (and (contains? rounding-policies (:rounding contract))
+                      (canonical-dtype? (:accumulator-dtype contract))
+                      (map? (:error-model contract))
+                      (keyword? (get-in contract [:error-model :kind])))
+         (fail! "bounded-error numerical contract requires rounding, accumulator dtype, and an error model"
+                {:value contract})))
+     contract)))

--- a/src/raster/compiler/ir/scheduled_graph_refinement.clj
+++ b/src/raster/compiler/ir/scheduled_graph_refinement.clj
@@ -6,47 +6,12 @@
    producing schedule pass remains responsible for proving its algorithm-specific numerical or
    effect law before constructing the witness.  Target emission subsequently remains a strict
    one-node-to-one-artifact projection of the refined graph."
-  (:require [raster.compiler.core.dtype :as dtype]
-            [raster.compiler.ir.kernel-graph :as graph]))
+  (:require [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.numerical-contract :as numerical-contract]))
 
 (defrecord ScheduledGraphRefinement [source graph schedule numerics provenance attributes])
 
-(def ^:private numerical-modes #{:exact :reassociated :bounded-error})
-(def ^:private rounding-policies
-  #{:nearest-even :toward-zero :up :down :implementation-defined})
-
 (declare fail!)
-
-(defn- validate-numerics!
-  "Validate the refinement producer's numerical attestation.
-
-   This is intentionally not presented as an automatic floating-point proof. The producer derives
-   the attestation while establishing schedule legality; this boundary makes its policy explicit
-   and rejects unstructured claims so later proof/checking machinery has one stable seam."
-  [numerics]
-  (when-not (and (map? numerics)
-                 (contains? numerical-modes (:mode numerics))
-                 (keyword? (:policy numerics)))
-    (fail! :scheduled-graph-refinement-numerics
-           "scheduled graph refinement requires a supported numerical mode and named policy"
-           {:field :numerics :value numerics :supported numerical-modes}))
-  (case (:mode numerics)
-    :exact nil
-    :reassociated
-    (when-not (and (contains? rounding-policies (:rounding numerics))
-                   (dtype/known? (:accumulator-dtype numerics)))
-      (fail! :scheduled-graph-refinement-numerics
-             "reassociated refinement requires rounding and accumulator dtype evidence"
-             {:field :numerics :value numerics}))
-    :bounded-error
-    (when-not (and (contains? rounding-policies (:rounding numerics))
-                   (dtype/known? (:accumulator-dtype numerics))
-                   (map? (:error-model numerics))
-                   (keyword? (get-in numerics [:error-model :kind])))
-      (fail! :scheduled-graph-refinement-numerics
-             "bounded-error refinement requires rounding, accumulator dtype, and an error model"
-             {:field :numerics :value numerics})))
-  numerics)
 
 (defn scheduled-graph-refinement?
   "Recognize refinement witnesses across Typed Clojure child classloaders."
@@ -93,7 +58,9 @@
       (fail! :scheduled-graph-refinement-description
              "scheduled graph refinement requires an identified schedule"
              {:field :schedule :value schedule}))
-    (validate-numerics! numerics)
+    (numerical-contract/validate!
+     numerics {:reason :scheduled-graph-refinement-numerics
+               :ir :scheduled-graph-refinement})
     (doseq [[field value] [[:schedule schedule]
                            [:numerics numerics]
                            [:provenance provenance]

--- a/src/raster/compiler/ir/scheduled_kernel_body.clj
+++ b/src/raster/compiler/ir/scheduled_kernel_body.clj
@@ -1,0 +1,301 @@
+(ns raster.compiler.ir.scheduled-kernel-body
+  "A checked semantic-operation to target-neutral KernelBody refinement.
+
+   KernelBody fixes execution and memory structure.  ScheduledKernelBody binds that body to the
+   exact operation it implements, its ordered compiler arguments, canonical memory effects, a
+   named legality witness, and one shared numerical contract.  Target emitters consume this value;
+   they must not reconstruct any of these facts from operation names or generated source."
+  (:require [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.numerical-contract :as numerics]
+            [raster.compiler.ir.segop :as segop]))
+
+(defrecord ScheduledKernelBody
+           [source body arguments scalar-bindings effects legality numerics provenance attributes])
+
+(defn scheduled-kernel-body?
+  [value]
+  (and value
+       (= "raster.compiler.ir.scheduled_kernel_body.ScheduledKernelBody"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :scheduled-kernel-body))))
+
+(defn- record-kind? [simple-name value]
+  (= (str "raster.compiler.ir.kernel_body." simple-name)
+     (some-> value class .getName)))
+
+(defn- nested-operations [operation]
+  (cond
+    (record-kind? "IfRegion" operation)
+    (concat (:then-operations operation) (:else-operations operation))
+    (or (record-kind? "ForLoop" operation) (record-kind? "PipelinedFor" operation)
+        (record-kind? "Loop" operation) (record-kind? "Guard" operation))
+    (:operations operation)
+    :else []))
+
+(defn- body-operations [kernel-body]
+  (letfn [(walk [operations]
+            (mapcat #(cons % (walk (nested-operations %))) operations))]
+    (walk (:operations kernel-body))))
+
+(defn- parameter-access
+  [kind]
+  (case kind
+    :input :read
+    :output :write
+    :inout :read-write
+    :scalar nil))
+
+(defn derive-uses
+  "Derive the canonical ordered external memory uses from body parameters and arguments.
+
+   Reusing a compiler value in several read-only positions is harmless and collapses to one use.
+   A repeated binding involving a write is not an alias proof and is rejected here. In-place
+   access is represented by one `:inout` parameter, not split input/output parameters."
+  [kernel-body arguments]
+  (let [kernel-body (body/validate! kernel-body)]
+    (when-not (and (vector? arguments) (= (count (:parameters kernel-body)) (count arguments)))
+      (fail! :scheduled-kernel-body-arguments
+             "scheduled body arguments must align one-to-one with KernelBody parameters"
+             {:parameters (mapv :id (:parameters kernel-body)) :arguments arguments}))
+    (reduce
+     (fn [uses [parameter argument]]
+       (if-let [access (parameter-access (:kind parameter))]
+         (if-let [prior (some #(when (= argument (:value %)) %) uses)]
+           (if (and (= :read (:access prior)) (= :read access))
+             uses
+             (fail! :scheduled-kernel-body-alias
+                    "one storage value is bound to several parameters involving a write"
+                    {:argument argument :prior prior :parameter parameter :access access}))
+           (conj uses {:value argument :access access}))
+         uses))
+     [] (map vector (:parameters kernel-body) arguments))))
+
+(defn derive-scalar-bindings
+  "Derive ordered identity scalar bindings. Schedules needing a representation conversion must
+   construct and certify that conversion explicitly rather than relying on an ABI rewrite."
+  [kernel-body arguments]
+  (let [kernel-body (body/validate! kernel-body)]
+    (mapv (fn [[parameter argument]]
+            {:parameter (:id parameter)
+             :value argument
+             :dtype (:dtype parameter)
+             :kernel-dtype (:dtype parameter)
+             :conversion :identity})
+          (filter (fn [[parameter _]] (= :scalar (:kind parameter)))
+                  (map vector (:parameters kernel-body) arguments)))))
+
+(defn- validate-scalar-bindings!
+  [kernel-body arguments scalar-bindings]
+  (let [expected (derive-scalar-bindings kernel-body arguments)]
+    (when-not (= expected scalar-bindings)
+      (fail! :scheduled-kernel-body-scalar-bindings
+             "scheduled scalar bindings must explicitly preserve logical and kernel dtypes"
+             {:expected expected :actual scalar-bindings}))
+    scalar-bindings))
+
+(defn- launch-expressions
+  [launch-spec]
+  (concat (:workgroup-size launch-spec) (:group-count launch-spec)))
+
+(defn realized-launch
+  "Return the checked semantic launch after substituting ordered compiler arguments."
+  [scheduled]
+  (let [{kernel-body :body arguments :arguments} scheduled
+        kernel-body (body/validate! kernel-body)
+        parameters (:parameters kernel-body)
+        substitutions (into {} (map (fn [[parameter argument]] [(:id parameter) argument]))
+                            (map vector parameters arguments))
+        scalar-parameters (filterv #(= :scalar (:kind %)) parameters)
+        parameter-types (into {} (map (juxt :id :dtype)) scalar-parameters)
+        allowed-parameters (set (keys parameter-types))
+        body-launch (:launch kernel-body)]
+    (doseq [expression (launch-expressions body-launch)
+            reference (launch/expression-references expression)]
+      (when-not (contains? allowed-parameters reference)
+        (fail! :scheduled-kernel-body-launch-closure
+               "KernelBody launch references a non-scalar or absent parameter"
+               {:reference reference :allowed allowed-parameters :launch body-launch})))
+    (doseq [expression (launch-expressions body-launch)]
+      (launch/validate-typed-expression! expression parameter-types))
+    ;; Compiler arguments may themselves be checked graph-derived integer expressions. Their
+    ;; leaves and logical dtypes belong to the surrounding KernelGraph, so standalone validation
+    ;; proves structural substitution while `validate-against-node!` closes that context.
+    (launch/rebind-spec body-launch substitutions)))
+
+(defn validate!
+  [scheduled]
+  (when-not (scheduled-kernel-body? scheduled)
+    (fail! :scheduled-kernel-body-type "expected a ScheduledKernelBody"
+           {:actual (type scheduled)}))
+  (let [{:keys [source arguments scalar-bindings effects legality numerics provenance attributes]
+         kernel-body :body} scheduled
+        kernel-body (body/validate! kernel-body)
+        expected-uses (derive-uses kernel-body arguments)]
+    (when (nil? source)
+      (fail! :scheduled-kernel-body-source
+             "scheduled kernel body requires its exact source operation" {}))
+    (when (some nil? arguments)
+      (fail! :scheduled-kernel-body-arguments
+             "scheduled body arguments cannot contain nil compiler values"
+             {:arguments arguments}))
+    (validate-scalar-bindings! kernel-body arguments scalar-bindings)
+    (when-not (and (map? effects) (keyword? (:kind effects)))
+      (fail! :scheduled-kernel-body-effects
+             "scheduled body requires a named canonical effects map"
+             {:actual effects}))
+    (when-not (= expected-uses (:uses effects))
+      (fail! :scheduled-kernel-body-effects
+             "scheduled body memory effects differ from its ordered parameter binding"
+             {:expected expected-uses :actual (:uses effects)}))
+    (let [expected-reads (mapv :value (filter #(contains? #{:read :read-write} (:access %))
+                                              expected-uses))
+          expected-writes (mapv :value (filter #(contains? #{:write :read-write} (:access %))
+                                               expected-uses))]
+      (doseq [[field expected] [[:reads expected-reads] [:writes expected-writes]]
+              :when (contains? effects field)]
+        (when-not (= expected (get effects field))
+          (fail! :scheduled-kernel-body-effects
+                 "scheduled body carries a contradictory derived effect projection"
+                 {:field field :expected expected :actual (get effects field)}))))
+    (when-not (and (map? legality) (keyword? (:kind legality)))
+      (fail! :scheduled-kernel-body-legality
+             "scheduled kernel body requires a named legality witness"
+             {:legality legality}))
+    (numerics/validate! numerics {:reason :scheduled-kernel-body-numerics
+                                  :ir :scheduled-kernel-body})
+    (realized-launch scheduled)
+    (doseq [[field value] [[:legality legality] [:numerics numerics]
+                           [:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :scheduled-kernel-body-description
+               "scheduled body descriptions must be maps"
+               {:field field :value value})))
+    scheduled))
+
+(defn make
+  [{:keys [source body arguments scalar-bindings effects legality numerics provenance attributes]
+    :or {provenance {} attributes {}}}]
+  (let [scalar-bindings (or scalar-bindings (derive-scalar-bindings body arguments))]
+    (validate! (->ScheduledKernelBody source body arguments scalar-bindings effects legality
+                                      numerics provenance attributes))))
+
+(defn validate-against-node!
+  "Require this refinement to implement one exact node in its complete KernelGraph context."
+  [scheduled node kernel-graph]
+  (when-not (graph/scheduled-kernel? node)
+    (fail! :scheduled-kernel-body-node
+           "scheduled body graph context must be a ScheduledKernel"
+           {:actual (type node)}))
+  (let [scheduled (validate! scheduled)
+        kernel-graph (graph/validate! kernel-graph)
+        expected (into {} (map (juxt :buffer :access)) (:uses node))
+        actual (into {} (map (juxt :value :access)) (get-in scheduled [:effects :uses]))
+        scalar-types (into {} (map (juxt :id :dtype)) (:scalars kernel-graph))
+        scalar-arguments (mapv :value (:scalar-bindings scheduled))
+        actual-scalars (reduce into #{} (map launch/expression-references scalar-arguments))
+        expected-scalars (if (segop/segop-node? (:source scheduled))
+                           (segop/operation-scalars (:source scheduled))
+                           actual-scalars)]
+    (when-not (= (:source scheduled) (:operation node))
+      (fail! :scheduled-kernel-body-source
+             "scheduled body does not refine the graph node's exact operation"
+             {:node (:id node)}))
+    (when-not (= expected actual)
+      (fail! :scheduled-kernel-body-node-effects
+             "scheduled body pointer effects differ from the graph node uses"
+             {:node (:id node) :expected expected :actual actual}))
+    (when-not (= expected-scalars actual-scalars)
+      (fail! :scheduled-kernel-body-node-scalars
+             "scheduled body scalar dependencies differ from its source operation"
+             {:node (:id node) :expected expected-scalars :actual actual-scalars}))
+    (doseq [{:keys [value dtype]} (:scalar-bindings scheduled)]
+      (if (contains? #{:int :long} dtype)
+        (let [actual-dtype (launch/typed-expression-dtype value scalar-types)]
+          (when-not (= dtype actual-dtype)
+            (fail! :scheduled-kernel-body-node-scalar-dtype
+                   "scheduled integer binding requires an explicit representation conversion"
+                   {:node (:id node) :value value :expected dtype :actual actual-dtype})))
+        (when-not (= dtype (get scalar-types value))
+          (fail! :scheduled-kernel-body-node-scalar-dtype
+                 "scheduled scalar binding differs from its GraphScalar dtype"
+                 {:node (:id node) :value value :expected dtype
+                  :actual (get scalar-types value)}))))
+    scheduled))
+
+(defn validate-artifact-projection!
+  "Validate the structural projection of this exact ScheduledKernelBody into an artifact.
+
+   Target emitters remain the trusted lowering boundary for source semantics; this check proves
+   that their artifact did not change the scheduled arguments, effects, launch, body, ABI memory
+   preconditions, or identity-bearing physical facts."
+  [scheduled emitted]
+  (let [scheduled (validate! scheduled)
+        emitted (artifact/validate! emitted)
+        parameters (get-in scheduled [:body :parameters])
+        bindings (into {} (map (juxt :parameter identity)) (:scalar-bindings scheduled))
+        target-facts (get-in emitted [:attributes :target-facts])
+        pointer-alignment (:pointer-alignment target-facts)
+        expected-slots
+        (body-abi/project-contracts
+         (mapv (fn [index {:keys [id kind dtype role]}]
+                 (let [binding (get bindings id)]
+                   (abi/slot id kind (or (:dtype binding) dtype)
+                             :kernel-dtype (or (:kernel-dtype binding) dtype)
+                             :c-name (str "p" index) :role role
+                             :alignment (when (and pointer-alignment (not= :scalar kind))
+                                          pointer-alignment))))
+               (range) parameters)
+         (:body scheduled))
+        fields [:kind :dtype :kernel-dtype :role :aliasing :alignment]
+        expected-abi (mapv #(select-keys % fields) expected-slots)
+        actual-abi (mapv #(select-keys % fields) (:abi emitted))
+        matrix-instructions (->> (body-operations (:body scheduled))
+                                 (filter #(record-kind? "MatrixMad" %))
+                                 (map :instruction) distinct vec)
+        expected-target ({:opencl-intel :opencl-c :opencl-portable :opencl-c
+                          :cuda :cuda-c :hip :hip-cpp}
+                         (:target-dialect target-facts))]
+    (doseq [[field expected actual]
+            [[:certificate scheduled (get-in emitted [:provenance :scheduled-operation])]
+             [:arguments (:arguments scheduled) (:arguments emitted)]
+             [:effects (:effects scheduled) (:effects emitted)]
+             [:launch (realized-launch scheduled) (:launch emitted)]
+             [:body (:body scheduled) (get-in emitted [:attributes :kernel-body])]
+             [:abi expected-abi actual-abi]]]
+      (when-not (= expected actual)
+        (fail! :scheduled-kernel-body-artifact-projection
+               "target artifact differs from its embedded scheduled-body certificate"
+               {:field field :expected expected :actual actual})))
+    (when-not (= target-facts (get-in emitted [:provenance :target-facts]))
+      (fail! :scheduled-kernel-body-artifact-projection
+             "artifact target facts disagree across provenance and attributes"
+             {:attributes target-facts
+              :provenance (get-in emitted [:provenance :target-facts])}))
+    (when-not (= expected-target (:target emitted))
+      (fail! :scheduled-kernel-body-artifact-projection
+             "artifact target module disagrees with its target dialect fact"
+             {:target-dialect (:target-dialect target-facts)
+              :expected expected-target :actual (:target emitted)}))
+    (when (seq matrix-instructions)
+      (when-not (and (= 1 (count matrix-instructions))
+                     (= (first matrix-instructions) (:instruction target-facts))
+                     (= (get-in (first matrix-instructions) [:family])
+                        (:instruction-family target-facts)))
+        (fail! :scheduled-kernel-body-artifact-projection
+               "matrix target facts differ from the scheduled MatrixMad instruction"
+               {:instructions matrix-instructions :target-facts target-facts}))
+      (when (and (= :cuda (:target-dialect target-facts))
+                 (= :mma (:instruction-family target-facts))
+                 (not= 32 pointer-alignment))
+        (fail! :scheduled-kernel-body-artifact-projection
+               "CUDA MMA projection requires its verified pointer alignment"
+               {:required 32 :actual pointer-alignment})))
+    emitted))

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -12,6 +12,7 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
@@ -152,6 +153,17 @@
                       "portable dense map writable results may only read their lane-owned element"
                       {:operation (:id segmap) :inputs inputs :outputs outputs}))
         default-dtype (dtype/canon (or (:dtype segmap) :float))
+        bound-dtype (cond
+                      (integer? bound)
+                      (if (<= Integer/MIN_VALUE bound Integer/MAX_VALUE) :int :long)
+
+                      (or (get scalar-types bound)
+                          (get scalar-types (when (or (symbol? bound) (keyword? bound))
+                                              (symbol (name bound)))))
+                      (dtype/canon (or (get scalar-types bound)
+                                       (get scalar-types (symbol (name bound)))))
+
+                      :else :int)
         array-dtype (fn [id]
                       (dtype/canon (or (get array-types id)
                                        (get array-types (symbol (name id)))
@@ -361,7 +373,7 @@
                    outputs)
               (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
                    scalars)
-              [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))]
+              [(body/->KernelParameter '_n_bound :scalar bound-dtype [] nil nil :bound)]))]
     {:kernel-body
      (body/make
       {:id [:segmap (:id segmap) :portable-one-item]
@@ -390,9 +402,75 @@
        :launch (if sequential-effects?
                  (launch/spec {:workgroup-size [1] :group-count [1]})
                  (launch/spec {:workgroup-size [workgroup-size]
-                               :group-count [(launch/ceil-div bound workgroup-size)]}))
+                               :group-count [(launch/ceil-div '_n_bound workgroup-size)]}))
        :provenance {:dialect :kernel-body :source-dialect :segmap
                     :segop-id (:id segmap)}
        :attributes {:kind :portable-segmap :extent bound :no-write-alias true
                     :effect-iteration-order iteration-order}})
      :bound bound :inputs read-only-inputs :outputs outputs :scalars scalars}))
+
+(defn schedule
+  "Refine one SegMap into a complete, target-neutral ScheduledKernelBody.
+
+   This is the algorithm/schedule boundary. Effects, conflict legality and numerical association
+   are fixed here; a target projector may only spell the resulting body and physical ABI."
+  [segmap options]
+  (let [{:keys [kernel-body bound inputs outputs scalars]} (lower segmap options)
+        arguments (mapv (fn [parameter]
+                          (if (= '_n_bound (:id parameter)) bound (:id parameter)))
+                        (:parameters kernel-body))
+        uses (scheduled-body/derive-uses kernel-body arguments)
+        reduction-destinations
+        (into #{}
+              (keep (fn [[destination conflict]]
+                      (when (= :reduce (:kind conflict)) destination)))
+              (:write-conflicts segmap))
+        reducing? (or (= :reduce (:write-conflict segmap))
+                      (seq reduction-destinations))
+        reduction-destinations (if (and reducing? (empty? reduction-destinations))
+                                 (set outputs)
+                                 reduction-destinations)
+        reduction-parameters
+        (filterv #(contains? reduction-destinations (:id %)) (:parameters kernel-body))
+        _ (when (and reducing? (not= (count reduction-destinations)
+                                     (count reduction-parameters)))
+            (decline! :reduction-accumulator-contract
+                      "every reducing destination requires one typed KernelBody parameter"
+                      {:operation (:id segmap) :destinations reduction-destinations
+                       :parameters (mapv :id reduction-parameters)}))
+        conflict-kind (or (:write-conflict segmap)
+                          (when reducing? :mixed)
+                          :unique)]
+    (scheduled-body/make
+     {:source segmap
+      :body kernel-body
+      :arguments arguments
+      :effects {:kind (cond
+                        (= :ordered-effects (:write-conflict segmap)) :side-effect-map
+                        reducing? :reducing-scatter
+                        (:out-sym segmap) :elementwise-map
+                        :else :side-effect-map)
+                :uses uses
+                :write-conflict conflict-kind
+                :write-conflicts (:write-conflicts segmap)
+                :conflict-contract (:conflict-contract segmap)}
+      :legality {:kind :segmap-body-lowering
+                 :write-conflict conflict-kind
+                 :write-conflicts (:write-conflicts segmap)
+                 :conflict-contract (:conflict-contract segmap)}
+      :numerics (if reducing?
+                  {:mode :reassociated :policy :certified-reducing-scatter
+                   :accumulators
+                   (mapv (fn [parameter]
+                           {:value (:id parameter)
+                            :dtype (dtype/canon (:dtype parameter))
+                            :rounding :implementation-defined
+                            :policy :proof-carrying-destination})
+                         reduction-parameters)}
+                  {:mode :exact :policy :same-scalar-evaluation-order})
+      :provenance {:dialect :kernel-body :source-dialect :segmap
+                   :segop-id (:id segmap)}
+      :attributes {:array-params (vec (concat inputs outputs))
+                   :scalar-params scalars
+                   :dtype (:dtype segmap)
+                   :aliasing :no-write-alias}})))

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -153,15 +153,21 @@
                       "portable dense map writable results may only read their lane-owned element"
                       {:operation (:id segmap) :inputs inputs :outputs outputs}))
         default-dtype (dtype/canon (or (:dtype segmap) :float))
+        ;; SegSpace bounds are index-domain values.  A compatibility ParallelProgram can still
+        ;; describe a let-bound integer literal with the selected floating kernel dtype; that is
+        ;; not permission to turn the launch domain into floating-point.  Preserve an explicitly
+        ;; typed integer width, otherwise use the ordinary 32-bit index representation.
+        declared-bound-dtype
+        (some-> (or (get scalar-types bound)
+                    (get scalar-types (when (or (symbol? bound) (keyword? bound))
+                                        (symbol (name bound)))))
+                dtype/canon)
         bound-dtype (cond
                       (integer? bound)
                       (if (<= Integer/MIN_VALUE bound Integer/MAX_VALUE) :int :long)
 
-                      (or (get scalar-types bound)
-                          (get scalar-types (when (or (symbol? bound) (keyword? bound))
-                                              (symbol (name bound)))))
-                      (dtype/canon (or (get scalar-types bound)
-                                       (get scalar-types (symbol (name bound)))))
+                      (contains? #{:int :long} declared-bound-dtype)
+                      declared-bound-dtype
 
                       :else :int)
         array-dtype (fn [id]

--- a/test/raster/compiler/backend/gpu/matrix_target_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_target_test.clj
@@ -1,12 +1,14 @@
 (ns raster.compiler.backend.gpu.matrix-target-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.backend.gpu.kernel-body-target :as body-target]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-artifact :as kernel-artifact]
             [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.kernel-call :as kernel-call]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
 
 (def ^:private mma
@@ -60,10 +62,23 @@
     (is (not (re-find #"__kernel" (:source emitted))))))
 
 (deftest verified-body-owns-the-complete-target-artifact
-  (let [body (assoc (mma-body) :provenance {:scheduled-operation :body-certificate
-                                            :dialect :matrix-schedule})
-        artifact (matrix-target/emit-matrix-artifact
-                  "matrix_artifact_cuda" body :cuda
+  (let [body (-> (mma-body)
+                 (assoc :provenance {:scheduled-operation :body-certificate
+                                     :dialect :matrix-schedule})
+                 (assoc-in [:attributes :instruction-family] :mfma))
+        scheduled (scheduled-body/make
+                   {:source :body-certificate
+                    :body body
+                    :arguments ['a 'b 'c 128 128 64]
+                    :effects {:kind :tensor-contraction-stage
+                              :uses [{:value 'a :access :read}
+                                     {:value 'b :access :read}
+                                     {:value 'c :access :write}]}
+                    :legality {:kind :matrix-instruction-tiling}
+                    :numerics {:mode :reassociated :policy :tiled-contraction
+                               :rounding :nearest-even :accumulator-dtype :float}})
+        artifact (body-target/emit-artifact
+                  "matrix_artifact_cuda" scheduled :cuda
                   {:provenance {:lowering :caller-lie :target-dialect :hip}
                    :attributes {:kernel-body :caller-lie :instruction-family :mfma}})
         aligned-buffer (fn [id] {:id id :alignment 32})
@@ -92,10 +107,19 @@
            (mapv :alignment (take 3 (:abi artifact))))
         "WMMA load/store alignment is a checked call precondition")
     (is (identical? body (get-in artifact [:attributes :kernel-body])))
-    (is (= :mma (get-in artifact [:attributes :instruction-family])))
-    (is (= :matrix-kernel-body (get-in artifact [:provenance :lowering])))
+    (is (= :matrix (get-in artifact [:attributes :body-family])))
+    (is (= :scheduled-kernel-body (get-in artifact [:provenance :lowering])))
     (is (= :cuda (get-in artifact [:provenance :target-dialect])))
-    (is (= :body-certificate (get-in artifact [:provenance :scheduled-operation])))
+    (is (identical? scheduled (get-in artifact [:provenance :scheduled-operation])))
+    (is (= :mma (get-in artifact [:attributes :target-facts :instruction-family]))
+        "physical identity comes from MatrixMad, not descriptive body attributes")
+    (let [downgraded (-> artifact
+                         (update :abi #(mapv (fn [slot] (dissoc slot :alignment)) %))
+                         (assoc-in [:attributes :target-facts :pointer-alignment] nil)
+                         (assoc-in [:provenance :target-facts :pointer-alignment] nil))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"requires its verified pointer alignment"
+           (scheduled-body/validate-artifact-projection! scheduled downgraded))))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"alignment contract"
          (kernel-call/make

--- a/test/raster/compiler/ir/scheduled_kernel_body_test.clj
+++ b/test/raster/compiler/ir/scheduled_kernel_body_test.clj
@@ -1,0 +1,160 @@
+(ns raster.compiler.ir.scheduled-kernel-body-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled]))
+
+(defn- scalar-body []
+  (body/make
+   {:id :scheduled-body-test
+    :parameters [(body/->KernelParameter
+                  'x :input :float [1] :global (layout/row-major [1] :float) :operand)
+                 (body/->KernelParameter
+                  'y :output :float [1] :global (layout/row-major [1] :float) :result)]
+    :stable-reads [(body/stable-read 'x)]
+    :operations [(body/->ScalarLoad (body/value 'value :float) 'x [0] nil nil :cached)
+                 (body/->ScalarStore 'y [0] 'value nil)]
+    :schedule {:kind :one-item}
+    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+    :provenance {:dialect :test}
+    :attributes {}}))
+
+(defn- fixture []
+  (scheduled/make
+   {:source :semantic-map
+    :body (scalar-body)
+    :arguments '[input output]
+    :effects {:kind :elementwise-map
+              :uses [{:value 'input :access :read}
+                     {:value 'output :access :write}]}
+    :legality {:kind :injective-store}
+    :numerics {:mode :exact :policy :same-scalar-evaluation-order}}))
+
+(defn- reason-of [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo exception (:reason (ex-data exception)))))
+
+(deftest scheduled-body-binds-one-operation-to-one-complete-kernel-plan
+  (let [value (fixture)]
+    (is (scheduled/scheduled-kernel-body? value))
+    (is (= {:kind :elementwise-map
+            :uses [{:value 'input :access :read}
+                   {:value 'output :access :write}]}
+           (:effects value)))
+    (is (= :scheduled-kernel-body-effects
+           (reason-of #(scheduled/validate!
+                        (assoc-in value [:effects :uses]
+                                  [{:value 'input :access :read}])))))
+    (is (= :scheduled-kernel-body-source
+           (reason-of #(scheduled/validate! (assoc value :source nil)))))
+    (is (= :scheduled-kernel-body-numerics
+           (reason-of #(scheduled/validate! (assoc value :numerics {})))))
+    (is (= :scheduled-kernel-body-effects
+           (reason-of #(scheduled/validate!
+                        (assoc-in value [:effects :reads] ['output])))))))
+
+(deftest duplicate-storage-bindings-require-an-explicit-alias-schedule
+  (let [kernel-body (scalar-body)]
+    (is (= :scheduled-kernel-body-alias
+           (reason-of #(scheduled/derive-uses kernel-body
+                                               '[same-buffer same-buffer]))))))
+
+(deftest scheduled-launch-is-closed-over-typed-scalar-parameters
+  (let [pointer-launch (assoc (scalar-body) :launch
+                              (launch/spec {:workgroup-size [1]
+                                            :group-count [(launch/runtime-value 'x)]}))
+        with-bound (update (scalar-body) :parameters conj
+                           (body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound))
+        with-bound (assoc with-bound :launch
+                          (launch/spec {:workgroup-size [1]
+                                        :group-count [(launch/ceil-div '_n_bound 16)]}))
+        value (scheduled/make
+               {:source :semantic-map
+                :body with-bound
+                :arguments '[input output logical-n]
+                :effects {:kind :elementwise-map
+                          :uses [{:value 'input :access :read}
+                                 {:value 'output :access :write}]}
+                :legality {:kind :injective-store}
+                :numerics {:mode :exact :policy :same-scalar-evaluation-order}})]
+    (is (= #{'logical-n}
+           (launch/expression-references
+            (first (:group-count (scheduled/realized-launch value))))))
+    (is (= :scheduled-kernel-body-launch-closure
+           (reason-of #(scheduled/make
+                        {:source :semantic-map
+                         :body pointer-launch
+                         :arguments '[input output]
+                         :effects {:kind :elementwise-map
+                                   :uses [{:value 'input :access :read}
+                                          {:value 'output :access :write}]}
+                         :legality {:kind :injective-store}
+                         :numerics {:mode :exact
+                                    :policy :same-scalar-evaluation-order}}))))))
+
+(deftest scheduled-body-validates-against-the-exact-graph-node
+  (let [value (fixture)
+        node (graph/->ScheduledKernel
+              :node :semantic-map
+              [(graph/->ValueUse 'input :read) (graph/->ValueUse 'output :write)] [])
+        kernel-graph
+        (graph/make
+         {:inputs [(graph/buffer 'input :float 1 :global :input)]
+          :outputs [(graph/buffer 'output :float 1 :global :output)]
+          :nodes [node]})]
+    (is (identical? value (scheduled/validate-against-node! value node kernel-graph)))
+    (testing "source identity and memory effects are independent obligations"
+      (is (= :scheduled-kernel-body-source
+             (reason-of #(scheduled/validate-against-node!
+                          value (assoc node :operation :other) kernel-graph))))
+      (is (= :scheduled-kernel-body-node-effects
+             (reason-of #(scheduled/validate-against-node!
+                          value (assoc node :uses [(graph/->ValueUse 'input :read)])
+                          kernel-graph)))))))
+
+(deftest scalar-and-control-bodies-use-the-same-complete-target-projection
+  (let [scheduled (fixture)
+        emitted (target/emit-artifact "scheduled_scalar" scheduled :opencl-portable)]
+    (is (artifact/kernel-artifact? emitted))
+    (is (= :opencl-c (:target emitted)))
+    (is (= '[input output] (:arguments emitted)))
+    (is (= [:input :output] (mapv :kind (:abi emitted))))
+    (is (= :scalar-control (get-in emitted [:attributes :body-family])))
+    (is (identical? scheduled (get-in emitted [:provenance :scheduled-operation])))
+    (is (= (:effects scheduled) (:effects emitted)))
+    (is (= {:target-dialect :opencl-portable}
+           (get-in emitted [:attributes :target-facts])))
+    (is (identical? scheduled (get-in emitted [:attributes :scheduled-kernel-body])))
+    (is (re-find #"__kernel void scheduled_scalar" (:source emitted)))
+    (is (= :scheduled-kernel-body-artifact-projection
+           (reason-of #(scheduled/validate-artifact-projection!
+                        scheduled (update-in emitted [:abi 0] dissoc :aliasing))))
+        "the certificate proves stable-read ABI preconditions, not just kinds and dtypes")
+    (is (= :kernel-body-target-parameter-name
+           (reason-of #(target/emit-artifact
+                        "scheduled_scalar" scheduled :opencl-portable
+                        {:parameter-names {'x "default"}}))))))
+
+(deftest fragment-vocabulary-cannot-fall-through-the-scalar-target
+  (let [matrix {:family :dpas :m 1 :n 1 :k 1 :subgroup 1}
+        fragment-body (-> (scalar-body)
+                          (assoc :fragments
+                                 [(body/->Fragment :acc :float [1 1]
+                                                   (layout/mma-frag matrix :float))])
+                          (update :operations conj (body/->FragmentInit :acc 0.0)))
+        value (scheduled/make
+               {:source :semantic-map
+                :body fragment-body
+                :arguments '[input output]
+                :effects {:kind :elementwise-map
+                          :uses [{:value 'input :access :read}
+                                 {:value 'output :access :write}]}
+                :legality {:kind :test-fragment-routing}
+                :numerics {:mode :exact :policy :same-scalar-evaluation-order}})]
+    (is (= :kernel-body-opencl-unimplemented
+           (reason-of #(target/emit-artifact
+                        "fragment_without_mad" value :opencl-portable))))))

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-loop-call :as loop-call]
@@ -94,12 +95,32 @@
       (is (= '[u-in u-next iteration n-in alpha-in] (:arguments emitted)))
       (is (= :opencl-c (get-in emitted [:provenance :target-dialect])))
       (is (= (mapv :operation (:nodes graph))
-             (mapv #(get-in % [:operation :provenance :scheduled-operation])
+             (mapv #(get-in % [:operation :provenance :scheduled-operation :source])
                    (:nodes emitted))))
       (is (every? #(re-find #"__kernel void graph_segmap" (:source %))
                   (map :operation (:nodes emitted))))
       (is (some #(re-find #"long iteration" (:source %))
                 (map :operation (:nodes emitted))))
+      (let [certificate (get-in emitted
+                                [:nodes 0 :operation :provenance :scheduled-operation])
+            replaced (-> certificate
+                         (update :arguments
+                                 #(mapv (fn [parameter argument]
+                                          (if (= 'alpha-in (:id parameter)) 1.0 argument))
+                                        (get-in certificate [:body :parameters]) %))
+                         (update :scalar-bindings
+                                 #(mapv (fn [binding]
+                                          (if (= 'alpha-in (:value binding))
+                                            (assoc binding :value 1.0)
+                                            binding))
+                                        %)))]
+        (is (= :scheduled-kernel-body-node-scalars
+               (try
+                 (scheduled-body/validate-against-node! replaced first-node graph)
+                 nil
+                 (catch clojure.lang.ExceptionInfo exception
+                   (:reason (ex-data exception)))))
+            "a schedule cannot silently replace one required public scalar by a constant"))
       (let [call (loop-call/make
                   scheduled emitted
                   {'u0 :initial-buffer 'u-final :output-buffer}
@@ -120,10 +141,10 @@
         (testing "a copied SegOp ID cannot hide a changed operation certificate"
           (let [tampered (assoc-in emitted
                                    [:nodes 0 :operation :provenance
-                                    :scheduled-operation :grid :block-size]
+                                    :scheduled-operation :source :grid :block-size]
                                    128)]
             (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo #"operation certificate"
+                 clojure.lang.ExceptionInfo #"exact operation|operation certificate"
                  (loop-call/validate! (assoc call :graph tampered))))))
         (testing "target emission cannot change buffers or graph effects"
           (is (thrown-with-msg?

--- a/test/raster/compiler/passes/parallel/typed_gather_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_gather_test.clj
@@ -69,7 +69,7 @@
     (testing "portable GPU emission consumes the same SegMap and keeps C names hygienic"
       (is (= 1 (get-in gpu [:stats :segop-reused])))
       (is (zero? (get-in gpu [:stats :fallback])))
-      (is (= [:int :float :float :int] (mapv :dtype (:abi kernel))))
+      (is (= [:int :float :float :long] (mapv :dtype (:abi kernel))))
       (is (= :kernel-body (get-in kernel [:provenance :dialect])))
       (is (re-find #"int rstr_map_load_[0-9]+ = .*idx\[" kernel-source))
       (is (re-find #"src\[.*rstr_map_load_[0-9]+" kernel-source)

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -117,6 +117,12 @@
           (is (some #(= "IfRegion" (some-> % class .getSimpleName)) operations))
           (is (some #(= "ScalarStore" (some-> % class .getSimpleName)) operations))
           (is (some #(= "AtomicRMW" (some-> % class .getSimpleName)) operations))
+          (is (= {:mode :reassociated :policy :certified-reducing-scatter
+                  :accumulators [{:value 'total :dtype :float
+                                  :rounding :implementation-defined
+                                  :policy :proof-carrying-destination}]}
+                 (get-in artifact [:attributes :numerics]))
+              "a proof-carrying per-destination reduction is never certified as exact")
           (is (str/includes? (:source artifact) atomic)))))))
 
 (deftest analyzed-source-selects-the-same-ordered-effect-schedule

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -10,6 +10,7 @@
             [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
@@ -329,6 +330,13 @@
         "the shared producer is emitted once, not projected into both results")
     (is (= :kernel-body (get-in (first (:kernels emitted))
                                 [:attributes :emission-route])))
+    (is (identical? operation
+                    (get-in portable
+                            [:attributes :scheduled-kernel-body :source]))
+        "the real SegMap route reaches the target only through its checked body refinement")
+    (is (scheduled-body/scheduled-kernel-body?
+         (get-in portable [:provenance :scheduled-operation]))
+        "the target artifact certifies the exact schedule/body refinement, not only its source")
     (is (= [:float :float] (mapv :dtype (get-in operation [:scalar-region :locals])))
         "SegMap scheduling retains TypedSOAC local dtypes as data, not symbol metadata")
     (is (= 1 (count (re-seq #"x\[" portable-source)))

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -135,7 +135,7 @@
         (let [compiled (pipeline/compile-gpu-program
                         #'block-transfer-half-roundtrip! target :dtype :float)]
           (is (= [:map-void :map-void] (mapv :convention (:steps compiled))))
-          (is (= #{:int :half}
+          (is (= #{:int :long :half}
                  (set (mapcat #(map :dtype (:abi %)) (:steps compiled))))))))))
 
 (deftest gather-rows-resident-lowering-test
@@ -156,7 +156,7 @@
       (is (= :kernel-body (get-in step [:artifact :provenance :dialect])))
       (is (= :kernel-body (get-in step [:artifact :attributes :emission-route])))
       (is (= '[indices src out width _n_bound] (mapv :name (:abi step))))
-      (is (= [:int :float :float :int :int] (mapv :dtype (:abi step))))
+      (is (= [:int :float :float :int :long] (mapv :dtype (:abi step))))
       (is (= 'rstr_extent_0 (last (get-in step [:artifact :arguments])))
           "the schedule names the typed scalar extent instead of embedding host code")
       (is (= 15 ((:value-fn (last (:argument-specs step)))

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -94,7 +94,7 @@
     (is (= 1 (count kernels)))
     (is (= '[[positions :input :int] [x :input :float] [out :output :float]
              [head-dim :scalar :int] [heads :scalar :int] [theta :scalar :float]
-             [_n_bound :scalar :int]]
+             [_n_bound :scalar :long]]
            (mapv (juxt :name :kind :dtype) (:abi (first kernels))))
         "KernelBody orders inputs, outputs, then scalars; row count is specialized out"))
   (when (gpu-available?)

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -239,7 +239,7 @@
         "the scheduled SegMap is preserved through OpenCL emission")
     (is (= '[[aq :byte] [bq :byte] [bsums :int] [da :float] [db :float]
              [wp :int] [xp :int] [xs :float] [y :float]
-             [in :int] [out :int] [_n_bound :int]]
+             [in :int] [out :int] [_n_bound :long]]
            (mapv (juxt :name :dtype) (:abi (first projection-kernels)))))
     (is (re-find #"rstr_dp4a" (:source (first projection-kernels)))
         "Q4_K row projection reaches the target-neutral integer-dot intrinsic")
@@ -269,7 +269,7 @@
               [xs :float] [y :float] [in :int] [_n_bound :int]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) (:kernels q6-pipeline))))
     (is (= '[[[wp :int] [ws :float] [xp :int] [xs :float] [y :float]
-              [in :int] [out :int] [_n_bound :int]]]
+              [in :int] [out :int] [_n_bound :long]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) (:kernels i8-pipeline))))
     (is (every? #(re-find #"rstr_dp4a" (:source %))
                 (concat (:kernels q6-pipeline) (:kernels i8-pipeline)))


### PR DESCRIPTION
## Summary
- introduce a checked ScheduledKernelBody refinement with canonical effects, scalar bindings, launch closure, legality, and shared numerical contracts
- project scalar/control and matrix bodies through one structural target boundary and preserve exact schedule plus physical target facts
- migrate the production typed SegMap path while retaining explicit OpenCL compatibility fallback for unsupported source
- validate graph and artifact certificates, including mixed effect-map reductions and ABI memory preconditions

## Validation
- 84 focused tests, 632 assertions, 0 failures/errors
- full and vendor compile gates delegated to CircleCI

## Scope
This establishes the common projector and migrates SegMap. Production GEMM still constructs its target artifact in gpu/gemm.clj; migrating its f16 matrix stage is the next stacked slice.