### PR TITLE
Make scheduled graph scalar dependencies explicit

### DIFF
--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -634,15 +634,18 @@
                           partial-specs)
        :abi external-abi
        :arguments (conj inputs output)
+       :scalars []
        :nodes [(kgraph/->ScheduledKernel
                 partial-node partial-artifact
                 (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
                              (map #(kgraph/->ValueUse % :write) partial-ids)))
+                #{}
                 [])
                (kgraph/->ScheduledKernel
                 merge-node merge-artifact
                 (vec (concat (map #(kgraph/->ValueUse % :read) partial-ids)
                              [(kgraph/->ValueUse output :write)]))
+                #{}
                 [partial-node])]
        :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
        :provenance {:operation-id id :semantic-op :attention
@@ -690,7 +693,8 @@
       :outputs [(graph-buffer output)]
       :abi (:abi artifact)
       :arguments (:arguments artifact)
-      :nodes [(kgraph/->ScheduledKernel node-id artifact uses [])]
+      :scalars []
+      :nodes [(kgraph/->ScheduledKernel node-id artifact uses #{} [])]
       :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
       :provenance {:operation-id id :semantic-op :attention}
       :attributes {:strategy strategy :reference? reference?

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -44,7 +44,15 @@
 
 (defn- node
   [id operation uses dependencies]
-  (kgraph/->ScheduledKernel id operation (vec uses) (vec dependencies)))
+  (let [scheduled (kart/attribute operation :scheduled-kernel-body)]
+    (when-not (scheduled-body/scheduled-kernel-body? scheduled)
+      (throw (ex-info "production GEMM graph node requires a scheduled-body certificate"
+                      {:reason :gemm-scheduled-body :node id})))
+    (kgraph/->ScheduledKernel
+     id operation (vec uses)
+     (reduce into #{} (map (comp klaunch/expression-references :value)
+                           (:scalar-bindings scheduled)))
+     (vec dependencies))))
 
 (defn- epilogue-interface
   [epilogue]
@@ -87,6 +95,16 @@
          (kabi/slot n :scalar :int :c-name "N" :role :extent)
          (kabi/slot k :scalar :int :c-name "K" :role :extent)]
    :arguments [a b c batch m n k]})
+
+(defn- public-outer-interface
+  [spec]
+  (let [{:keys [abi arguments]} (outer-interface spec)]
+    (kgraph/public-interface abi arguments)))
+
+(defn- public-batched-outer-interface
+  [spec]
+  (let [{:keys [abi arguments]} (batched-outer-interface spec)]
+    (kgraph/public-interface abi arguments)))
 
 (defn- extents
   [{:keys [m n k variant]}]
@@ -173,7 +191,7 @@
 
 (defn- scalar-graph
   [{:keys [id a b c m n k variant] :as spec}]
-  (let [{:keys [abi arguments]} (outer-interface spec)
+  (let [{:keys [abi arguments]} (public-outer-interface spec)
         {:keys [a-elements b-elements c-elements]} (extents spec)
         prefix (identifier (str id "_scalar"))
         kernel-name (str prefix "_gemm")
@@ -194,6 +212,7 @@
      {:inputs [(graph-buffer a :float a-elements :input)
                (graph-buffer b :float b-elements :input)]
       :outputs [(graph-buffer c :float c-elements :output)]
+      :scalars (kgraph/interface-scalars abi arguments)
       :nodes [(node stage-id gemm
                     [(value-use a :read) (value-use b :read) (value-use c :write)] [])]
       :abi abi :arguments arguments
@@ -256,25 +275,31 @@
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
            k-range launch-group-count attributes epilogue]
     :or {result-dtype :float provenance {}}}]
-  (contraction-schedule/matrix-body
-   {:id (or id [:gemm kernel-name])
-    :row a :col b :out c
-    :dimensions [m n k]
-    :dimension-parameters (or dimension-parameters [m n k])
-    :axis-symbols ['i 'j 'l]
-    :tile tile
-    :bindings {:row a :col b}
-    :epilogue epilogue
-    :result-dtype result-dtype
-    :additional-parameters additional-parameters
-    :additional-indices additional-indices
-    :buffer-shapes buffer-shapes
-    :buffer-views buffer-views
-    :operation-buffers operation-buffers
-    :k-range k-range
-    :launch-group-count launch-group-count
-    :attributes attributes
-    :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)}))
+  (let [dimension-parameters
+        (or dimension-parameters
+            (if (and (every? #(or (symbol? %) (keyword? %)) [m n k])
+                     (= 3 (count (set [m n k]))))
+              [m n k]
+              ['M 'N 'K]))]
+    (contraction-schedule/matrix-body
+     {:id (or id [:gemm kernel-name])
+      :row a :col b :out c
+      :dimensions [m n k]
+      :dimension-parameters dimension-parameters
+      :axis-symbols ['i 'j 'l]
+      :tile tile
+      :bindings {:row a :col b}
+      :epilogue epilogue
+      :result-dtype result-dtype
+      :additional-parameters additional-parameters
+      :additional-indices additional-indices
+      :buffer-shapes buffer-shapes
+      :buffer-views buffer-views
+      :operation-buffers operation-buffers
+      :k-range k-range
+      :launch-group-count launch-group-count
+      :attributes attributes
+      :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})))
 
 (defn emit-scheduled-matrix-kernel
   "Build and directly lower one canonical f16 matrix contraction.
@@ -513,7 +538,7 @@
   [{:keys [id a b c m n k variant tile vector-width requested-splits split-k? epilogue
            strategy]
     :as spec}]
-  (let [{:keys [abi arguments]} (outer-interface spec)
+  (let [{:keys [abi arguments]} (public-outer-interface spec)
         {:keys [a-elements b-elements c-elements]} (extents spec)
         epilogue-buffers (epilogue-buffer-specs epilogue)
         strategy (or strategy (if split-k? :xmx-split-k :xmx-direct))
@@ -588,6 +613,7 @@
                    epilogue-buffers)
       :outputs [(graph-buffer c :float c-elements :output)]
       :temporaries temporaries
+      :scalars (kgraph/interface-scalars abi arguments)
       :nodes nodes
       :abi abi :arguments arguments
       :effects (effects spec)
@@ -636,7 +662,7 @@
     (when (nil? value)
       (throw (ex-info "batched matrix schedule is missing a required field"
                       {:reason :raster/bug :field field :spec spec}))))
-  (let [{:keys [abi arguments]} (batched-outer-interface spec)
+  (let [{:keys [abi arguments]} (public-batched-outer-interface spec)
         a-elements (if (get batching :row true)
                      (klaunch/product batch m k)
                      (klaunch/product m k))
@@ -665,6 +691,7 @@
           :outputs [(graph-buffer c :float c-elements :output)]
           :temporaries [(graph-buffer a16 :half a-elements :temporary)
                         (graph-buffer b16 :half b-elements :temporary)]
+          :scalars (kgraph/interface-scalars abi arguments)
           :nodes [(node convert-a-id convert-a
                         [(value-use a :read) (value-use a16 :write)] [])
                   (node convert-b-id convert-b

--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -252,7 +252,7 @@
         membership (:membership plan)
         storage (:storage plan)
         value (:value plan)
-        output-elements (:elements (:output plan))]
+        output-elements (klaunch/product (:extent destination-axis) (:total-dim storage))]
     [{:name 'n_entities :c-name "n_entities" :value (:extent destination-axis)}
      {:name 'n_edges :c-name "n_edges" :value (:edges membership)}
      {:name 'total_dim :c-name "total_dim" :value (:total-dim storage)}
@@ -532,8 +532,10 @@
       :outputs [(graph-buffer output :output)]
       :abi (:abi artifact)
       :arguments (:arguments artifact)
+      :scalars []
       :nodes [(kgraph/->ScheduledKernel
-               [:segmented-weighted-reduction (:id plan) :indexed-reference] artifact uses [])]
+               [:segmented-weighted-reduction (:id plan) :indexed-reference]
+               artifact uses #{} [])]
       :effects {:kind :segmented-weighted-reduction :materialized-intermediates []}
       :provenance {:operation-id (get-in plan [:provenance :operation-id])
                    :semantic-op (get-in plan [:provenance :semantic-op])}
@@ -544,6 +546,8 @@
   [plan artifact]
   (let [plan (indexed-attention-plan! plan)
         artifact (kart/validate! artifact)
+        {public-abi :abi public-arguments :arguments}
+        (kgraph/public-interface (:abi artifact) (:arguments artifact))
         inputs (swr/ordered-input-ids plan)
         output (get-in plan [:output :id])
         descriptors (into {} (map (juxt :id identity))
@@ -551,12 +555,15 @@
         edge-ids #{(get-in plan [:membership :destination-indices])
                    (get-in plan [:membership :source-indices])}
         edge-elements (:edges (:membership plan))
-        value-elements (:elements (:output plan))
+        value-elements (klaunch/product
+                        (get-in plan [:segment-axes 0 :extent])
+                        (get-in plan [:storage :total-dim]))
         graph-buffer (fn [id role]
                        (kgraph/buffer
                         id (:dtype (get descriptors id))
-                        (klaunch/runtime-value
-                         (if (contains? edge-ids id) edge-elements value-elements))
+                        (if (contains? edge-ids id)
+                          (klaunch/runtime-value edge-elements)
+                          value-elements)
                         :device role))
         uses (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
                           [(kgraph/->ValueUse output :write)]))
@@ -565,11 +572,13 @@
     (kgraph/make
      {:inputs (mapv #(graph-buffer % :input) inputs)
       :outputs [(graph-buffer output :output)]
-      :abi (:abi artifact)
-      :arguments (:arguments artifact)
+      :abi public-abi
+      :arguments public-arguments
+      :scalars (kgraph/interface-scalars public-abi public-arguments)
       :nodes [(kgraph/->ScheduledKernel
                [:segmented-weighted-reduction (:id plan) :indexed-dynamic-reference]
-               artifact uses [])]
+               artifact uses
+               (kgraph/scalar-argument-uses (:abi artifact) (:arguments artifact)) [])]
       :effects {:kind :segmented-weighted-reduction :materialized-intermediates []}
       :provenance {:operation-id (get-in plan [:provenance :operation-id])
                    :semantic-op (get-in plan [:provenance :semantic-op])}

--- a/src/raster/compiler/backend/gpu/paged_kv_append.clj
+++ b/src/raster/compiler/backend/gpu/paged_kv_append.clj
@@ -114,9 +114,10 @@
       :outputs output-buffers
       :abi (:abi emitted)
       :arguments (:arguments emitted)
+      :scalars []
       :nodes [(graph/->ScheduledKernel
                [:paged-kv-append id :fp32-to-fp16-reference]
-               emitted uses [])]
+               emitted uses #{} [])]
       :effects {:kind :paged-kv-append :assignment :unique-slot}
       :provenance {:operation-id id :semantic-op :paged-kv-append}
       :attributes {:strategy :fp32-to-fp16-reference :reference? true}})))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -850,6 +850,7 @@
                           (filter (fn [[slot argument]]
                                     (and (= :scalar (:kind slot))
                                          (or (symbol? argument)
+                                             (keyword? argument)
                                              (contains? declared-scalar-ids argument)))))
                           vec)
         scalar-groups (group-by second scalar-pairs)
@@ -898,10 +899,31 @@
                                         :target supplied-dtype})))
                              (kabi/slot argument :scalar logical-dtype
                                         :kernel-dtype kernel-dtype :role role)))
-                         scalar-arguments)]
+                         scalar-arguments)
+        explicit-scalars
+        (if (some? declared-scalars)
+          declared-scalars
+          (mapv (fn [slot argument]
+                  (kgraph/scalar argument (:dtype slot)))
+                scalar-abi scalar-arguments))
+        explicit-nodes
+        (mapv (fn [node]
+                (let [artifact (:operation node)
+                      actual (kgraph/scalar-argument-uses
+                              (:abi artifact) (:arguments artifact))
+                      scheduled (:scalar-uses node)]
+                  (when (and (some? scheduled) (not= scheduled actual))
+                    (throw (ex-info "emitted kernel scalar dependencies differ from its schedule"
+                                    {:reason :kernel-graph-artifact-scalar-uses
+                                     :node (:id node)
+                                     :expected scheduled :actual actual})))
+                  (assoc node :scalar-uses actual)))
+              (:nodes emitted))]
     (-> emitted
         (assoc :abi (vec (concat pointer-abi scalar-abi))
-               :arguments (vec (concat (map :id external-buffers) scalar-arguments)))
+               :arguments (vec (concat (map :id external-buffers) scalar-arguments))
+               :scalars explicit-scalars
+               :nodes explicit-nodes)
         (assoc-in [:provenance :target-dialect] target-dialect)
         (assoc-in [:attributes :emitted?] true)
         kgraph/validate!)))

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -56,7 +56,7 @@
               (keep (fn [[slot argument]]
                       (when (= :scalar (:kind slot)) [argument slot])))
               (map vector (:abi graph) (:arguments graph)))]
-    (doseq [{:keys [id operation uses]} (:nodes graph)]
+    (doseq [{:keys [id operation uses scalar-uses]} (:nodes graph)]
       (let [artifact (kart/validate! operation)
             pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot)))
                                    (mapv vector (:abi artifact) (:arguments artifact)))
@@ -109,7 +109,13 @@
                                    :references references
                                    :public-scalars (set (keys public-scalars))
                                    :expression-error (ex-data exception)}
-                                  exception)))))))))
+                                  exception)))))))
+        (let [actual-scalar-uses
+              (kgraph/scalar-argument-uses (:abi artifact) (:arguments artifact))]
+          (when (not= scalar-uses actual-scalar-uses)
+            (throw (ex-info "kernel artifact scalar arguments differ from scheduled graph uses"
+                            {:reason :kernel-graph-artifact-scalar-uses
+                             :node id :expected scalar-uses :actual actual-scalar-uses}))))))
     graph))
 
 (defn validate!
@@ -125,6 +131,12 @@
       (when-not (seq (:nodes graph))
         (throw (ex-info "emitted kernel graph requires at least one kernel node"
                         {:reason :kernel-graph-executable-empty :graph graph})))
+      (when (or (nil? (:scalars graph))
+                (some (comp nil? :scalar-uses) (:nodes graph)))
+        (throw (ex-info "emitted kernel graph requires explicit scalar dependencies"
+                        {:reason :kernel-graph-executable-scalars
+                         :scalars (:scalars graph)
+                         :node-scalar-uses (mapv (juxt :id :scalar-uses) (:nodes graph))})))
       (validate-node-artifact-bindings! graph)
       (let [targets (set (map :target (artifacts graph)))]
         (when-not (= 1 (count targets))

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -8,12 +8,13 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]))
 
 (defrecord GraphBuffer [id dtype elements memory-space role])
 (defrecord GraphScalar [id dtype])
 (defrecord ValueUse [buffer access])
-(defrecord ScheduledKernel [id operation uses dependencies])
+(defrecord ScheduledKernel [id operation uses scalar-uses dependencies])
 (defrecord KernelGraph
            [inputs outputs temporaries scalars nodes abi arguments effects provenance attributes])
 
@@ -66,6 +67,50 @@
                     {:id id :dtype scalar-dtype})))
   (->GraphScalar id (dtype/canon scalar-dtype)))
 
+(defn interface-scalars
+  "Project the ordered public scalar values from an ordered logical ABI.
+
+   Target-private scalar expressions do not belong in a KernelGraph boundary; those are introduced
+   by a later ScheduledKernelBody and remain closed over the public identities represented here."
+  [abi arguments]
+  (kabi/validate-arguments! abi arguments)
+  (mapv (fn [[slot argument]]
+          (when-not (or (symbol? argument) (keyword? argument))
+            (throw (ex-info "public graph scalar arguments require stable compiler identities"
+                            {:reason :kernel-graph-scalar-interface
+                             :slot slot :argument argument})))
+          (scalar argument (:dtype slot)))
+        (filter (fn [[slot _]] (= :scalar (:kind slot)))
+                (map vector abi arguments))))
+
+(defn public-interface
+  "Remove target-private scalar literals and arithmetic from an artifact-style interface.
+
+   Pointer arguments and stable symbolic scalar identities form the callable graph boundary.
+   Literal dimensions and derived integer expressions remain node-private specialization facts."
+  [abi arguments]
+  (kabi/validate-arguments! abi arguments)
+  (let [pairs (filterv (fn [[slot argument]]
+                         (or (not= :scalar (:kind slot))
+                             (symbol? argument)
+                             (keyword? argument)))
+                       (mapv vector abi arguments))]
+    {:abi (mapv first pairs)
+     :arguments (mapv second pairs)}))
+
+(defn scalar-argument-uses
+  "Return public compiler-value leaves consumed by scalar ABI arguments.
+
+   Numeric literals and target-private arithmetic nodes are not graph values. Derived expressions
+   contribute only their opaque leaves, which the graph validator then checks against GraphScalar."
+  [abi arguments]
+  (kabi/validate-arguments! abi arguments)
+  (reduce into #{}
+          (map (fn [[_ argument]]
+                 (if (number? argument) #{} (launch/expression-references argument)))
+               (filter (fn [[slot _]] (= :scalar (:kind slot)))
+                       (map vector abi arguments)))))
+
 (defn- reads? [access] (contains? #{:read :read-write} access))
 (defn- writes? [access] (contains? #{:write :read-write} access))
 
@@ -106,6 +151,13 @@
             scalar-pairs (filterv (fn [[slot _]] (= :scalar (:kind slot)))
                                   (mapv vector abi arguments))
             scalar-arguments (mapv second scalar-pairs)]
+        (when-let [[slot argument]
+                   (first (remove (fn [[_ argument]]
+                                    (or (symbol? argument) (keyword? argument)))
+                                  scalar-pairs))]
+          (throw (ex-info "kernel graph public scalar requires a stable compiler identity"
+                          {:reason :kernel-graph-scalar-interface
+                           :slot slot :argument argument})))
         (when-not (= (set (keys external-by-id)) (set pointer-arguments))
           (throw (ex-info "kernel graph pointer interface differs from its external buffers"
                           {:external (set (keys external-by-id))
@@ -228,6 +280,31 @@
               (throw (ex-info "scheduled kernel identities must be unique" {:id (:id node)})))
             (when-not (vector? (:uses node))
               (throw (ex-info "scheduled kernel uses must be an ordered vector" {:node (:id node)})))
+            (when-not (or (nil? (:scalar-uses node)) (set? (:scalar-uses node)))
+              (throw (ex-info "scheduled kernel scalar uses must be a set"
+                              {:node (:id node) :scalar-uses (:scalar-uses node)})))
+            (when-not (= (some? scalars) (some? (:scalar-uses node)))
+              (throw (ex-info "scheduled kernel and graph must agree on explicit scalar dependencies"
+                              {:reason :kernel-graph-node-scalar-interface
+                               :node (:id node) :graph-scalars scalars
+                               :scalar-uses (:scalar-uses node)})))
+            (when (some? (:scalar-uses node))
+              (let [uses (:scalar-uses node)
+                    declared-scalars (set (map :id scalars))]
+                (when-not (set/subset? (set uses) declared-scalars)
+                  (throw (ex-info "scheduled kernel uses an undeclared graph scalar"
+                                  {:reason :kernel-graph-node-scalar-use
+                                   :node (:id node) :scalar-uses uses
+                                   :declared declared-scalars})))))
+            (when (and (some? (:scalar-uses node))
+                       (segop/segop-node? (:operation node))
+                       (not= (:scalar-uses node)
+                             (segop/operation-scalars (:operation node))))
+              (throw (ex-info "scheduled SegOp scalar dependencies differ from its operation"
+                              {:reason :kernel-graph-node-scalar-use
+                               :node (:id node)
+                               :expected (segop/operation-scalars (:operation node))
+                               :actual (:scalar-uses node)})))
             (when-not (vector? (:dependencies node))
               (throw (ex-info "scheduled kernel dependencies must be an ordered vector"
                               {:node (:id node)})))
@@ -309,7 +386,7 @@
      :outputs (:outputs graph)
      :temporaries (:temporaries graph)
      :scalars (:scalars graph)
-     :nodes (mapv #(select-keys % [:id :uses :dependencies]) (:nodes graph))
+     :nodes (mapv #(select-keys % [:id :uses :scalar-uses :dependencies]) (:nodes graph))
      :effects (:effects graph)}))
 
 (defn boundary-contract
@@ -413,7 +490,18 @@
                                      (ordered (set/union ins outs)))
                           ;; A scheduled-node identity is not a SegOp identity. The position makes
                           ;; repeated/colliding source ids safe when larger graphs are assembled.
-                          candidate (->ScheduledKernel [:segop (:id op) index] op uses [])
+                          operation-scalars (segop/operation-scalars op)
+                          scalar-uses (when (some? scalars)
+                                        (let [declared (set (map :id scalars))
+                                              missing (set/difference operation-scalars declared)]
+                                          (when (seq missing)
+                                            (throw (ex-info
+                                                    "scheduled operation uses undeclared graph scalars"
+                                                    {:reason :kernel-graph-node-scalar-use
+                                                     :operation (:id op) :missing missing
+                                                     :declared declared})))
+                                          operation-scalars))
+                          candidate (->ScheduledKernel [:segop (:id op) index] op uses scalar-uses [])
                           dependencies (->> previous
                                             (filter #(hazard? % candidate))
                                             (mapv :id))

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -28,6 +28,35 @@
   [graph]
   (set (map :id (graph-buffers graph))))
 
+(defn- scalar-interface
+  [graph]
+  (filterv (fn [[slot _]] (= :scalar (:kind slot)))
+           (mapv vector (:abi graph) (:arguments graph))))
+
+(defn- validate-scalar-values!
+  [graph scalar-values]
+  (when-not (map? scalar-values)
+    (throw (ex-info "kernel graph call scalar values must be a map"
+                    {:scalar-values scalar-values})))
+  (let [interface (scalar-interface graph)
+        expected (set (map second interface))
+        actual (set (keys scalar-values))]
+    (when-not (= expected actual)
+      (throw (ex-info "kernel graph call requires exactly every public scalar"
+                      {:reason :kernel-graph-call-scalars
+                       :expected expected :bound actual})))
+    (doseq [[slot argument] interface
+            :let [value (get scalar-values argument)]]
+      (when-not (and (map? value) (contains? value :type) (contains? value :value))
+        (throw (ex-info "graph symbolic scalar requires an explicitly typed runtime value"
+                        {:reason :kernel-graph-call-scalar-type
+                         :argument argument :slot slot :value value})))
+      (when-not (= (:kernel-dtype slot) (:type value))
+        (throw (ex-info "kernel graph scalar argument has the wrong ABI dtype"
+                        {:reason :kernel-graph-call-scalar-type
+                         :argument argument :slot slot :value value}))))
+    scalar-values))
+
 (defn- scalar-number
   [scalar-values value]
   (let [resolved (if (contains? scalar-values value)
@@ -95,9 +124,7 @@
                       {:declared declared :bound (set (keys buffers))})))
     (when (some nil? (vals buffers))
       (throw (ex-info "kernel graph call buffer cannot be nil" {})))
-    (when-not (map? scalar-values)
-      (throw (ex-info "kernel graph call scalar values must be a map"
-                      {:scalar-values scalar-values})))
+    (validate-scalar-values! graph scalar-values)
     (when-not (vector? nodes)
       (throw (ex-info "kernel graph call nodes must be an ordered vector" {:nodes nodes})))
     (when-not (= (count (:nodes graph)) (count nodes))
@@ -129,7 +156,7 @@
   [graph buffers scalar-values]
   (let [graph (kgraph/validate! graph)
         declared (declared-buffer-ids graph)
-        scalar-values (or scalar-values {})]
+        scalar-values (validate-scalar-values! graph (or scalar-values {}))]
     (when-not (= declared (set (keys buffers)))
       (throw (ex-info "kernel graph call requires exactly every declared graph buffer"
                       {:declared declared :bound (set (keys buffers))})))

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -240,7 +240,7 @@
   [expression]
   (cond
     (integer? expression) #{}
-    (runtime-value? expression) #{(:value expression)}
+    (runtime-value? expression) (expression-references (:value expression))
     (ceil-div? expression) (into (expression-references (:value expression))
                                  (expression-references (:divisor expression)))
     (floor-div? expression) (into (expression-references (:value expression))

--- a/src/raster/compiler/ir/scheduled_kernel_body.clj
+++ b/src/raster/compiler/ir/scheduled_kernel_body.clj
@@ -11,8 +11,7 @@
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.kernel-body-abi :as body-abi]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.numerical-contract :as numerics]
-            [raster.compiler.ir.segop :as segop]))
+            [raster.compiler.ir.numerical-contract :as numerics]))
 
 (defrecord ScheduledKernelBody
            [source body arguments scalar-bindings effects legality numerics provenance attributes])
@@ -201,9 +200,11 @@
         scalar-types (into {} (map (juxt :id :dtype)) (:scalars kernel-graph))
         scalar-arguments (mapv :value (:scalar-bindings scheduled))
         actual-scalars (reduce into #{} (map launch/expression-references scalar-arguments))
-        expected-scalars (if (segop/segop-node? (:source scheduled))
-                           (segop/operation-scalars (:source scheduled))
-                           actual-scalars)]
+        expected-scalars (set (:scalar-uses node))]
+    (when (nil? (:scalar-uses node))
+      (fail! :scheduled-kernel-body-node-scalars
+             "scheduled-body certification requires explicit graph-node scalar dependencies"
+             {:node (:id node)}))
     (when-not (= (:source scheduled) (:operation node))
       (fail! :scheduled-kernel-body-source
              "scheduled body does not refine the graph node's exact operation"

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -874,7 +874,9 @@
   [candidate operation-id common-abi common-arguments]
   (let [{:keys [family strategy artifact candidate-schedule]} candidate
         artifact (kart/validate! artifact)
-        interface (mapv vector common-abi common-arguments)
+        {public-abi :abi public-arguments :arguments}
+        (kgraph/public-interface common-abi common-arguments)
+        interface (mapv vector public-abi public-arguments)
         pointer-interface (filterv #(not= :scalar (:kind (first %))) interface)
         buffers (mapv (fn [[slot argument]]
                         [argument
@@ -896,10 +898,12 @@
     (kgraph/make
      {:inputs inputs
       :outputs outputs
-      :abi common-abi
-      :arguments common-arguments
+      :scalars (kgraph/interface-scalars public-abi public-arguments)
+      :abi public-abi
+      :arguments public-arguments
       :nodes [(kgraph/->ScheduledKernel
-               [:typed-contraction operation-id family strategy] artifact uses [])]
+               [:typed-contraction operation-id family strategy] artifact uses
+               (kgraph/scalar-argument-uses (:abi artifact) (:arguments artifact)) [])]
       :effects (:effects artifact)
       :provenance {:operation-id operation-id
                    :semantic-op :contraction
@@ -950,13 +954,16 @@
 
 (defn- reinterface-graph
   [graph abi arguments effects operation-id]
-  (kgraph/validate!
-   (-> graph
-       (assoc :abi abi :arguments arguments :effects effects)
-       (update :provenance merge {:operation-id operation-id
-                                  :source-dialect :typed-soac})
-       (update :attributes merge {:candidate-family :matrix
-                                  :semantic-op :contraction}))))
+  (let [{public-abi :abi public-arguments :arguments}
+        (kgraph/public-interface abi arguments)]
+    (kgraph/validate!
+     (-> graph
+         (assoc :abi public-abi :arguments public-arguments :effects effects
+                :scalars (kgraph/interface-scalars public-abi public-arguments))
+         (update :provenance merge {:operation-id operation-id
+                                    :source-dialect :typed-soac})
+         (update :attributes merge {:candidate-family :matrix
+                                    :semantic-op :contraction})))))
 
 (defn- mixed-dpas-alternatives
   "Derive graph-valued mixed-precision DPAS schedules from ordinary typed contraction facts.

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -65,6 +65,16 @@
       (is (= [256] (get-in kernel-body [:launch :workgroup-size])))
       (is (graph-call/kernel-graph-call? call)))))
 
+(deftest literal-dimensions-are-private-specialization-facts
+  (let [scheduled (gemm/emit-executable
+                   {:id "literal-gemm" :a 'a :b 'b :c 'c
+                    :m 3 :n 2 :k 4 :variant :nn :precision :mixed-f16-f32
+                    :tile (hardware/derive-gemm-tile {}) :fill-workgroups 32})
+        graph (dispatch/select-alternative scheduled [:a-buffer :b-buffer :c-buffer])]
+    (is (= '[a b c] (:arguments graph)))
+    (is (= [] (:scalars graph)))
+    (is (every? empty? (map :scalar-uses (:nodes graph))))))
+
 (deftest explicit-split-factors-are-finite-schedule-alternatives
   (let [scheduled (emitted :nn {:split-factors [2 8 32]})
         by-strategy (into {} (map (juxt executable/strategy identity))

--- a/test/raster/compiler/ir/emitted_parallel_equation_test.clj
+++ b/test/raster/compiler/ir/emitted_parallel_equation_test.clj
@@ -36,6 +36,7 @@
                  [:refined index]
                  [:refined-operation index]
                  (:uses source-node)
+                 (:scalar-uses source-node)
                  (mapv (fn [earlier] [:refined earlier]) (range index))))
               (range 3))
         refined (graph/validate! (assoc source :nodes refined-nodes))
@@ -50,20 +51,27 @@
   (case access :read :input :write :output :read-write :inout))
 
 (defn- test-artifact
-  ([index operation uses buffers]
-   (test-artifact index operation uses buffers :opencl-c))
-  ([index operation uses buffers target]
+  ([index operation uses scalar-uses buffers scalar-types]
+   (test-artifact index operation uses scalar-uses buffers scalar-types :opencl-c))
+  ([index operation uses scalar-uses buffers scalar-types target]
    (let [kernel-name (str "refined_" index)
-         slots (mapv (fn [{:keys [buffer access]}]
-                       (abi/slot buffer (use-kind access) (:dtype (get buffers buffer))
-                                 :c-name (c-emit/c-symbol buffer)))
-                     uses)
+         pointer-slots (mapv (fn [{:keys [buffer access]}]
+                               (abi/slot buffer (use-kind access) (:dtype (get buffers buffer))
+                                         :c-name (c-emit/c-symbol buffer)))
+                             uses)
+         ordered-scalars (vec (sort-by str scalar-uses))
+         scalar-slots (mapv #(abi/slot % :scalar (get scalar-types %)
+                                      :c-name (c-emit/c-symbol %))
+                            ordered-scalars)
+         slots (into pointer-slots scalar-slots)
          parameters
          (mapv (fn [slot]
-                 (str (if (= :opencl-c target)
-                        (if (= :input (:kind slot)) "__global const " "__global ")
-                        (if (= :input (:kind slot)) "const " ""))
-                      "float* " (:c-name slot)))
+                 (if (= :scalar (:kind slot))
+                   (str "long " (:c-name slot))
+                   (str (if (= :opencl-c target)
+                          (if (= :input (:kind slot)) "__global const " "__global ")
+                          (if (= :input (:kind slot)) "const " ""))
+                        "float* " (:c-name slot))))
                slots)
          prefix (if (= :opencl-c target) "__kernel void " "extern \"C\" __global__ void ")]
      (artifact/certify-scheduled-operation
@@ -73,7 +81,7 @@
         :source (str prefix kernel-name "(" (str/join ", " parameters)
                      ") { " (:c-name (first (filter #(not= :input (:kind %)) slots)))
                      "[0] = 0.0f; }")
-        :abi slots :arguments (mapv :buffer uses)
+        :abi slots :arguments (into (mapv :buffer uses) ordered-scalars)
         :launch (launch/spec {:workgroup-size [1] :group-count [1]})})
       operation))))
 
@@ -98,12 +106,13 @@
 (defn- emit-graph
   [scheduled]
   (let [buffers (into {} (map (juxt :id identity))
-                      (concat (:inputs scheduled) (:outputs scheduled) (:temporaries scheduled)))]
+                      (concat (:inputs scheduled) (:outputs scheduled) (:temporaries scheduled)))
+        scalar-types (into {} (map (juxt :id :dtype)) (:scalars scheduled))]
     (graph-interface
      (graph/map-operations
       scheduled
-      (fn [{:keys [id operation uses]}]
-        (test-artifact (last id) operation uses buffers))))))
+      (fn [{:keys [id operation uses scalar-uses]}]
+        (test-artifact (last id) operation uses scalar-uses buffers scalar-types))))))
 
 (defn- append-int-scalar
   [kernel argument]
@@ -160,7 +169,9 @@
                           (assoc-in emitted [:nodes 0 :operation :arguments 0] 'undeclared)
                           {:refinement witness}))))
       (let [output-use (filterv #(not= :read (:access %)) (:uses node))
-            output-only (test-artifact 99 (:operation node) output-use buffers)]
+            scalar-types (into {} (map (juxt :id :dtype)) (:scalars refined))
+            output-only (test-artifact 99 (:operation node) output-use
+                                       (:scalar-uses node) buffers scalar-types)]
         (is (= :kernel-graph-artifact-uses
                (reason-of #(emitted-equation/make
                             algorithm body
@@ -171,8 +182,10 @@
              (reason-of #(emitted-equation/make
                           algorithm body (assoc emitted :abi nil :arguments nil)
                           {:refinement witness}))))
-      (let [{:keys [id operation uses]} node
-            hip (test-artifact (last id) operation uses buffers :hip-cpp)]
+      (let [{:keys [id operation uses scalar-uses]} node
+            scalar-types (into {} (map (juxt :id :dtype)) (:scalars refined))
+            hip (test-artifact (last id) operation uses scalar-uses
+                               buffers scalar-types :hip-cpp)]
         (is (= :kernel-graph-executable-targets
                (reason-of #(emitted-equation/make
                             algorithm body (assoc-in emitted [:nodes 1 :operation] hip)

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -84,14 +84,15 @@
       :temporaries [(kgraph/buffer temporary :float 'width :device :temporary)]
       :abi abi
       :arguments '[x out width]
+      :scalars [(kgraph/scalar 'width :long)]
       :nodes [(kgraph/->ScheduledKernel
                :stage-one first-stage
                [(kgraph/->ValueUse 'x :read)
-                (kgraph/->ValueUse temporary :write)] [])
+                (kgraph/->ValueUse temporary :write)] #{'width} [])
               (kgraph/->ScheduledKernel
                :stage-two second-stage
                [(kgraph/->ValueUse temporary :read)
-                (kgraph/->ValueUse 'out :write)] [:stage-one])]
+                (kgraph/->ValueUse 'out :write)] #{'width} [:stage-one])]
       :effects (:effects reference)
       :attributes {:strategy :two-stage}})))
 

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -24,6 +24,9 @@
         scalars {'n {:type :int :value 1025}}
         call (graph-call/make graph buffers scalars)
         [intra block carry] (mapv :call (:nodes call))]
+    (is (= [['n :int]] (mapv (juxt :id :dtype) (:scalars graph))))
+    (is (every? set? (map :scalar-uses (:nodes graph))))
+    (is (= #{'n} (reduce into #{} (map :scalar-uses (:nodes graph)))))
     (is (graph-call/kernel-graph-call? call))
     (is (every? kcall/kernel-call? [intra block carry]))
     (is (= [[5] [1] [5]]
@@ -42,7 +45,16 @@
                           (graph-call/make graph (dissoc buffers (first ids))
                                            {'n {:type :int :value 1025}})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicitly typed"
-                          (graph-call/make graph buffers {'n 1025})))))
+                          (graph-call/make graph buffers {'n 1025})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exactly every public scalar"
+                          (graph-call/make graph buffers {})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exactly every public scalar"
+                          (graph-call/make graph buffers
+                                           {'n {:type :int :value 1025}
+                                            'extra {:type :int :value 1}})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"wrong ABI dtype"
+                          (graph-call/make graph buffers
+                                           {'n {:type :long :value 1025}})))))
 
 (deftest derived-int-scalars-refuse-narrowing-overflow
   (let [graph (emitted-graph)
@@ -61,3 +73,11 @@
     (is (= {'n n} (:scalar-values bindings)))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicitly typed"
                           (executable/graph-bindings graph [:values :out 1025])))))
+
+(deftest executable-graphs-cannot-retain-the-pre-emission-nil-scalar-escape
+  (let [graph (emitted-graph)
+        incomplete (-> graph
+                       (assoc :scalars nil)
+                       (update :nodes #(mapv (fn [node] (assoc node :scalar-uses nil)) %)))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicit scalar dependencies"
+                          (executable/validate! incomplete)))))

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -107,6 +107,13 @@
                    [operation]
                    {:inputs #{'values} :outputs #{'out} :dtype :float :scalars scalars})]
     (is (= scalars (:scalars scheduled)))
+    (is (= #{'n 'alpha} (get-in scheduled [:nodes 0 :scalar-uses])))
+    (is (= :kernel-graph-node-scalar-use
+           (try
+             (graph/validate! (assoc-in scheduled [:nodes 0 :scalar-uses] #{'n}))
+             nil
+             (catch clojure.lang.ExceptionInfo exception
+               (:reason (ex-data exception))))))
     (is (not (graph/dataflow-equivalent?
               scheduled (assoc scheduled :scalars (vec (reverse scalars))))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar identities must be unique"

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -98,6 +98,10 @@
     (is (= [2 3]
            (:group-count (launch/realize specialized {'rows 129}))))))
 
+(deftest runtime-literals-are-specialization-values-not-public-scalar-leaves
+  (is (= #{} (launch/expression-references (launch/runtime-value 3))))
+  (is (= #{'n} (launch/expression-references (launch/runtime-value 'n)))))
+
 (deftest concrete-geometry-rejects-invalid-backend-launches
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"positive integer"
                         (launch/geometry {:workgroup-size [0] :group-count [1]})))

--- a/test/raster/compiler/ir/scheduled_graph_refinement_test.clj
+++ b/test/raster/compiler/ir/scheduled_graph_refinement_test.clj
@@ -24,22 +24,23 @@
                    :semantic-contract :contract
                    [(graph/->ValueUse 'a :read)
                     (graph/->ValueUse 'b :read)
-                    (graph/->ValueUse 'c :write)] [])]
+                    (graph/->ValueUse 'c :write)] #{} [])]
           :scalars scalars :abi interface :arguments arguments :effects effects})
         refined
         (graph/make
          {:inputs [a b] :outputs [c] :temporaries [ah bh]
           :nodes [(graph/->ScheduledKernel
                    :cast-a :cast-a
-                   [(graph/->ValueUse 'a :read) (graph/->ValueUse 'a-half :write)] [])
+                   [(graph/->ValueUse 'a :read) (graph/->ValueUse 'a-half :write)] #{} [])
                   (graph/->ScheduledKernel
                    :cast-b :cast-b
-                   [(graph/->ValueUse 'b :read) (graph/->ValueUse 'b-half :write)] [])
+                   [(graph/->ValueUse 'b :read) (graph/->ValueUse 'b-half :write)] #{} [])
                   (graph/->ScheduledKernel
                    :matrix :matrix
                    [(graph/->ValueUse 'a-half :read)
                     (graph/->ValueUse 'b-half :read)
                     (graph/->ValueUse 'c :write)]
+                   #{}
                    [:cast-a :cast-b])]
           :scalars scalars :abi interface :arguments arguments :effects effects})]
     {:a a :b b :c c :source source :refined refined}))

--- a/test/raster/compiler/ir/scheduled_kernel_body_test.clj
+++ b/test/raster/compiler/ir/scheduled_kernel_body_test.clj
@@ -107,11 +107,12 @@
   (let [value (fixture)
         node (graph/->ScheduledKernel
               :node :semantic-map
-              [(graph/->ValueUse 'input :read) (graph/->ValueUse 'output :write)] [])
+              [(graph/->ValueUse 'input :read) (graph/->ValueUse 'output :write)] #{} [])
         kernel-graph
         (graph/make
          {:inputs [(graph/buffer 'input :float 1 :global :input)]
           :outputs [(graph/buffer 'output :float 1 :global :output)]
+          :scalars []
           :nodes [node]})]
     (is (identical? value (scheduled/validate-against-node! value node kernel-graph)))
     (testing "source identity and memory effects are independent obligations"

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -4,6 +4,7 @@
             [clojure.java.shell :as shell]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-graph-call :as kgcall]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
             [raster.compiler.passes.parallel.indexed-attention-route :as route]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as swr-route]))
@@ -77,21 +78,42 @@
                                     (map (fn [value] {:type :long :value value})
                                          [3 4 5 2 2 15])))
         call (kcall/make artifact runtime-values)
-        output-elements (get-in (plan) [:output :elements])
+        graph-scalars (zipmap (map :id (:scalars graph))
+                              (map (fn [value] {:type :long :value value})
+                                   [3 4 5 2 2]))
+        graph-buffers (into {}
+                            (map (fn [{:keys [id]}] [id (Object.)]))
+                            (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
+        graph-call (kgcall/make graph graph-buffers graph-scalars)
+        output-elements (launch/product 'n-nodes 'emb-dim)
         graph-output (first (:outputs graph))]
     (is (= '[Q K V dst src normalized
              n_entities n_edges total_dim n_heads n_components output_elements]
            (mapv :name (:abi artifact))))
-    (is (= '[Q K V dst src normalized
-             n-nodes n-edges emb-dim n-heads dk
-             (clojure.core/* n-nodes emb-dim)]
-           (:arguments artifact)))
+    (is (= '[Q K V dst src normalized n-nodes n-edges emb-dim n-heads dk]
+           (vec (butlast (:arguments artifact))))
+        "the final target-private extent has explicit arithmetic IR")
+    (is (= (launch/product 'n-nodes 'emb-dim)
+           (last (:arguments artifact))))
+    (is (= '[Q K V dst src normalized n-nodes n-edges emb-dim n-heads dk]
+           (:arguments graph))
+        "the graph boundary exposes logical shape scalars, not a derived duplicate")
+    (is (= #{'n-nodes 'n-edges 'emb-dim 'n-heads 'dk}
+           (get-in graph [:nodes 0 :scalar-uses])))
     (is (= [16 1] (get-in call [:geometry :workgroup-size])))
     (is (= [1 3] (get-in call [:geometry :group-count])))
-    (is (= output-elements (get-in artifact [:attributes :out-elems])))
-    (is (= 15 (kgcall/resolve-integer
-               {output-elements {:type :long :value 15}}
-               (:elements graph-output))))
+    (is (= (launch/product 'n-nodes 'emb-dim)
+           (get-in artifact [:attributes :out-elems])))
+    (is (= {:type :long :value 15}
+           (last (get-in graph-call [:nodes 0 :call :arguments])))
+        "the graph derives the target-private output extent from public shape scalars")
+    (is (every? #(= output-elements (:elements %))
+                (remove (comp #{'dst 'src} :id)
+                        (concat (:inputs graph) (:outputs graph)))))
+    (is (every? #(= #{'n-edges}
+                     (launch/expression-references (:elements %)))
+                (filter (comp #{'dst 'src} :id) (:inputs graph))))
+    (is (= 15 (kgcall/resolve-integer graph-scalars (:elements graph-output))))
     (is (str/includes? (:source artifact) "long n_entities"))
     (is (str/includes? (:source artifact) "sqrt((float)n_components)"))))
 

--- a/test/raster/gpu/buffer_view_test.clj
+++ b/test/raster/gpu/buffer_view_test.clj
@@ -64,7 +64,7 @@
         right (bview/view allocation {:id :right :byte-offset 32 :dtype :float :shape [8]})
         overlap (bview/view allocation {:id :overlap :byte-offset 16 :dtype :float :shape [8]})
         use (fn [id access] (kgraph/->ValueUse id access))
-        node (fn [id uses deps] (kgraph/->ScheduledKernel id :mock uses deps))
+        node (fn [id uses deps] (kgraph/->ScheduledKernel id :mock uses nil deps))
         validate! (ns-resolve 'raster.gpu.core 'validate-physical-aliases!)]
     (testing "disjoint views of one allocation are legal"
       (is (map? (validate! {:nodes [(node :one [(use :a :read) (use :b :write)] [])]}


### PR DESCRIPTION
Scheduled graph nodes now state the exact public GraphScalar leaves they consume. Graph, ScheduledKernelBody, emitted executable, and direct KernelGraphCall validation agree on that closure; derived target-private integer expressions and literal dimensions remain internal specialization facts. Legacy scan emission is normalized to an explicit scalar interface before it becomes executable, and dynamic indexed-attention extents now use checked arithmetic IR end to end.\n\nIndependent review found and this revision fixes opaque dynamic extents, the executable nil-scalar escape, literal GEMM specialization, incomplete direct graph-call environments, and RuntimeValue literal leaf accounting.\n\nFocused verification: 178 tests, 1,290 assertions, zero failures/errors. Full suite delegated to CircleCI.