### PR TITLE
Realize derived scalars in linked dispatch

### DIFF
--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -12,6 +12,8 @@
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]
+            [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.gpu.core :as gpu]
             [raster.gpu.parallel-program :as parallel-program]
@@ -402,6 +404,24 @@
                        [value])))))
              (:argument-specs step) logical-arguments))))
 
+(defn- realize-derived-scalar
+  "Turn a target-private integer-expression into the concrete scalar required by a resident ABI.
+
+   KernelGraphs deliberately retain products, alignment and division as inspectable compiler IR
+   until graph binding.  A descriptor dispatch has no graph binder, however: its ordered ABI is
+   submitted immediately.  Resolve only explicit non-literal KernelLaunch expressions here from
+   the descriptor's public scalar environment; ordinary scalar values remain untouched."
+  [scalar-environment type value]
+  (if (and (not (number? value)) (klaunch/expression? value))
+    (let [resolved (kgcall/resolve-integer scalar-environment value)]
+      {:type type
+       :value (case type
+                :int (Math/toIntExact resolved)
+                :long resolved
+                (throw (ex-info "derived resident scalar must use an integer ABI dtype"
+                                {:type type :expression value :resolved resolved})))})
+    {:type type :value value}))
+
 (defn- resident-fields [value]
   (if (resident-value/resident-composite? value)
     (:fields value)
@@ -506,7 +526,7 @@
          logical-arguments
          (mapv (fn [{:keys [kind sym type value-fn]}]
                  (if (= :scalar kind)
-                   {:type type :value (value-fn descriptor-arguments)}
+                   (realize-derived-scalar argmap type (value-fn descriptor-arguments))
                    (resident-of sym)))
                (:argument-specs step))
          arguments (physical-step-arguments step logical-arguments)

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -236,7 +236,13 @@
                                  (Object.)))
                              (:argument-specs step))
         {:keys [buffers scalar-values]} (kexec/graph-bindings executable call-arguments)
-        call (kgcall/make executable buffers scalar-values)
+        ;; `graph-bindings` exposes only the public interface.  The graph runner owns the
+        ;; XMX staging allocations; a direct KernelGraphCall test supplies equivalent mock
+        ;; values for each declared private temporary.
+        temporary-buffers (into {}
+                                (map (fn [id] [id [:temporary-buffer id]]))
+                                (keys (kgcall/temporary-specs executable scalar-values)))
+        call (kgcall/make executable (merge buffers temporary-buffers) scalar-values)
         kernel-call (get-in call [:nodes 0 :call])]
     (is (= :executable (:convention step)))
     (is (kgraph/kernel-graph? executable)


### PR DESCRIPTION
Fixes the two deterministic CircleCI regressions from #364.\n\n- Resolve explicit KernelLaunch integer expressions against the descriptor's public scalar environment before submitting a linked resident ABI.\n- Make the direct KernelGraphCall contraction test supply its declared graph-private XMX temporary buffers, matching the runner ownership contract.\n\nThe pre-existing segmented weighted reduction assertion now covers the concrete derived product extent regression; the contraction test covers the private-temporary contract.