### PR TITLE
Route production XMX contractions through ScheduledKernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -7,6 +7,7 @@
    the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.backend.gpu.kernel-body-target :as kernel-body-target]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
@@ -18,6 +19,8 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.matrix-stage :as matrix-stage]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
@@ -227,6 +230,32 @@
      phase {:layout :transpose :dtype :half
             :kernel-body kernel-body :cacheable-transform? true})))
 
+(defn- scheduled-matrix-body
+  "Build one canonical f16 matrix KernelBody without selecting a target spelling."
+  [{:keys [kernel-name id a b c m n k dimension-parameters tile result-dtype provenance
+           additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
+           k-range launch-group-count attributes epilogue]
+    :or {result-dtype :float provenance {}}}]
+  (contraction-schedule/matrix-body
+   {:id (or id [:gemm kernel-name])
+    :row a :col b :out c
+    :dimensions [m n k]
+    :dimension-parameters (or dimension-parameters [m n k])
+    :axis-symbols ['i 'j 'l]
+    :tile tile
+    :bindings {:row a :col b}
+    :epilogue epilogue
+    :result-dtype result-dtype
+    :additional-parameters additional-parameters
+    :additional-indices additional-indices
+    :buffer-shapes buffer-shapes
+    :buffer-views buffer-views
+    :operation-buffers operation-buffers
+    :k-range k-range
+    :launch-group-count launch-group-count
+    :attributes attributes
+    :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)}))
+
 (defn emit-scheduled-matrix-kernel
   "Build and directly lower one canonical f16 matrix contraction.
 
@@ -241,63 +270,50 @@
            k-range launch-group-count attributes parameter-names epilogue]
     :or {result-dtype :float provenance {} target-dialect :opencl-intel}}]
   (let [kernel-name (c-emit/c-symbol kernel-name)
-        kernel-body
-        (contraction-schedule/matrix-body
-         {:id (or id [:gemm kernel-name])
-          :row a :col b :out c
-          :dimensions [m n k]
-          :dimension-parameters (or dimension-parameters [m n k])
-          :axis-symbols ['i 'j 'l]
-          :tile tile
-          :bindings {:row a :col b}
-          :epilogue epilogue
-          :result-dtype result-dtype
-          :additional-parameters additional-parameters
-          :additional-indices additional-indices
-          :buffer-shapes buffer-shapes
-          :buffer-views buffer-views
-          :operation-buffers operation-buffers
-          :k-range k-range
-          :launch-group-count launch-group-count
-          :attributes attributes
-          :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})
+        kernel-body (scheduled-matrix-body
+                     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
+                      :dimension-parameters dimension-parameters :tile tile
+                      :result-dtype result-dtype :provenance provenance
+                      :additional-parameters additional-parameters
+                      :additional-indices additional-indices :buffer-shapes buffer-shapes
+                      :buffer-views buffer-views :operation-buffers operation-buffers
+                      :k-range k-range :launch-group-count launch-group-count
+                      :attributes attributes :epilogue epilogue})
         emitted (matrix-target/emit-matrix-kernel
                  kernel-name kernel-body target-dialect {:parameter-names parameter-names})]
     (assoc emitted
            :kernel-name kernel-name
            :workgroup-size (get-in kernel-body [:launch :workgroup-size]))))
 
-(defn emit-scheduled-split-k-kernel
-  "Lower a grid-Z partition of the K reduction into disjoint f32 output views."
+(defn- split-k-matrix-spec
   [{:keys [kernel-name id a b c m n k kc splits tile provenance]}]
   (let [z 'k-slice
         c-view 'split-result-view
         k-lower (kbody/expression :mul z kc)
         k-upper (kbody/expression :min (kbody/expression :add k-lower kc) k)]
-    (emit-scheduled-matrix-kernel
-     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
-      :tile tile :result-dtype :float :provenance provenance
-      :additional-parameters [(kbody/->KernelParameter kc :scalar :int [] nil nil :schedule)
-                              (kbody/->KernelParameter splits :scalar :int [] nil nil :schedule)]
-      :additional-indices [(kbody/->IndexBinding z :group 2)]
-      :buffer-shapes {c [splits m n]}
-      :buffer-views [{:id c-view :buffer c
-                      :element-offset (kbody/expression :mul z m n)
-                      :shape [m n]}]
-      :operation-buffers {c c-view}
-      :k-range [k-lower k-upper]
-      :launch-group-count [(klaunch/ceil-div (klaunch/runtime-value n) (:block-n tile))
-                           (klaunch/ceil-div (klaunch/runtime-value m) (:block-m tile))
-                           (klaunch/runtime-value splits)]
-      :attributes {:grid-z {:index z :extent splits :purpose :reduction-partition}}
-      :parameter-names {kc "KC" splits "splits"}})))
+    {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
+     :tile tile :result-dtype :float :provenance provenance
+     :additional-parameters [(kbody/->KernelParameter kc :scalar :int [] nil nil :schedule)
+                             (kbody/->KernelParameter splits :scalar :int [] nil nil :schedule)]
+     :additional-indices [(kbody/->IndexBinding z :group 2)]
+     :buffer-shapes {c [splits m n]}
+     :buffer-views [{:id c-view :buffer c
+                     :element-offset (kbody/expression :mul z m n)
+                     :shape [m n]}]
+     :operation-buffers {c c-view}
+     :k-range [k-lower k-upper]
+     :launch-group-count [(klaunch/ceil-div (klaunch/runtime-value n) (:block-n tile))
+                          (klaunch/ceil-div (klaunch/runtime-value m) (:block-m tile))
+                          (klaunch/runtime-value splits)]
+     :attributes {:grid-z {:index z :extent splits :purpose :reduction-partition}}
+     :parameter-names {kc "KC" splits "splits"}}))
 
-(defn emit-scheduled-batched-matrix-kernel
-  "Lower independent dense matrix slabs as grid-Z-selected contiguous buffer views.
+(defn emit-scheduled-split-k-kernel
+  "Lower a grid-Z partition of the K reduction into disjoint f32 output views."
+  [spec]
+  (emit-scheduled-matrix-kernel (split-k-matrix-spec spec)))
 
-   `batching` states whether each operand carries the leading batch axis.  A false entry denotes a
-   stable broadcast operand (most commonly shared model weights), so its view has zero batch
-   offset instead of materializing a repeated tensor."
+(defn- batched-matrix-spec
   [{:keys [kernel-name id a b c m n k batch tile provenance batching]
     :or {batching {:row true :col true}}}]
   (let [z 'slab
@@ -321,64 +337,98 @@
         (cond-> {c c-view}
           row-batched? (assoc a a-view)
           col-batched? (assoc b b-view))]
-    (emit-scheduled-matrix-kernel
-     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
-      :tile tile :result-dtype :float :provenance provenance
-      :additional-parameters [(kbody/->KernelParameter batch :scalar :int [] nil nil :schedule)]
-      :additional-indices [(kbody/->IndexBinding z :group 2)]
-      :buffer-shapes {a a-shape b b-shape c [batch m n]}
-      :buffer-views buffer-views
-      :operation-buffers operation-buffers
-      :launch-group-count [(klaunch/ceil-div (klaunch/runtime-value n) (:block-n tile))
-                           (klaunch/ceil-div (klaunch/runtime-value m) (:block-m tile))
-                           (klaunch/runtime-value batch)]
-      :attributes {:grid-z {:index z :extent batch :purpose :independent-slices}
-                   :batching batching}
-      :parameter-names {batch "batch"}})))
+    {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
+     :tile tile :result-dtype :float :provenance provenance
+     :additional-parameters [(kbody/->KernelParameter batch :scalar :int [] nil nil :schedule)]
+     :additional-indices [(kbody/->IndexBinding z :group 2)]
+     :buffer-shapes {a a-shape b b-shape c [batch m n]}
+     :buffer-views buffer-views
+     :operation-buffers operation-buffers
+     :launch-group-count [(klaunch/ceil-div (klaunch/runtime-value n) (:block-n tile))
+                          (klaunch/ceil-div (klaunch/runtime-value m) (:block-m tile))
+                          (klaunch/runtime-value batch)]
+     :attributes {:grid-z {:index z :extent batch :purpose :independent-slices}
+                  :batching batching}
+     :parameter-names {batch "batch"}}))
 
-(defn- kernel-epilogue-interface
-  [kernel-body]
-  (mapv
-   (fn [{:keys [id kind dtype]}]
-     [(kabi/slot id kind dtype :c-name (name id) :role :epilogue)
-      id])
-   (filterv #(= :epilogue (:role %)) (:parameters kernel-body))))
+(defn emit-scheduled-batched-matrix-kernel
+  "Lower independent dense matrix slabs as grid-Z-selected contiguous buffer views.
+
+   `batching` states whether each operand carries the leading batch axis.  A false entry denotes a
+   stable broadcast operand (most commonly shared model weights), so its view has zero batch
+   offset instead of materializing a repeated tensor."
+  [spec]
+  (emit-scheduled-matrix-kernel (batched-matrix-spec spec)))
+
+(defn- emit-scheduled-matrix-artifact
+  [{:keys [kernel-name target-dialect parameter-names argument-values source-operation phase]
+    :or {target-dialect :opencl-intel argument-values {}}
+    :as spec}]
+  (let [kernel-name (c-emit/c-symbol kernel-name)
+        kernel-body (scheduled-matrix-body spec)
+        dimension-values (get-in kernel-body [:attributes :dimension-values])
+        arguments (mapv (fn [{:keys [id role]}]
+                          (cond
+                            (contains? argument-values id) (get argument-values id)
+                            (= :dimension role) (get dimension-values id)
+                            :else id))
+                        (:parameters kernel-body))
+        uses (scheduled-body/derive-uses kernel-body arguments)
+        scheduled
+        (scheduled-body/make
+         {:source (or source-operation
+                      (throw (ex-info "matrix artifact requires its exact scheduled stage"
+                                      {:reason :matrix-stage-source :id (:id spec)
+                                       :phase phase})))
+          :body kernel-body
+          :arguments arguments
+          :effects {:kind :tensor-contraction-stage :uses uses}
+          :legality {:kind :matrix-instruction-tiling
+                     :scheduled-body (:id kernel-body)}
+          :numerics {:mode :reassociated :policy :tiled-contraction
+                     :rounding :nearest-even :accumulator-dtype :float}
+          :provenance {:semantic-op :contraction :lowering :gemm-graph :phase phase}
+          :attributes (cond-> {:strategy phase
+                               ;; Temporary compatibility projection; the body schedule is the
+                               ;; authority and target/device tests use this flattened view.
+                               :tile (:schedule kernel-body)
+                               :accumulator-dtype :float}
+                        (get-in kernel-body [:attributes :batching])
+                        (assoc :batched? true
+                               :batching (get-in kernel-body [:attributes :batching])))} )]
+    (kernel-body-target/emit-artifact
+     kernel-name scheduled target-dialect {:parameter-names parameter-names})))
 
 (defn- gemm-artifact
   [{:keys [id m n k tile epilogue]} kernel-name a b c split-k? kc splits phase]
-  (let [{:keys [block-m block-n]} tile
-        group-count (cond-> [(klaunch/ceil-div n block-n)
-                             (klaunch/ceil-div m block-m)]
-                      split-k? (conj (klaunch/runtime-value splits)))
+  (let [reduction (if split-k?
+                    (let [slice 'k-slice
+                          lower (kbody/expression :mul slice kc)]
+                      {:kind :split-k :slice slice :chunk kc :partitions splits
+                       :range [lower (kbody/expression
+                                      :min (kbody/expression :add lower kc) k)]})
+                    {:kind :full :range [0 k]})
+        stage (matrix-stage/make
+               {:id [:gemm id phase]
+                :lhs a :rhs b :result c :dimensions [m n k]
+                :reduction reduction
+                :result-shape (if split-k? [splits m n] [m n])
+                :epilogue (when-not split-k? epilogue)})
         emit-args {:kernel-name kernel-name
                    :id [:gemm id phase]
                    :a a :b b :c c :m m :n n :k k
                    :tile tile :result-dtype :float
                    :epilogue (when-not split-k? epilogue)
-                   :provenance {:operation-id id :phase phase}}
-        scheduled (if split-k?
-                    (emit-scheduled-split-k-kernel
-                     (assoc emit-args :kc :k-chunk :splits :splits))
-                    (emit-scheduled-matrix-kernel emit-args))
-        base-interface
-        (cond-> [[(kabi/slot a :input :half :c-name "A") a]
-                 [(kabi/slot b :input :half :c-name "B") b]
-                 [(kabi/slot c :output :float :c-name "C") c]
-                 [(kabi/slot m :scalar :int :c-name "M") m]
-                 [(kabi/slot n :scalar :int :c-name "N") n]
-                 [(kabi/slot k :scalar :int :c-name "K") k]]
-          split-k? (conj [(kabi/slot :k-chunk :scalar :int :c-name "KC") kc]
-                         [(kabi/slot :splits :scalar :int :c-name "splits") splits]))
-        interface (into base-interface (kernel-epilogue-interface (:kernel-body scheduled)))
-        abi (mapv first interface)
-        arguments (mapv second interface)]
-    (artifact
-     (:kernel-name scheduled) (:source scheduled)
-     abi arguments
-     (klaunch/spec {:workgroup-size (:workgroup-size scheduled)
-                    :group-count group-count})
-     phase (cond-> {:tile tile :split-k? split-k? :accumulator-dtype :float}
-             scheduled (assoc :kernel-body (:kernel-body scheduled))))))
+                   :phase phase
+                   :source-operation stage
+                   :provenance {:operation-id id :phase phase}}]
+    (emit-scheduled-matrix-artifact
+     (if split-k?
+       (assoc (split-k-matrix-spec
+               (assoc emit-args :kc :k-chunk :splits :splits))
+              :phase phase :source-operation stage
+              :argument-values {:k-chunk kc :splits splits})
+       emit-args))))
 
 (defn emit-split-k-combine-kernel
   "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
@@ -511,35 +561,24 @@
 
 (defn- batched-gemm-artifact
   [{:keys [id a b c batch m n k tile batching]}]
-  (let [{:keys [block-m block-n]} tile
-        kernel-name (str (identifier (str id "_xmx_batched")) "_contract")
-        scheduled (emit-scheduled-batched-matrix-kernel
-                   {:kernel-name kernel-name
-                    :id [:gemm id :xmx-batched]
-                    :a a :b b :c c :m m :n n :k k :batch batch :batching batching
-                    :tile tile
-                    :provenance {:operation-id id :phase :matrix-contract}})]
-    (artifact
-     (:kernel-name scheduled) (:source scheduled)
-     [(kabi/slot a :input :half :c-name "A")
-      (kabi/slot b :input :half :c-name "B")
-      (kabi/slot c :output :float :c-name "C")
-      (kabi/slot m :scalar :int :c-name "M")
-      (kabi/slot n :scalar :int :c-name "N")
-      (kabi/slot k :scalar :int :c-name "K")
-      (kabi/slot batch :scalar :int :c-name "batch")]
-     [a b c m n k batch]
-     (klaunch/spec
-      {:workgroup-size (:workgroup-size scheduled)
-       :group-count [(klaunch/ceil-div n block-n)
-                     (klaunch/ceil-div m block-m)
-                     (klaunch/runtime-value batch)]})
-     :matrix-contract
-     {:tile tile
-      :batched? true
-      :batching batching
-      :accumulator-dtype :float
-      :kernel-body (:kernel-body scheduled)})))
+  (let [kernel-name (str (identifier (str id "_xmx_batched")) "_contract")
+        stage (matrix-stage/make
+               {:id [:gemm id :xmx-batched]
+                :lhs a :rhs b :result c :dimensions [m n k]
+                :batching {:extent batch
+                           :lhs (get batching :row true)
+                           :rhs (get batching :col true)}
+                :reduction {:kind :full :range [0 k]}
+                :result-shape [batch m n]})]
+    (emit-scheduled-matrix-artifact
+     (assoc (batched-matrix-spec
+             {:kernel-name kernel-name
+              :id [:gemm id :xmx-batched]
+              :a a :b b :c c :m m :n n :k k :batch batch :batching batching
+              :tile tile
+              :provenance {:operation-id id :phase :matrix-contract}})
+            :phase :matrix-contract
+            :source-operation stage))))
 
 (defn emit-batched-matrix-alternative
   "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.

--- a/src/raster/compiler/ir/matrix_stage.clj
+++ b/src/raster/compiler/ir/matrix_stage.clj
@@ -1,0 +1,70 @@
+(ns raster.compiler.ir.matrix-stage
+  "Exact target-neutral operations introduced by matrix-contraction graph scheduling.
+
+   A MatrixStage is later than a semantic SegRed and earlier than KernelBody. It records the
+   representation, batching, reduction partition and result transform chosen for one graph node;
+   distinct direct, split-K and batched stages therefore cannot share a fabricated source
+   identity in refinement certificates."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(defrecord MatrixStage
+           [id lhs rhs result dimensions batching reduction result-shape epilogue
+            operand-dtype accumulator-dtype result-dtype])
+
+(defn matrix-stage?
+  [value]
+  (and value
+       (= "raster.compiler.ir.matrix_stage.MatrixStage" (.getName (class value)))))
+
+(defn validate!
+  [stage]
+  (when-not (matrix-stage? stage)
+    (throw (ex-info "expected a MatrixStage"
+                    {:reason :matrix-stage-type :actual (type stage)})))
+  (let [{:keys [id lhs rhs result dimensions batching reduction result-shape epilogue
+                operand-dtype accumulator-dtype result-dtype]} stage]
+    (doseq [[field value] [[:id id] [:lhs lhs] [:rhs rhs] [:result result]]]
+      (when (nil? value)
+        (throw (ex-info "matrix stage is missing an identity"
+                        {:reason :matrix-stage-identity :field field :stage stage}))))
+    (when-not (and (vector? dimensions) (= 3 (count dimensions)) (not-any? nil? dimensions))
+      (throw (ex-info "matrix stage requires exact M/N/K dimensions"
+                      {:reason :matrix-stage-dimensions :dimensions dimensions})))
+    (when-not (and (map? reduction)
+                   (contains? #{:full :split-k} (:kind reduction))
+                   (vector? (:range reduction)) (= 2 (count (:range reduction))))
+      (throw (ex-info "matrix stage requires an exact reduction partition"
+                      {:reason :matrix-stage-reduction :reduction reduction})))
+    (when (= :split-k (:kind reduction))
+      (doseq [field [:slice :chunk :partitions]]
+        (when (nil? (get reduction field))
+          (throw (ex-info "split-K matrix stage is missing partition geometry"
+                          {:reason :matrix-stage-reduction :field field
+                           :reduction reduction})))))
+    (when-not (and (vector? result-shape) (seq result-shape) (not-any? nil? result-shape))
+      (throw (ex-info "matrix stage requires its exact result shape"
+                      {:reason :matrix-stage-result-shape :result-shape result-shape})))
+    (when-not (or (nil? batching)
+                  (and (map? batching) (some? (:extent batching))
+                       (every? boolean? ((juxt :lhs :rhs) batching))))
+      (throw (ex-info "matrix stage batching must state extent and operand broadcast semantics"
+                      {:reason :matrix-stage-batching :batching batching})))
+    (when-not (or (nil? epilogue) (map? epilogue))
+      (throw (ex-info "matrix stage epilogue must be an exact transform description"
+                      {:reason :matrix-stage-epilogue :epilogue epilogue})))
+    (doseq [[field value] [[:operand-dtype operand-dtype]
+                           [:accumulator-dtype accumulator-dtype]
+                           [:result-dtype result-dtype]]]
+      (when-not (and (dtype/known? value) (= value (dtype/canon value)))
+        (throw (ex-info "matrix stage requires canonical numerical dtypes"
+                        {:reason :matrix-stage-dtype :field field :dtype value}))))
+    stage))
+
+(defn make
+  [{:keys [id lhs rhs result dimensions batching reduction result-shape epilogue
+           operand-dtype accumulator-dtype result-dtype]
+    :or {operand-dtype :half accumulator-dtype :float result-dtype :float}}]
+  (validate!
+   (->MatrixStage id lhs rhs result (vec dimensions) batching reduction (vec result-shape)
+                  epilogue (dtype/canon operand-dtype) (dtype/canon accumulator-dtype)
+                  (dtype/canon result-dtype))))

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -9,7 +9,9 @@
             [raster.compiler.ir.kernel-dispatch :as dispatch]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
-            [raster.compiler.ir.kernel-launch :as launch]))
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.matrix-stage :as matrix-stage]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
 
 (defn- matrix-contract
   [graph]
@@ -94,6 +96,8 @@
                          (:operation %))
                       (:nodes graph))
         kernel-body (artifact/attribute contract :kernel-body)
+        scheduled-contract (artifact/attribute contract :scheduled-kernel-body)
+        stage (:source scheduled-contract)
         combine-body (artifact/attribute combine :kernel-body)
         outer-loop (first (filter #(instance? raster.compiler.ir.kernel_body.Loop %)
                                   (get-in kernel-body [:operations 0 :operations])))]
@@ -106,6 +110,14 @@
                             #(graph-call/resolve-integer scalar-values %)))))
     (is (= 4 (count (:nodes graph))))
     (is (body/kernel-body? kernel-body))
+    (is (scheduled-body/scheduled-kernel-body? scheduled-contract))
+    (is (matrix-stage/matrix-stage? stage))
+    (is (= :split-k (get-in stage [:reduction :kind])))
+    (is (= [(get-in stage [:reduction :partitions]) :m :n]
+           (:result-shape stage)))
+    (is (= (:arguments scheduled-contract) (:arguments contract)))
+    (is (= (:effects scheduled-contract) (:effects contract)))
+    (is (= (scheduled-body/realized-launch scheduled-contract) (:launch contract)))
     (is (body/kernel-body? combine-body)
         "split-K combination is the portable typed contraction schedule")
     (is (= :contraction (artifact/attribute combine :semantic-op)))
@@ -120,6 +132,8 @@
         graph (dispatch/alternative (emitted :nn) :xmx-direct)
         contract (matrix-contract graph)
         kernel-body (artifact/attribute contract :kernel-body)
+        scheduled (artifact/attribute contract :scheduled-kernel-body)
+        stage (:source scheduled)
         dimensions (filter #(= :dimension (:role %)) (:parameters kernel-body))
         result (first (filter #(= :result (:role %)) (:parameters kernel-body)))
         oracle (apply opencl-codegen/emit-gemm-tiled (:kernel-name contract)
@@ -128,11 +142,52 @@
                               (select-keys tile
                                            [:block-m :block-n :sg-m :sg-n :block-k :matrix])))]
     (is (body/kernel-body? kernel-body))
+    (is (scheduled-body/scheduled-kernel-body? scheduled))
+    (is (matrix-stage/matrix-stage? stage))
+    (is (= {:kind :full :range [0 :k]} (:reduction stage)))
+    (is (= [:m :n] (:result-shape stage)))
+    (is (= (:arguments scheduled) (:arguments contract)))
+    (is (= (:effects scheduled) (:effects contract)))
     (is (= [:m :n :k] (mapv :id dimensions))
         "the body retains graph ABI identities instead of a parallel M/N/K convention")
     (is (= :float (:dtype result)))
     (is (= (:source contract) oracle)
         "direct KernelBody lowering preserves the proven f32 GEMM source exactly")))
+
+(deftest production-xmx-epilogue-is-part-of-the-certified-stage
+  (let [tile (hardware/derive-gemm-tile {})
+        epilogue {:acc 'acc
+                  :expr '(raster.numeric/*
+                          (raster.numeric/+ acc (aget bias j)) scale)
+                  :operands [{:sym 'bias :map (axis-map/of-axes [['j 'n]]) :dtype :half}]
+                  :scalars [{:sym 'scale :dtype :float}]}
+        {:keys [alternatives]}
+        (gemm/emit-matrix-alternatives
+         {:id "gemm-epilogue" :a 'a :b 'b :c 'c :m :m :n :n :k :k
+          :variant :nn :precision :mixed-f16-f32 :tile tile :fill-workgroups 32
+          :vector-width 4 :epilogue epilogue})
+        graph (first alternatives)
+        contract (matrix-contract graph)
+        scheduled (artifact/attribute contract :scheduled-kernel-body)
+        stage (:source scheduled)
+        runtime-arguments [:a-buffer :b-buffer :c-buffer
+                           {:type :int :value 16} {:type :int :value 16}
+                           {:type :int :value 16} :bias-buffer
+                           {:type :float :value 0.5}]
+        {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
+        temporary-specs (graph-call/temporary-specs graph scalar-values)
+        temporaries (into {} (map (fn [id] [id [:temporary-buffer id]]))
+                          (keys temporary-specs))
+        call (graph-call/make graph (merge buffers temporaries) scalar-values)]
+    (is (= 1 (count alternatives)) "a result transform intentionally disables split-K")
+    (is (= epilogue (:epilogue stage)))
+    (is (= '[bias scale]
+           (mapv :name (filter #(= :epilogue (:role %)) (:abi contract)))))
+    (is (= '[bias scale] (take-last 2 (:arguments contract))))
+    (is (= (:effects scheduled) (:effects contract)))
+    (is (= #{:no-write-alias}
+           (set (keep :aliasing (filter #(= :input (:kind %)) (:abi contract))))))
+    (is (graph-call/kernel-graph-call? call))))
 
 (deftest shared-direct-emission-does-not-call-the-legacy-template
   (with-redefs [opencl-codegen/emit-gemm-tiled
@@ -223,7 +278,8 @@
       (let [graph (dispatch/alternative (emitted variant) strategy)
             {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
             temporary-specs (graph-call/temporary-specs graph scalar-values)
-            temporary-buffers (zipmap (keys temporary-specs) (repeat :temporary-buffer))
+            temporary-buffers (into {} (map (fn [id] [id [:temporary-buffer id]]))
+                                    (keys temporary-specs))
             call (graph-call/make graph (merge buffers temporary-buffers) scalar-values)]
         (is (graph-call/kernel-graph-call? call) (str (name variant) "/" (name strategy)))
         (is (= (count (:nodes graph)) (count (:nodes call))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -9,6 +9,7 @@
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
+            [raster.compiler.ir.matrix-stage :as matrix-stage]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
@@ -1172,6 +1173,8 @@
         matrix-graph (kdispatch/alternative scheduled :xmx-batched)
         matrix-node (last (:nodes matrix-graph))
         matrix-body (get-in matrix-node [:operation :attributes :kernel-body])
+        scheduled-matrix (get-in matrix-node [:operation :attributes :scheduled-kernel-body])
+        matrix-stage (:source scheduled-matrix)
         buffer-views (into {} (map (juxt :id identity)) (:views matrix-body))
         select (fn [batch m n k]
                  (-> (kdispatch/select-alternative
@@ -1185,6 +1188,15 @@
     (is (= :portable-segred (select 4 64 128 62)))
     (is (= {:row true :col false}
            (get-in matrix-graph [:attributes :batching])))
+    (is (scheduled-body/scheduled-kernel-body? scheduled-matrix))
+    (is (matrix-stage/matrix-stage? matrix-stage))
+    (is (= {:extent 'batch :lhs true :rhs false} (:batching matrix-stage)))
+    (is (= '[batch m n] (:result-shape matrix-stage)))
+    (is (= (:effects scheduled-matrix) (get-in matrix-node [:operation :effects])))
+    (is (= (scheduled-body/realized-launch scheduled-matrix)
+           (get-in matrix-node [:operation :launch])))
+    (is (= (:arguments scheduled-matrix)
+           (get-in matrix-node [:operation :arguments])))
     (is (nil? (get buffer-views 'batch-rhs-view))
         "shared weights remain the original stable buffer, not a fabricated batched view")
     (is (= '[k n]


### PR DESCRIPTION
## Summary

- introduce an exact target-neutral MatrixStage operation so direct, split-K, batched, broadcast-weight, and epilogue stages have distinct certificate identities
- construct direct, split-K, and batched XMX contraction bodies from shared target-neutral specifications
- project production matrix artifacts through the verified ScheduledKernelBody target boundary
- remove duplicated ABI, launch, and effects reconstruction from production matrix graph builders
- retain body-derived compatibility metadata while keeping KernelBody as the schedule authority

## Verification

Focused GEMM, typed SOAC route, and one-tile source tests are green. Production tests cover epilogue ABI/binding/effects, split-K partition geometry, batched shared weights, realized 3-D launches, numerical contracts, and stable-read aliasing.

Independent review findings about incomplete synthetic source identity and missing production epilogue coverage were addressed.