### PR TITLE
Certify mixed-precision GEMM as a scheduled graph refinement

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -5,7 +5,9 @@
    scalar kernel or a graph containing conversion, layout conversion, matrix contraction, and
    split-K combination. All mixed-precision scratch and derived scheduling scalars are private to
    the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.walk :as walk]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.kernel-body-target :as kernel-body-target]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
@@ -16,12 +18,15 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.layout-stage :as layout-stage]
             [raster.compiler.ir.matrix-stage :as matrix-stage]
+            [raster.compiler.ir.scheduled-graph-refinement :as graph-refinement]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
@@ -42,17 +47,20 @@
   [buffer access]
   (kgraph/->ValueUse buffer access))
 
-(defn- node
-  [id operation uses dependencies]
-  (let [scheduled (kart/attribute operation :scheduled-kernel-body)]
+(defn- stage-node
+  [id operation uses scalar-values dependencies]
+  (kgraph/->ScheduledKernel
+   id operation (vec uses)
+   (reduce into #{} (map klaunch/expression-references scalar-values))
+   (vec dependencies)))
+
+(defn- emitted-node
+  [id artifact uses dependencies]
+  (let [scheduled (kart/attribute artifact :scheduled-kernel-body)]
     (when-not (scheduled-body/scheduled-kernel-body? scheduled)
       (throw (ex-info "production GEMM graph node requires a scheduled-body certificate"
                       {:reason :gemm-scheduled-body :node id})))
-    (kgraph/->ScheduledKernel
-     id operation (vec uses)
-     (reduce into #{} (map (comp klaunch/expression-references :value)
-                           (:scalar-bindings scheduled)))
-     (vec dependencies))))
+    (stage-node id artifact uses (mapv :value (:scalar-bindings scheduled)) dependencies)))
 
 (defn- epilogue-interface
   [epilogue]
@@ -213,28 +221,43 @@
                (graph-buffer b :float b-elements :input)]
       :outputs [(graph-buffer c :float c-elements :output)]
       :scalars (kgraph/interface-scalars abi arguments)
-      :nodes [(node stage-id gemm
-                    [(value-use a :read) (value-use b :read) (value-use c :write)] [])]
+      :nodes [(emitted-node stage-id gemm
+                            [(value-use a :read) (value-use b :read)
+                             (value-use c :write)] [])]
       :abi abi :arguments arguments
       :effects (effects spec)
       :provenance {:semantic-op :contraction :variant variant :lowering :scalar-gemm}
       :attributes {:strategy :f32-scalar :variant variant :precision :f32}})))
 
+(defn- convert-stage
+  [stage-id in out elements]
+  (layout-stage/make
+   {:id stage-id :operation :cast :input in :output out
+    :input-shape [elements] :output-shape [elements]
+    :input-dtype :float :output-dtype :half
+    :policy {:rounding :nearest-even :overflow :ieee}}))
+
+(defn- transpose-stage
+  [stage-id in out rows cols]
+  (layout-stage/make
+   {:id stage-id :operation :transpose :input in :output out
+    :input-shape [rows cols] :output-shape [cols rows]
+    :input-dtype :half :output-dtype :half
+    :policy {:permutation [1 0]}}))
+
 (defn- convert-artifact
-  [kernel-name stage-id in out elements vector-width phase]
-  (let [kernel-name (c-emit/c-symbol kernel-name)
+  [kernel-name stage vector-width phase target-dialect]
+  (let [{stage-id :id in :input out :output input-shape :input-shape} stage
+        elements (first input-shape)
+        kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/cast-body
-         {:kernel-name kernel-name :input in :output out
+         {:id stage-id :input in :output out
           :source-dtype :float :destination-dtype :half :vector-width vector-width
           :rounding :nearest-even :overflow :ieee})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
-      :source (layout-stage/make
-               {:id stage-id :operation :cast :input in :output out
-                :input-shape [elements] :output-shape [elements]
-                :input-dtype :float :output-dtype :half
-                :policy {:rounding :nearest-even :overflow :ieee}})
+      :source stage
       :body kernel-body :arguments [in out elements]
       :effects {:kind :layout-transform-stage}
       :legality {:kind :dense-affine-cast :vector-width vector-width}
@@ -242,29 +265,29 @@
                  :rounding :nearest-even :accumulator-dtype :half
                  :error-model {:kind :ieee-f16-conversion :overflow :ieee}}
       :phase phase
+      :target-dialect target-dialect
       :attributes {:vector-width vector-width :from :float :to :half
                    :rounding :nearest-even :overflow :ieee
                    :cacheable-transform? true}
       :parameter-names {in "input" out "output" :layout-elements "n"}})))
 
 (defn- transpose-artifact
-  [kernel-name stage-id in out rows cols phase]
-  (let [kernel-name (c-emit/c-symbol kernel-name)
+  [kernel-name stage phase target-dialect]
+  (let [{stage-id :id in :input out :output
+         [rows cols] :input-shape} stage
+        kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/transpose-body
-         {:kernel-name kernel-name :input in :output out :element-dtype :half})]
+         {:id stage-id :input in :output out :element-dtype :half})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
-      :source (layout-stage/make
-               {:id stage-id :operation :transpose :input in :output out
-                :input-shape [rows cols] :output-shape [cols rows]
-                :input-dtype :half :output-dtype :half
-                :policy {:permutation [1 0]}})
+      :source stage
       :body kernel-body :arguments [in out rows cols]
       :effects {:kind :layout-transform-stage}
       :legality {:kind :bijective-affine-permutation :permutation [1 0]}
       :numerics {:mode :exact :policy :bit-preserving-permutation}
       :phase phase
+      :target-dialect target-dialect
       :attributes {:layout :transpose :dtype :half :cacheable-transform? true}
       :parameter-names {in "input" out "output"
                         :layout-rows "rows" :layout-cols "cols"}})))
@@ -450,36 +473,55 @@
     (kernel-body-target/emit-artifact
      kernel-name scheduled target-dialect {:parameter-names parameter-names})))
 
-(defn- gemm-artifact
-  [{:keys [id m n k tile epilogue]} stage-id kernel-name a b c split-k? kc splits phase]
+(defn- matrix-stage-for
+  [{:keys [m n k epilogue]} stage-id a b c split-k? kc splits]
   (let [reduction (if split-k?
                     (let [slice 'k-slice
                           lower (kbody/expression :mul slice kc)]
                       {:kind :split-k :slice slice :chunk kc :partitions splits
                        :range [lower (kbody/expression
                                       :min (kbody/expression :add lower kc) k)]})
-                    {:kind :full :range [0 k]})
-        stage (matrix-stage/make
-               {:id stage-id
-                :lhs a :rhs b :result c :dimensions [m n k]
-                :reduction reduction
-                :result-shape (if split-k? [splits m n] [m n])
-                :epilogue (when-not split-k? epilogue)})
+                    {:kind :full :range [0 k]})]
+    (matrix-stage/make
+     {:id stage-id
+      :lhs a :rhs b :result c :dimensions [m n k]
+      :reduction reduction
+      :result-shape (if split-k? [splits m n] [m n])
+      :epilogue (when-not split-k? epilogue)})))
+
+(defn- gemm-artifact
+  [{:keys [id tile]} stage kernel-name phase target-dialect]
+  (let [{stage-id :id a :lhs b :rhs c :result
+         [m n k] :dimensions reduction :reduction epilogue :epilogue
+         batching :batching} stage
+        split-k? (= :split-k (:kind reduction))
+        kc (:chunk reduction)
+        splits (:partitions reduction)
         emit-args {:kernel-name kernel-name
                    :id stage-id
                    :a a :b b :c c :m m :n n :k k
-                   :tile tile :result-dtype :float
-                   :epilogue (when-not split-k? epilogue)
+                   :tile tile :result-dtype (:result-dtype stage)
+                   :epilogue epilogue
                    :phase phase
+                   :target-dialect target-dialect
                    :source-operation stage
                    :provenance {:operation-id id :phase phase}}]
     (emit-scheduled-matrix-artifact
-     (if split-k?
+     (cond
+       batching
+       (assoc (batched-matrix-spec
+               (assoc emit-args
+                      :batch (:extent batching)
+                      :batching {:row (:lhs batching) :col (:rhs batching)}))
+              :phase phase :source-operation stage)
+
+       split-k?
        (assoc (split-k-matrix-spec
                (assoc emit-args :kc :k-chunk :splits :splits))
               :phase phase :source-operation stage
               :argument-values {:k-chunk kc :splits splits})
-       emit-args))))
+
+       :else emit-args))))
 
 (defn- split-k-combine-plan
   [stage-id]
@@ -512,8 +554,8 @@
      {:kernel-name kernel-name :source source :kernel-body kernel-body :workgroup-size 256})))
 
 (defn- combine-artifact
-  [kernel-name stage-id partials c mn splits]
-  (let [{:keys [operation body]} (split-k-combine-plan stage-id)]
+  [kernel-name operation partials c mn splits target-dialect]
+  (let [{body :body} (split-k-combine-plan (:id operation))]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name :source operation :body body
       :arguments [partials c mn splits mn]
@@ -522,6 +564,7 @@
       :numerics {:mode :reassociated :policy :sequential-segment-fold
                  :rounding :nearest-even :accumulator-dtype :float}
       :phase :split-k-combine
+      :target-dialect target-dialect
       :attributes {:accumulator-dtype :float :semantic-op :contraction}
       :parameter-names {'partials "partials" 'C "C"
                         'mn "mn" 'splits "splits" '_nseg "_nseg"}})))
@@ -534,11 +577,128 @@
                     {:split-factor factor})))
   (keyword (str "xmx-split-k-" factor)))
 
+(defn- semantic-source-graph
+  [stage-graph operation]
+  (when-not (instance? raster.compiler.ir.segop.SegRed operation)
+    (throw (ex-info "mixed-precision graph refinement requires its exact semantic SegRed"
+                    {:reason :gemm-refinement-source :operation operation})))
+  (let [stage-graph (kgraph/validate! stage-graph)
+        inputs (set (map :id (:inputs stage-graph)))
+        outputs (set (map :id (:outputs stage-graph)))
+        expected-inputs (segop/operation-inputs operation)
+        expected-outputs (segop/operation-outputs operation)
+        scalar-uses (segop/operation-scalars operation)
+        declared-scalars (set (map :id (:scalars stage-graph)))]
+    (when-not (and (= inputs expected-inputs) (= outputs expected-outputs))
+      (throw (ex-info "mixed-precision stage graph changed the semantic storage boundary"
+                      {:reason :gemm-refinement-storage
+                       :expected-inputs expected-inputs :actual-inputs inputs
+                       :expected-outputs expected-outputs :actual-outputs outputs})))
+    (when-not (set/subset? scalar-uses declared-scalars)
+      (throw (ex-info "mixed-precision source uses undeclared graph scalars"
+                      {:reason :gemm-refinement-scalars :uses scalar-uses
+                       :declared declared-scalars})))
+    (kgraph/make
+     {:inputs (:inputs stage-graph)
+      :outputs (:outputs stage-graph)
+      :scalars (:scalars stage-graph)
+      :nodes [(kgraph/->ScheduledKernel
+               [:semantic-contraction (:id operation)] operation
+               (vec (concat (map #(value-use (:id %) :read) (:inputs stage-graph))
+                            (map #(value-use (:id %) :write) (:outputs stage-graph))))
+               scalar-uses [])]
+      :abi (:abi stage-graph) :arguments (:arguments stage-graph)
+      :effects (:effects stage-graph)
+      :provenance {:semantic-op :contraction :source-dialect :typed-soac}
+      :attributes {:semantic-operation (:id operation)}})))
+
+(defn- refinement-numerics
+  [{:keys [epilogue]} split-k?]
+  (cond-> {:mode :bounded-error
+           :policy :f32-input-f16-matrix-f32-output
+           :rounding :nearest-even
+           :accumulator-dtype :float
+           :error-model {:kind :composed-mixed-precision-stages
+                         :operand-conversion {:from :float :to :half
+                                              :rounding :nearest-even :overflow :ieee}
+                         :reduction-order (if split-k? :split-k-tree :tiled)}}
+    (seq epilogue)
+    (assoc :result-transform
+           {:kind :typed-scalar-region
+            :policy :same-typed-ssa-evaluation-order
+            :input-dtype :float :result-dtype :float})))
+
+(defn- make-refinement
+  [stage-graph source-operation {:keys [strategy variant tile vector-width requested-splits
+                                        split-k?] :as spec}]
+  (when source-operation
+    (graph-refinement/make
+     {:source (semantic-source-graph stage-graph source-operation)
+      :graph stage-graph
+      :schedule {:kind :mixed-precision-contraction
+                 :strategy strategy :variant variant :tile tile
+                 :vector-width vector-width :split-k? (boolean split-k?)
+                 :requested-splits requested-splits}
+      :numerics (refinement-numerics spec split-k?)
+      :provenance {:operation-id (:id source-operation)
+                   :source-dialect :typed-soac}
+      :attributes {:compiler-stage :gemm-graph-schedule}})))
+
+(defn- emit-stage-artifact
+  [graph spec prefix {:keys [operation] :as node}]
+  (let [target-dialect (get spec :target-dialect :opencl-intel)
+        phase (last (:id node))]
+    (cond
+      (layout-stage/layout-stage? operation)
+      (case (:operation operation)
+        :cast (convert-artifact (str prefix "_" (name phase)) operation
+                                (:vector-width spec) phase target-dialect)
+        :transpose (transpose-artifact (str prefix "_" (name phase)) operation
+                                       phase target-dialect))
+
+      (matrix-stage/matrix-stage? operation)
+      (gemm-artifact spec operation (str prefix "_" (name phase))
+                     :matrix-contract target-dialect)
+
+      (instance? raster.compiler.ir.segop.SegRed operation)
+      (combine-artifact (str prefix "_" (name phase)) operation
+                        (first (:inputs operation)) (first (:outputs operation))
+                        (klaunch/product (:m spec) (:n spec))
+                        (get-in spec [:stage-values :splits]) target-dialect)
+
+      :else
+      (throw (ex-info "GEMM stage has no ScheduledKernelBody lowering"
+                      {:reason :gemm-stage-lowering :node (:id node)
+                       :operation operation})))))
+
+(defn- emit-stage-graph
+  [stage-graph spec prefix refinement]
+  (let [stage-graph (kgraph/validate! stage-graph)
+        emitted
+        (kgraph/map-operations
+         stage-graph
+         (fn [node]
+           (let [artifact (emit-stage-artifact stage-graph spec prefix node)
+                 scheduled (kart/attribute artifact :scheduled-kernel-body)]
+             (scheduled-body/validate-against-node! scheduled node stage-graph)
+             (scheduled-body/validate-artifact-projection! scheduled artifact)
+             artifact)))
+        emitted (cond-> emitted
+                  refinement
+                  (assoc-in [:attributes :scheduled-graph-refinement] refinement))]
+    (when-not (kgraph/dataflow-equivalent? stage-graph emitted)
+      (throw (ex-info "GEMM target emission changed scheduled graph dataflow"
+                      {:reason :gemm-emission-dataflow
+                       :scheduled (kgraph/dataflow-contract stage-graph)
+                       :emitted (kgraph/dataflow-contract emitted)})))
+    (kexec/validate! emitted)))
+
 (defn- xmx-graph
   [{:keys [id a b c m n k variant tile vector-width requested-splits split-k? epilogue
-           strategy]
+           strategy source-operation external-interface]
     :as spec}]
-  (let [{:keys [abi arguments]} (public-outer-interface spec)
+  (let [{:keys [abi arguments effects]}
+        (or external-interface (assoc (public-outer-interface spec) :effects (effects spec)))
         {:keys [a-elements b-elements c-elements]} (extents spec)
         epilogue-buffers (epilogue-buffer-specs epilogue)
         strategy (or strategy (if split-k? :xmx-split-k :xmx-direct))
@@ -559,88 +719,72 @@
         transpose-a-id [:gemm id strategy :transpose-a]
         transpose-b-id [:gemm id strategy :transpose-b]
         contract-id [:gemm id strategy :contract]
-        convert-a (convert-artifact (str prefix "_convert_a") convert-a-id
-                                    a a16 a-elements vector-width
-                                    :convert-a)
-        convert-b (convert-artifact (str prefix "_convert_b") convert-b-id
-                                    b b16 b-elements vector-width
-                                    :convert-b)
+        convert-a (convert-stage convert-a-id a a16 a-elements)
+        convert-b (convert-stage convert-b-id b b16 b-elements)
         transpose-a (when (contains? #{:tn :tt} variant)
-                      (transpose-artifact (str prefix "_transpose_a") transpose-a-id
-                                          a16 at16 k m
-                                          :transpose-a))
+                      (transpose-stage transpose-a-id a16 at16 k m))
         transpose-b (when (contains? #{:nt :tt} variant)
-                      (transpose-artifact (str prefix "_transpose_b") transpose-b-id
-                                          b16 bt16 n k
-                                          :transpose-b))
+                      (transpose-stage transpose-b-id b16 bt16 n k))
         contract-output (if split-k? partials c)
-        contract (gemm-artifact spec contract-id (str prefix "_contract")
-                                final-a final-b contract-output
-                                split-k? kc splits :matrix-contract)
+        contract (matrix-stage-for spec contract-id final-a final-b contract-output
+                                   split-k? kc splits)
         combine (when split-k?
-                  (combine-artifact (str prefix "_combine")
-                                    [:gemm id strategy :combine]
-                                    partials c c-elements splits))
+                  (walk/postwalk-replace
+                   {'mn c-elements 'splits splits}
+                   (:operation (split-k-combine-plan [:gemm id strategy :combine]))))
         nodes (cond->
-               [(node convert-a-id convert-a [(value-use a :read) (value-use a16 :write)] [])
-                (node convert-b-id convert-b [(value-use b :read) (value-use b16 :write)] [])]
+               [(stage-node convert-a-id convert-a
+                            [(value-use a :read) (value-use a16 :write)] [a-elements] [])
+                (stage-node convert-b-id convert-b
+                            [(value-use b :read) (value-use b16 :write)] [b-elements] [])]
                 transpose-a
-                (conj (node transpose-a-id transpose-a
-                            [(value-use a16 :read) (value-use at16 :write)] [convert-a-id]))
+                (conj (stage-node transpose-a-id transpose-a
+                                  [(value-use a16 :read) (value-use at16 :write)]
+                                  [k m] [convert-a-id]))
                 transpose-b
-                (conj (node transpose-b-id transpose-b
-                            [(value-use b16 :read) (value-use bt16 :write)] [convert-b-id]))
+                (conj (stage-node transpose-b-id transpose-b
+                                  [(value-use b16 :read) (value-use bt16 :write)]
+                                  [n k] [convert-b-id]))
                 true
-                (conj (node contract-id contract
-                            (into [(value-use final-a :read) (value-use final-b :read)
-                                   (value-use contract-output :write)]
-                                  (map #(value-use (:id %) :read))
-                                  epilogue-buffers)
-                            [(if transpose-a transpose-a-id convert-a-id)
-                             (if transpose-b transpose-b-id convert-b-id)]))
+                (conj (stage-node
+                       contract-id contract
+                       (into [(value-use final-a :read) (value-use final-b :read)
+                              (value-use contract-output :write)]
+                             (map #(value-use (:id %) :read)) epilogue-buffers)
+                       (vec (concat [m n k] (when split-k? [kc splits])
+                                    (map :sym (:scalars epilogue))))
+                       [(if transpose-a transpose-a-id convert-a-id)
+                        (if transpose-b transpose-b-id convert-b-id)]))
                 combine
-                (conj (node [:gemm id strategy :combine] combine
-                            [(value-use partials :read) (value-use c :write)] [contract-id])))
+                (conj (stage-node [:gemm id strategy :combine] combine
+                                  [(value-use partials :read) (value-use c :write)]
+                                  (vec (segop/operation-scalars combine)) [contract-id])))
         temporaries (cond-> [(graph-buffer a16 :half a-elements :temporary)
                              (graph-buffer b16 :half b-elements :temporary)]
                       transpose-a (conj (graph-buffer at16 :half a-elements :temporary))
                       transpose-b (conj (graph-buffer bt16 :half b-elements :temporary))
                       split-k? (conj (graph-buffer partials :float partial-elements :temporary)))]
-    (kgraph/make
-     {:inputs (into [(graph-buffer a :float a-elements :input)
-                    (graph-buffer b :float b-elements :input)]
-                   (map #(graph-buffer (:id %) (:dtype %) (:elements %) :input))
-                   epilogue-buffers)
-      :outputs [(graph-buffer c :float c-elements :output)]
-      :temporaries temporaries
-      :scalars (kgraph/interface-scalars abi arguments)
-      :nodes nodes
-      :abi abi :arguments arguments
-      :effects (effects spec)
-      :provenance {:semantic-op :contraction :variant variant :lowering :xmx-gemm}
-      :attributes {:strategy strategy :variant variant :precision :mixed-f16-f32
-                   :tile tile :requested-splits requested-splits}})))
-
-(defn- batched-gemm-artifact
-  [{:keys [id a b c batch m n k tile batching]}]
-  (let [kernel-name (str (identifier (str id "_xmx_batched")) "_contract")
-        stage (matrix-stage/make
-               {:id [:gemm id :xmx-batched :contract]
-                :lhs a :rhs b :result c :dimensions [m n k]
-                :batching {:extent batch
-                           :lhs (get batching :row true)
-                           :rhs (get batching :col true)}
-                :reduction {:kind :full :range [0 k]}
-                :result-shape [batch m n]})]
-    (emit-scheduled-matrix-artifact
-     (assoc (batched-matrix-spec
-             {:kernel-name kernel-name
-              :id [:gemm id :xmx-batched]
-              :a a :b b :c c :m m :n n :k k :batch batch :batching batching
-              :tile tile
-              :provenance {:operation-id id :phase :matrix-contract}})
-            :phase :matrix-contract
-            :source-operation stage))))
+    (let [stage-graph
+          (kgraph/make
+           {:inputs (into [(graph-buffer a :float a-elements :input)
+                           (graph-buffer b :float b-elements :input)]
+                          (map #(graph-buffer (:id %) (:dtype %) (:elements %) :input))
+                          epilogue-buffers)
+            :outputs [(graph-buffer c :float c-elements :output)]
+            :temporaries temporaries
+            :scalars (kgraph/interface-scalars abi arguments)
+            :nodes nodes
+            :abi abi :arguments arguments
+            :effects effects
+            :provenance {:semantic-op :contraction :variant variant
+                         :lowering :xmx-gemm-schedule}
+            :attributes {:strategy strategy :variant variant :precision :mixed-f16-f32
+                         :tile tile :vector-width vector-width
+                         :requested-splits requested-splits}})
+          emit-spec (assoc spec :strategy strategy
+                          :stage-values {:kc kc :splits splits})
+          refinement (make-refinement stage-graph source-operation emit-spec)]
+      (emit-stage-graph stage-graph emit-spec prefix refinement))))
 
 (defn emit-batched-matrix-alternative
   "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.
@@ -650,7 +794,8 @@
    [batch,M,K], [batch,K,N], and [batch,M,N] views.  The return value deliberately is not a
    standalone dispatch: the originating typed contraction supplies its general fallback and this
    schedule contributes the alignment selector that chooses between them."
-  [{:keys [id a b c batch m n k variant tile vector-width batching]
+  [{:keys [id a b c batch m n k variant tile vector-width batching
+           source-operation external-interface]
     :or {vector-width 4 batching {:row true :col true}}
     :as spec}]
   (when-not (= :nn variant)
@@ -662,7 +807,9 @@
     (when (nil? value)
       (throw (ex-info "batched matrix schedule is missing a required field"
                       {:reason :raster/bug :field field :spec spec}))))
-  (let [{:keys [abi arguments]} (public-batched-outer-interface spec)
+  (let [{:keys [abi arguments effects]}
+        (or external-interface
+            (assoc (public-batched-outer-interface spec) :effects (effects spec)))
         a-elements (if (get batching :row true)
                      (klaunch/product batch m k)
                      (klaunch/product m k))
@@ -676,15 +823,17 @@
         convert-a-id [:gemm id :xmx-batched :convert-a]
         convert-b-id [:gemm id :xmx-batched :convert-b]
         contract-id [:gemm id :xmx-batched :contract]
-        convert-a (convert-artifact (str prefix "_convert_a") convert-a-id
-                                    a a16 a-elements vector-width
-                                    :convert-a)
-        convert-b (convert-artifact (str prefix "_convert_b") convert-b-id
-                                    b b16 b-elements vector-width
-                                    :convert-b)
-        contract (batched-gemm-artifact
-                  (assoc spec :a a16 :b b16 :c c :batching batching))
-        graph
+        convert-a (convert-stage convert-a-id a a16 a-elements)
+        convert-b (convert-stage convert-b-id b b16 b-elements)
+        contract (matrix-stage/make
+                  {:id contract-id
+                   :lhs a16 :rhs b16 :result c :dimensions [m n k]
+                   :batching {:extent batch
+                              :lhs (get batching :row true)
+                              :rhs (get batching :col true)}
+                   :reduction {:kind :full :range [0 k]}
+                   :result-shape [batch m n]})
+        stage-graph
         (kgraph/make
          {:inputs [(graph-buffer a :float a-elements :input)
                    (graph-buffer b :float b-elements :input)]
@@ -692,16 +841,19 @@
           :temporaries [(graph-buffer a16 :half a-elements :temporary)
                         (graph-buffer b16 :half b-elements :temporary)]
           :scalars (kgraph/interface-scalars abi arguments)
-          :nodes [(node convert-a-id convert-a
-                        [(value-use a :read) (value-use a16 :write)] [])
-                  (node convert-b-id convert-b
-                        [(value-use b :read) (value-use b16 :write)] [])
-                  (node contract-id contract
-                        [(value-use a16 :read) (value-use b16 :read)
-                         (value-use c :write)]
-                        [convert-a-id convert-b-id])]
+          :nodes [(stage-node convert-a-id convert-a
+                              [(value-use a :read) (value-use a16 :write)]
+                              [a-elements] [])
+                  (stage-node convert-b-id convert-b
+                              [(value-use b :read) (value-use b16 :write)]
+                              [b-elements] [])
+                  (stage-node contract-id contract
+                              [(value-use a16 :read) (value-use b16 :read)
+                               (value-use c :write)]
+                              [batch m n k]
+                              [convert-a-id convert-b-id])]
           :abi abi :arguments arguments
-          :effects (effects spec)
+          :effects effects
           :provenance {:semantic-op :contraction
                        :variant :nn
                        :lowering :batched-xmx-gemm}
@@ -710,8 +862,14 @@
                        :batched? true
                        :batching batching
                        :precision :mixed-f16-f32
-                       :tile tile}})]
+                       :vector-width vector-width
+                       :tile tile}})
+        emit-spec (assoc spec :strategy :xmx-batched
+                         :vector-width vector-width :batching batching)
+        refinement (make-refinement stage-graph source-operation emit-spec)
+        graph (emit-stage-graph stage-graph emit-spec prefix refinement)]
     {:graph graph
+     :refinement refinement
      :selector
      {:kind :runtime-expression-cases
       :cases [{:expression n :op :< :value 8 :strategy :f32-scalar}

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -730,7 +730,7 @@
                                    split-k? kc splits)
         combine (when split-k?
                   (walk/postwalk-replace
-                   {'mn c-elements 'splits splits}
+                   {'partials partials 'C c 'mn c-elements 'splits splits}
                    (:operation (split-k-combine-plan [:gemm id strategy :combine]))))
         nodes (cond->
                [(stage-node convert-a-id convert-a

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -5,8 +5,7 @@
    scalar kernel or a graph containing conversion, layout conversion, matrix contraction, and
    split-K combination. All mixed-precision scratch and derived scheduling scalars are private to
    the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
-  (:require [clojure.set :as set]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.walk :as walk]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.kernel-body-target :as kernel-body-target]
@@ -252,6 +251,12 @@
         (layout-stage/validate! stage)
         elements (first input-shape)
         vector-width (:vector-width policy)
+        _ (when-not (and (= :float (:input-dtype stage)) (= :half (:output-dtype stage))
+                         (= :nearest-even (:rounding policy)) (= :ieee (:overflow policy)))
+            (throw (ex-info "GEMM cast emitter does not implement the scheduled representation"
+                            {:reason :gemm-stage-emission-unsupported :stage stage-id
+                             :input-dtype (:input-dtype stage)
+                             :output-dtype (:output-dtype stage) :policy policy})))
         _ (when-not (and (integer? vector-width) (pos? vector-width))
             (throw (ex-info "scheduled layout cast does not close its emission choices"
                             {:reason :gemm-stage-emission-open :stage stage-id
@@ -282,6 +287,12 @@
   [kernel-name stage phase target-dialect]
   (let [{stage-id :id in :input out :output
          [rows cols] :input-shape} (layout-stage/validate! stage)
+        _ (when-not (and (= :half (:input-dtype stage)) (= :half (:output-dtype stage))
+                         (= [1 0] (get-in stage [:policy :permutation])))
+            (throw (ex-info "GEMM transpose emitter does not implement the scheduled representation"
+                            {:reason :gemm-stage-emission-unsupported :stage stage-id
+                             :input-dtype (:input-dtype stage)
+                             :output-dtype (:output-dtype stage) :policy (:policy stage)})))
         kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/transpose-body
@@ -503,6 +514,16 @@
          [m n k] :dimensions reduction :reduction epilogue :epilogue
          batching :batching schedule :schedule} (matrix-stage/validate! stage)
         tile (:tile schedule)
+        _ (when-not (and (= :matrix-instruction-tiling (:kind schedule))
+                         (= :half (:operand-dtype stage))
+                         (= :float (:accumulator-dtype stage))
+                         (= :float (:result-dtype stage)))
+            (throw (ex-info "GEMM matrix emitter does not implement the scheduled numerical form"
+                            {:reason :gemm-stage-emission-unsupported :stage stage-id
+                             :schedule schedule
+                             :operand-dtype (:operand-dtype stage)
+                             :accumulator-dtype (:accumulator-dtype stage)
+                             :result-dtype (:result-dtype stage)})))
         _ (when-not (map? tile)
             (throw (ex-info "scheduled matrix stage does not close its emission choices"
                             {:reason :gemm-stage-emission-open :stage stage-id
@@ -590,41 +611,6 @@
                     {:split-factor factor})))
   (keyword (str "xmx-split-k-" factor)))
 
-(defn- semantic-source-graph
-  [stage-graph operation]
-  (when-not (instance? raster.compiler.ir.segop.SegRed operation)
-    (throw (ex-info "mixed-precision graph refinement requires its exact semantic SegRed"
-                    {:reason :gemm-refinement-source :operation operation})))
-  (let [stage-graph (kgraph/validate! stage-graph)
-        inputs (set (map :id (:inputs stage-graph)))
-        outputs (set (map :id (:outputs stage-graph)))
-        expected-inputs (segop/operation-inputs operation)
-        expected-outputs (segop/operation-outputs operation)
-        scalar-uses (segop/operation-scalars operation)
-        declared-scalars (set (map :id (:scalars stage-graph)))]
-    (when-not (and (= inputs expected-inputs) (= outputs expected-outputs))
-      (throw (ex-info "mixed-precision stage graph changed the semantic storage boundary"
-                      {:reason :gemm-refinement-storage
-                       :expected-inputs expected-inputs :actual-inputs inputs
-                       :expected-outputs expected-outputs :actual-outputs outputs})))
-    (when-not (set/subset? scalar-uses declared-scalars)
-      (throw (ex-info "mixed-precision source uses undeclared graph scalars"
-                      {:reason :gemm-refinement-scalars :uses scalar-uses
-                       :declared declared-scalars})))
-    (kgraph/make
-     {:inputs (:inputs stage-graph)
-      :outputs (:outputs stage-graph)
-      :scalars (:scalars stage-graph)
-      :nodes [(kgraph/->ScheduledKernel
-               [:semantic-contraction (:id operation)] operation
-               (vec (concat (map #(value-use (:id %) :read) (:inputs stage-graph))
-                            (map #(value-use (:id %) :write) (:outputs stage-graph))))
-               scalar-uses [])]
-      :abi (:abi stage-graph) :arguments (:arguments stage-graph)
-      :effects (:effects stage-graph)
-      :provenance {:semantic-op :contraction :source-dialect :typed-soac}
-      :attributes {:semantic-operation (:id operation)}})))
-
 (defn- refinement-numerics
   [{:keys [epilogue]} split-k?]
   (cond-> {:mode :bounded-error
@@ -647,20 +633,29 @@
             :input-dtype :float :result-dtype :float})))
 
 (defn- make-refinement
-  [stage-graph source-operation {:keys [strategy variant tile vector-width requested-splits
-                                        split-k?] :as spec}]
+  [stage-graph source-operation source-graph
+   {:keys [strategy variant tile vector-width requested-splits split-k?] :as spec}]
   (when source-operation
-    (graph-refinement/make
-     {:source (semantic-source-graph stage-graph source-operation)
-      :graph stage-graph
-      :schedule {:kind :mixed-precision-contraction
-                 :strategy strategy :variant variant :tile tile
-                 :vector-width vector-width :split-k? (boolean split-k?)
-                 :requested-splits requested-splits}
-      :numerics (refinement-numerics spec split-k?)
-      :provenance {:operation-id (:id source-operation)
-                   :source-dialect :typed-soac}
-      :attributes {:compiler-stage :gemm-graph-schedule}})))
+    (when-not source-graph
+      (throw (ex-info "typed mixed-precision scheduling requires its independent source graph"
+                      {:reason :gemm-refinement-source-graph
+                       :operation (:id source-operation)})))
+    (let [source-graph (kgraph/validate! source-graph)]
+      (when-not (identical? source-operation (-> source-graph :nodes first :operation))
+        (throw (ex-info "mixed-precision refinement source graph lost exact SegRed identity"
+                        {:reason :gemm-refinement-source
+                         :operation (:id source-operation)})))
+      (graph-refinement/make
+       {:source source-graph
+        :graph stage-graph
+        :schedule {:kind :mixed-precision-contraction
+                   :strategy strategy :variant variant :tile tile
+                   :vector-width vector-width :split-k? (boolean split-k?)
+                   :requested-splits requested-splits}
+        :numerics (refinement-numerics spec split-k?)
+        :provenance {:operation-id (:id source-operation)
+                     :source-dialect :typed-soac}
+        :attributes {:compiler-stage :gemm-graph-schedule}}))))
 
 (defn- split-combine-values
   [operation]
@@ -739,7 +734,7 @@
 
 (defn- xmx-graph
   [{:keys [id a b c m n k variant tile vector-width requested-splits split-k? epilogue
-           strategy source-operation external-interface]
+           strategy source-operation source-graph external-interface]
     :as spec}]
   (let [{:keys [abi arguments effects]}
         (or external-interface (assoc (public-outer-interface spec) :effects (effects spec)))
@@ -826,7 +821,7 @@
                          :tile tile :vector-width vector-width
                          :requested-splits requested-splits}})
           emit-spec (assoc spec :strategy strategy)
-          refinement (make-refinement stage-graph source-operation emit-spec)]
+          refinement (make-refinement stage-graph source-operation source-graph emit-spec)]
       (emit-scheduled-stage-graph
        stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
                     :prefix prefix :refinement refinement}))))
@@ -840,7 +835,7 @@
    standalone dispatch: the originating typed contraction supplies its general fallback and this
    schedule contributes the alignment selector that chooses between them."
   [{:keys [id a b c batch m n k variant tile vector-width batching
-           source-operation external-interface]
+           source-operation source-graph external-interface]
     :or {vector-width 4 batching {:row true :col true}}
     :as spec}]
   (when-not (= :nn variant)
@@ -912,7 +907,7 @@
                        :tile tile}})
         emit-spec (assoc spec :strategy :xmx-batched
                          :vector-width vector-width :batching batching)
-        refinement (make-refinement stage-graph source-operation emit-spec)
+        refinement (make-refinement stage-graph source-operation source-graph emit-spec)
         graph (emit-scheduled-stage-graph
                stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
                             :prefix prefix :refinement refinement})]

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -230,12 +230,13 @@
       :attributes {:strategy :f32-scalar :variant variant :precision :f32}})))
 
 (defn- convert-stage
-  [stage-id in out elements]
+  [stage-id in out elements vector-width]
   (layout-stage/make
    {:id stage-id :operation :cast :input in :output out
     :input-shape [elements] :output-shape [elements]
     :input-dtype :float :output-dtype :half
-    :policy {:rounding :nearest-even :overflow :ieee}}))
+    :policy {:rounding :nearest-even :overflow :ieee
+             :vector-width vector-width}}))
 
 (defn- transpose-stage
   [stage-id in out rows cols]
@@ -246,9 +247,15 @@
     :policy {:permutation [1 0]}}))
 
 (defn- convert-artifact
-  [kernel-name stage vector-width phase target-dialect]
-  (let [{stage-id :id in :input out :output input-shape :input-shape} stage
+  [kernel-name stage phase target-dialect]
+  (let [{stage-id :id in :input out :output input-shape :input-shape policy :policy}
+        (layout-stage/validate! stage)
         elements (first input-shape)
+        vector-width (:vector-width policy)
+        _ (when-not (and (integer? vector-width) (pos? vector-width))
+            (throw (ex-info "scheduled layout cast does not close its emission choices"
+                            {:reason :gemm-stage-emission-open :stage stage-id
+                             :missing :vector-width})))
         kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/cast-body
@@ -274,7 +281,7 @@
 (defn- transpose-artifact
   [kernel-name stage phase target-dialect]
   (let [{stage-id :id in :input out :output
-         [rows cols] :input-shape} stage
+         [rows cols] :input-shape} (layout-stage/validate! stage)
         kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/transpose-body
@@ -474,7 +481,7 @@
      kernel-name scheduled target-dialect {:parameter-names parameter-names})))
 
 (defn- matrix-stage-for
-  [{:keys [m n k epilogue]} stage-id a b c split-k? kc splits]
+  [{:keys [m n k epilogue tile]} stage-id a b c split-k? kc splits]
   (let [reduction (if split-k?
                     (let [slice 'k-slice
                           lower (kbody/expression :mul slice kc)]
@@ -487,13 +494,19 @@
       :lhs a :rhs b :result c :dimensions [m n k]
       :reduction reduction
       :result-shape (if split-k? [splits m n] [m n])
-      :epilogue (when-not split-k? epilogue)})))
+      :epilogue (when-not split-k? epilogue)
+      :schedule {:kind :matrix-instruction-tiling :tile tile}})))
 
 (defn- gemm-artifact
-  [{:keys [id tile]} stage kernel-name phase target-dialect]
+  [stage kernel-name phase target-dialect]
   (let [{stage-id :id a :lhs b :rhs c :result
          [m n k] :dimensions reduction :reduction epilogue :epilogue
-         batching :batching} stage
+         batching :batching schedule :schedule} (matrix-stage/validate! stage)
+        tile (:tile schedule)
+        _ (when-not (map? tile)
+            (throw (ex-info "scheduled matrix stage does not close its emission choices"
+                            {:reason :gemm-stage-emission-open :stage stage-id
+                             :missing :tile})))
         split-k? (= :split-k (:kind reduction))
         kc (:chunk reduction)
         splits (:partitions reduction)
@@ -505,7 +518,7 @@
                    :phase phase
                    :target-dialect target-dialect
                    :source-operation stage
-                   :provenance {:operation-id id :phase phase}}]
+                   :provenance {:operation-id stage-id :phase phase}}]
     (emit-scheduled-matrix-artifact
      (cond
        batching
@@ -621,7 +634,12 @@
            :error-model {:kind :composed-mixed-precision-stages
                          :operand-conversion {:from :float :to :half
                                               :rounding :nearest-even :overflow :ieee}
-                         :reduction-order (if split-k? :split-k-tree :tiled)}}
+                         :reduction-order
+                         (if split-k?
+                           {:kind :split-k
+                            :within-partition :tiled
+                            :partial-combine :ordered-sequential}
+                           {:kind :tiled})}}
     (seq epilogue)
     (assoc :result-transform
            {:kind :typed-scalar-region
@@ -644,41 +662,67 @@
                    :source-dialect :typed-soac}
       :attributes {:compiler-stage :gemm-graph-schedule}})))
 
+(defn- split-combine-values
+  [operation]
+  (let [operation (if (instance? raster.compiler.ir.segop.SegRed operation)
+                    operation
+                    (throw (ex-info "split combine emission requires a SegRed stage"
+                                    {:reason :gemm-stage-lowering :operation operation})))
+        partials (segop/operation-inputs operation)
+        outputs (segop/operation-outputs operation)
+        dimensions (get-in operation [:space :dims])
+        mn (get-in dimensions [0 :bound])
+        splits (get-in dimensions [1 :bound])]
+    (when-not (and (= 1 (count partials)) (= 1 (count outputs))
+                   (some? mn) (some? splits))
+      (throw (ex-info "split combine stage does not close its storage and reduction geometry"
+                      {:reason :gemm-stage-emission-open :stage (:id operation)
+                       :inputs partials :outputs outputs :mn mn :splits splits})))
+    {:partials (first partials) :output (first outputs) :mn mn :splits splits}))
+
 (defn- emit-stage-artifact
-  [graph spec prefix {:keys [operation] :as node}]
-  (let [target-dialect (get spec :target-dialect :opencl-intel)
-        phase (last (:id node))]
+  [target-dialect prefix {:keys [operation] :as node}]
+  (let [phase (last (:id node))]
     (cond
       (layout-stage/layout-stage? operation)
       (case (:operation operation)
         :cast (convert-artifact (str prefix "_" (name phase)) operation
-                                (:vector-width spec) phase target-dialect)
+                                phase target-dialect)
         :transpose (transpose-artifact (str prefix "_" (name phase)) operation
                                        phase target-dialect))
 
       (matrix-stage/matrix-stage? operation)
-      (gemm-artifact spec operation (str prefix "_" (name phase))
+      (gemm-artifact operation (str prefix "_" (name phase))
                      :matrix-contract target-dialect)
 
       (instance? raster.compiler.ir.segop.SegRed operation)
-      (combine-artifact (str prefix "_" (name phase)) operation
-                        (first (:inputs operation)) (first (:outputs operation))
-                        (klaunch/product (:m spec) (:n spec))
-                        (get-in spec [:stage-values :splits]) target-dialect)
+      (let [{:keys [partials output mn splits]} (split-combine-values operation)]
+        (combine-artifact (str prefix "_" (name phase)) operation
+                          partials output mn splits target-dialect))
 
       :else
       (throw (ex-info "GEMM stage has no ScheduledKernelBody lowering"
                       {:reason :gemm-stage-lowering :node (:id node)
                        :operation operation})))))
 
-(defn- emit-stage-graph
-  [stage-graph spec prefix refinement]
+(defn emit-scheduled-stage-graph
+  "Emit an already scheduled mixed-precision GEMM graph.
+
+   Every physical choice is recovered from its validated stage operations. Only target spelling
+   and entry-point naming remain emission inputs. When supplied, `refinement` must retain this
+   exact graph rather than a boundary-compatible reconstruction."
+  [stage-graph {:keys [target-dialect prefix refinement]
+                :or {target-dialect :opencl-intel prefix "scheduled_gemm"}}]
   (let [stage-graph (kgraph/validate! stage-graph)
+        _ (when (and refinement
+                     (not= stage-graph (graph-refinement/scheduled-graph refinement)))
+            (throw (ex-info "GEMM emission refinement does not retain the exact scheduled graph"
+                            {:reason :gemm-emission-refinement})))
         emitted
         (kgraph/map-operations
          stage-graph
          (fn [node]
-           (let [artifact (emit-stage-artifact stage-graph spec prefix node)
+           (let [artifact (emit-stage-artifact target-dialect prefix node)
                  scheduled (kart/attribute artifact :scheduled-kernel-body)]
              (scheduled-body/validate-against-node! scheduled node stage-graph)
              (scheduled-body/validate-artifact-projection! scheduled artifact)
@@ -719,8 +763,8 @@
         transpose-a-id [:gemm id strategy :transpose-a]
         transpose-b-id [:gemm id strategy :transpose-b]
         contract-id [:gemm id strategy :contract]
-        convert-a (convert-stage convert-a-id a a16 a-elements)
-        convert-b (convert-stage convert-b-id b b16 b-elements)
+        convert-a (convert-stage convert-a-id a a16 a-elements vector-width)
+        convert-b (convert-stage convert-b-id b b16 b-elements vector-width)
         transpose-a (when (contains? #{:tn :tt} variant)
                       (transpose-stage transpose-a-id a16 at16 k m))
         transpose-b (when (contains? #{:nt :tt} variant)
@@ -781,10 +825,11 @@
             :attributes {:strategy strategy :variant variant :precision :mixed-f16-f32
                          :tile tile :vector-width vector-width
                          :requested-splits requested-splits}})
-          emit-spec (assoc spec :strategy strategy
-                          :stage-values {:kc kc :splits splits})
+          emit-spec (assoc spec :strategy strategy)
           refinement (make-refinement stage-graph source-operation emit-spec)]
-      (emit-stage-graph stage-graph emit-spec prefix refinement))))
+      (emit-scheduled-stage-graph
+       stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
+                    :prefix prefix :refinement refinement}))))
 
 (defn emit-batched-matrix-alternative
   "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.
@@ -823,8 +868,8 @@
         convert-a-id [:gemm id :xmx-batched :convert-a]
         convert-b-id [:gemm id :xmx-batched :convert-b]
         contract-id [:gemm id :xmx-batched :contract]
-        convert-a (convert-stage convert-a-id a a16 a-elements)
-        convert-b (convert-stage convert-b-id b b16 b-elements)
+        convert-a (convert-stage convert-a-id a a16 a-elements vector-width)
+        convert-b (convert-stage convert-b-id b b16 b-elements vector-width)
         contract (matrix-stage/make
                   {:id contract-id
                    :lhs a16 :rhs b16 :result c :dimensions [m n k]
@@ -832,7 +877,8 @@
                               :lhs (get batching :row true)
                               :rhs (get batching :col true)}
                    :reduction {:kind :full :range [0 k]}
-                   :result-shape [batch m n]})
+                   :result-shape [batch m n]
+                   :schedule {:kind :matrix-instruction-tiling :tile tile}})
         stage-graph
         (kgraph/make
          {:inputs [(graph-buffer a :float a-elements :input)
@@ -867,7 +913,9 @@
         emit-spec (assoc spec :strategy :xmx-batched
                          :vector-width vector-width :batching batching)
         refinement (make-refinement stage-graph source-operation emit-spec)
-        graph (emit-stage-graph stage-graph emit-spec prefix refinement)]
+        graph (emit-scheduled-stage-graph
+               stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
+                            :prefix prefix :refinement refinement})]
     {:graph graph
      :refinement refinement
      :selector

--- a/src/raster/compiler/backend/gpu/layout_transform.clj
+++ b/src/raster/compiler/backend/gpu/layout_transform.clj
@@ -5,10 +5,10 @@
 
 (defn cast-body
   "Build the target-neutral body for one dense representation conversion."
-  [{:keys [kernel-name input output source-dtype destination-dtype vector-width rounding overflow]
+  [{:keys [id kernel-name input output source-dtype destination-dtype vector-width rounding overflow]
     :or {vector-width 1}}]
   (schedule/cast-body
-   {:id [:layout-transform kernel-name]
+   {:id (or id [:layout-transform kernel-name])
     :input input :output output
     :source-dtype source-dtype :destination-dtype destination-dtype
     :vector-width vector-width
@@ -16,9 +16,9 @@
 
 (defn transpose-body
   "Build the target-neutral body for one dense row-major matrix transpose."
-  [{:keys [kernel-name input output element-dtype]}]
+  [{:keys [id kernel-name input output element-dtype]}]
   (schedule/transpose-body
-   {:id [:layout-transform kernel-name]
+   {:id (or id [:layout-transform kernel-name])
     :input input :output output
     :element-dtype element-dtype}))
 

--- a/src/raster/compiler/ir/layout_stage.clj
+++ b/src/raster/compiler/ir/layout_stage.clj
@@ -46,6 +46,11 @@
         (when-not (and (numerics/rounding-policy? (:rounding policy))
                        (numerics/cast-overflow-policy? (:overflow policy)))
           (throw (ex-info "layout cast requires supported rounding and overflow semantics"
+                          {:reason :layout-stage-policy :policy policy})))
+        (when (and (contains? policy :vector-width)
+                   (not (and (integer? (:vector-width policy))
+                             (pos? (:vector-width policy)))))
+          (throw (ex-info "layout cast vector width must be a positive integer"
                           {:reason :layout-stage-policy :policy policy}))))
 
       :transpose

--- a/src/raster/compiler/ir/matrix_stage.clj
+++ b/src/raster/compiler/ir/matrix_stage.clj
@@ -9,7 +9,7 @@
 
 (defrecord MatrixStage
            [id lhs rhs result dimensions batching reduction result-shape epilogue
-            operand-dtype accumulator-dtype result-dtype])
+            operand-dtype accumulator-dtype result-dtype schedule])
 
 (defn matrix-stage?
   [value]
@@ -22,7 +22,7 @@
     (throw (ex-info "expected a MatrixStage"
                     {:reason :matrix-stage-type :actual (type stage)})))
   (let [{:keys [id lhs rhs result dimensions batching reduction result-shape epilogue
-                operand-dtype accumulator-dtype result-dtype]} stage]
+                operand-dtype accumulator-dtype result-dtype schedule]} stage]
     (doseq [[field value] [[:id id] [:lhs lhs] [:rhs rhs] [:result result]]]
       (when (nil? value)
         (throw (ex-info "matrix stage is missing an identity"
@@ -52,6 +52,9 @@
     (when-not (or (nil? epilogue) (map? epilogue))
       (throw (ex-info "matrix stage epilogue must be an exact transform description"
                       {:reason :matrix-stage-epilogue :epilogue epilogue})))
+    (when-not (or (nil? schedule) (map? schedule))
+      (throw (ex-info "matrix stage schedule must be an explicit map"
+                      {:reason :matrix-stage-schedule :schedule schedule})))
     (doseq [[field value] [[:operand-dtype operand-dtype]
                            [:accumulator-dtype accumulator-dtype]
                            [:result-dtype result-dtype]]]
@@ -62,9 +65,9 @@
 
 (defn make
   [{:keys [id lhs rhs result dimensions batching reduction result-shape epilogue
-           operand-dtype accumulator-dtype result-dtype]
+           operand-dtype accumulator-dtype result-dtype schedule]
     :or {operand-dtype :half accumulator-dtype :float result-dtype :float}}]
   (validate!
    (->MatrixStage id lhs rhs result (vec dimensions) batching reduction (vec result-shape)
                   epilogue (dtype/canon operand-dtype) (dtype/canon accumulator-dtype)
-                  (dtype/canon result-dtype))))
+                  (dtype/canon result-dtype) schedule)))

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -17,6 +17,7 @@
             [raster.runtime.hardware :as hw]
             [raster.compiler.core.hardware :as chw]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.reduction :as reduction]))
 
 ;; ================================================================
@@ -165,6 +166,17 @@
     #{(get-in operation [:facts :out])}
     (set (or (:outputs operation) #{}))))
 
+(defn- scalar-entry-references
+  "Project one scalar expression to the stable compiler identities it reads."
+  [value]
+  (cond
+    (or (symbol? value) (keyword? value)) #{value}
+    (number? value) #{}
+    (launch/expression? value) (launch/expression-references value)
+    (or (seq? value) (vector? value) (map? value) (set? value))
+    (util/free-syms value)
+    :else #{}))
+
 (defn operation-scalars
   "Scalar shape operands of a scheduled operation.
 
@@ -178,15 +190,17 @@
           axis-indices (set (map first axes))
           expressions (conj (mapv second axes) (:body facts))]
       (set/difference
-       (reduce set/union #{} (map util/free-syms expressions))
+       (reduce set/union #{} (map scalar-entry-references expressions))
        arrays axis-indices))
     (let [space (:space operation)
           axes (into #{(:flat-idx space)} (map :name) (:dims space))
           arrays (set/union (operation-inputs operation) (operation-outputs operation))
           extent-expressions (cond-> (mapv :bound (:dims space))
                                (:extent operation) (conj (:extent operation)))
-          extent-scalars (reduce set/union #{} (map util/free-syms extent-expressions))]
-      (set/union (or (:scalars operation) #{})
+          extent-scalars (reduce set/union #{} (map scalar-entry-references extent-expressions))
+          explicit-scalars (reduce set/union #{}
+                                   (map scalar-entry-references (or (:scalars operation) #{})))]
+      (set/union explicit-scalars
                  (set/difference extent-scalars arrays axes)))))
 
 (defn segop-grid

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -952,19 +952,6 @@
                       :interface interface}
      :layout {:external-interface interface}}))
 
-(defn- reinterface-graph
-  [graph abi arguments effects operation-id]
-  (let [{public-abi :abi public-arguments :arguments}
-        (kgraph/public-interface abi arguments)]
-    (kgraph/validate!
-     (-> graph
-         (assoc :abi public-abi :arguments public-arguments :effects effects
-                :scalars (kgraph/interface-scalars public-abi public-arguments))
-         (update :provenance merge {:operation-id operation-id
-                                    :source-dialect :typed-soac})
-         (update :attributes merge {:candidate-family :matrix
-                                    :semantic-op :contraction})))))
-
 (defn- mixed-dpas-alternatives
   "Derive graph-valued mixed-precision DPAS schedules from ordinary typed contraction facts.
 

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -979,10 +979,17 @@
         batching (:batching matrix-view)
         {:keys [row col]} (:bindings matrix-view)
         batched? (:batched? matrix-view)
+        variant (:variant matrix-view)
         counts {row (if (and batched? (get batching :row true))
-                      (klaunch/product batch m k) (klaunch/product m k))
+                      (klaunch/product batch m k)
+                      (if (contains? #{:tn :tt} variant)
+                        (klaunch/product k m)
+                        (klaunch/product m k)))
                 col (if (and batched? (get batching :col true))
-                      (klaunch/product batch k n) (klaunch/product k n))
+                      (klaunch/product batch k n)
+                      (if (contains? #{:nt :tt} variant)
+                        (klaunch/product n k)
+                        (klaunch/product k n)))
                 (:out facts) (if batched?
                                (klaunch/product batch m n) (klaunch/product m n))}]
     (reduce

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -24,6 +24,7 @@
             [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.kernel-abi :as kabi]
@@ -32,6 +33,7 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scheduled-graph-refinement :as graph-refinement]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
@@ -749,6 +751,15 @@
             (if (some #(= value %) result) result (conj result value)))
           [] values))
 
+(defn- semantic-scalar-order
+  [operation]
+  (let [axis-bounds (mapv :bound (get-in operation [:space :dims]))
+        extent-scalars (ordered-distinct
+                        (mapcat #(sort-by str (util/free-syms %)) axis-bounds))
+        semantic-scalars (segop/operation-scalars operation)
+        parameter-scalars (sort-by str (remove (set extent-scalars) semantic-scalars))]
+    (filterv semantic-scalars (into extent-scalars parameter-scalars))))
+
 (defn- semantic-scalar-interface
   "Construct the scalar part of a typed contraction's public ABI from semantic inputs.
 
@@ -761,8 +772,7 @@
         extent-scalars (ordered-distinct
                         (mapcat #(sort-by str (util/free-syms %)) axis-bounds))
         semantic-scalars (segop/operation-scalars operation)
-        parameter-scalars (sort-by str (remove (set extent-scalars) semantic-scalars))
-        ordered-scalars (filterv semantic-scalars (into extent-scalars parameter-scalars))]
+        ordered-scalars (semantic-scalar-order operation)]
     (into []
           (comp
            (remove (set existing-arguments))
@@ -871,7 +881,7 @@
     :inout :inout))
 
 (defn- candidate-graph
-  [candidate operation-id common-abi common-arguments]
+  [candidate operation-id common-abi common-arguments semantic-effects]
   (let [{:keys [family strategy artifact candidate-schedule]} candidate
         artifact (kart/validate! artifact)
         {public-abi :abi public-arguments :arguments}
@@ -904,7 +914,7 @@
       :nodes [(kgraph/->ScheduledKernel
                [:typed-contraction operation-id family strategy] artifact uses
                (kgraph/scalar-argument-uses (:abi artifact) (:arguments artifact)) [])]
-      :effects (:effects artifact)
+      :effects semantic-effects
       :provenance {:operation-id operation-id
                    :semantic-op :contraction
                    :lowering :typed-contraction-candidate}
@@ -952,6 +962,138 @@
                       :interface interface}
      :layout {:external-interface interface}}))
 
+(defn- semantic-equation-effects
+  [program operation-id]
+  (let [equation-facts (or (get-in (soac-dialect/facts program) [:equations operation-id])
+                           (throw (ex-info "typed contraction lacks independent equation facts"
+                                           {:reason :typed-contraction-semantic-effects
+                                            :operation operation-id})))]
+    {:kind :typed-soac-contraction
+     :effects (:effects equation-facts)
+     :aliases (:aliases equation-facts)}))
+
+(defn- exact-element-counts
+  [facts matrix-view]
+  (let [[m n k] (:dimensions matrix-view)
+        batch (:batch matrix-view)
+        batching (:batching matrix-view)
+        {:keys [row col]} (:bindings matrix-view)
+        batched? (:batched? matrix-view)
+        counts {row (if (and batched? (get batching :row true))
+                      (klaunch/product batch m k) (klaunch/product m k))
+                col (if (and batched? (get batching :col true))
+                      (klaunch/product batch k n) (klaunch/product k n))
+                (:out facts) (if batched?
+                               (klaunch/product batch m n) (klaunch/product m n))}]
+    (reduce
+     (fn [counts {:keys [sym map]}]
+       (let [shape (am/shape map)
+             elements (if (seq shape) (apply klaunch/product shape) 1)]
+         (if-let [prior (get counts sym)]
+           (if (= prior elements)
+             counts
+             (throw (ex-info "typed contraction gives one value incompatible exact extents"
+                             {:reason :typed-contraction-semantic-elements
+                              :value sym :first prior :second elements})))
+           (assoc counts sym elements))))
+     counts (get-in facts [:epilogue :operands]))))
+
+(defn- semantic-source-graph
+  "Build the semantic graph from TypedSOAC/SegRed facts, independently of emitted candidates."
+  [{:keys [program operation operation-id facts equation]} matrix-view abi arguments]
+  (let [program-facts (soac-dialect/facts program)
+        values (:values program-facts)
+        {public-abi :abi public-arguments :arguments}
+        (kgraph/public-interface abi arguments)
+        interface (mapv vector public-abi public-arguments)
+        pointer-interface (filterv #(not= :scalar (:kind (first %))) interface)
+        scalar-interface (filterv #(= :scalar (:kind (first %))) interface)
+        input-ids (segop/operation-inputs operation)
+        output-ids (segop/operation-outputs operation)
+        storage-ids (into input-ids output-ids)
+        pointer-ids (mapv second pointer-interface)
+        scalar-order (semantic-scalar-order operation)
+        element-counts (exact-element-counts facts matrix-view)
+        semantic-effects (semantic-equation-effects program operation-id)]
+    (when-not (= storage-ids (set pointer-ids))
+      (throw (ex-info "candidate-derived pointer ABI differs from TypedSOAC storage"
+                      {:reason :typed-contraction-semantic-pointer-identity
+                       :operation operation-id :expected storage-ids :actual pointer-ids})))
+    (when-not (= scalar-order (mapv second scalar-interface))
+      (throw (ex-info "candidate-derived scalar ABI differs from TypedSOAC scalar order"
+                      {:reason :typed-contraction-semantic-scalar-order
+                       :operation operation-id :expected scalar-order
+                       :actual (mapv second scalar-interface)})))
+    (doseq [[slot id] interface]
+      (let [value (some-> (get values id) av/validate!)]
+        (when-not value
+          (throw (ex-info "typed contraction public ABI value lacks an AbstractValue"
+                          {:reason :typed-contraction-semantic-abstract-value
+                           :operation operation-id :value id})))
+        (when-not (= (dtype/canon (:dtype value)) (:dtype slot))
+          (throw (ex-info "candidate-derived ABI dtype differs from its AbstractValue"
+                          {:reason :typed-contraction-semantic-dtype
+                           :operation operation-id :value id
+                           :expected (dtype/canon (:dtype value)) :actual (:dtype slot)})))
+        (if (= :scalar (:kind slot))
+          (when-not (= [] (:shape value))
+            (throw (ex-info "typed contraction scalar ABI names a non-scalar AbstractValue"
+                            {:reason :typed-contraction-semantic-scalar-shape
+                             :operation operation-id :value id :shape (:shape value)})))
+          (do
+            (when-not (= :tensor (:kind value))
+              (throw (ex-info "typed contraction pointer ABI requires a tensor AbstractValue"
+                              {:reason :typed-contraction-semantic-storage-kind
+                               :operation operation-id :value id :kind (:kind value)})))
+            (when-not (contains? #{nil :device} (:memory-space value))
+              (throw (ex-info "mixed GPU contraction requires device-compatible memory semantics"
+                              {:reason :typed-contraction-semantic-memory
+                               :operation operation-id :value id
+                               :memory-space (:memory-space value)})))
+            (when-not (contains? #{nil {:kind :plain}} (:representation value))
+              (throw (ex-info "mixed GPU contraction requires plain tensor representation"
+                              {:reason :typed-contraction-semantic-representation
+                               :operation operation-id :value id
+                               :representation (:representation value)})))
+            (when-not (= (:kind slot)
+                         (cond
+                           (and (contains? input-ids id) (contains? output-ids id)) :inout
+                           (contains? input-ids id) :input
+                           :else :output))
+              (throw (ex-info "candidate-derived pointer direction differs from TypedSOAC"
+                              {:reason :typed-contraction-semantic-pointer-kind
+                               :operation operation-id :value id :actual (:kind slot)})))
+            (when-not (contains? element-counts id)
+              (throw (ex-info "typed contraction pointer lacks a verified matrix extent"
+                              {:reason :typed-contraction-semantic-elements
+                               :operation operation-id :value id})))))))
+    (let [buffers (into {}
+                        (map (fn [[slot id]]
+                               [id (kgraph/buffer id (:dtype slot) (get element-counts id)
+                                                  :device (graph-buffer-role (:kind slot)))])
+                             pointer-interface))
+          inputs (into [] (comp (filter #(contains? #{:input :inout} (:kind (first %))))
+                                (map #(get buffers (second %))))
+                       pointer-interface)
+          outputs (into [] (comp (filter #(contains? #{:output :inout} (:kind (first %))))
+                                 (map #(get buffers (second %))))
+                        pointer-interface)
+          uses (mapv (fn [[slot id]]
+                       (kgraph/->ValueUse id (kabi/slot-access slot)))
+                     pointer-interface)]
+      (kgraph/make
+       {:inputs inputs :outputs outputs
+        :scalars (kgraph/interface-scalars public-abi public-arguments)
+        :nodes [(kgraph/->ScheduledKernel
+                 [:typed-contraction-semantic operation-id]
+                 operation uses (set scalar-order) [])]
+        :abi public-abi :arguments public-arguments
+        :effects semantic-effects
+        :provenance {:operation-id operation-id :source-dialect :typed-soac
+                     :equation (second equation)}
+        :attributes {:semantic-op :contraction
+                     :abstract-values (select-keys values (into storage-ids scalar-order))}}))))
+
 (defn- mixed-dpas-alternatives
   "Derive graph-valued mixed-precision DPAS schedules from ordinary typed contraction facts.
 
@@ -959,8 +1101,8 @@
    explicit f32→f16 layout adapters, a canonical matrix KernelBody, and an optional typed split-K
    reduction.  It declines as data when the algebra, layout, precision policy, enabled families,
    or target capability does not justify that transformation."
-  [program operation options abi arguments effects]
-  (let [{:keys [facts dtype operation-id]}
+  [program operation options abi arguments]
+  (let [{:keys [facts dtype operation-id] :as context}
         (scheduled-typed-contraction-context program operation)
         precision (or (:precision options) :mixed-f16-f32)
         matrix-enabled? (contains? (set (get-in operation [:schedule :tuning-space :families]))
@@ -995,6 +1137,8 @@
       :else
       (let [[m n k] (:dimensions matrix-view)
             {:keys [row col]} (:bindings matrix-view)
+            source-graph (semantic-source-graph context matrix-view abi arguments)
+            semantic-effects (:effects source-graph)
             emit-spec {:id [:typed-contraction operation-id]
                        :a row :b col :c (:out facts)
                        :m m :n n :k k
@@ -1004,7 +1148,9 @@
                        :tile (:tile target-schedule)
                        :fill-workgroups (:fill-workgroups target-schedule)
                        :source-operation operation
-                       :external-interface {:abi abi :arguments arguments :effects effects}
+                       :source-graph source-graph
+                       :external-interface {:abi abi :arguments arguments
+                                            :effects semantic-effects}
                        :split-factors (or (:split-factors options) [])}
             emitted (if (:batched? matrix-view)
                       (gpu-gemm/emit-batched-matrix-alternative
@@ -1017,16 +1163,23 @@
                                (:alternatives emitted))
             alternatives (mapv (fn [graph]
                                  (let [graph (kgraph/validate! graph)]
-                                   (when-not (= [abi arguments effects]
+                                   (when-not (= [abi arguments semantic-effects]
                                                 [(:abi graph) (:arguments graph) (:effects graph)])
                                      (throw (ex-info
                                              "typed matrix schedule changed its supplied public interface"
                                              {:reason :typed-contraction-matrix-interface
                                               :operation operation-id})))
+                                   (graph-refinement/validate-against!
+                                    (or (get-in graph [:attributes :scheduled-graph-refinement])
+                                        (throw (ex-info "typed matrix graph lacks its refinement"
+                                                        {:reason :typed-contraction-matrix-refinement
+                                                         :operation operation-id})))
+                                    source-graph)
                                    graph))
                                raw-alternatives)
             selector (:selector emitted)]
         {:alternatives alternatives
+         :source-graph source-graph
          :selector selector
          :schedule {:family :matrix
                     :precision :mixed-f16-f32
@@ -1061,6 +1214,9 @@
   [program operation & options]
   (let [options (apply hash-map options)
         operation-id (:id operation)
+        semantic-effects (semantic-equation-effects
+                          (:program (scheduled-typed-contraction-context program operation))
+                          operation-id)
         schedule (reduction/validate-schedule! (:schedule operation))
         {:keys [candidates] :as routed}
         (apply route-typed-contraction-candidates!
@@ -1069,14 +1225,14 @@
         (common-logical-interface candidates operation operation-id)
         candidates (mapv #(bindable-private-scalars! % operation-id public-scalars) candidates)
         fallback-strategy (:strategy (first candidates))
-        common-effects (:effects (:artifact (first candidates)))
-        mixed (mixed-dpas-alternatives program operation options abi arguments common-effects)
+        mixed (mixed-dpas-alternatives program operation options abi arguments)
         matrix-default (some-> mixed :alternatives first kdispatch/alternative-strategy)
         default-strategy (or matrix-default fallback-strategy)
         schedule-identity (select-keys mixed [:schedule :decline])
         dispatch-id (candidate-dispatch-id operation-id candidates schedule-identity)
         candidates (mapv #(deterministic-candidate-entry-point % dispatch-id) candidates)
-        alternatives (into (mapv #(candidate-graph % operation-id abi arguments) candidates)
+        alternatives (into (mapv #(candidate-graph % operation-id abi arguments semantic-effects)
+                                 candidates)
                            (:alternatives mixed))
         selector (if (seq (:alternatives mixed))
                    (replace-selector-strategy (:selector mixed)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -752,27 +752,31 @@
           [] values))
 
 (defn- semantic-scalar-order
-  [operation]
+  [operation epilogue]
   (let [axis-bounds (mapv :bound (get-in operation [:space :dims]))
         extent-scalars (ordered-distinct
                         (mapcat #(sort-by str (util/free-syms %)) axis-bounds))
         semantic-scalars (segop/operation-scalars operation)
-        parameter-scalars (sort-by str (remove (set extent-scalars) semantic-scalars))]
-    (filterv semantic-scalars (into extent-scalars parameter-scalars))))
+        epilogue-scalars (filterv semantic-scalars (mapv :sym (:scalars epilogue)))
+        already-ordered (into (set extent-scalars) epilogue-scalars)
+        parameter-scalars (sort-by str (remove already-ordered semantic-scalars))]
+    ;; Existing resident calls place a result transform's explicit captures before dimensions.
+    ;; Preserve that semantic order, then append axis bounds and any remaining scalar captures.
+    (filterv semantic-scalars
+             (into epilogue-scalars (concat extent-scalars parameter-scalars)))))
 
 (defn- semantic-scalar-interface
   "Construct the scalar part of a typed contraction's public ABI from semantic inputs.
 
-   Axis-bound inputs precede other scalar captures and follow axis order. A target leaf may bake
-   one of these values or expose it under a different parameter name; neither changes the logical
-   call. Conversely, leaf-derived values such as a flattened segment count are deliberately absent
-   and remain graph-private expressions over this interface."
-  [candidates operation operation-id existing-arguments]
+   Result-transform captures preserve their established call order, followed by axis bounds and
+   remaining captures. A target leaf may bake one of these values or expose it under a different
+   parameter name; neither changes the logical call. Conversely, leaf-derived values such as a
+   flattened segment count are deliberately absent and remain graph-private expressions."
+  [candidates operation operation-id epilogue existing-arguments]
   (let [axis-bounds (mapv :bound (get-in operation [:space :dims]))
         extent-scalars (ordered-distinct
                         (mapcat #(sort-by str (util/free-syms %)) axis-bounds))
-        semantic-scalars (segop/operation-scalars operation)
-        ordered-scalars (semantic-scalar-order operation)]
+        ordered-scalars (semantic-scalar-order operation epilogue)]
     (into []
           (comp
            (remove (set existing-arguments))
@@ -808,7 +812,7 @@
           ordered-scalars)))
 
 (defn- common-logical-interface
-  [candidates operation operation-id]
+  [candidates operation operation-id epilogue]
   (let [interfaces (mapv (comp artifact-logical-interface :artifact) candidates)
         arguments (mapv second (first interfaces))]
     (doseq [[candidate interface] (map vector candidates interfaces)]
@@ -840,7 +844,8 @@
                  alignment (assoc :alignment alignment)
                  (nil? alignment) (dissoc :alignment))))
            (range (count arguments)) arguments)
-          scalar-interface (semantic-scalar-interface candidates operation operation-id arguments)
+          scalar-interface (semantic-scalar-interface candidates operation operation-id
+                                                      epilogue arguments)
           abi (into abi (map first) scalar-interface)
           arguments (into arguments (map second) scalar-interface)]
       (kabi/validate! abi)
@@ -1019,7 +1024,7 @@
         output-ids (segop/operation-outputs operation)
         storage-ids (into input-ids output-ids)
         pointer-ids (mapv second pointer-interface)
-        scalar-order (semantic-scalar-order operation)
+        scalar-order (semantic-scalar-order operation (:epilogue facts))
         element-counts (exact-element-counts facts matrix-view)
         semantic-effects (semantic-equation-effects program operation-id)]
     (when-not (= storage-ids (set pointer-ids))
@@ -1221,15 +1226,17 @@
   [program operation & options]
   (let [options (apply hash-map options)
         operation-id (:id operation)
+        context (scheduled-typed-contraction-context program operation)
         semantic-effects (semantic-equation-effects
-                          (:program (scheduled-typed-contraction-context program operation))
+                          (:program context)
                           operation-id)
         schedule (reduction/validate-schedule! (:schedule operation))
         {:keys [candidates] :as routed}
         (apply route-typed-contraction-candidates!
                program operation (mapcat identity options))
         {:keys [abi arguments public-scalars]}
-        (common-logical-interface candidates operation operation-id)
+        (common-logical-interface candidates operation operation-id
+                                  (get-in context [:facts :epilogue]))
         candidates (mapv #(bindable-private-scalars! % operation-id public-scalars) candidates)
         fallback-strategy (:strategy (first candidates))
         mixed (mixed-dpas-alternatives program operation options abi arguments)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1016,6 +1016,8 @@
                        :precision :mixed-f16-f32
                        :tile (:tile target-schedule)
                        :fill-workgroups (:fill-workgroups target-schedule)
+                       :source-operation operation
+                       :external-interface {:abi abi :arguments arguments :effects effects}
                        :split-factors (or (:split-factors options) [])}
             emitted (if (:batched? matrix-view)
                       (gpu-gemm/emit-batched-matrix-alternative
@@ -1026,7 +1028,15 @@
             raw-alternatives (if (:batched? matrix-view)
                                [(:graph emitted)]
                                (:alternatives emitted))
-            alternatives (mapv #(reinterface-graph % abi arguments effects operation-id)
+            alternatives (mapv (fn [graph]
+                                 (let [graph (kgraph/validate! graph)]
+                                   (when-not (= [abi arguments effects]
+                                                [(:abi graph) (:arguments graph) (:effects graph)])
+                                     (throw (ex-info
+                                             "typed matrix schedule changed its supplied public interface"
+                                             {:reason :typed-contraction-matrix-interface
+                                              :operation operation-id})))
+                                   graph))
                                raw-alternatives)
             selector (:selector emitted)]
         {:alternatives alternatives

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -152,6 +152,8 @@
                       (mapcat identity
                               (select-keys tile
                                            [:block-m :block-n :sg-m :sg-n :block-k :matrix])))]
+    (is (nil? (get-in graph [:attributes :scheduled-graph-refinement]))
+        "the standalone compatibility API does not invent a semantic-source witness")
     (is (body/kernel-body? kernel-body))
     (is (scheduled-body/scheduled-kernel-body? scheduled))
     (is (matrix-stage/matrix-stage? stage))

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -45,6 +45,19 @@
           "a contract is legal SegOp dialect input but not yet a scheduled KernelGraph operation")
       (is (not (segop/segop? {:not "a segop"}))))))
 
+(deftest operation-scalars-normalize-derived-expressions-to-public-leaves
+  (let [space (segop/make-seg-space 'i (launch/product :m :n))
+        operation (segop/->SegMap
+                   :derived-scalars space (segop/->SegLevel :thread :none)
+                   '(aget input i) nil #{'input} #{'output}
+                   #{(launch/ceil-div :k 16) '(+ width padding) :scale 4}
+                   (segop/->KernelGrid 1 32 0) :float 'output nil)]
+    (is (= #{:m :n :k 'width 'padding :scale}
+           (segop/operation-scalars operation)))
+    (is (every? #(or (symbol? %) (keyword? %))
+                (segop/operation-scalars operation))
+        "scheduled arithmetic is projected to its stable public scalar identities")))
+
 ;; ================================================================
 ;; Launch parameter computation
 ;; ================================================================

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1341,6 +1341,54 @@
            (get-in matrix-node [:operation :launch :group-count 2 :value]))
         "the third launch dimension is the semantic batch extent")))
 
+(deftest transposed-mixed-contractions-certify-their-physical-storage-order
+  (let [descriptor {:backend :ze
+                    :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                    :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                    :subgroup-size 16 :max-workgroup-size 1024
+                    :grf-bytes-per-lane 256 :machine-lanes 8192
+                    :shared-local-memory 131072}
+        variants
+        [[:nt '(let* [step (raster.par/contract
+                            C [[i m] [j n]] [[l k]]
+                            (* (clojure.core/aget A (+ (* i k) l))
+                               (clojure.core/aget B (+ (* j k) l))))]
+                 step)
+          (kernel-launch/product 'm 'k) (kernel-launch/product 'n 'k)]
+         [:tn '(let* [step (raster.par/contract
+                            C [[i m] [j n]] [[l k]]
+                            (* (clojure.core/aget A (+ (* l m) i))
+                               (clojure.core/aget B (+ (* l n) j))))]
+                 step)
+          (kernel-launch/product 'k 'm) (kernel-launch/product 'k 'n)]
+         [:tt '(let* [step (raster.par/contract
+                            C [[i m] [j n]] [[l k]]
+                            (* (clojure.core/aget A (+ (* l m) i))
+                               (clojure.core/aget B (+ (* j k) l))))]
+                 step)
+          (kernel-launch/product 'k 'm) (kernel-launch/product 'n 'k)]]]
+    (doseq [[variant source expected-a expected-b] variants]
+      (let [{:keys [form]}
+            (pipeline/schedule-parallel-form
+             source {:target-device :ze:0 :dtype :float
+                     :array-types {'A :float 'B :float 'C :float}
+                     :scalar-types {'m :int 'n :int 'k :int}})
+            operation (-> form :equations first :operations first)
+            algorithm (-> form :equations first :algorithm)
+            dispatch (contract-route/route-typed-contraction-dispatch
+                      algorithm operation :dtype :float :desc descriptor
+                      :precision :mixed-f16-f32)
+            refinement (get-in (kdispatch/alternative dispatch :xmx-direct)
+                               [:attributes :scheduled-graph-refinement])
+            inputs (into {} (map (juxt :id identity))
+                         (:inputs (:source refinement)))]
+        (is (= expected-a (get-in inputs ['A :elements])) (name variant))
+        (is (= expected-b (get-in inputs ['B :elements])) (name variant))
+        (is (= (kernel-graph/boundary-contract (:source refinement))
+               (kernel-graph/boundary-contract
+                (graph-refinement/scheduled-graph refinement)))
+            (name variant))))))
+
 (deftest typed-contraction-schedule-families-control-leaf-selection
   (let [source
         '(let* [step (raster.par/contract C [[i 128] [j 128]] [[l 128]]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.typed-soac-route-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gpu-gemm]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
@@ -1172,6 +1173,51 @@
           (is false "tampered source identity must be rejected")
           (catch clojure.lang.ExceptionInfo exception
             (is (= :scheduled-kernel-body-source (:reason (ex-data exception))))))))
+    (testing "the retained schedule graph is independently replayable and emission-closed"
+      (let [stage-graph (graph-refinement/scheduled-graph direct-refinement)
+            replay (gpu-gemm/emit-scheduled-stage-graph
+                    stage-graph {:prefix "typed_contraction_replay"})
+            descriptive-tamper (assoc-in stage-graph [:attributes :tile] {:ignored true})
+            replay-after-tamper (gpu-gemm/emit-scheduled-stage-graph
+                                 descriptive-tamper {:prefix "typed_contraction_replay"})
+            bodies (fn [graph]
+                     (mapv #(get-in % [:operation :attributes :scheduled-kernel-body :body])
+                           (:nodes graph)))]
+        (is (= (bodies direct-graph) (bodies replay)))
+        (is (= (bodies replay) (bodies replay-after-tamper))
+            "unverified graph descriptions cannot steer target emission")
+        (doseq [[stage-node emitted-node] (map vector (:nodes stage-graph) (:nodes replay))
+                :when (layout-stage/layout-stage? (:operation stage-node))]
+          (is (= (get-in stage-node [:operation :id])
+                 (get-in emitted-node
+                         [:operation :attributes :scheduled-kernel-body :body :id]))
+              "a LayoutStage identity survives exactly into KernelBody"))
+        (try
+          (gpu-gemm/emit-scheduled-stage-graph
+           descriptive-tamper {:prefix "typed_contraction_replay"
+                               :refinement direct-refinement})
+          (is false "a refinement cannot certify a merely boundary-compatible graph")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :gemm-emission-refinement (:reason (ex-data exception))))))))
+    (testing "tampering with a stage-owned physical choice is rejected"
+      (let [stage-graph (graph-refinement/scheduled-graph direct-refinement)
+            without-vector-width
+            (update-in stage-graph [:nodes 0 :operation :policy] dissoc :vector-width)
+            matrix-index (first (keep-indexed
+                                 #(when (matrix-stage/matrix-stage? (:operation %2)) %1)
+                                 (:nodes stage-graph)))
+            without-tile (update-in stage-graph
+                                    [:nodes matrix-index :operation :schedule] dissoc :tile)]
+        (doseq [tampered [without-vector-width without-tile]]
+          (try
+            (gpu-gemm/emit-scheduled-stage-graph tampered {:prefix "tampered_schedule"})
+            (is false "an emission-open scheduled stage must be rejected")
+            (catch clojure.lang.ExceptionInfo exception
+              (is (= :gemm-stage-emission-open (:reason (ex-data exception)))))))))
+    (is (= {:kind :split-k
+            :within-partition :tiled
+            :partial-combine :ordered-sequential}
+           (get-in split-refinement [:numerics :error-model :reduction-order])))
     (testing "explicit split factors remain compiler schedule candidates over the same typed equation"
       (let [tunable (contract-route/route-typed-contraction-dispatch
                      algorithm operation :dtype :float :desc descriptor

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -4,14 +4,17 @@
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-artifact :as kernel-artifact]
             [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
+            [raster.compiler.ir.layout-stage :as layout-stage]
             [raster.compiler.ir.matrix-stage :as matrix-stage]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
+            [raster.compiler.ir.scheduled-graph-refinement :as graph-refinement]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
@@ -1109,6 +1112,10 @@
         dispatch (contract-route/route-typed-contraction-dispatch
                   algorithm operation :dtype :float :desc descriptor
                   :precision :mixed-f16-f32)
+        direct-graph (kdispatch/alternative dispatch :xmx-direct)
+        split-graph (kdispatch/alternative dispatch :xmx-split-k)
+        direct-refinement (get-in direct-graph [:attributes :scheduled-graph-refinement])
+        split-refinement (get-in split-graph [:attributes :scheduled-graph-refinement])
         strategies (mapv kdispatch/alternative-strategy (:alternatives dispatch))
         select (fn [m n k]
                  (kdispatch/alternative-strategy
@@ -1126,6 +1133,45 @@
     (is (= :mixed-f16-f32
            (get-in dispatch [:attributes :candidate-schedules :xmx-direct :precision])))
     (is (nil? (get-in dispatch [:attributes :matrix-graph-decline])))
+    (testing "mixed-precision alternatives refine the exact typed SegRed through stage graphs"
+      (doseq [[graph refinement expected-types]
+              [[direct-graph direct-refinement
+                [raster.compiler.ir.layout_stage.LayoutStage
+                 raster.compiler.ir.layout_stage.LayoutStage
+                 raster.compiler.ir.matrix_stage.MatrixStage]]
+               [split-graph split-refinement
+                [raster.compiler.ir.layout_stage.LayoutStage
+                 raster.compiler.ir.layout_stage.LayoutStage
+                 raster.compiler.ir.matrix_stage.MatrixStage
+                 raster.compiler.ir.segop.SegRed]]]]
+        (let [stage-graph (graph-refinement/scheduled-graph refinement)]
+          (is (identical? operation (graph-refinement/source-operation refinement)))
+          (is (= (kernel-graph/boundary-contract (:source refinement))
+                 (kernel-graph/boundary-contract stage-graph)))
+          (is (= expected-types (mapv (comp class :operation) (:nodes stage-graph))))
+          (is (kernel-graph/dataflow-equivalent? stage-graph graph))
+          (is (= (mapv :id (:nodes stage-graph)) (mapv :id (:nodes graph))))
+          (doseq [[stage-node emitted-node] (map vector (:nodes stage-graph) (:nodes graph))]
+            (let [artifact (:operation emitted-node)
+                  certificate (kernel-artifact/attribute artifact :scheduled-kernel-body)]
+              (is (= (:operation stage-node) (:source certificate)))
+              (is (= certificate (get-in artifact [:provenance :scheduled-operation])))
+              (is (= certificate
+                     (scheduled-body/validate-against-node!
+                      certificate stage-node stage-graph)))
+              (is (= artifact
+                     (scheduled-body/validate-artifact-projection! certificate artifact))))))))
+    (testing "an emitted certificate cannot be rebound to a different scheduled stage"
+      (let [stage-graph (graph-refinement/scheduled-graph direct-refinement)
+            stage-node (first (:nodes stage-graph))
+            artifact (-> direct-graph :nodes first :operation)
+            certificate (kernel-artifact/attribute artifact :scheduled-kernel-body)
+            tampered (assoc certificate :source (assoc (:source certificate) :id ::tampered))]
+        (try
+          (scheduled-body/validate-against-node! tampered stage-node stage-graph)
+          (is false "tampered source identity must be rejected")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :scheduled-kernel-body-source (:reason (ex-data exception))))))))
     (testing "explicit split factors remain compiler schedule candidates over the same typed equation"
       (let [tunable (contract-route/route-typed-contraction-dispatch
                      algorithm operation :dtype :float :desc descriptor
@@ -1171,6 +1217,8 @@
                    algorithm operation :dtype :float :desc descriptor
                    :precision :mixed-f16-f32)
         matrix-graph (kdispatch/alternative scheduled :xmx-batched)
+        refinement (get-in matrix-graph [:attributes :scheduled-graph-refinement])
+        stage-graph (graph-refinement/scheduled-graph refinement)
         matrix-node (last (:nodes matrix-graph))
         matrix-body (get-in matrix-node [:operation :attributes :kernel-body])
         scheduled-matrix (get-in matrix-node [:operation :attributes :scheduled-kernel-body])
@@ -1188,6 +1236,12 @@
     (is (= :portable-segred (select 4 64 128 62)))
     (is (= {:row true :col false}
            (get-in matrix-graph [:attributes :batching])))
+    (is (identical? operation (graph-refinement/source-operation refinement)))
+    (is (= [raster.compiler.ir.layout_stage.LayoutStage
+            raster.compiler.ir.layout_stage.LayoutStage
+            raster.compiler.ir.matrix_stage.MatrixStage]
+           (mapv (comp class :operation) (:nodes stage-graph))))
+    (is (kernel-graph/dataflow-equivalent? stage-graph matrix-graph))
     (is (scheduled-body/scheduled-kernel-body? scheduled-matrix))
     (is (matrix-stage/matrix-stage? matrix-stage))
     (is (= {:extent 'batch :lhs true :rhs false} (:batching matrix-stage)))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1134,6 +1134,23 @@
     (is (= :mixed-f16-f32
            (get-in dispatch [:attributes :candidate-schedules :xmx-direct :precision])))
     (is (nil? (get-in dispatch [:attributes :matrix-graph-decline])))
+    (testing "logical effects come from TypedSOAC rather than any fallback artifact"
+      (let [semantic-effects (get-in direct-refinement [:source :effects])]
+        (is (= :typed-soac-contraction (:kind semantic-effects)))
+        (is (= (get-in (dialect/facts algorithm)
+                       [:equations (:id operation) :effects])
+               (:effects semantic-effects)))
+        (is (every? #(= semantic-effects (:effects %)) (:alternatives dispatch)))
+        (is (not= semantic-effects
+                  (get-in (first (:alternatives dispatch)) [:nodes 0 :operation :effects]))
+            "artifact effects remain a distinct physical certificate")
+        (try
+          (graph-refinement/validate-against!
+           direct-refinement
+           (assoc-in (:source direct-refinement) [:effects :effects] #{:tampered}))
+          (is false "a source graph with different semantic effects must not validate")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :scheduled-graph-refinement-source (:reason (ex-data exception))))))))
     (testing "mixed-precision alternatives refine the exact typed SegRed through stage graphs"
       (doseq [[graph refinement expected-types]
               [[direct-graph direct-refinement
@@ -1214,6 +1231,23 @@
             (is false "an emission-open scheduled stage must be rejected")
             (catch clojure.lang.ExceptionInfo exception
               (is (= :gemm-stage-emission-open (:reason (ex-data exception)))))))))
+    (testing "valid but unsupported stage semantics cannot be silently hardcoded away"
+      (let [stage-graph (graph-refinement/scheduled-graph direct-refinement)
+            matrix-index (first (keep-indexed
+                                 #(when (matrix-stage/matrix-stage? (:operation %2)) %1)
+                                 (:nodes stage-graph)))
+            unsupported
+            [(assoc-in stage-graph [:nodes 0 :operation :input-dtype] :double)
+             (assoc-in stage-graph [:nodes 0 :operation :policy :rounding] :toward-zero)
+             (assoc-in stage-graph [:nodes matrix-index :operation :schedule :kind]
+                       :different-matrix-schedule)
+             (assoc-in stage-graph [:nodes matrix-index :operation :accumulator-dtype] :double)]]
+        (doseq [tampered unsupported]
+          (try
+            (gpu-gemm/emit-scheduled-stage-graph tampered {:prefix "unsupported_schedule"})
+            (is false "an unsupported scheduled semantic must be rejected")
+            (catch clojure.lang.ExceptionInfo exception
+              (is (= :gemm-stage-emission-unsupported (:reason (ex-data exception)))))))))
     (is (= {:kind :split-k
             :within-partition :tiled
             :partial-combine :ordered-sequential}


### PR DESCRIPTION
## Summary

- schedule an exact typed contraction into explicit cast, transpose, matrix, and split-combine stages before target emission
- bind every mixed GEMM refinement to an independent TypedSOAC/SegRed/AbstractValue source graph with checked ABI, storage, scalar, effect, and numerical contracts
- make scheduled graphs emission-closed and replayable: physical choices live in validated stages, and unsupported dtype/policy mutations fail loudly
- preserve the standalone compatibility API without fabricating a semantic refinement

## Evidence

- focused GEMM suite previously green: 16 tests / 173 assertions
- split-K refinement focused test green: 1 test / 19 assertions
- dynamic typed contraction focused test green: 1 test / 60 assertions before final assertion-only additions
- dynamic epilogue plus NT/TN/TT semantic-boundary tests green locally after review fixes
- independent review found and resolved out-of-band schedule facts, lost stage identity, inaccurate split-K numerics, tautological source certification, ignored stage semantics, transposed extent ordering, and epilogue scalar ordering
- full build/device compile/test matrix delegated to CircleCI