### PR TITLE
Route every production GEMM graph stage through ScheduledKernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -19,6 +19,7 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.layout-stage :as layout-stage]
             [raster.compiler.ir.matrix-stage :as matrix-stage]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
@@ -101,17 +102,27 @@
    :reads (into [a b] (map :sym) (:operands epilogue))
    :writes [c]})
 
-(defn- artifact
-  [kernel-name source abi arguments launch phase attributes]
-  (kart/make
-   {:kernel-name kernel-name
-    :source source
-    :abi abi
-    :arguments arguments
-    :launch launch
-    :effects {:kind :tensor-contraction-stage}
-    :provenance {:semantic-op :contraction :lowering :gemm-graph :phase phase}
-    :attributes (merge {:strategy phase} attributes)}))
+(defn- emit-scheduled-body-artifact
+  [{:keys [kernel-name source body arguments effects legality numerics phase target-dialect
+           parameter-names provenance attributes]
+    :or {target-dialect :opencl-intel effects {:kind :tensor-contraction-stage}
+         provenance {} attributes {}}}]
+  (let [uses (scheduled-body/derive-uses body arguments)
+        scheduled
+        (scheduled-body/make
+         {:source source
+          :body body
+          :arguments arguments
+          :effects (assoc effects :uses uses)
+          :legality legality
+          :numerics numerics
+          :provenance (merge {:semantic-op :contraction
+                              :lowering :gemm-graph :phase phase}
+                             provenance)
+          :attributes (merge {:strategy phase} attributes)})]
+    (kernel-body-target/emit-artifact
+     (c-emit/c-symbol kernel-name) scheduled target-dialect
+     {:parameter-names parameter-names})))
 
 (defn- scalar-contraction-form
   [variant]
@@ -129,22 +140,26 @@
                                (* (aget A (+ (* l m) i))
                                   (aget B (+ (* j k) l))))))
 
+(defn- portable-scalar-matrix-plan
+  [variant]
+  (let [form (scalar-contraction-form variant)
+        facts (contraction-facts/contraction-facts form :dtype :float)
+        operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
+        planned (contraction-schedule/plan-portable-body
+                 facts operation {}
+                 {:array-types {'A :float 'B :float 'C :float}
+                  :scalar-types {'m :int 'n :int 'k :int}})]
+    (when-not (:ok planned)
+      (throw (ex-info "matrix product did not admit the portable contraction schedule"
+                      {:reason :raster/bug :variant variant :plan planned})))
+    {:operation operation :body (:body planned) :plan planned}))
+
 (defn emit-portable-scalar-matrix-kernel
   "Lower a dynamic f32 NN/NT/TN/TT matrix product through the portable contraction schedule."
   ([kernel-name variant]
    (emit-portable-scalar-matrix-kernel kernel-name variant :opencl-intel))
   ([kernel-name variant target-dialect]
-   (let [form (scalar-contraction-form variant)
-         facts (contraction-facts/contraction-facts form :dtype :float)
-         operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
-         planned (contraction-schedule/plan-portable-body
-                  facts operation {}
-                  {:array-types {'A :float 'B :float 'C :float}
-                   :scalar-types {'m :int 'n :int 'k :int}})
-         _ (when-not (:ok planned)
-             (throw (ex-info "matrix product did not admit the portable contraction schedule"
-                             {:reason :raster/bug :variant variant :plan planned})))
-         kernel-body (:body planned)]
+   (let [kernel-body (:body (portable-scalar-matrix-plan variant))]
      {:source
       (kernel-body-opencl/emit-scalar-kernel
        kernel-name kernel-body
@@ -160,24 +175,18 @@
         {:keys [a-elements b-elements c-elements]} (extents spec)
         prefix (identifier (str id "_scalar"))
         kernel-name (str prefix "_gemm")
-        emitted (emit-portable-scalar-matrix-kernel kernel-name variant)
-        gemm (artifact
-              kernel-name
-              (:source emitted)
-              [(kabi/slot 'A :input :float :c-name "A" :role :operand
-                          :aliasing :no-write-alias)
-               (kabi/slot 'B :input :float :c-name "B" :role :operand
-                          :aliasing :no-write-alias)
-               (kabi/slot 'C :output :float :c-name "C" :role :result)
-               (kabi/slot 'k :scalar :int :c-name "k" :role :extent)
-               (kabi/slot 'm :scalar :int :c-name "m" :role :extent)
-               (kabi/slot 'n :scalar :int :c-name "n" :role :extent)
-               (kabi/slot '_nseg :scalar :int :c-name "_nseg" :role :bound)]
-              [a b c k m n c-elements]
-              (klaunch/spec {:workgroup-size [256]
-                             :group-count [(klaunch/ceil-div c-elements 256)]})
-              :scalar-gemm {:variant variant :kernel-body (:kernel-body emitted)
-                            :semantic-op :contraction})]
+        {:keys [operation body]} (portable-scalar-matrix-plan variant)
+        gemm (emit-scheduled-body-artifact
+              {:kernel-name kernel-name :source operation :body body
+               :arguments [a b c k m n c-elements]
+               :effects {:kind :tensor-contraction-stage}
+               :legality {:kind :portable-contraction :variant variant}
+               :numerics {:mode :reassociated :policy :sequential-segment-fold
+                          :rounding :nearest-even :accumulator-dtype :float}
+               :phase :scalar-gemm
+               :attributes {:variant variant :semantic-op :contraction}
+               :parameter-names {'A "A" 'B "B" 'C "C" 'k "k" 'm "m" 'n "n"
+                                 '_nseg "_nseg"}})]
     (kgraph/make
      {:inputs [(graph-buffer a :float a-elements :input)
                (graph-buffer b :float b-elements :input)]
@@ -192,43 +201,51 @@
 (defn- convert-artifact
   [kernel-name in out elements vector-width phase]
   (let [kernel-name (c-emit/c-symbol kernel-name)
-        {:keys [source kernel-body]}
-        (layout-emitter/emit-cast-kernel
+        kernel-body
+        (layout-emitter/cast-body
          {:kernel-name kernel-name :input in :output out
           :source-dtype :float :destination-dtype :half :vector-width vector-width
           :rounding :nearest-even :overflow :ieee})]
-    (artifact
-     kernel-name source
-     [(kabi/slot in :input :float :c-name "in")
-      (kabi/slot out :output :half :c-name "out")
-      (kabi/slot :layout-elements :scalar :int :c-name "n")]
-     [in out elements]
-     (klaunch/spec
-      {:workgroup-size [256]
-       :group-count [(klaunch/ceil-div
-                      (klaunch/ceil-div (klaunch/runtime-value elements) vector-width)
-                      256)]})
-     phase {:vector-width vector-width :from :float :to :half
-            :rounding :nearest-even :overflow :ieee
-            :kernel-body kernel-body :cacheable-transform? true})))
+    (emit-scheduled-body-artifact
+     {:kernel-name kernel-name
+      :source (layout-stage/make
+               {:id [:gemm phase] :operation :cast :input in :output out
+                :input-shape [elements] :output-shape [elements]
+                :input-dtype :float :output-dtype :half
+                :policy {:rounding :nearest-even :overflow :ieee}})
+      :body kernel-body :arguments [in out elements]
+      :effects {:kind :layout-transform-stage}
+      :legality {:kind :dense-affine-cast :vector-width vector-width}
+      :numerics {:mode :bounded-error :policy :f32-to-f16-storage
+                 :rounding :nearest-even :accumulator-dtype :half
+                 :error-model {:kind :ieee-f16-conversion :overflow :ieee}}
+      :phase phase
+      :attributes {:vector-width vector-width :from :float :to :half
+                   :rounding :nearest-even :overflow :ieee
+                   :cacheable-transform? true}
+      :parameter-names {in "input" out "output" :layout-elements "n"}})))
 
 (defn- transpose-artifact
   [kernel-name in out rows cols phase]
   (let [kernel-name (c-emit/c-symbol kernel-name)
-        {:keys [source kernel-body]}
-        (layout-emitter/emit-transpose-kernel
+        kernel-body
+        (layout-emitter/transpose-body
          {:kernel-name kernel-name :input in :output out :element-dtype :half})]
-    (artifact
-     kernel-name source
-     [(kabi/slot in :input :half :c-name "in")
-      (kabi/slot out :output :half :c-name "out")
-      (kabi/slot :layout-rows :scalar :int :c-name "rows")
-      (kabi/slot :layout-cols :scalar :int :c-name "cols")]
-     [in out rows cols]
-     (klaunch/spec {:workgroup-size [256]
-                    :group-count [(klaunch/ceil-div (klaunch/product rows cols) 256)]})
-     phase {:layout :transpose :dtype :half
-            :kernel-body kernel-body :cacheable-transform? true})))
+    (emit-scheduled-body-artifact
+     {:kernel-name kernel-name
+      :source (layout-stage/make
+               {:id [:gemm phase] :operation :transpose :input in :output out
+                :input-shape [rows cols] :output-shape [cols rows]
+                :input-dtype :half :output-dtype :half
+                :policy {:permutation [1 0]}})
+      :body kernel-body :arguments [in out rows cols]
+      :effects {:kind :layout-transform-stage}
+      :legality {:kind :bijective-affine-permutation :permutation [1 0]}
+      :numerics {:mode :exact :policy :bit-preserving-permutation}
+      :phase phase
+      :attributes {:layout :transpose :dtype :half :cacheable-transform? true}
+      :parameter-names {in "input" out "output"
+                        :layout-rows "rows" :layout-cols "cols"}})))
 
 (defn- scheduled-matrix-body
   "Build one canonical f16 matrix KernelBody without selecting a target spelling."
@@ -430,14 +447,11 @@
               :argument-values {:k-chunk kc :splits splits})
        emit-args))))
 
-(defn emit-split-k-combine-kernel
-  "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
-  ([kernel-name] (emit-split-k-combine-kernel kernel-name :opencl-intel))
-  ([kernel-name target-dialect]
-   (let [kernel-name (c-emit/c-symbol kernel-name)
-         form '(raster.par/contract C [[i mn]] [[s splits]]
-                                     (clojure.core/aget
-                                      partials (clojure.core/+ (clojure.core/* s mn) i)))
+(defn- split-k-combine-plan
+  []
+  (let [form '(raster.par/contract C [[i mn]] [[s splits]]
+                                   (clojure.core/aget
+                                    partials (clojure.core/+ (clojure.core/* s mn) i)))
         facts (contraction-facts/contraction-facts form :dtype :float)
         operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
         planned (contraction-schedule/plan-portable-body
@@ -446,10 +460,17 @@
                   :scalar-types {'mn :int 'splits :int}})
         _ (when-not (:ok planned)
             (throw (ex-info "split-K combination did not admit the portable contraction schedule"
-                            {:reason :raster/bug :plan planned})))
-        kernel-body (:body planned)
-        source (kernel-body-opencl/emit-scalar-kernel
-                kernel-name kernel-body
+                            {:reason :raster/bug :plan planned})))]
+    {:operation operation :body (:body planned) :plan planned}))
+
+(defn emit-split-k-combine-kernel
+  "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
+  ([kernel-name] (emit-split-k-combine-kernel kernel-name :opencl-intel))
+  ([kernel-name target-dialect]
+   (let [kernel-name (c-emit/c-symbol kernel-name)
+         kernel-body (:body (split-k-combine-plan))
+         source (kernel-body-opencl/emit-scalar-kernel
+                 kernel-name kernel-body
                 {:target-dialect target-dialect
                  :parameter-names {'partials "partials" 'C "C"
                                    'mn "mn" 'splits "splits" '_nseg "_nseg"}})]
@@ -457,20 +478,18 @@
 
 (defn- combine-artifact
   [kernel-name partials c mn splits]
-  (let [{:keys [kernel-name source kernel-body]} (emit-split-k-combine-kernel kernel-name)]
-    (artifact
-     kernel-name source
-     [(kabi/slot 'partials :input :float :c-name "partials" :role :operand
-                 :aliasing :no-write-alias)
-      (kabi/slot 'C :output :float :c-name "C" :role :result)
-      (kabi/slot 'mn :scalar :int :c-name "mn" :role :extent)
-      (kabi/slot 'splits :scalar :int :c-name "splits" :role :extent)
-      (kabi/slot '_nseg :scalar :int :c-name "_nseg" :role :bound)]
-     [partials c mn splits mn]
-     (klaunch/spec {:workgroup-size [256]
-                    :group-count [(klaunch/ceil-div (klaunch/runtime-value mn) 256)]})
-     :split-k-combine {:accumulator-dtype :float :kernel-body kernel-body
-                       :semantic-op :contraction})))
+  (let [{:keys [operation body]} (split-k-combine-plan)]
+    (emit-scheduled-body-artifact
+     {:kernel-name kernel-name :source operation :body body
+      :arguments [partials c mn splits mn]
+      :effects {:kind :tensor-contraction-stage}
+      :legality {:kind :portable-contraction :purpose :split-k-combine}
+      :numerics {:mode :reassociated :policy :sequential-segment-fold
+                 :rounding :nearest-even :accumulator-dtype :float}
+      :phase :split-k-combine
+      :attributes {:accumulator-dtype :float :semantic-op :contraction}
+      :parameter-names {'partials "partials" 'C "C"
+                        'mn "mn" 'splits "splits" '_nseg "_nseg"}})))
 
 (defn split-factor-strategy
   "Stable strategy identity for one explicit split-K candidate."

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -141,10 +141,11 @@
                                   (aget B (+ (* j k) l))))))
 
 (defn- portable-scalar-matrix-plan
-  [variant]
+  [variant stage-id]
   (let [form (scalar-contraction-form variant)
         facts (contraction-facts/contraction-facts form :dtype :float)
-        operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
+        operation (contract-lower/contract-form->segred
+                   form :id stage-id :dtype :float :facts facts)
         planned (contraction-schedule/plan-portable-body
                  facts operation {}
                  {:array-types {'A :float 'B :float 'C :float}
@@ -159,7 +160,8 @@
   ([kernel-name variant]
    (emit-portable-scalar-matrix-kernel kernel-name variant :opencl-intel))
   ([kernel-name variant target-dialect]
-   (let [kernel-body (:body (portable-scalar-matrix-plan variant))]
+   (let [kernel-body (:body (portable-scalar-matrix-plan
+                             variant [:direct-gemm kernel-name]))]
      {:source
       (kernel-body-opencl/emit-scalar-kernel
        kernel-name kernel-body
@@ -175,7 +177,8 @@
         {:keys [a-elements b-elements c-elements]} (extents spec)
         prefix (identifier (str id "_scalar"))
         kernel-name (str prefix "_gemm")
-        {:keys [operation body]} (portable-scalar-matrix-plan variant)
+        stage-id [:gemm id :f32-scalar :contract]
+        {:keys [operation body]} (portable-scalar-matrix-plan variant stage-id)
         gemm (emit-scheduled-body-artifact
               {:kernel-name kernel-name :source operation :body body
                :arguments [a b c k m n c-elements]
@@ -191,7 +194,7 @@
      {:inputs [(graph-buffer a :float a-elements :input)
                (graph-buffer b :float b-elements :input)]
       :outputs [(graph-buffer c :float c-elements :output)]
-      :nodes [(node [:gemm id :scalar] gemm
+      :nodes [(node stage-id gemm
                     [(value-use a :read) (value-use b :read) (value-use c :write)] [])]
       :abi abi :arguments arguments
       :effects (effects spec)
@@ -199,7 +202,7 @@
       :attributes {:strategy :f32-scalar :variant variant :precision :f32}})))
 
 (defn- convert-artifact
-  [kernel-name in out elements vector-width phase]
+  [kernel-name stage-id in out elements vector-width phase]
   (let [kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/cast-body
@@ -209,7 +212,7 @@
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
       :source (layout-stage/make
-               {:id [:gemm phase] :operation :cast :input in :output out
+               {:id stage-id :operation :cast :input in :output out
                 :input-shape [elements] :output-shape [elements]
                 :input-dtype :float :output-dtype :half
                 :policy {:rounding :nearest-even :overflow :ieee}})
@@ -226,7 +229,7 @@
       :parameter-names {in "input" out "output" :layout-elements "n"}})))
 
 (defn- transpose-artifact
-  [kernel-name in out rows cols phase]
+  [kernel-name stage-id in out rows cols phase]
   (let [kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/transpose-body
@@ -234,7 +237,7 @@
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
       :source (layout-stage/make
-               {:id [:gemm phase] :operation :transpose :input in :output out
+               {:id stage-id :operation :transpose :input in :output out
                 :input-shape [rows cols] :output-shape [cols rows]
                 :input-dtype :half :output-dtype :half
                 :policy {:permutation [1 0]}})
@@ -402,8 +405,14 @@
           :effects {:kind :tensor-contraction-stage :uses uses}
           :legality {:kind :matrix-instruction-tiling
                      :scheduled-body (:id kernel-body)}
-          :numerics {:mode :reassociated :policy :tiled-contraction
-                     :rounding :nearest-even :accumulator-dtype :float}
+          :numerics (cond-> {:mode :reassociated :policy :tiled-contraction
+                             :rounding :nearest-even :accumulator-dtype :float}
+                      (seq (:epilogue source-operation))
+                      (assoc :result-transform
+                             {:kind :typed-scalar-region
+                              :policy :same-typed-ssa-evaluation-order
+                              :input-dtype :float
+                              :result-dtype (:result-dtype source-operation)}))
           :provenance {:semantic-op :contraction :lowering :gemm-graph :phase phase}
           :attributes (cond-> {:strategy phase
                                ;; Temporary compatibility projection; the body schedule is the
@@ -417,7 +426,7 @@
      kernel-name scheduled target-dialect {:parameter-names parameter-names})))
 
 (defn- gemm-artifact
-  [{:keys [id m n k tile epilogue]} kernel-name a b c split-k? kc splits phase]
+  [{:keys [id m n k tile epilogue]} stage-id kernel-name a b c split-k? kc splits phase]
   (let [reduction (if split-k?
                     (let [slice 'k-slice
                           lower (kbody/expression :mul slice kc)]
@@ -426,13 +435,13 @@
                                       :min (kbody/expression :add lower kc) k)]})
                     {:kind :full :range [0 k]})
         stage (matrix-stage/make
-               {:id [:gemm id phase]
+               {:id stage-id
                 :lhs a :rhs b :result c :dimensions [m n k]
                 :reduction reduction
                 :result-shape (if split-k? [splits m n] [m n])
                 :epilogue (when-not split-k? epilogue)})
         emit-args {:kernel-name kernel-name
-                   :id [:gemm id phase]
+                   :id stage-id
                    :a a :b b :c c :m m :n n :k k
                    :tile tile :result-dtype :float
                    :epilogue (when-not split-k? epilogue)
@@ -448,12 +457,13 @@
        emit-args))))
 
 (defn- split-k-combine-plan
-  []
+  [stage-id]
   (let [form '(raster.par/contract C [[i mn]] [[s splits]]
                                    (clojure.core/aget
                                     partials (clojure.core/+ (clojure.core/* s mn) i)))
         facts (contraction-facts/contraction-facts form :dtype :float)
-        operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
+        operation (contract-lower/contract-form->segred
+                   form :id stage-id :dtype :float :facts facts)
         planned (contraction-schedule/plan-portable-body
                  facts operation {}
                  {:array-types {'partials :float 'C :float}
@@ -468,7 +478,7 @@
   ([kernel-name] (emit-split-k-combine-kernel kernel-name :opencl-intel))
   ([kernel-name target-dialect]
    (let [kernel-name (c-emit/c-symbol kernel-name)
-         kernel-body (:body (split-k-combine-plan))
+         kernel-body (:body (split-k-combine-plan [:direct-split-k-combine kernel-name]))
          source (kernel-body-opencl/emit-scalar-kernel
                  kernel-name kernel-body
                 {:target-dialect target-dialect
@@ -477,8 +487,8 @@
      {:kernel-name kernel-name :source source :kernel-body kernel-body :workgroup-size 256})))
 
 (defn- combine-artifact
-  [kernel-name partials c mn splits]
-  (let [{:keys [operation body]} (split-k-combine-plan)]
+  [kernel-name stage-id partials c mn splits]
+  (let [{:keys [operation body]} (split-k-combine-plan stage-id)]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name :source operation :body body
       :arguments [partials c mn splits mn]
@@ -524,21 +534,28 @@
         transpose-a-id [:gemm id strategy :transpose-a]
         transpose-b-id [:gemm id strategy :transpose-b]
         contract-id [:gemm id strategy :contract]
-        convert-a (convert-artifact (str prefix "_convert_a") a a16 a-elements vector-width
+        convert-a (convert-artifact (str prefix "_convert_a") convert-a-id
+                                    a a16 a-elements vector-width
                                     :convert-a)
-        convert-b (convert-artifact (str prefix "_convert_b") b b16 b-elements vector-width
+        convert-b (convert-artifact (str prefix "_convert_b") convert-b-id
+                                    b b16 b-elements vector-width
                                     :convert-b)
         transpose-a (when (contains? #{:tn :tt} variant)
-                      (transpose-artifact (str prefix "_transpose_a") a16 at16 k m
+                      (transpose-artifact (str prefix "_transpose_a") transpose-a-id
+                                          a16 at16 k m
                                           :transpose-a))
         transpose-b (when (contains? #{:nt :tt} variant)
-                      (transpose-artifact (str prefix "_transpose_b") b16 bt16 n k
+                      (transpose-artifact (str prefix "_transpose_b") transpose-b-id
+                                          b16 bt16 n k
                                           :transpose-b))
         contract-output (if split-k? partials c)
-        contract (gemm-artifact spec (str prefix "_contract") final-a final-b contract-output
+        contract (gemm-artifact spec contract-id (str prefix "_contract")
+                                final-a final-b contract-output
                                 split-k? kc splits :matrix-contract)
         combine (when split-k?
-                  (combine-artifact (str prefix "_combine") partials c c-elements splits))
+                  (combine-artifact (str prefix "_combine")
+                                    [:gemm id strategy :combine]
+                                    partials c c-elements splits))
         nodes (cond->
                [(node convert-a-id convert-a [(value-use a :read) (value-use a16 :write)] [])
                 (node convert-b-id convert-b [(value-use b :read) (value-use b16 :write)] [])]
@@ -582,7 +599,7 @@
   [{:keys [id a b c batch m n k tile batching]}]
   (let [kernel-name (str (identifier (str id "_xmx_batched")) "_contract")
         stage (matrix-stage/make
-               {:id [:gemm id :xmx-batched]
+               {:id [:gemm id :xmx-batched :contract]
                 :lhs a :rhs b :result c :dimensions [m n k]
                 :batching {:extent batch
                            :lhs (get batching :row true)
@@ -633,9 +650,11 @@
         convert-a-id [:gemm id :xmx-batched :convert-a]
         convert-b-id [:gemm id :xmx-batched :convert-b]
         contract-id [:gemm id :xmx-batched :contract]
-        convert-a (convert-artifact (str prefix "_convert_a") a a16 a-elements vector-width
+        convert-a (convert-artifact (str prefix "_convert_a") convert-a-id
+                                    a a16 a-elements vector-width
                                     :convert-a)
-        convert-b (convert-artifact (str prefix "_convert_b") b b16 b-elements vector-width
+        convert-b (convert-artifact (str prefix "_convert_b") convert-b-id
+                                    b b16 b-elements vector-width
                                     :convert-b)
         contract (batched-gemm-artifact
                   (assoc spec :a a16 :b b16 :c c :batching batching))

--- a/src/raster/compiler/backend/gpu/layout_transform.clj
+++ b/src/raster/compiler/backend/gpu/layout_transform.clj
@@ -3,16 +3,33 @@
   (:require [raster.compiler.backend.gpu.kernel-body-opencl :as emitter]
             [raster.compiler.passes.parallel.layout-transform-schedule :as schedule]))
 
+(defn cast-body
+  "Build the target-neutral body for one dense representation conversion."
+  [{:keys [kernel-name input output source-dtype destination-dtype vector-width rounding overflow]
+    :or {vector-width 1}}]
+  (schedule/cast-body
+   {:id [:layout-transform kernel-name]
+    :input input :output output
+    :source-dtype source-dtype :destination-dtype destination-dtype
+    :vector-width vector-width
+    :rounding rounding :overflow overflow}))
+
+(defn transpose-body
+  "Build the target-neutral body for one dense row-major matrix transpose."
+  [{:keys [kernel-name input output element-dtype]}]
+  (schedule/transpose-body
+   {:id [:layout-transform kernel-name]
+    :input input :output output
+    :element-dtype element-dtype}))
+
 (defn emit-cast-kernel
   [{:keys [kernel-name input output source-dtype destination-dtype vector-width rounding overflow
            target-dialect]
     :or {vector-width 1 target-dialect :opencl-intel}}]
-  (let [kernel-body (schedule/cast-body
-                     {:id [:layout-transform kernel-name]
-                      :input input :output output
+  (let [kernel-body (cast-body
+                     {:kernel-name kernel-name :input input :output output
                       :source-dtype source-dtype :destination-dtype destination-dtype
-                      :vector-width vector-width
-                      :rounding rounding :overflow overflow})]
+                      :vector-width vector-width :rounding rounding :overflow overflow})]
     {:source (emitter/emit-scalar-kernel
               kernel-name kernel-body
               {:target-dialect target-dialect
@@ -22,9 +39,8 @@
 (defn emit-transpose-kernel
   [{:keys [kernel-name input output element-dtype target-dialect]
     :or {target-dialect :opencl-intel}}]
-  (let [kernel-body (schedule/transpose-body
-                     {:id [:layout-transform kernel-name]
-                      :input input :output output
+  (let [kernel-body (transpose-body
+                     {:kernel-name kernel-name :input input :output output
                       :element-dtype element-dtype})]
     {:source (emitter/emit-scalar-kernel
               kernel-name kernel-body

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -10,7 +10,8 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
-            [raster.compiler.ir.kernel-launch :as launch]))
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.numerical-contract :as numerics]))
 
 (defrecord KernelParameter [id kind dtype shape memory-space layout role])
 (defrecord BufferView [id buffer element-offset shape layout])
@@ -75,8 +76,6 @@
 (def ^:private cache-policies #{:default :cached :streaming})
 (def ^:private internal-types #{:predicate})
 (def ^:private special-scalar-ops #{:cast :select :isnan})
-(def ^:private cast-rounding-policies #{:toward-zero :nearest-even :up :down :exact})
-(def ^:private cast-overflow-policies #{:wrap :saturate :trap :exact :ieee})
 (def ^:private arithmetic-overflow-policies #{:wrap :trap :no-overflow})
 (def ^:private collective-kinds #{:reduce :broadcast})
 (def ^:private workgroup-memory-spaces #{:workgroup})
@@ -222,7 +221,7 @@
     (or (integer? value) (value-id? value)) true
     (record-kind? "raster.compiler.ir.kernel_body.IndexCast" value)
     (and (contains? #{:int :long} (dtype/canon (:dtype value)))
-         (contains? cast-overflow-policies (:overflow value))
+         (numerics/cast-overflow-policy? (:overflow value))
          (expression? (:argument value)))
     (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
     (and (contains? index-ops (:op value))
@@ -1058,8 +1057,8 @@
         (when-not (= #{:rounding :overflow} (set (keys options)))
           (throw (ex-info "scalar cast must state exactly its rounding and overflow policies"
                           {:reason :kernel-body-cast-policy :options options})))
-        (when-not (and (contains? cast-rounding-policies (:rounding options))
-                       (contains? cast-overflow-policies (:overflow options)))
+        (when-not (and (numerics/rounding-policy? (:rounding options))
+                       (numerics/cast-overflow-policy? (:overflow options)))
           (throw (ex-info "scalar cast has an unsupported numerical policy"
                           {:reason :kernel-body-cast-policy :options options})))
         (when (or (= :predicate result-type) (= :predicate (:type (first infos))))
@@ -1180,7 +1179,7 @@
         (throw (ex-info "index conversion target must be integral"
                         {:reason :kernel-body-index-cast-dtype
                          :expression expression :target target})))
-      (when-not (contains? cast-overflow-policies (:overflow expression))
+      (when-not (numerics/cast-overflow-policy? (:overflow expression))
         (throw (ex-info "index conversion requires an explicit overflow policy"
                         {:reason :kernel-body-index-cast-overflow
                          :expression expression :overflow (:overflow expression)})))

--- a/src/raster/compiler/ir/layout_stage.clj
+++ b/src/raster/compiler/ir/layout_stage.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.ir.layout-stage
   "Exact target-neutral representation operations inserted into scheduled kernel graphs."
-  (:require [raster.compiler.core.dtype :as dtype]))
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.numerical-contract :as numerics]))
 
 (defrecord LayoutStage
            [id operation input output input-shape output-shape input-dtype output-dtype policy])
@@ -37,14 +38,29 @@
                       {:reason :layout-stage-policy :policy policy})))
     (case operation
       :cast
-      (when-not (every? #(contains? policy %) [:rounding :overflow])
-        (throw (ex-info "layout cast requires rounding and overflow semantics"
-                        {:reason :layout-stage-policy :policy policy})))
+      (do
+        (when-not (= input-shape output-shape)
+          (throw (ex-info "layout cast must preserve its logical shape"
+                          {:reason :layout-stage-shape
+                           :input-shape input-shape :output-shape output-shape})))
+        (when-not (and (numerics/rounding-policy? (:rounding policy))
+                       (numerics/cast-overflow-policy? (:overflow policy)))
+          (throw (ex-info "layout cast requires supported rounding and overflow semantics"
+                          {:reason :layout-stage-policy :policy policy}))))
 
       :transpose
-      (when-not (= [1 0] (:permutation policy))
-        (throw (ex-info "matrix transpose stage requires the [1 0] permutation"
-                        {:reason :layout-stage-policy :policy policy}))))
+      (do
+        (when-not (and (= [1 0] (:permutation policy))
+                       (= 2 (count input-shape))
+                       (= (vec (reverse input-shape)) output-shape))
+          (throw (ex-info "matrix transpose stage requires a rank-2 reversed shape"
+                          {:reason :layout-stage-shape
+                           :input-shape input-shape :output-shape output-shape
+                           :policy policy})))
+        (when-not (= input-dtype output-dtype)
+          (throw (ex-info "layout transpose must preserve its storage dtype"
+                          {:reason :layout-stage-dtype
+                           :input-dtype input-dtype :output-dtype output-dtype})))))
     stage))
 
 (defn make

--- a/src/raster/compiler/ir/layout_stage.clj
+++ b/src/raster/compiler/ir/layout_stage.clj
@@ -1,0 +1,55 @@
+(ns raster.compiler.ir.layout-stage
+  "Exact target-neutral representation operations inserted into scheduled kernel graphs."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(defrecord LayoutStage
+           [id operation input output input-shape output-shape input-dtype output-dtype policy])
+
+(defn layout-stage?
+  [value]
+  (and value
+       (= "raster.compiler.ir.layout_stage.LayoutStage" (.getName (class value)))))
+
+(defn validate!
+  [stage]
+  (when-not (layout-stage? stage)
+    (throw (ex-info "expected a LayoutStage"
+                    {:reason :layout-stage-type :actual (type stage)})))
+  (let [{:keys [id operation input output input-shape output-shape
+                input-dtype output-dtype policy]} stage]
+    (doseq [[field value] [[:id id] [:input input] [:output output]]]
+      (when (nil? value)
+        (throw (ex-info "layout stage is missing an identity"
+                        {:reason :layout-stage-identity :field field :stage stage}))))
+    (when-not (contains? #{:cast :transpose} operation)
+      (throw (ex-info "layout stage has an unsupported operation"
+                      {:reason :layout-stage-operation :operation operation})))
+    (doseq [[field shape] [[:input-shape input-shape] [:output-shape output-shape]]]
+      (when-not (and (vector? shape) (seq shape) (not-any? nil? shape))
+        (throw (ex-info "layout stage requires an exact logical shape"
+                        {:reason :layout-stage-shape :field field :shape shape}))))
+    (doseq [[field value] [[:input-dtype input-dtype] [:output-dtype output-dtype]]]
+      (when-not (and (dtype/known? value) (= value (dtype/canon value)))
+        (throw (ex-info "layout stage requires canonical storage dtypes"
+                        {:reason :layout-stage-dtype :field field :dtype value}))))
+    (when-not (map? policy)
+      (throw (ex-info "layout stage requires an explicit semantic policy"
+                      {:reason :layout-stage-policy :policy policy})))
+    (case operation
+      :cast
+      (when-not (every? #(contains? policy %) [:rounding :overflow])
+        (throw (ex-info "layout cast requires rounding and overflow semantics"
+                        {:reason :layout-stage-policy :policy policy})))
+
+      :transpose
+      (when-not (= [1 0] (:permutation policy))
+        (throw (ex-info "matrix transpose stage requires the [1 0] permutation"
+                        {:reason :layout-stage-policy :policy policy}))))
+    stage))
+
+(defn make
+  [{:keys [id operation input output input-shape output-shape
+           input-dtype output-dtype policy]}]
+  (validate!
+   (->LayoutStage id operation input output (vec input-shape) (vec output-shape)
+                  (dtype/canon input-dtype) (dtype/canon output-dtype) policy)))

--- a/src/raster/compiler/ir/numerical_contract.clj
+++ b/src/raster/compiler/ir/numerical_contract.clj
@@ -9,7 +9,18 @@
 
 (def modes #{:exact :reassociated :bounded-error})
 (def rounding-policies
-  #{:nearest-even :toward-zero :up :down :implementation-defined})
+  #{:nearest-even :toward-zero :up :down :exact :implementation-defined})
+
+(def cast-overflow-policies
+  #{:wrap :saturate :trap :exact :ieee})
+
+(defn rounding-policy?
+  [value]
+  (contains? rounding-policies value))
+
+(defn cast-overflow-policy?
+  [value]
+  (contains? cast-overflow-policies value))
 
 (defn- canonical-dtype?
   [value]
@@ -30,6 +41,14 @@
          (seq components)
          (every? accumulator-component? components)
          (= (count components) (count (set (map :value components)))))))
+
+(defn- result-transform?
+  [transform]
+  (and (map? transform)
+       (= :typed-scalar-region (:kind transform))
+       (= :same-typed-ssa-evaluation-order (:policy transform))
+       (canonical-dtype? (:input-dtype transform))
+       (canonical-dtype? (:result-dtype transform))))
 
 (defn validate!
   "Validate and return a numerical contract.
@@ -61,4 +80,8 @@
                       (keyword? (get-in contract [:error-model :kind])))
          (fail! "bounded-error numerical contract requires rounding, accumulator dtype, and an error model"
                 {:value contract})))
+     (when (and (contains? contract :result-transform)
+                (not (result-transform? (:result-transform contract))))
+       (fail! "numerical result transform requires a checked typed scalar-region policy"
+              {:value (:result-transform contract)}))
      contract)))

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -186,6 +186,11 @@
            (mapv :name (filter #(= :epilogue (:role %)) (:abi contract)))))
     (is (= '[bias scale] (take-last 2 (:arguments contract))))
     (is (= (:effects scheduled) (:effects contract)))
+    (is (= {:kind :typed-scalar-region
+            :policy :same-typed-ssa-evaluation-order
+            :input-dtype :float
+            :result-dtype :float}
+           (get-in scheduled [:numerics :result-transform])))
     (is (= #{:no-write-alias}
            (set (keep :aliasing (filter #(= :input (:kind %)) (:abi contract))))))
     (is (graph-call/kernel-graph-call? call))))
@@ -294,6 +299,36 @@
             source)]
       (is (seq layout-sources))
       (is (every? #(contains? #{:cast :transpose} (:operation %)) layout-sources)))))
+
+(deftest scheduled-stage-identities-include-the-candidate-strategy
+  (let [graphs (mapv #(dispatch/alternative (emitted :tt {:split-factors [2 8]}) %)
+                     [:f32-scalar :xmx-direct :xmx-split-k
+                      :xmx-split-k-2 :xmx-split-k-8])
+        stages (for [graph graphs
+                     node (:nodes graph)
+                     :let [source (get-in node [:operation :attributes
+                                                :scheduled-kernel-body :source])]]
+                 [(:id node) (:id source)])
+        stage-ids (mapv second stages)]
+    (is (every? (fn [[node-id stage-id]] (= node-id stage-id)) stages)
+        "the certificate names the exact scheduled graph node")
+    (is (= (count stage-ids) (count (distinct stage-ids)))
+        "a stage identity denotes one exact alternative, not merely a phase name")))
+
+(deftest batched-production-graph-stages-use-the-common-scheduled-body-projection
+  (let [{graph :graph}
+        (gemm/emit-batched-matrix-alternative
+         {:id :batched-certificate
+          :a 'a :b 'b :c 'c :batch 'batch :m 'm :n 'n :k 'k
+          :variant :nn :tile (hardware/derive-gemm-tile {})
+          :batching {:row true :col false}})]
+    (doseq [node (:nodes graph)]
+      (let [artifact (:operation node)
+            certificate (artifact/attribute artifact :scheduled-kernel-body)]
+        (is (scheduled-body/scheduled-kernel-body? certificate))
+        (is (= (:arguments certificate) (:arguments artifact)))
+        (is (= (:effects certificate) (:effects artifact)))
+        (is (= (scheduled-body/realized-launch certificate) (:launch artifact)))))))
 
 (deftest every-layout-schedule-realizes-to-kernel-calls
   (let [runtime-arguments (arguments 13 640 262144)]

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -10,6 +10,7 @@
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.layout-stage :as layout-stage]
             [raster.compiler.ir.matrix-stage :as matrix-stage]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
 
@@ -270,6 +271,29 @@
       (is (= expected-node-count (count (:nodes graph))) (name variant))
       (when transpose-phase
         (is (some #{transpose-phase} phases) (name variant))))))
+
+(deftest every-production-gemm-graph-stage-has-one-certified-target-projection
+  (let [scheduled (emitted :tt)
+        graphs (mapv #(dispatch/alternative scheduled %)
+                     [:f32-scalar :xmx-direct :xmx-split-k])]
+    (doseq [graph graphs
+            node (:nodes graph)]
+      (let [artifact (:operation node)
+            refinement (artifact/attribute artifact :scheduled-kernel-body)]
+        (is (scheduled-body/scheduled-kernel-body? refinement)
+            (str (executable/strategy graph) " / " (:id node)))
+        (is (= (:arguments refinement) (:arguments artifact)))
+        (is (= (:effects refinement) (:effects artifact)))
+        (is (= (scheduled-body/realized-launch refinement) (:launch artifact)))))
+    (let [layout-sources
+          (for [graph (rest graphs)
+                node (:nodes graph)
+                :let [source (get-in node [:operation :attributes
+                                           :scheduled-kernel-body :source])]
+                :when (layout-stage/layout-stage? source)]
+            source)]
+      (is (seq layout-sources))
+      (is (every? #(contains? #{:cast :transpose} (:operation %)) layout-sources)))))
 
 (deftest every-layout-schedule-realizes-to-kernel-calls
   (let [runtime-arguments (arguments 13 640 262144)]

--- a/test/raster/compiler/ir/layout_stage_test.clj
+++ b/test/raster/compiler/ir/layout_stage_test.clj
@@ -1,0 +1,37 @@
+(ns raster.compiler.ir.layout-stage-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.layout-stage :as stage]))
+
+(defn- reason-of [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo exception
+         (:reason (ex-data exception)))))
+
+(deftest casts-preserve-shape-and-state-a-supported-conversion-policy
+  (let [base {:id :cast :operation :cast :input 'x :output 'y
+              :input-shape '[m k] :output-shape '[m k]
+              :input-dtype :float :output-dtype :half
+              :policy {:rounding :nearest-even :overflow :ieee}}]
+    (is (stage/layout-stage? (stage/make base)))
+    (is (= :layout-stage-shape
+           (reason-of #(stage/make (assoc base :output-shape '[m])))))
+    (is (= :layout-stage-policy
+           (reason-of #(stage/make (assoc-in base [:policy :rounding] :unknown)))))
+    (is (= :layout-stage-policy
+           (reason-of #(stage/make (assoc-in base [:policy :overflow] :unknown)))))))
+
+(deftest transpose-is-a-bit-preserving-rank-two-permutation
+  (let [base {:id :transpose :operation :transpose :input 'x :output 'y
+              :input-shape '[m k] :output-shape '[k m]
+              :input-dtype :half :output-dtype :half
+              :policy {:permutation [1 0]}}]
+    (is (stage/layout-stage? (stage/make base)))
+    (testing "shape and permutation must describe the same bijection"
+      (is (= :layout-stage-shape
+             (reason-of #(stage/make (assoc base :output-shape '[m k])))))
+      (is (= :layout-stage-shape
+             (reason-of #(stage/make (assoc base
+                                            :input-shape '[b m k]
+                                            :output-shape '[k m b]))))))
+    (is (= :layout-stage-dtype
+           (reason-of #(stage/make (assoc base :output-dtype :float)))))))

--- a/test/raster/compiler/ir/scheduled_kernel_body_test.clj
+++ b/test/raster/compiler/ir/scheduled_kernel_body_test.clj
@@ -53,6 +53,13 @@
            (reason-of #(scheduled/validate! (assoc value :source nil)))))
     (is (= :scheduled-kernel-body-numerics
            (reason-of #(scheduled/validate! (assoc value :numerics {})))))
+    (is (= :scheduled-kernel-body-numerics
+           (reason-of #(scheduled/validate!
+                        (assoc-in value [:numerics :result-transform]
+                                  {:kind :typed-scalar-region
+                                   :policy :unverified
+                                   :input-dtype :float
+                                   :result-dtype :float})))))
     (is (= :scheduled-kernel-body-effects
            (reason-of #(scheduled/validate!
                         (assoc-in value [:effects :reads] ['output])))))))

--- a/test/raster/gpu/gemm_link_topology_test.clj
+++ b/test/raster/gpu/gemm_link_topology_test.clj
@@ -79,6 +79,10 @@
         session (atom {:device-id :ze:0 :session-id :mock-session
                        :buffers {} :allocations {} :prepared {} :graphs {}
                        :kernel-graphs {} :events {} :closed? false})
+        ;; Runtime allocations are distinct even when their dtype and extent agree.  The
+        ;; graph binder now enforces no-write-alias contracts, so the mock must retain that
+        ;; physical identity rather than representing two allocations by equal Clojure maps.
+        buffer-counter (atom 0)
         registered (atom [])
         recorded (atom [])
         replayed (atom [])
@@ -87,7 +91,8 @@
           (case name
             "make-buffer"
             (fn [elements dtype]
-              {:dtype dtype :n-elements elements
+              {:mock-allocation-id (swap! buffer-counter inc)
+               :dtype dtype :n-elements elements
                :byte-size (* (long elements) (element-bytes dtype))
                :alignment 64})
 


### PR DESCRIPTION
Completes the GEMM production vertical through the common scheduled-body projection boundary. Adds an exact target-neutral LayoutStage for cast and transpose stages, routes scalar fallback, casts, transpose, split-K combine, and matrix stages through ScheduledKernelBody, and verifies exact ABI, effects, launch geometry, and source identity. This replaces closed stacked PR #362 after its temporary base branch was removed.