### PR TITLE
Require explicit overflow policy for scalar integral add/sub/mul

### DIFF
--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -165,11 +165,11 @@
 (defn trapping-arithmetic-name
   "Name a checked signed-integer operation only when the target can terminate the invocation.
 
-  OpenCL C has no standard trap operation.  A portable OpenCL dialect must therefore decline this
-  contract instead of quietly depending on one vendor compiler's builtin or turning the operation
-  into undefined signed arithmetic."
+  OpenCL C has no standard trap operation.  The Intel dialect deliberately names the vendor
+  builtin contract used by Raster's production OpenCL row; portable OpenCL must still decline
+  rather than quietly depending on it or turning the operation into undefined signed arithmetic."
   [dialect operation type]
-  (when (opencl? dialect)
+  (when (= :opencl-portable (:id dialect))
     (throw (ex-info "OpenCL C has no portable trapping-arithmetic primitive"
                     {:reason :kernel-body-c-trap-unsupported
                      :dialect (:id dialect) :operation operation :type (dtype/canon type)})))
@@ -191,6 +191,10 @@
         helper-name (trapping-arithmetic-name dialect operation type)
         sign-bit (str "((" unsigned-type ")1 << " (dec (* 8 (dtype/bytes-of type))) ")")
         trap-source (case (:id dialect)
+                      ;; Intel's OpenCL frontend accepts this Clang builtin and lowers it to a
+                      ;; terminating device trap.  It is intentionally unavailable to the
+                      ;; portable dialect above.
+                      :opencl-intel "__builtin_trap();"
                       :cuda "asm volatile(\"trap;\");"
                       :hip "__builtin_trap();")
         arithmetic ({:+ "+" :- "-" :* "*"} operation)]

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -389,14 +389,24 @@
 
 (defn- scalar-expressions
   [value]
-  (when (record-kind? "ScalarExpr" value)
-    (cons value (mapcat scalar-expressions (:arguments value)))))
+  ;; ScalarExpr is legal in any scalar-valued operation field, not only ScalarCompute: masked
+  ;; load fallbacks, stores/atomics, loop arguments and yields, and collective inputs all carry
+  ;; values.  Traverse the complete verified operation tree so helper discovery is not coupled to
+  ;; one convenient placement of an expression.
+  (cond
+    (record-kind? "ScalarExpr" value)
+    (cons value (mapcat scalar-expressions (:arguments value)))
+
+    (map? value) (mapcat scalar-expressions (vals value))
+    ;; Keep this deliberately broader than vectors/lists: the verifier may add a scalar-valued
+    ;; collection field to a legal operation without making helper discovery placement-sensitive.
+    (coll? value) (mapcat scalar-expressions value)
+    :else []))
 
 (defn- trapping-arithmetic-requirements
   [operations]
   (->> operations
-       (filter #(record-kind? "ScalarCompute" %))
-       (mapcat #(scalar-expressions (:expression %)))
+       (mapcat scalar-expressions)
        (keep (fn [expression]
                (when (= :trap (get-in expression [:options :overflow]))
                  [(intrinsics/canonical (:op expression))

--- a/src/raster/compiler/ir/attention.clj
+++ b/src/raster/compiler/ir/attention.clj
@@ -93,6 +93,21 @@
                      :owner owner :field field :value value})))
   value)
 
+(defn- int32-offset-capacity!
+  "Validate capacities addressed by the public int32 CSR metadata ABI.
+
+  Page/key offsets are uploaded and consumed as `int` values in every current routed-attention
+  backend.  Accepting a larger descriptor would make an otherwise semantic value impossible to
+  represent before any target schedule is selected."
+  [owner field value]
+  (positive-integer! owner field value)
+  (when (> value Integer/MAX_VALUE)
+    (throw (ex-info (str owner " exceeds the int32 offset capacity")
+                    {:reason :attention-int32-offset-capacity
+                     :owner owner :field field :value value
+                     :maximum Integer/MAX_VALUE})))
+  value)
+
 (defn- finite-positive!
   [field value]
   (when-not (and (number? value)
@@ -145,7 +160,7 @@
   (when (some nil? [row-offsets key-indices])
     (throw (ex-info "CSR visibility requires row offsets and logical key indices"
                     {:reason :attention-csr-visibility-missing-buffer})))
-  (positive-integer! "CSR visibility" :key-index-capacity key-index-capacity)
+  (int32-offset-capacity! "CSR visibility" :key-index-capacity key-index-capacity)
   (when-not (contains? #{:set :multiset} duplicate-policy)
     (throw (ex-info "CSR visibility requires a set or multiset duplicate policy"
                     {:reason :attention-invalid-duplicate-policy
@@ -176,7 +191,7 @@
   (when (some nil? [page-offsets page-indices last-page-lengths start-positions])
     (throw (ex-info "CSR page route requires offsets, indices, final lengths and start positions"
                     {:reason :attention-csr-route-missing-buffer})))
-  (positive-integer! "CSR page route" :page-index-capacity page-index-capacity)
+  (int32-offset-capacity! "CSR page route" :page-index-capacity page-index-capacity)
   (->CSRPagedRoute page-offsets page-indices last-page-lengths start-positions
                    page-index-capacity))
 
@@ -258,6 +273,14 @@
     (when-not (paged-route? route)
       (throw (ex-info "attention requires a dense or CSR paged route"
                       {:reason :attention-unsupported-route :route route})))
+    ;; Check the descriptor-level int32 ABI before derived token-capacity arithmetic so callers
+    ;; receive the representation error rather than an incidental later overflow diagnosis.
+    (when (csr-paged-route? route)
+      (int32-offset-capacity! "CSR page route" :page-index-capacity
+                              (:page-index-capacity route)))
+    (when (csr-visibility? visibility)
+      (int32-offset-capacity! "CSR visibility" :key-index-capacity
+                              (:key-index-capacity visibility)))
     (doseq [[field value] [[:batch-size batch-size] [:q-heads q-heads]
                            [:kv-heads kv-heads] [:qk-head-dim qk-head-dim]
                            [:value-head-dim value-head-dim] [:page-size page-size]
@@ -313,13 +336,8 @@
         (throw (ex-info "page route lengths use int32 and exceed their token capacity"
                         {:reason :attention-route-token-capacity-overflow
                          :page-capacity page-capacity :page-size page-size}))))
-    (if (dense-paged-route? route)
-      (checked-product :page-table [batch-size (:pages-per-sequence route)])
-      (positive-integer! "CSR page route" :page-index-capacity
-                         (:page-index-capacity route)))
-    (when (csr-visibility? visibility)
-      (positive-integer! "CSR visibility" :key-index-capacity
-                         (:key-index-capacity visibility)))
+    (when (dense-paged-route? route)
+      (checked-product :page-table [batch-size (:pages-per-sequence route)]))
     problem))
 
 (defn make

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1045,6 +1045,9 @@
       (contains? #{:min :max} canonical-op)
       (scalar-range/minmax canonical-op ranges)
 
+      (= :quot canonical-op)
+      (scalar-range/quotient ranges)
+
       (= :select canonical-op)
       (scalar-range/hull (subvec ranges 1))
 
@@ -1063,6 +1066,15 @@
        derived-range
        (<= (:lower proof) (:lower derived-range))
        (<= (:upper derived-range) (:upper proof))))
+
+(defn- conservative-loop-info
+  "A loop body is checked once, not interpreted to an inductive fixed point.  In particular a
+  carried integer can change on every backedge and a loop may execute zero times.  Preserve only
+  its dtype fact until a future verifier grows explicit checked invariants."
+  [info type]
+  (if (contains? #{:byte :int :long} (canonical-type type))
+    (assoc info :range (scalar-range/for-dtype type))
+    info))
 
 (defn- scalar-info!
   [expression values]
@@ -1513,12 +1525,14 @@
                                       :uniformity loop-control})
                               (map (fn [arg initial]
                                      [(:id (:binding arg))
-                                      (if (contains? uniform-iter-args (:id (:binding arg)))
+                                      (let [initial (conservative-loop-info
+                                                     initial (:type (:binding arg)))]
+                                        (if (contains? uniform-iter-args (:id (:binding arg)))
                                         ;; This is an inductive claim, checked against the
                                         ;; backedge yield below. Unclaimed carries remain
                                         ;; conservative because a later iteration may diverge.
                                         initial
-                                        (assoc initial :uniformity lane-varying))])
+                                        (assoc initial :uniformity lane-varying)))])
                                    iter-args initials))
             yielded (validate-region! "kernel for-loop body" (:operations operation)
                                       (mapv :binding iter-args) loop-values
@@ -1539,7 +1553,7 @@
                                     {:reason :kernel-body-loop-result
                                      :result result :yielded yielded-info})))
                   (assoc env (:id result)
-                         (assoc yielded-info :uniformity
+                         (assoc (conservative-loop-info yielded-info (:type result)) :uniformity
                                 ;; The loop may execute zero times, so its result cannot be
                                 ;; more uniform than either the initial or backedge value.
                                 (reduce set/intersection loop-control
@@ -1578,9 +1592,11 @@
                                       :uniformity loop-control})
                               (map (fn [arg initial]
                                      [(:id (:binding arg))
-                                      (if (contains? uniform-iter-args (:id (:binding arg)))
+                                      (let [initial (conservative-loop-info
+                                                     initial (:type (:binding arg)))]
+                                        (if (contains? uniform-iter-args (:id (:binding arg)))
                                         initial
-                                        (assoc initial :uniformity lane-varying))])
+                                        (assoc initial :uniformity lane-varying)))])
                                    iter-args initials))
             body-values (validate-dataflow-operations!
                          (pop (:operations operation)) loop-values
@@ -1611,7 +1627,7 @@
                             {:reason :kernel-body-loop-result
                              :result result :yielded yielded-info})))
                   (assoc env (:id result)
-                         (assoc yielded-info :uniformity
+                         (assoc (conservative-loop-info yielded-info (:type result)) :uniformity
                                 (reduce set/intersection loop-control
                                         [(:uniformity initial-info)
                                          (:uniformity yielded-info)]))))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1130,10 +1130,10 @@
         (when-not (= arity (count infos))
           (throw (ex-info "scalar intrinsic arity mismatch"
                           {:operation canonical-op :expected arity :actual (count infos)})))
-        (when (and arithmetic-overflow? (seq options)
+        (when (and arithmetic-overflow?
                    (not (and (= #{:overflow} (set (keys options)))
                              (contains? arithmetic-overflow-policies overflow-policy))))
-          (throw (ex-info "integral arithmetic has an unsupported explicit overflow contract"
+          (throw (ex-info "integral arithmetic requires exactly one overflow contract"
                           {:reason :kernel-body-intrinsic-overflow
                            :operation canonical-op :operand-type operand-type
                            :options options})))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -11,7 +11,8 @@
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.numerical-contract :as numerics]))
+            [raster.compiler.ir.numerical-contract :as numerics]
+            [raster.compiler.ir.scalar-range :as scalar-range]))
 
 (defrecord KernelParameter [id kind dtype shape memory-space layout role])
 (defrecord BufferView [id buffer element-offset shape layout])
@@ -1126,13 +1127,23 @@
             integral? (contains? #{:byte :int :long} operand-type)
             overflow-op? (contains? #{:+ :- :*} canonical-op)
             arithmetic-overflow? (and integral? overflow-op?)
-            overflow-policy (:overflow options)]
+            overflow-policy (:overflow options)
+            proof (:proof options)
+            valid-proof?
+            (and (= :no-overflow overflow-policy)
+                 (= :typed-scalar-range (:kind proof))
+                 (integer? (:lower proof))
+                 (integer? (:upper proof))
+                 (<= (:lower proof) (:upper proof))
+                 (scalar-range/contained-in-dtype? proof operand-type))
+            valid-options?
+            (or (and (= #{:overflow} (set (keys options)))
+                     (contains? arithmetic-overflow-policies overflow-policy))
+                (and (= #{:overflow :proof} (set (keys options))) valid-proof?))]
         (when-not (= arity (count infos))
           (throw (ex-info "scalar intrinsic arity mismatch"
                           {:operation canonical-op :expected arity :actual (count infos)})))
-        (when (and arithmetic-overflow?
-                   (not (and (= #{:overflow} (set (keys options)))
-                             (contains? arithmetic-overflow-policies overflow-policy))))
+        (when (and arithmetic-overflow? (not valid-options?))
           (throw (ex-info "integral arithmetic requires exactly one overflow contract"
                           {:reason :kernel-body-intrinsic-overflow
                            :operation canonical-op :operand-type operand-type

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1221,12 +1221,24 @@
        (let [source-range (:range (first infos))]
          ;; Exact widening retains its fact.  Narrowing, wrapping and floating conversion are
          ;; intentionally conservative.
-         (when (and source-range
-                    (scalar-range/contained-in-dtype? source-range result-type))
-           source-range))
+         (if (and source-range
+                  (scalar-range/contained-in-dtype? source-range result-type))
+           source-range
+           (scalar-range/for-dtype result-type)))
 
        (= :isnan op) nil
-       :else (scalar-result-range canonical-op result-type infos))}))
+       :else
+       (let [integral-arithmetic?
+             (and (contains? #{:byte :int :long} result-type)
+                  (contains? #{:+ :- :*} canonical-op))]
+         (if integral-arithmetic?
+           ;; A checked operation may trap and a wrapping operation may narrow modulo its
+           ;; representation.  Neither permits downstream arithmetic to borrow an unbounded
+           ;; mathematical interval; only an independently proved operation retains it.
+           (if (= :no-overflow (:overflow options))
+             (scalar-result-range canonical-op result-type infos)
+             (scalar-range/for-dtype result-type))
+           (scalar-result-range canonical-op result-type infos))))}))
 
 (defn- expression-info!
   [expression values]

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1005,7 +1005,10 @@
 (defn- literal-info!
   [literal]
   (literal! literal)
-  {:type (canonical-type (:type literal)) :uniformity all-uniform})
+  (let [type (canonical-type (:type literal))]
+    {:type type
+     :uniformity all-uniform
+     :range (scalar-range/literal (:value literal) type)}))
 
 (defn- scalar-argument-info!
   [argument values]
@@ -1029,6 +1032,37 @@
     (when-not (apply = types)
       (throw (ex-info (str owner " operand types must agree") {:types types})))
     (first types)))
+
+(defn- scalar-result-range
+  "Derive a range from verifier-owned operand facts.  This deliberately knows only canonical
+  scalar semantics; producer-supplied proof maps are diagnostic evidence, never facts."
+  [canonical-op result-type infos]
+  (let [ranges (mapv :range infos)]
+    (cond
+      (contains? #{:+ :- :*} canonical-op)
+      (scalar-range/arithmetic canonical-op ranges)
+
+      (contains? #{:min :max} canonical-op)
+      (scalar-range/minmax canonical-op ranges)
+
+      (= :select canonical-op)
+      (scalar-range/hull (subvec ranges 1))
+
+      :else
+      ;; Operations without an independently modelled transfer function remain unknown.  For
+      ;; integral values that means the complete declared dtype, never a guessed subrange.
+      (scalar-range/for-dtype result-type))))
+
+(defn- proof-covers-derived-range?
+  [proof derived-range result-type]
+  (and (= :typed-scalar-range (:kind proof))
+       (integer? (:lower proof))
+       (integer? (:upper proof))
+       (<= (:lower proof) (:upper proof))
+       (scalar-range/contained-in-dtype? proof result-type)
+       derived-range
+       (<= (:lower proof) (:lower derived-range))
+       (<= (:upper derived-range) (:upper proof))))
 
 (defn- scalar-info!
   [expression values]
@@ -1129,17 +1163,16 @@
             arithmetic-overflow? (and integral? overflow-op?)
             overflow-policy (:overflow options)
             proof (:proof options)
-            valid-proof?
-            (and (= :no-overflow overflow-policy)
-                 (= :typed-scalar-range (:kind proof))
-                 (integer? (:lower proof))
-                 (integer? (:upper proof))
-                 (<= (:lower proof) (:upper proof))
-                 (scalar-range/contained-in-dtype? proof operand-type))
+            derived-range (when arithmetic-overflow?
+                            (scalar-range/arithmetic canonical-op (mapv :range infos)))
+            no-overflow-proved?
+            (and derived-range
+                 (scalar-range/contained-in-dtype? derived-range result-type))
             valid-options?
-            (or (and (= #{:overflow} (set (keys options)))
-                     (contains? arithmetic-overflow-policies overflow-policy))
-                (and (= #{:overflow :proof} (set (keys options))) valid-proof?))]
+            (and (contains? #{#{:overflow} #{:overflow :proof}} (set (keys options)))
+                 (contains? arithmetic-overflow-policies overflow-policy)
+                 (or (not (contains? options :proof))
+                     (proof-covers-derived-range? proof derived-range result-type)))]
         (when-not (= arity (count infos))
           (throw (ex-info "scalar intrinsic arity mismatch"
                           {:operation canonical-op :expected arity :actual (count infos)})))
@@ -1148,6 +1181,14 @@
                           {:reason :kernel-body-intrinsic-overflow
                            :operation canonical-op :operand-type operand-type
                            :options options})))
+        (when (and arithmetic-overflow?
+                   (= :no-overflow overflow-policy)
+                   (not no-overflow-proved?))
+          (throw (ex-info "integral no-overflow contract is not derivable from operand ranges"
+                          {:reason :kernel-body-intrinsic-overflow-proof
+                           :operation canonical-op :operand-type operand-type
+                           :derived-range derived-range :result-type result-type
+                           :proof proof})))
         (when (and (seq options) (not arithmetic-overflow?))
           (throw (ex-info "overflow contracts are only defined for integral add, subtract, and multiply"
                           {:reason :kernel-body-intrinsic-overflow
@@ -1172,13 +1213,26 @@
       :else
       (throw (ex-info "scalar expression has an unknown canonical operation"
                       {:operation op :allowed-special special-scalar-ops})))
-    {:type result-type :uniformity (join-uniformity infos)}))
+    {:type result-type
+     :uniformity (join-uniformity infos)
+     :range
+     (cond
+       (= :cast op)
+       (let [source-range (:range (first infos))]
+         ;; Exact widening retains its fact.  Narrowing, wrapping and floating conversion are
+         ;; intentionally conservative.
+         (when (and source-range
+                    (scalar-range/contained-in-dtype? source-range result-type))
+           source-range))
+
+       (= :isnan op) nil
+       :else (scalar-result-range canonical-op result-type infos))}))
 
 (defn- expression-info!
   [expression values]
   (cond
     (integer? expression)
-    {:type :int :uniformity all-uniform}
+    {:type :int :uniformity all-uniform :range (scalar-range/literal expression :int)}
 
     (value-id? expression)
     (typed-info! values expression "index expression")
@@ -1201,7 +1255,9 @@
                         {:reason :kernel-body-index-cast-semantics
                          :expression expression :source (:type source) :target target
                          :overflow (:overflow expression)})))
-      {:type target :uniformity (:uniformity source)})
+      {:type target :uniformity (:uniformity source)
+       :range (when (scalar-range/contained-in-dtype? (:range source) target)
+                (:range source))})
 
     (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" expression)
     (let [infos (mapv #(expression-info! % values) (:arguments expression))
@@ -1213,7 +1269,19 @@
         (throw (ex-info "index expression mixes integral widths without an explicit conversion"
                         {:reason :kernel-body-index-dtype :expression expression :types types})))
       {:type (or (first types) :int)
-       :uniformity (join-uniformity infos)})
+       :uniformity (join-uniformity infos)
+       ;; Index expressions are scheduling arithmetic; conservatively retain a range only for
+       ;; the canonical operations whose interval transfer is total and explicitly modelled.
+       :range (let [op (:op expression)
+                    result-type (or (first types) :int)
+                    ranges (mapv :range infos)]
+                (case op
+                  :add (scalar-range/arithmetic :+ ranges)
+                  :sub (scalar-range/arithmetic :- ranges)
+                  :mul (scalar-range/arithmetic :* ranges)
+                  :min (scalar-range/minmax :min ranges)
+                  :max (scalar-range/minmax :max ranges)
+                  (scalar-range/for-dtype result-type)))})
 
     :else
     (throw (ex-info "unsupported kernel index expression"
@@ -1337,6 +1405,12 @@
                          :expected result-type :actual (:type other-info)})))
       (assoc values (:id result)
              {:type result-type
+              ;; A device load is unconstrained unless a preceding scalar operation derives a
+              ;; narrower fact.  `other` is included because a masked load may produce it.
+              :range (if other-info
+                       (scalar-range/hull [(scalar-range/for-dtype result-type)
+                                           (:range other-info)])
+                       (scalar-range/for-dtype result-type))
               ;; Only a body-level StableRead contract can establish memory uniformity. Its
               ;; corresponding ABI slot requires no write alias for the whole parallel launch.
               :uniformity (reduce set/intersection
@@ -1387,6 +1461,7 @@
                   (claim-value! claimed reserved values result "kernel if result")
                   (assoc env (:id result)
                          {:type (canonical-type (:type result))
+                          :range (scalar-range/hull [(:range then-info) (:range else-info)])
                           :uniformity (reduce set/intersection (:uniformity condition)
                                               [(:uniformity then-info)
                                                (:uniformity else-info)])}))
@@ -1418,6 +1493,11 @@
                             {:reason :kernel-body-loop-initial :arg arg :initial initial})))))
       (let [loop-values (into (assoc values (:id index)
                                      {:type (canonical-type (:type index))
+                                      ;; The verifier checks these are the actual loop bounds;
+                                      ;; including the upper endpoint is conservative and avoids
+                                      ;; assuming a particular trip-count convention.
+                                      :range (scalar-range/hull [(:range lower-info)
+                                                                 (:range upper-info)])
                                       :uniformity loop-control})
                               (map (fn [arg initial]
                                      [(:id (:binding arg))
@@ -1480,7 +1560,10 @@
             (throw (ex-info "kernel pipelined loop initial value disagrees with its binding"
                             {:reason :kernel-body-loop-initial :arg arg :initial initial})))))
       (let [loop-values (into (assoc values (:id index)
-                                     {:type index-type :uniformity loop-control})
+                                     {:type index-type
+                                      :range (scalar-range/hull [(:range lower-info)
+                                                                 (:range upper-info)])
+                                      :uniformity loop-control})
                               (map (fn [arg initial]
                                      [(:id (:binding arg))
                                       (if (contains? uniform-iter-args (:id (:binding arg)))
@@ -2145,11 +2228,21 @@
                         {:type (if (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" idx)
                                  :int
                                  (:type (expression-info! (:expression idx) values)))
+                         :range (if (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" idx)
+                                  ;; Hardware ids have target-dependent launch ranges.  Until a
+                                  ;; launch contract proves one, they are ordinary full-width
+                                  ;; ints, never implicit no-overflow evidence.
+                                  (scalar-range/for-dtype :int)
+                                  (:range (expression-info! (:expression idx) values)))
                          :uniformity uniformity})))
              (into {}
                    (map (fn [parameter]
                           [(:id parameter)
                            {:type (canonical-type (:dtype parameter))
+                            ;; ABI scalars and all loads begin at their complete dtype range.
+                            ;; Producers may derive a narrower range with real clamp/select
+                            ;; operations; roles alone are not assertions.
+                            :range (scalar-range/for-dtype (:dtype parameter))
                             :uniformity all-uniform}])
                         (filter #(= :scalar (:kind %)) parameters)))
              indices)

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -73,3 +73,17 @@
       :max {:lower (reduce max (map :lower operands))
             :upper (reduce max (map :upper operands))}
       nil)))
+
+(defn quotient
+  "Interval transfer for truncating quotient by one statically positive divisor.
+
+  Truncation toward zero is monotone for a positive divisor, including negative numerators.  We
+  intentionally require an exact divisor literal/range: a zero or sign-varying denominator has
+  distinct exceptional semantics and carries no schedule proof here."
+  [operands]
+  (when (every? some? operands)
+    (let [[numerator divisor] operands
+          divisor-value (:lower divisor)]
+      (when (and (= divisor-value (:upper divisor)) (pos? divisor-value))
+        {:lower (quot (:lower numerator) divisor-value)
+         :upper (quot (:upper numerator) divisor-value)}))))

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -1,0 +1,52 @@
+(ns raster.compiler.ir.scalar-range
+  "Small reusable interval facts for typed scalar lowering.
+
+   These facts are proof-only: they are derived from retained scalar/storage dtypes, explicit
+   literals and exact widening casts. Unknown values retain their full declared range, so the
+   analysis can certify `:no-overflow` only when a canonical scalar operation is representable
+   for every runtime value admitted by the typed contract."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(def ^:private integral-bounds
+  {:byte [Byte/MIN_VALUE Byte/MAX_VALUE]
+   :int [Integer/MIN_VALUE Integer/MAX_VALUE]
+   :long [Long/MIN_VALUE Long/MAX_VALUE]})
+
+(defn for-dtype
+  "The complete representable interval for an integral dtype, else nil."
+  [type]
+  (when-let [[lower upper] (get integral-bounds (dtype/canon type))]
+    {:lower lower :upper upper}))
+
+(defn contained-in-dtype?
+  "Whether every value in `range` is representable in `type`."
+  [range type]
+  (when-let [{minimum :lower maximum :upper} (for-dtype type)]
+    (and range (<= minimum (:lower range)) (<= (:upper range) maximum))))
+
+(defn literal
+  "An exact integral literal interval when representable in `type`, else nil."
+  [value type]
+  (let [range {:lower value :upper value}]
+    (when (contained-in-dtype? range type) range)))
+
+(defn arithmetic
+  "Exact interval transfer for a canonical binary integral `operator`.
+
+  `+'`, `-'`, and `*'` keep the proof calculation unbounded, preventing host arithmetic from
+  wrapping into a false certificate. Unknown input ranges produce nil."
+  [operator operands]
+  (when (every? some? operands)
+    (let [lowers (mapv :lower operands)
+          uppers (mapv :upper operands)]
+      (case operator
+        :+ {:lower (reduce +' lowers) :upper (reduce +' uppers)}
+        :- (let [[left right] operands]
+             {:lower (-' (:lower left) (:upper right))
+              :upper (-' (:upper left) (:lower right))})
+        :* (let [[left right] operands
+                 products (map #(*' %1 %2)
+                               [(:lower left) (:lower left) (:upper left) (:upper left)]
+                               [(:lower right) (:upper right) (:lower right) (:upper right)])]
+             {:lower (reduce min products) :upper (reduce max products)})
+        nil))))

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -15,7 +15,11 @@
 (defn for-dtype
   "The complete representable interval for an integral dtype, else nil."
   [type]
-  (when-let [[lower upper] (get integral-bounds (dtype/canon type))]
+  ;; Predicate values are deliberately outside `dtype/canon`: a predicate is a control
+  ;; value, not a numeric scalar.  Range analysis is optional evidence, so it must be
+  ;; harmless when asked about one.
+  (when-let [[lower upper] (get integral-bounds (when (not= :predicate type)
+                                                   (dtype/canon type)))]
     {:lower lower :upper upper}))
 
 (defn contained-in-dtype?
@@ -50,3 +54,22 @@
                                [(:lower right) (:upper right) (:lower right) (:upper right)])]
              {:lower (reduce min products) :upper (reduce max products)})
         nil))))
+
+(defn hull
+  "The least interval containing every non-nil input interval, or nil when an input is
+  unknown.  It is used for control-flow joins rather than as an assertion mechanism."
+  [ranges]
+  (when (every? some? ranges)
+    {:lower (reduce min (map :lower ranges))
+     :upper (reduce max (map :upper ranges))}))
+
+(defn minmax
+  "Sound interval transfer for canonical integral min/max."
+  [operator operands]
+  (when (every? some? operands)
+    (case operator
+      :min {:lower (reduce min (map :lower operands))
+            :upper (reduce min (map :upper operands))}
+      :max {:lower (reduce max (map :lower operands))
+            :upper (reduce max (map :upper operands))}
+      nil)))

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -47,7 +47,12 @@
       (and (pos-int? tile-size)
            (<= tile-size Integer/MAX_VALUE)
            (pos-int? tile-count)
+           ;; These values become launch dimensions and scalar int literals in the portable
+           ;; tiled body.  Keep the schedule target-neutral, but never permit a value the body
+           ;; cannot represent without narrowing.
+           (<= tile-count Integer/MAX_VALUE)
            (pos-int? membership-capacity)
+           (<= membership-capacity Integer/MAX_VALUE)
            (= tile-count (quot (+ membership-capacity (dec tile-size)) tile-size))
            (= :increasing-membership-tile merge-order)))
 

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -57,6 +57,13 @@
                       "portable contraction body requires at least one free axis"
                       {:segred-id (:id segred)}))
         dtype (dtype/canon (:dtype segred))
+        ;; The product and accumulator of an integer contraction need an algebraic overflow
+        ;; contract, not merely address-range facts.  No portable contract has been introduced
+        ;; yet, so decline instead of assigning an arbitrary target integer behavior.
+        _ (when (dtype/integral? dtype)
+            (decline! :integral-overflow-algebra
+                      "portable integer contraction requires explicit product and accumulation overflow contracts"
+                      {:dtype dtype :segred-id (:id segred)}))
         result-transform (:epilogue contract-facts)
         result-region (scalar-region-lower/make-region result-transform)
         transform-operands (vec (:operands result-transform))

--- a/src/raster/compiler/passes/parallel/register_tiled_body.clj
+++ b/src/raster/compiler/passes/parallel/register_tiled_body.clj
@@ -147,6 +147,13 @@
             (decline! :storage-dtype
                       "register-tiled schedule requires a known storage dtype"
                       {:dtype dtype}))
+        ;; Matrix arithmetic is semantic value algebra, unlike the schedule's bounded indices.
+        ;; Until an integer accumulation algebra is carried by contraction facts, do not choose
+        ;; wrap, trap, or saturation implicitly for this target-specific schedule.
+        _ (when (dtype/integral? dtype)
+            (decline! :integral-overflow-contract
+                      "register-tiled integer contraction requires an explicit accumulation overflow algebra"
+                      {:dtype dtype :operation-id operation-id}))
         tile (select-tile tile descriptor dtype)
         {:keys [combine neutral]} (facts/scalar-reduction-view contract-facts)
         {:keys [block-m block-n block-k thread-m thread-n]} tile

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -331,7 +331,16 @@
                                               operand-type expression)
                                             arguments)
                               result-type (if comparison? :predicate operand-type)
-                              overflow (intrinsics/source-overflow-policy semantic-operation)
+                              ;; Typed source arithmetic has a semantic overflow contract: normal
+                              ;; Clojure integral arithmetic is checked, while the explicitly
+                              ;; `unchecked-*` forms wrap.  Retain that distinction in KernelBody
+                              ;; rather than leaving a C-family emitter to choose signed overflow.
+                              integral-arithmetic?
+                              (and (contains? #{:byte :int :long} operand-type)
+                                   (contains? #{:+ :- :*} operator))
+                              overflow (when integral-arithmetic?
+                                         (or (intrinsics/source-overflow-policy semantic-operation)
+                                             :trap))
                               options (cond-> {} overflow (assoc :overflow overflow))
                               _ (when-not (every? #(= operand-type (:type %)) lowered)
                                   (decline! :operand-dtype

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -9,6 +9,7 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.scalar-range :as scalar-range]
             [raster.compiler.passes.parallel.patterns :as patterns]))
 
 (def ^:private cast-heads
@@ -72,6 +73,15 @@
   (let [canon-type #(if (= :predicate %) :predicate (dtype/canon %))
         counter (atom 0)
         fresh (fn [prefix] (symbol (str id-prefix "-" prefix "-" (swap! counter inc))))
+        ;; Lowered SSA names retain their exact interval here.  The public local environment still
+        ;; carries only authoritative dtypes; this private table is a proof cache, not a type or
+        ;; function registry, and a missing entry simply declines certification.
+        value-ranges (atom {})
+        remember-range! (fn [id range]
+                          (when range (swap! value-ranges assoc id range))
+                          range)
+        known-range (fn [value type]
+                      (or (get @value-ranges value) (scalar-range/for-dtype type)))
         source-type
         (fn source-type [expression expected env]
           (let [expression (inline-lets expression)]
@@ -122,12 +132,15 @@
                                     "scalar cast has no portable rounding and overflow policy"
                                     {:expression expression :source source :target target}))
                         id (fresh "cast")]
-                    {:operations (conj (:operations lowered)
+                    (let [range (when (scalar-range/contained-in-dtype? (:range lowered) target)
+                                  (:range lowered))]
+                      (remember-range! id (or range (scalar-range/for-dtype target)))
+                      {:operations (conj (:operations lowered)
                                        (body/->ScalarCompute
                                         (body/value id target)
                                         (body/cast-expression (:result lowered) target
                                                               rounding overflow)))
-                     :result id :type target}))))
+                       :result id :type target :range (or range (scalar-range/for-dtype target))})))))
 
             (lower [expression expected env]
               (let [expression (inline-lets expression)
@@ -135,7 +148,8 @@
                 (cond
                   (instance? raster.compiler.ir.kernel_body.Literal expression)
                   {:operations [] :result expression
-                   :type (canon-type (:type expression))}
+                   :type (canon-type (:type expression))
+                   :range (scalar-range/literal (:value expression) (:type expression))}
 
                   (and (= :predicate expected) (number? expression))
                   (if (contains? #{0 1} expression)
@@ -146,14 +160,18 @@
                               {:expression expression}))
 
                   (number? expression)
-                  {:operations [] :result (body/literal expression expected) :type expected}
+                  (let [range (scalar-range/literal expression expected)]
+                    {:operations [] :result (body/literal expression expected)
+                     :type expected :range range})
 
                   (boolean? expression)
                   {:operations [] :result (body/literal expression :predicate) :type :predicate}
 
                   (symbol? expression)
                   (if-let [actual (or (get env expression) (get scalar-types expression))]
-                    {:operations [] :result expression :type (canon-type actual)}
+                    (let [type (canon-type actual)]
+                      {:operations [] :result expression :type type
+                       :range (known-range expression type)})
                     (decline! :unbound-scalar
                               "scalar expression references an undeclared value"
                               {:expression expression :environment (set (keys env))}))
@@ -178,12 +196,14 @@
                             (:result coordinate-value)
                             (lower-index coordinate (set (keys env))))
                           id (fresh "load")]
-                      {:operations (conj (vec (:operations coordinate-value))
+                      (let [range (scalar-range/for-dtype array-type)]
+                        (remember-range! id range)
+                        {:operations (conj (vec (:operations coordinate-value))
                                          (body/->ScalarLoad
                                           (body/value id array-type) array
                                           [coordinate-expression] predicate
                                           (when predicate (body/literal 0 array-type)) :cached))
-                       :result id :type array-type}))
+                         :result id :type array-type :range range})))
 
                   (and (seq? expression) (contains? cast-heads (first expression))
                        (= 2 (count expression)))
@@ -338,24 +358,35 @@
                               integral-arithmetic?
                               (and (contains? #{:byte :int :long} operand-type)
                                    (contains? #{:+ :- :*} operator))
+                              operand-ranges (mapv :range lowered)
+                              proven-range (when integral-arithmetic?
+                                             (scalar-range/arithmetic operator operand-ranges))
                               overflow (when integral-arithmetic?
                                          (or (intrinsics/source-overflow-policy semantic-operation)
+                                             (when (scalar-range/contained-in-dtype? proven-range operand-type)
+                                               :no-overflow)
                                              :trap))
-                              options (cond-> {} overflow (assoc :overflow overflow))
+                              options (cond-> {} overflow (assoc :overflow overflow)
+                                               (= :no-overflow overflow)
+                                               (assoc :proof (assoc proven-range
+                                                              :kind :typed-scalar-range)))
                               _ (when-not (every? #(= operand-type (:type %)) lowered)
                                   (decline! :operand-dtype
                                             "scalar intrinsic operands require one dtype"
                                             {:expression expression :operand-type operand-type
                                              :actual (mapv :type lowered)}))
                               result (fresh "value")]
-                          {:operations
-                           (conj (vec (mapcat :operations lowered))
-                                 (body/->ScalarCompute
-                                 (body/value result result-type)
-                                  (body/scalar-expression operator result-type
-                                                          (mapv :result lowered)
-                                                          options)))
-                           :result result :type result-type}))))
+                          (let [range (when (= :no-overflow overflow) proven-range)]
+                            (remember-range! result (or range (scalar-range/for-dtype result-type)))
+                            {:operations
+                             (conj (vec (mapcat :operations lowered))
+                                   (body/->ScalarCompute
+                                    (body/value result result-type)
+                                    (body/scalar-expression operator result-type
+                                                            (mapv :result lowered)
+                                                            options)))
+                             :result result :type result-type
+                             :range (or range (scalar-range/for-dtype result-type))})))))
 
                   :else
                   (decline! :scalar-expression

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -196,7 +196,8 @@
                   (cast (lower-expression (second expression) env) target))
 
                 (seq? expression)
-                (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                (let [semantic-operation (descriptor/semantic-op expression)
+                      operator (intrinsics/canonical semantic-operation)
                       intrinsic (intrinsics/descriptor operator)
                       arguments (vec (descriptor/call-args expression))]
                   (when-not (and intrinsic
@@ -208,10 +209,19 @@
                               {:expression expression :operator operator
                                :result-dtype result-dtype}))
                   (let [inputs (mapv #(:value (lower-expression % env)) arguments)
+                        ;; Result transforms retain the same source contract as ordinary scalar
+                        ;; regions.  Their arithmetic is not schedule index arithmetic and may
+                        ;; therefore never be silently certified as `:no-overflow`.
+                        overflow (when (and (contains? #{:byte :int :long} result-dtype)
+                                            (contains? #{:+ :- :*} operator))
+                                   (or (intrinsics/source-overflow-policy semantic-operation)
+                                       :trap))
                         result (fresh "result-transform-value")]
                     (emit! (body/->ScalarCompute
                             (body/value result result-dtype)
-                            (body/scalar-expression operator result-dtype inputs))
+                            (body/scalar-expression
+                             operator result-dtype inputs
+                             (cond-> {} overflow (assoc :overflow overflow))))
                            result result-dtype)))
 
                 :else

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -269,8 +269,13 @@
      (compute 'safe-page-end :int
               (expr :min :int (expr :max :int 'page-end (lit 0 :int))
                     (lit capacity :int)))
-     (compute 'routed-page-count :int
+     ;; This subtraction is range-safe but can be negative for malformed raw offsets.  Clamp the
+     ;; derived count before the `(count - 1) * page-size` schedule expression below; validity is
+     ;; still enforced independently by `route-valid`, so clamping cannot admit a malformed row.
+     (compute 'raw-routed-page-count :int
               (bounded-expr :- :int 'safe-page-end 'safe-page-begin))
+     (compute 'routed-page-count :int
+              (expr :max :int 'raw-routed-page-count (lit 0 :int)))
      (compute 'has-routed-pages :predicate
               (expr :gt :predicate 'routed-page-count (lit 0 :int)))
      (compute 'empty-last-page-valid :predicate
@@ -1253,23 +1258,29 @@
         offset (if csr? 'history-tile-offset-int 'history-tile-offset)]
     (vec
      (concat
+      ;; `history-tile` is group axis 2, whose launch extent is the schedule's tile-count.
+      ;; Schedule validation fixes tile-count=ceil(capacity/tile-size), so its product below is
+      ;; strictly below the validated int32 membership capacity.
       [(compute 'history-tile-offset-int :int
                 (bounded-expr :* :int 'history-tile (lit tile-size :int)))]
       (when-not csr?
         [(compute 'history-tile-offset :long
                   (cast-expr 'history-tile-offset-int :long))])
+      ;; Both interval and CSR membership lowering clamp begin/end to their statically validated
+      ;; int32 capacity.  The tile offset is nonnegative and below the same capacity, so each
+      ;; difference/sum below stays within the selected int32/long representation.
       [(compute 'membership-count type
-                (expr :- type 'attention-end 'attention-begin))
+                (bounded-expr :- type 'attention-end 'attention-begin))
        (compute 'tile-relative-begin type
                 (expr :min type 'membership-count offset))
        (compute 'tile-membership-begin type
-                (expr :+ type 'attention-begin 'tile-relative-begin))
+                (bounded-expr :+ type 'attention-begin 'tile-relative-begin))
        (compute 'tile-membership-remaining type
-                (expr :- type 'membership-count 'tile-relative-begin))
+                (bounded-expr :- type 'membership-count 'tile-relative-begin))
        (compute 'tile-membership-width type
                 (expr :min type 'tile-membership-remaining (lit tile-size type)))
        (compute 'tile-membership-end type
-                (expr :+ type 'tile-membership-begin 'tile-membership-width))]))))
+                (bounded-expr :+ type 'tile-membership-begin 'tile-membership-width))]))))
 
 (defn- partial-store-operations
   [partial-ids slots]

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -16,10 +16,13 @@
   (body/literal value type))
 
 (defn- expr [op type & arguments]
-  ;; This body owns only bounded route, page, membership and loop cursor arithmetic.  The
-  ;; schedule validates their int-width capacities before lowering and widens intermediate route
-  ;; values to long; these are address calculations, not the attention value algebra.  Preserve
-  ;; that certificate explicitly for the verifier and target emitter.
+  ;; Arithmetic over raw device metadata intentionally carries no implied proof.  Callers must
+  ;; sanitize/bound its operands and use `bounded-expr` before claiming `:no-overflow`.
+  (body/scalar-expression op type arguments))
+
+(defn- bounded-expr
+  "Build an integral schedule calculation after its local range proof has bounded every operand."
+  [op type & arguments]
   (body/scalar-expression
    op type arguments
    (if (and (contains? #{:byte :int :long} type)
@@ -226,7 +229,7 @@
               (expr :ge :predicate 'kv-start-position (lit 0 :int)))
      (compute 'kv-start-long :long (cast-expr 'kv-start-position :long))
      (compute 'kv-length-long :long (cast-expr 'kv-length :long))
-     (compute 'kv-end-long :long (expr :+ :long 'kv-start-long 'kv-length-long))
+     (compute 'kv-end-long :long (bounded-expr :+ :long 'kv-start-long 'kv-length-long))
      (compute 'kv-end-bounded :predicate
               (expr :le :predicate 'kv-end-long (lit 2147483648 :long)))
      (compute 'route-valid :predicate
@@ -257,7 +260,17 @@
               (expr :le :predicate 'page-end (lit capacity :int)))
      (compute 'kv-start-nonnegative :predicate
               (expr :ge :predicate 'kv-start-position (lit 0 :int)))
-     (compute 'routed-page-count :int (expr :- :int 'page-end 'page-begin))
+     ;; Raw offsets are untrusted device metadata. Clamp both endpoints before deriving a count;
+     ;; each resulting operand lies in [0, capacity] and attention validation proves that the
+     ;; static capacity itself fits int32.
+     (compute 'safe-page-begin :int
+              (expr :min :int (expr :max :int 'page-begin (lit 0 :int))
+                    (lit capacity :int)))
+     (compute 'safe-page-end :int
+              (expr :min :int (expr :max :int 'page-end (lit 0 :int))
+                    (lit capacity :int)))
+     (compute 'routed-page-count :int
+              (bounded-expr :- :int 'safe-page-end 'safe-page-begin))
      (compute 'has-routed-pages :predicate
               (expr :gt :predicate 'routed-page-count (lit 0 :int)))
      (compute 'empty-last-page-valid :predicate
@@ -266,32 +279,31 @@
               (expr :ge :predicate 'final-page-length (lit 1 :int)))
      (compute 'last-page-bounded :predicate
               (expr :le :predicate 'final-page-length (lit page-size :int)))
+     (compute 'safe-final-page-length :int
+              (expr :min :int (expr :max :int 'final-page-length (lit 0 :int))
+                    (lit page-size :int)))
      (compute 'nonempty-last-page-valid :predicate
               (and-expr 'last-page-positive 'last-page-bounded))
      (compute 'last-page-valid :predicate
               (select-expr 'has-routed-pages 'nonempty-last-page-valid
                            'empty-last-page-valid :predicate))
      (compute 'computed-kv-length :int
-              (expr :+ :int
-                    (expr :* :int
-                          (expr :- :int 'routed-page-count (lit 1 :int))
+              (bounded-expr :+ :int
+                    (bounded-expr :* :int
+                          (bounded-expr :- :int 'routed-page-count (lit 1 :int))
                           (lit page-size :int))
-                    'final-page-length))
+                    'safe-final-page-length))
      (compute 'kv-length :int
               (select-expr 'has-routed-pages 'computed-kv-length (lit 0 :int) :int))
      (compute 'kv-start-long :long (cast-expr 'kv-start-position :long))
      (compute 'kv-length-long :long (cast-expr 'kv-length :long))
-     (compute 'kv-end-long :long (expr :+ :long 'kv-start-long 'kv-length-long))
+     (compute 'kv-end-long :long (bounded-expr :+ :long 'kv-start-long 'kv-length-long))
      (compute 'kv-end-bounded :predicate
               (expr :le :predicate 'kv-end-long (lit 2147483648 :long)))
      (compute 'route-valid :predicate
               (all-expr ['page-zero-valid 'page-begin-nonnegative 'page-order-valid
                          'page-end-bounded 'kv-start-nonnegative 'last-page-valid
                          'kv-end-bounded]))
-     (compute 'safe-page-begin :int
-              (expr :min :int
-                    (expr :max :int 'page-begin (lit 0 :int))
-                    (lit (dec capacity) :int)))
      (compute 'safe-kv-length :int
               (expr :min :int
                     (expr :max :int 'kv-length (lit 0 :int))
@@ -300,12 +312,17 @@
 (defn- interval-membership-operations
   [{:keys [visibility]}]
   (let [{:keys [causal? window-left window-right]} visibility
+        ;; Query positions are int32 device values.  A larger static window is observationally
+        ;; equivalent to this cap for the validated int32 logical route, and retaining that cap
+        ;; keeps every widened long calculation within a four-int32 range.
+        window-left (when (some? window-left) (long (min window-left Integer/MAX_VALUE)))
+        window-right (when (some? window-right) (long (min window-right Integer/MAX_VALUE)))
         begin-expression
         (if (some? window-left)
           (expr :min :long
                 (expr :max :long
-                      (expr :- :long
-                            (expr :- :long 'query-position-long (lit window-left :long))
+                      (bounded-expr :- :long
+                            (bounded-expr :- :long 'query-position-long (lit window-left :long))
                             'kv-start-long)
                       (lit 0 :long))
                 'safe-kv-length-long)
@@ -315,17 +332,17 @@
           causal?
           (expr :max :long
                 (expr :min :long 'safe-kv-length-long
-                      (expr :+ :long
-                            (expr :- :long 'query-position-long 'kv-start-long)
+                      (bounded-expr :+ :long
+                            (bounded-expr :- :long 'query-position-long 'kv-start-long)
                             (lit 1 :long)))
                 (lit 0 :long))
 
           (some? window-right)
           (expr :max :long
                 (expr :min :long 'safe-kv-length-long
-                      (expr :+ :long
-                            (expr :- :long
-                                  (expr :+ :long 'query-position-long
+                      (bounded-expr :+ :long
+                            (bounded-expr :- :long
+                                  (bounded-expr :+ :long 'query-position-long
                                         (lit window-right :long))
                                   'kv-start-long)
                             (lit 1 :long)))
@@ -334,9 +351,9 @@
           :else 'safe-kv-length-long)]
     [(compute 'safe-kv-length-long :long (cast-expr 'safe-kv-length :long))
      (compute 'attention-begin :long
-              (expr :+ :long begin-expression (lit 0 :long)))
+              (bounded-expr :+ :long begin-expression (lit 0 :long)))
      (compute 'attention-end :long
-              (expr :+ :long end-expression (lit 0 :long)))
+              (bounded-expr :+ :long end-expression (lit 0 :long)))
      (compute 'membership-valid :predicate (true-expr))]))
 
 (defn- csr-membership-operations
@@ -368,18 +385,20 @@
 
 (defn- position-visible-expression
   [{:keys [causal? window-left window-right]}]
-  (all-expr
-   (cond-> []
-     causal?
-     (conj (expr :le :predicate 'kv-position 'query-position-long))
+  (let [window-left (when (some? window-left) (long (min window-left Integer/MAX_VALUE)))
+        window-right (when (some? window-right) (long (min window-right Integer/MAX_VALUE)))]
+    (all-expr
+     (cond-> []
+       causal?
+       (conj (expr :le :predicate 'kv-position 'query-position-long))
 
-     (some? window-left)
-     (conj (expr :ge :predicate 'kv-position
-                 (expr :- :long 'query-position-long (lit window-left :long))))
+       (some? window-left)
+       (conj (expr :ge :predicate 'kv-position
+                   (bounded-expr :- :long 'query-position-long (lit window-left :long))))
 
-     (some? window-right)
-     (conj (expr :le :predicate 'kv-position
-                 (expr :+ :long 'query-position-long (lit window-right :long)))))))
+       (some? window-right)
+       (conj (expr :le :predicate 'kv-position
+                   (bounded-expr :+ :long 'query-position-long (lit window-right :long))))))))
 
 (defn- cache-coordinates
   [layout kv-head physical-page page-token component]
@@ -399,7 +418,7 @@
               (and-expr 'logical-token-nonnegative 'logical-token-bounded))
      (compute 'logical-token-long :long (cast-expr 'logical-token :long))]
     [(compute 'logical-token-long :long
-              (expr :+ :long member (lit 0 :long)))
+              (bounded-expr :+ :long member (lit 0 :long)))
      (compute 'logical-token-valid :predicate (true-expr))]))
 
 (defn- physical-page-operations
@@ -414,8 +433,8 @@
      (load-value 'physical-page :int (:page-table route)
                  ['safe-query-batch 'safe-logical-page])
      (compute 'page-token :long
-              (expr :- :long 'logical-token-long
-                    (expr :* :long 'safe-logical-page (lit page-size :long))))
+              (bounded-expr :- :long 'logical-token-long
+                    (bounded-expr :* :long 'safe-logical-page (lit page-size :long))))
      (compute 'physical-page-nonnegative :predicate
               (expr :ge :predicate 'physical-page (lit 0 :int)))
      (compute 'physical-page-bounded :predicate
@@ -425,15 +444,15 @@
                 (expr :quot :long 'logical-token-long (lit page-size :long)))
        (compute 'safe-page-begin-long :long (cast-expr 'safe-page-begin :long))
        (compute 'raw-page-index :long
-                (expr :+ :long 'safe-page-begin-long 'logical-page))
+                (bounded-expr :+ :long 'safe-page-begin-long 'logical-page))
        (compute 'safe-page-index :long
                 (expr :min :long
                       (expr :max :long 'raw-page-index (lit 0 :long))
                       (lit (dec capacity) :long)))
        (load-value 'physical-page :int (:page-indices route) ['safe-page-index])
        (compute 'page-token :long
-                (expr :- :long 'logical-token-long
-                      (expr :* :long 'logical-page (lit page-size :long))))
+                (bounded-expr :- :long 'logical-token-long
+                      (bounded-expr :* :long 'logical-page (lit page-size :long))))
        (compute 'physical-page-nonnegative :predicate
                 (expr :ge :predicate 'physical-page (lit 0 :int)))
        (compute 'physical-page-bounded :predicate
@@ -553,7 +572,7 @@
          (concat
           token-ops
           [(compute 'kv-position :long
-                    (expr :+ :long 'kv-start-long 'logical-token-long))
+                    (bounded-expr :+ :long 'kv-start-long 'logical-token-long))
            (compute 'position-visible :predicate
                     (and-expr filter-expr (true-expr)))]
           page-ops
@@ -705,8 +724,8 @@
       (load-value physical-page :int (get-in problem [:route :page-table])
                   ['safe-query-batch safe-logical-page])
       (compute page-token :long
-               (expr :- :long member
-                     (expr :* :long safe-logical-page (lit page-size :long))))
+               (bounded-expr :- :long member
+                     (bounded-expr :* :long safe-logical-page (lit page-size :long))))
       (compute physical-page-nonnegative :predicate
                (expr :ge :predicate physical-page (lit 0 :int)))
       (compute physical-page-bounded :predicate
@@ -917,22 +936,22 @@
           (body/->AsyncLoopArg 'pipeline-carry-b (:group warm-b))]
          (flatten-operations
           [(compute current-a :long
-                    (expr :+ :long 'attention-begin
-                          (expr :* :long pair-index (lit 2 :long))))
-           (compute current-b :long (expr :+ :long current-a (lit 1 :long)))
+                    (bounded-expr :+ :long 'attention-begin
+                          (bounded-expr :* :long pair-index (lit 2 :long))))
+           (compute current-b :long (bounded-expr :+ :long current-a (lit 1 :long)))
            (body/->AsyncWait ['pipeline-carry-a] 1 :acquire
                              (body/full-participation))
            (workgroup-barrier)
            (:operations consume-a)
            (workgroup-barrier)
-           (compute next-a :long (expr :+ :long current-a (lit 2 :long)))
+           (compute next-a :long (bounded-expr :+ :long current-a (lit 2 :long)))
            (:operations refill-a)
            (body/->AsyncWait ['pipeline-carry-b] 1 :acquire
                              (body/full-participation))
            (workgroup-barrier)
            (:operations consume-b)
            (workgroup-barrier)
-           (compute next-b :long (expr :+ :long current-b (lit 2 :long)))
+           (compute next-b :long (bounded-expr :+ :long current-b (lit 2 :long)))
            (:operations refill-b)
            (body/->PipelineYield (pipeline-state-values (:state consume-b))
                                  [(:group refill-a) (:group refill-b)])])
@@ -948,14 +967,14 @@
      :operations
      (flatten-operations
       [(compute 'pipeline-membership-count :long
-                (expr :- :long 'attention-end 'attention-begin))
+                (bounded-expr :- :long 'attention-end 'attention-begin))
        (compute 'pipeline-zero :long
-                (expr :- :long 'attention-begin 'attention-begin))
+                (bounded-expr :- :long 'attention-begin 'attention-begin))
        (compute 'pipeline-pair-count :long
                 (expr :quot :long 'pipeline-membership-count (lit 2 :long)))
        (compute 'pipeline-refill-pairs :long
                 (expr :max :long
-                      (expr :- :long 'pipeline-pair-count (lit 1 :long))
+                      (bounded-expr :- :long 'pipeline-pair-count (lit 1 :long))
                       (lit 0 :long)))
        (compute 'pipeline-has-pair :predicate
                 (expr :ge :predicate 'pipeline-membership-count (lit 2 :long)))
@@ -963,9 +982,9 @@
         'pipeline-has-pair
         (flatten-operations
          [(compute warm-a-member :long
-                   (expr :+ :long 'attention-begin (lit 0 :long)))
+                   (bounded-expr :+ :long 'attention-begin (lit 0 :long)))
           (compute warm-b-member :long
-                   (expr :+ :long 'attention-begin (lit 1 :long)))
+                   (bounded-expr :+ :long 'attention-begin (lit 1 :long)))
           (:operations warm-a)
           (:operations warm-b)
           pipeline
@@ -973,12 +992,12 @@
                             0 :acquire (body/full-participation))
           (workgroup-barrier)
           (compute 'pipeline-final-pair :long
-                   (expr :- :long 'pipeline-pair-count (lit 1 :long)))
+                   (bounded-expr :- :long 'pipeline-pair-count (lit 1 :long)))
           (compute epilogue-a-member :long
-                   (expr :+ :long 'attention-begin
-                         (expr :* :long 'pipeline-final-pair (lit 2 :long))))
+                   (bounded-expr :+ :long 'attention-begin
+                         (bounded-expr :* :long 'pipeline-final-pair (lit 2 :long))))
           (compute epilogue-b-member :long
-                   (expr :+ :long epilogue-a-member (lit 1 :long)))
+                   (bounded-expr :+ :long epilogue-a-member (lit 1 :long)))
           (:operations epilogue-a)
           (:operations epilogue-b)
           (compute 'pipeline-has-odd :predicate
@@ -986,8 +1005,8 @@
                          (expr :rem :long 'pipeline-membership-count (lit 2 :long))
                          (lit 1 :long)))
           (compute odd-member :long
-                   (expr :+ :long 'attention-begin
-                         (expr :* :long 'pipeline-pair-count (lit 2 :long))))
+                   (bounded-expr :+ :long 'attention-begin
+                         (bounded-expr :* :long 'pipeline-pair-count (lit 2 :long))))
           (body/->IfRegion
            'pipeline-has-odd
            (flatten-operations
@@ -1235,7 +1254,7 @@
     (vec
      (concat
       [(compute 'history-tile-offset-int :int
-                (expr :* :int 'history-tile (lit tile-size :int)))]
+                (bounded-expr :* :int 'history-tile (lit tile-size :int)))]
       (when-not csr?
         [(compute 'history-tile-offset :long
                   (cast-expr 'history-tile-offset-int :long))])

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -16,7 +16,16 @@
   (body/literal value type))
 
 (defn- expr [op type & arguments]
-  (body/scalar-expression op type arguments))
+  ;; This body owns only bounded route, page, membership and loop cursor arithmetic.  The
+  ;; schedule validates their int-width capacities before lowering and widens intermediate route
+  ;; values to long; these are address calculations, not the attention value algebra.  Preserve
+  ;; that certificate explicitly for the verifier and target emitter.
+  (body/scalar-expression
+   op type arguments
+   (if (and (contains? #{:byte :int :long} type)
+            (contains? #{:+ :- :*} op))
+     {:overflow :no-overflow}
+     {})))
 
 (defn- select-expr [condition if-true if-false type]
   (body/scalar-expression :select type [condition if-true if-false]))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -1255,14 +1255,20 @@
   (let [csr? (attention/csr-visibility? (:visibility problem))
         type (if csr? :int :long)
         tile-size (get-in scheduled [:membership-tiling :tile-size])
+        tile-count (get-in scheduled [:membership-tiling :tile-count])
         offset (if csr? 'history-tile-offset-int 'history-tile-offset)]
     (vec
      (concat
-      ;; `history-tile` is group axis 2, whose launch extent is the schedule's tile-count.
-      ;; Schedule validation fixes tile-count=ceil(capacity/tile-size), so its product below is
-      ;; strictly below the validated int32 membership capacity.
-      [(compute 'history-tile-offset-int :int
-                (bounded-expr :* :int 'history-tile (lit tile-size :int)))]
+      ;; Hardware ids are typed ints, but their launch range is not an arithmetic proof.  Tie the
+      ;; schedule's static tile-count to a real clamp before the certified product.  Schedule
+      ;; validation fixes tile-count=ceil(capacity/tile-size), so the resulting literal interval
+      ;; has a representable int32 product.
+      [(compute 'safe-history-tile :int
+                (expr :min :int
+                      (expr :max :int 'history-tile (lit 0 :int))
+                      (lit (max 0 (dec tile-count)) :int)))
+       (compute 'history-tile-offset-int :int
+                (bounded-expr :* :int 'safe-history-tile (lit tile-size :int)))]
       (when-not csr?
         [(compute 'history-tile-offset :long
                   (cast-expr 'history-tile-offset-int :long))])

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -1031,6 +1031,29 @@
          (body/->Yield (pipeline-state-values fallback-state))]
         (pipeline-state-specs final-state))])}))
 
+(defn- source-membership-capacity
+  "The semantic membership extent represented by this concrete routed attention problem.
+
+  A tiled schedule may be self-consistent while still naming a different extent.  Keep this
+  computation adjacent to lowering rather than trusting a schedule-private copy of the fact."
+  [problem]
+  (if (attention/csr-visibility? (:visibility problem))
+    (get-in problem [:visibility :key-index-capacity])
+    (let [page-size (:page-size problem)]
+      (* page-size
+         (case (attention/route-kind (:route problem))
+           :dense-paged (get-in problem [:route :pages-per-sequence])
+           :csr-paged (get-in problem [:route :page-index-capacity]))))))
+
+(defn- int-literal-range!
+  [field value plan scheduled problem]
+  (when-not (and (integer? value) (<= 0 value Integer/MAX_VALUE))
+    (throw (ex-info "tiled weighted-reduction schedule exceeds portable int literal range"
+                    {:reason :segmented-weighted-reduction-body-int-literal-range
+                     :field field :value value :maximum Integer/MAX_VALUE
+                     :plan-id (:id plan) :schedule scheduled
+                     :operation-id (:id problem)}))))
+
 (defn- lowering-row!
   [plan scheduled problem]
   (let [visibility-kind (attention/visibility-kind (:visibility problem))
@@ -1081,6 +1104,25 @@
     (throw (ex-info "partial/merge bodies require a tiled weighted-reduction schedule"
                     {:reason :segmented-weighted-reduction-body-schedule-phase
                      :expected :tiled :schedule scheduled})))
+  (let [tiling (:membership-tiling scheduled)
+        actual-capacity (source-membership-capacity problem)
+        scheduled-capacity (:membership-capacity tiling)
+        csr-capacity (when (attention/csr-visibility? (:visibility problem))
+                       (get-in problem [:visibility :key-index-capacity]))]
+    ;; Equality, not a lower/upper relation: either mismatch changes which source members the
+    ;; tiled graph visits and is therefore a semantic schedule forgery.
+    (when-not (= actual-capacity scheduled-capacity)
+      (throw (ex-info "tiled weighted-reduction schedule capacity disagrees with source problem"
+                      {:reason :segmented-weighted-reduction-body-membership-capacity
+                       :plan-id (:id plan) :operation-id (:id problem)
+                       :actual-capacity actual-capacity
+                       :scheduled-capacity scheduled-capacity
+                       :schedule scheduled})))
+    (doseq [[field value] [[:membership-capacity scheduled-capacity]
+                           [:tile-count (:tile-count tiling)]
+                           [:csr-key-index-capacity csr-capacity]]
+            :when (some? value)]
+      (int-literal-range! field value plan scheduled problem)))
   [plan scheduled problem])
 
 (defn- pipelined-lowering-row!

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -270,7 +270,10 @@
                  (body/->Mask :scan-loop-active
                               [(body/predicate
                                 :lt (body/expression :add 'scan-base 'scan-lane)
-                                safe-bound)])]
+                                ;; Masks are declared outside dataflow operation scope.  The
+                                ;; loop itself is clamped below; this raw bound remains only a
+                                ;; memory guard and establishes no arithmetic range fact.
+                                '_n_bound)])]
                 (map #(body/->Mask (offset-mask %)
                                    [(body/predicate :lte % 'scan-lane)])
                      offsets)))

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -260,6 +260,9 @@
         identity (identity-value (:identity scan-algebra) result-type)
         scratch 'scan-workgroup-values
         carry 'scan-workgroup-carry
+        ;; Do not treat the ABI's `:bound` role as a proof.  The loop owns this clamp, so the
+        ;; verifier can replay the non-negative extent fact used by its schedule arithmetic.
+        safe-bound 'scan-safe-bound
         offsets (take-while #(< % workgroup-size) (iterate #(* 2 %) 1))
         masks (vec
                (concat
@@ -267,7 +270,7 @@
                  (body/->Mask :scan-loop-active
                               [(body/predicate
                                 :lt (body/expression :add 'scan-base 'scan-lane)
-                                '_n_bound)])]
+                                safe-bound)])]
                 (map #(body/->Mask (offset-mask %)
                                    [(body/predicate :lte % 'scan-lane)])
                      offsets)))
@@ -296,7 +299,7 @@
             (body/scalar-expression :min :int
                                     [(body/literal workgroup-size :int)
                                      (body/scalar-expression :- :int
-                                                             ['_n_bound 'scan-base]
+                                                             [safe-bound 'scan-base]
                                                              {:overflow :no-overflow})]))
            (body/->ScalarLoad
             (body/value 'scan-chunk-last result-type) scratch
@@ -325,10 +328,17 @@
                      (dtype/bytes-of result-type))]
       :indices [(body/->IndexBinding 'scan-lane :local 0)]
       :masks masks
-      :operations [(body/->ScalarStore carry [0] identity :scan-lane-zero)
+      :operations [(body/->ScalarCompute
+                    (body/value safe-bound :int)
+                    (body/scalar-expression
+                     :min :int
+                     [(body/scalar-expression :max :int
+                                              ['_n_bound (body/literal 0 :int)])
+                      (body/literal Integer/MAX_VALUE :int)]))
+                   (body/->ScalarStore carry [0] identity :scan-lane-zero)
                    (barrier)
                    (body/->ForLoop
-                    (body/value 'scan-base :int) 0 '_n_bound workgroup-size []
+                    (body/value 'scan-base :int) 0 safe-bound workgroup-size []
                     loop-body [] {:association :ordered
                                   :uniform-iter-args #{}})]
       :schedule {:strategy :ordered-workgroup-chunks :association :certified

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -117,6 +117,13 @@
                                                    :parameter)
                           scalar-ids)
                      [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))]
+    ;; Scan's combine is semantic value arithmetic.  Its association certification does not prove
+    ;; a finite-width overflow algebra, so a schedule may not label it `:no-overflow`.
+    (when (dtype/integral? result-type)
+      (decline! :integral-overflow-algebra
+                "portable integer scan requires an explicit combine overflow contract"
+                {:phase phase :mode scan-mode :algebra scan-algebra
+                 :result-type result-type}))
     (when-not (and (contains? #{:single :intra-block :block-scan :carry-in} phase)
                    (contains? #{:inclusive :exclusive} scan-mode)
                    (scan/associative-scan? scan-algebra)

--- a/src/raster/compiler/passes/parallel/segstencil_body.clj
+++ b/src/raster/compiler/passes/parallel/segstencil_body.clj
@@ -102,6 +102,9 @@
                                     (assoc scalar-types index :long))
         group-index 'stencil-group
         local-index 'stencil-lane
+        ;; The public extent is an ABI scalar.  Clamp it in the body before using it in
+        ;; certified schedule arithmetic: this is a replayable fact, unlike trusting a role.
+        safe-bound 'stencil-safe-bound
         right-limit 'stencil-right-limit
         left-interior 'stencil-left-interior
         right-interior 'stencil-right-interior
@@ -139,12 +142,18 @@
                 [(body/predicate :lt index (body/index-cast '_n_bound :long :exact))])]
        :operations
        [(body/->ScalarCompute
+         (body/value safe-bound :int)
+         (body/scalar-expression
+          :min :int
+          [(body/scalar-expression :max :int ['_n_bound (body/literal 0 :int)])
+           (body/literal Integer/MAX_VALUE :int)]))
+        (body/->ScalarCompute
          (body/value right-limit :long)
          (body/scalar-expression
-          :- :long [(body/cast-expression '_n_bound :long :exact :exact)
+          :- :long [(body/cast-expression safe-bound :long :exact :exact)
                     (body/literal radius :long)]
-          ;; `_n_bound` is a non-negative int extent and radius is a validated static stencil
-          ;; radius, so this widened schedule-bound subtraction cannot overflow long.
+          ;; `safe-bound` was clamped above and the only admitted radius is one, so this
+          ;; widened schedule-bound subtraction is independently derivable by KernelBody.
           {:overflow :no-overflow}))
         (body/->ScalarCompute
          (body/value left-interior :predicate)

--- a/src/raster/compiler/passes/parallel/segstencil_body.clj
+++ b/src/raster/compiler/passes/parallel/segstencil_body.clj
@@ -142,7 +142,10 @@
          (body/value right-limit :long)
          (body/scalar-expression
           :- :long [(body/cast-expression '_n_bound :long :exact :exact)
-                    (body/literal radius :long)]))
+                    (body/literal radius :long)]
+          ;; `_n_bound` is a non-negative int extent and radius is a validated static stencil
+          ;; radius, so this widened schedule-bound subtraction cannot overflow long.
+          {:overflow :no-overflow}))
         (body/->ScalarCompute
          (body/value left-interior :predicate)
          (body/scalar-expression :le :predicate

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -54,19 +54,38 @@
         types))
       :operations
       (vec
-       (mapcat
-        (fn [[type suffix]]
-          (mapcat
-           (fn [index [operation operation-name]]
-             (let [result (symbol-of operation-name "_" suffix)]
-               [(body/->ScalarCompute
-                 (body/value result type)
-                 (body/scalar-expression
-                  operation type [(symbol-of "a_" suffix) (symbol-of "b_" suffix)]
-                  {:overflow :trap}))
-                (body/->ScalarStore (symbol-of "out_" suffix) [index] result nil)]))
-           (range) operations))
-        types))
+       (concat
+        (mapcat
+         (fn [[type suffix]]
+           (mapcat
+            (fn [index [operation operation-name]]
+              (let [result (symbol-of operation-name "_" suffix)]
+                ;; The add helper is referenced directly by a store, exercising complete helper
+                ;; discovery rather than relying on ScalarCompute as a privileged expression site.
+                (if (= :+ operation)
+                  [(body/->ScalarStore
+                    (symbol-of "out_" suffix) [index]
+                    (body/scalar-expression
+                     operation type [(symbol-of "a_" suffix) (symbol-of "b_" suffix)]
+                     {:overflow :trap}) nil)]
+                  [(body/->ScalarCompute
+                    (body/value result type)
+                    (body/scalar-expression
+                     operation type [(symbol-of "a_" suffix) (symbol-of "b_" suffix)]
+                     {:overflow :trap}))
+                   (body/->ScalarStore (symbol-of "out_" suffix) [index] result nil)])))
+            (range) operations))
+         types)
+        ;; LoopArg.initial is another legal, nested scalar-expression placement.  Retain it in
+        ;; the compiler fixture so CUDA/HIP helper discovery traverses region metadata as well.
+        [(body/->ForLoop
+          (body/value 'trap-loop-index :int) 0 1 1
+          [(body/->LoopArg
+            (body/value 'trap-loop-carry :int)
+            (body/scalar-expression :+ :int ['a_i32 'b_i32] {:overflow :trap}))]
+          [(body/->Yield ['trap-loop-carry])]
+          [(body/value 'trap-loop-result :int)]
+          {})]))
       :schedule {}
       :launch (launch/spec {:workgroup-size [1] :group-count [1]})
       :provenance {:dialect :compile-gate}

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -156,6 +156,29 @@
 (defn- wrapping-arithmetic-kernel-body []
   (integer-arithmetic-kernel-body :wrap))
 
+(defn- bounded-byte-add-kernel-body []
+  (let [decline! (fn [rule message data]
+                   (throw (ex-info message (assoc data :rule rule))))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types {'q :byte} :scalar-types {'i :long} :arrays #{'q}
+                  :index-scope #{'i} :lower-index (fn [value _] value)
+                  :decline! decline!})
+        lowered ((:lower lowerer) '(clojure.core/+ (int (clojure.core/aget q i)) 7)
+                 :int {'i :long})]
+    (body/make
+     {:id :bounded-byte-add
+      :parameters [(body/->KernelParameter 'q :input :byte [16] :global
+                                            (layout/row-major [16] :byte) :input)
+                   (body/->KernelParameter 'i :scalar :long [] nil nil :index)
+                   (body/->KernelParameter 'out :output :int [1] :global
+                                            (layout/row-major [1] :int) :result)]
+      :stable-reads [(body/stable-read 'q)]
+      :operations (conj (vec (:operations lowered))
+                        (body/->ScalarStore 'out [0] (:result lowered) nil))
+      :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+      :provenance {:dialect :test}
+      :attributes {:kind :scalar}})))
+
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
                 "scheduled_scalar"
@@ -317,12 +340,7 @@
         bounded ((:lower lowerer) '(clojure.core/+ (int (clojure.core/aget q i)) 7)
                  :int {'i :long})
         unknown ((:lower lowerer) '(clojure.core/+ a i) :long {'a :long 'i :long})
-        proved-kernel (-> (integer-arithmetic-kernel-body :no-overflow :+ :int)
-                          (assoc-in [:operations 0 :expression :options]
-                                    {:overflow :no-overflow
-                                     :proof {:kind :typed-scalar-range
-                                             :lower -121 :upper 134}})
-                          body/validate!)
+        proved-kernel (bounded-byte-add-kernel-body)
         opencl-source (opencl/emit-scalar-kernel
                        "proved_byte_add" proved-kernel {:target-dialect :opencl-portable})]
     (is (= {:overflow :no-overflow
@@ -332,7 +350,12 @@
            (get-in unknown [:operations 0 :expression :options])))
     (is (= :+ (get-in (peek (:operations bounded)) [:expression :op]))
         "byte storage, exact widening, and a literal prove this OpenCL-safe operation")
-    (is (str/includes? opencl-source "rstr_a + rstr_b")
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"not derivable from operand ranges"
+         (integer-arithmetic-kernel-body :no-overflow :+ :int))
+        "a producer cannot certify arbitrary scalar parameters with a bare no-overflow tag")
+    (is (str/includes? opencl-source "+ 7")
         "a range-certified semantic operation remains legal portable OpenCL C"))
   (doseq [[target unsigned-type]
           [[:opencl-portable "ulong"]
@@ -352,9 +375,9 @@
     (testing (name target)
       (let [source (opencl/emit-scalar-kernel
                     "proved_arithmetic"
-                    (integer-arithmetic-kernel-body :no-overflow)
+                    (bounded-byte-add-kernel-body)
                     {:target-dialect target})]
-        (is (str/includes? source "rstr_a + rstr_b")
+        (is (str/includes? source "+ 7")
             "a proved in-range operation may use the target's signed instruction"))))
   (testing "OpenCL C declines a contract for which the language has no standard trap primitive"
     (doseq [target [:opencl-portable :opencl-intel]]

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -308,6 +308,32 @@
     (is (= {:overflow :wrap}
            (get-in lowered [:operations 0 :expression :options])))
     (is (= :+ (get-in lowered [:operations 0 :expression :op]))))
+  (let [decline! (fn [rule message data]
+                   (throw (ex-info message (assoc data :rule rule))))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types {'q :byte} :scalar-types {'i :long} :arrays #{'q}
+                  :index-scope #{'i} :lower-index (fn [value _] value)
+                  :decline! decline!})
+        bounded ((:lower lowerer) '(clojure.core/+ (int (clojure.core/aget q i)) 7)
+                 :int {'i :long})
+        unknown ((:lower lowerer) '(clojure.core/+ a i) :long {'a :long 'i :long})
+        proved-kernel (-> (integer-arithmetic-kernel-body :no-overflow :+ :int)
+                          (assoc-in [:operations 0 :expression :options]
+                                    {:overflow :no-overflow
+                                     :proof {:kind :typed-scalar-range
+                                             :lower -121 :upper 134}})
+                          body/validate!)
+        opencl-source (opencl/emit-scalar-kernel
+                       "proved_byte_add" proved-kernel {:target-dialect :opencl-portable})]
+    (is (= {:overflow :no-overflow
+            :proof {:kind :typed-scalar-range :lower -121 :upper 134}}
+           (get-in (peek (:operations bounded)) [:expression :options])))
+    (is (= {:overflow :trap}
+           (get-in unknown [:operations 0 :expression :options])))
+    (is (= :+ (get-in (peek (:operations bounded)) [:expression :op]))
+        "byte storage, exact widening, and a literal prove this OpenCL-safe operation")
+    (is (str/includes? opencl-source "rstr_a + rstr_b")
+        "a range-certified semantic operation remains legal portable OpenCL C"))
   (doseq [[target unsigned-type]
           [[:opencl-portable "ulong"]
            [:cuda "unsigned long long"]

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -406,16 +406,20 @@
                     {:target-dialect target})]
         (is (str/includes? source "+ 7")
             "a proved in-range operation may use the target's signed instruction"))))
-  (testing "OpenCL C declines a contract for which the language has no standard trap primitive"
-    (doseq [target [:opencl-portable :opencl-intel]]
-      (try
-        (opencl/emit-scalar-kernel
-         "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
-         {:target-dialect target})
-        (is false "trapping arithmetic must not silently become signed target overflow")
-        (catch clojure.lang.ExceptionInfo exception
-          (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception)))
-              (name target))))))
+  (testing "portable OpenCL declines a contract for which the language has no standard trap primitive"
+    (try
+      (opencl/emit-scalar-kernel
+       "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
+       {:target-dialect :opencl-portable})
+      (is false "trapping arithmetic must not silently become signed target overflow")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception))))))
+  (testing "Intel OpenCL uses its explicit vendor trap contract"
+    (let [source (opencl/emit-scalar-kernel
+                  "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
+                  {:target-dialect :opencl-intel})]
+      (is (str/includes? source "rstr_trap_add_i64(rstr_a, rstr_b)"))
+      (is (str/includes? source "__builtin_trap();"))))
   (doseq [[target compiler trap-spelling]
           [[:cuda "nvcc" "asm volatile(\"trap;\")"]
            [:hip "hipcc" "__builtin_trap()"]]]

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -413,7 +413,7 @@
        {:target-dialect :opencl-portable})
       (is false "trapping arithmetic must not silently become signed target overflow")
       (catch clojure.lang.ExceptionInfo exception
-        (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception))))))
+        (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception)))))))
   (testing "Intel OpenCL uses its explicit vendor trap contract"
     (let [source (opencl/emit-scalar-kernel
                   "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -288,15 +288,23 @@
                                          "-fsyntax-only" "-" :in source)]
         (is (zero? exit) err)))))
 
-(deftest unchecked-source-arithmetic-retains-wrapping-semantics
+(deftest source-integral-arithmetic-retains-its-overflow-semantics
   (let [decline! (fn [rule message data]
                    (throw (ex-info message (assoc data :rule rule))))
         lowerer (scalar-expression/make-lowerer
                  {:array-types {} :scalar-types {'a :long 'b :long} :arrays #{}
                   :index-scope #{} :lower-index (fn [value _] value)
                   :decline! decline!})
+        checked (mapv #((:lower lowerer) % :long {'a :long 'b :long})
+                      ['(clojure.core/+ a b)
+                       '(clojure.core/- a b)
+                       '(clojure.core/* a b)])
         lowered ((:lower lowerer) '(unchecked-add a b) :long
                  {'a :long 'b :long})]
+    (is (every? #(= {:overflow :trap}
+                     (get-in % [:operations 0 :expression :options]))
+                checked)
+        "ordinary Clojure integer arithmetic is checked, never target-signed overflow")
     (is (= {:overflow :wrap}
            (get-in lowered [:operations 0 :expression :options])))
     (is (= :+ (get-in lowered [:operations 0 :expression :op]))))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -179,6 +179,25 @@
       :provenance {:dialect :test}
       :attributes {:kind :scalar}})))
 
+(defn- forged-no-overflow-kernel-body []
+  (body/make
+   {:id :forged-no-overflow
+    :parameters [(body/->KernelParameter 'a :scalar :int [] nil nil :left)
+                 (body/->KernelParameter 'b :scalar :int [] nil nil :right)
+                 (body/->KernelParameter 'out :output :int [1] :global
+                                          (layout/row-major [1] :int) :result)]
+    :operations [(body/->ScalarCompute
+                  (body/value 'result :int)
+                  (body/scalar-expression
+                   :+ :int ['a 'b]
+                   {:overflow :no-overflow
+                    ;; This looks plausible, but is intentionally unrelated to the operands.
+                    :proof {:kind :typed-scalar-range :lower -121 :upper 134}}))
+                 (body/->ScalarStore 'out [0] 'result nil)]
+    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+    :provenance {:dialect :test}
+    :attributes {:kind :scalar}}))
+
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
                 "scheduled_scalar"
@@ -355,6 +374,11 @@
          #"not derivable from operand ranges"
          (integer-arithmetic-kernel-body :no-overflow :+ :int))
         "a producer cannot certify arbitrary scalar parameters with a bare no-overflow tag")
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"not derivable from operand ranges"
+         (forged-no-overflow-kernel-body))
+        "a producer proof map is evidence to check, never an authority to forge")
     (is (str/includes? opencl-source "+ 7")
         "a range-certified semantic operation remains legal portable OpenCL C"))
   (doseq [[target unsigned-type]

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -191,8 +191,11 @@
                   (body/scalar-expression
                    :+ :int ['a 'b]
                    {:overflow :no-overflow
-                    ;; This looks plausible, but is intentionally unrelated to the operands.
-                    :proof {:kind :typed-scalar-range :lower -121 :upper 134}}))
+                    ;; This contains the verifier's full operand result interval, but cannot
+                    ;; make that interval fit in int.  Evidence may describe a derivation; it
+                    ;; cannot turn overflow-prone arithmetic into `:no-overflow`.
+                    :proof {:kind :typed-scalar-range
+                            :lower Integer/MIN_VALUE :upper Integer/MAX_VALUE}}))
                  (body/->ScalarStore 'out [0] 'result nil)]
     :launch (launch/spec {:workgroup-size [1] :group-count [1]})
     :provenance {:dialect :test}
@@ -376,7 +379,7 @@
         "a producer cannot certify arbitrary scalar parameters with a bare no-overflow tag")
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
-         #"not derivable from operand ranges"
+         #"integral arithmetic"
          (forged-no-overflow-kernel-body))
         "a producer proof map is evidence to check, never an authority to forge")
     (is (str/includes? opencl-source "+ 7")

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -360,6 +360,13 @@
           (is (str/includes? source trap-spelling))
           (is (= 2 (count (re-seq (re-pattern (str helper-name "\\(")) source)))
               "one checked definition accompanies one typed call")))
+      ;; `trapping-arithmetic-body` puts an add expression directly in ScalarStore.value.  This
+      ;; keeps helper discovery honest for legal non-ScalarCompute expression placements.
+      (let [source (opencl/emit-scalar-kernel
+                    "trapping_arithmetic" (fixtures/trapping-arithmetic-body)
+                    {:target-dialect target})]
+        (is (= 3 (count (re-seq #"rstr_trap_add_i32\(" source)))
+            "direct ScalarStore and nested LoopArg trap expressions receive their CUDA/HIP helper"))
       (when (command-available? compiler)
         (let [source (opencl/emit-scalar-kernel
                       "trapping_arithmetic" (fixtures/trapping-arithmetic-body)

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -291,10 +291,19 @@
                   operations))))
     (testing "block totals are scanned in one chunked workgroup for unbounded symbolic sizes"
       (is (= [1] (get-in block [:launch :group-count])))
-      (let [loop (some #(when (= "ForLoop" (operation-kind %)) %) (kernel-body-operations block))]
-        (is (= [0 '_n_bound 256 :ordered]
+      (let [operations (kernel-body-operations block)
+            loop (some #(when (= "ForLoop" (operation-kind %)) %) operations)
+            safe-bound (some #(when (and (= "ScalarCompute" (operation-kind %))
+                                         (= 'scan-safe-bound (get-in % [:result :id])))
+                                %)
+            safe-expression (:expression safe-bound)]
+        (is (= [0 'scan-safe-bound 256 :ordered]
                [(:lower loop) (:upper loop) (:step loop)
-                (get-in loop [:attributes :association])]))))
+                (get-in loop [:attributes :association])]))
+        (is (= :min (:op safe-expression)))
+        (is (= :max (get-in safe-expression [:arguments 0 :op])))
+        (is (= '_n_bound (get-in safe-expression [:arguments 0 :arguments 0]))
+            "the in-body clamp, rather than an ABI role assertion, proves the loop extent")))
     (testing "carry consumes the scanned total of the preceding block"
       (let [loads (filter #(= "ScalarLoad" (operation-kind %))
                           (kernel-body-operations carry))]

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -296,6 +296,7 @@
             safe-bound (some #(when (and (= "ScalarCompute" (operation-kind %))
                                          (= 'scan-safe-bound (get-in % [:result :id])))
                                 %)
+                             operations)
             safe-expression (:expression safe-bound)]
         (is (= [0 'scan-safe-bound 256 :ordered]
                [(:lower loop) (:upper loop) (:step loop)

--- a/test/raster/compiler/ir/attention_test.clj
+++ b/test/raster/compiler/ir/attention_test.clj
@@ -169,6 +169,31 @@
            (try
              (problem :batch-size Long/MAX_VALUE)
              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "CSR metadata capacities remain representable by their int32 offset ABI"
+    (let [oversized (inc (long Integer/MAX_VALUE))]
+      (is (= :attention-int32-offset-capacity
+             (try
+               (csr-visibility :key-index-capacity oversized)
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+      (is (= :attention-int32-offset-capacity
+             (try
+               (csr-route :page-index-capacity oversized)
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+      ;; Records can be associated after construction, so `validate!` repeats the descriptor
+      ;; invariant before any route/schedule chooses an emitter.
+      (is (= :attention-int32-offset-capacity
+             (try
+               (attention/validate!
+                (assoc (problem :visibility (csr-visibility))
+                       :visibility
+                       (assoc (csr-visibility) :key-index-capacity oversized)))
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+      (is (= :attention-int32-offset-capacity
+             (try
+               (attention/validate!
+                (assoc (problem :route (csr-route))
+                       :route (assoc (csr-route) :page-index-capacity oversized)))
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
   (testing "K and V layouts are independent and explicit"
     (is (= :attention-unsupported-cache-layout
            (try

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -683,6 +683,35 @@
             [(body/->Yield [])]
             [])])))))
 
+(deftest loop-carried-integral-ranges-do-not-become-unchecked-proofs
+  (testing "a single checked body pass cannot certify repeated increment"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"not derivable from operand ranges"
+         (scalar-body
+          [(body/->ForLoop
+            (body/value 'i :int) 0 4 1
+            [(body/->LoopArg (body/value 'carry :int) (body/literal 0 :int))]
+            [(body/->ScalarCompute
+              (body/value 'next-carry :int)
+              (body/scalar-expression :+ :int ['carry (body/literal 1 :int)]
+                                      {:overflow :no-overflow}))
+             (body/->Yield ['next-carry])]
+            [(body/value 'loop-result :int)] {})]))))
+  (testing "a zero-trip loop cannot borrow its body yield's narrow range"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"not derivable from operand ranges"
+         (scalar-body
+          [(body/->ForLoop
+            (body/value 'i :int) 0 0 1
+            [(body/->LoopArg (body/value 'carry :int)
+                             (body/literal Integer/MIN_VALUE :int))]
+            [(body/->Yield [(body/literal 0 :int)])]
+            [(body/value 'loop-result :int)] {})
+           (body/->ScalarCompute
+            (body/value 'unsafe-after-zero-trip :int)
+            (body/scalar-expression :- :int ['loop-result (body/literal 1 :int)]
+                                    {:overflow :no-overflow}))])))))
+
 (deftest scalar-and-collective-operators-have-semantic-dtype-domains
   (testing "floating intrinsics do not accept integers"
     (is (thrown-with-msg?

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -324,6 +324,14 @@
              :* :long [(body/literal Long/MAX_VALUE :long)
                        (body/literal 2 :long)]
              {:overflow :wrap}))]))))
+  (testing "integral arithmetic cannot omit its overflow semantics"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"requires exactly one overflow contract"
+         (scalar-body
+          [(body/->ScalarCompute
+            (body/value 'ambiguous :long)
+            (body/scalar-expression
+             :+ :long [(body/literal 1 :long) (body/literal 2 :long)]))]))))
   (testing "trapping and compiler-proved arithmetic are distinct legal contracts"
     (doseq [policy [:trap :no-overflow]]
       (is (body/kernel-body?

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -419,7 +419,31 @@
            (get-in (route/route
                     (problem)
                     (assoc desc :segmented-weighted-reduction-history-tile-size 0))
-                   [:declines 0 :reason])))))
+                   [:declines 0 :reason])))
+    (testing "a self-consistent tile plan cannot forge the source membership capacity"
+      (let [plan (:plan reference)
+            lower! (fn [candidate]
+                     (try
+                       (swr-body/lower-routed-paged-partial plan candidate)
+                       :accepted
+                       (catch clojure.lang.ExceptionInfo exception
+                         (:reason (ex-data exception)))))
+            under (assoc scheduled :membership-tiling
+                         {:kind :static-contiguous-tiles :tile-size 2 :tile-count 2
+                          :membership-capacity 4 :merge-order :increasing-membership-tile})
+            over (assoc scheduled :membership-tiling
+                        {:kind :static-contiguous-tiles :tile-size 2 :tile-count 4
+                         :membership-capacity 8 :merge-order :increasing-membership-tile})
+            oversized-capacity (inc (long Integer/MAX_VALUE))
+            oversized (assoc scheduled :membership-tiling
+                            {:kind :static-contiguous-tiles :tile-size 2
+                             :tile-count (quot (+ oversized-capacity 1) 2)
+                             :membership-capacity oversized-capacity
+                             :merge-order :increasing-membership-tile})]
+        (is (= :segmented-weighted-reduction-body-membership-capacity (lower! under)))
+        (is (= :segmented-weighted-reduction-body-membership-capacity (lower! over)))
+        (is (= :segmented-weighted-reduction-membership-tiling (lower! oversized))
+            "values that become int literals are rejected before lowering")))))
 
 (deftest tiled-history-sources-cover-route-and-visibility-products
   (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -548,7 +548,8 @@
                        "rstr_empty_last_page_valid = (rstr_final_page_length == 0)"))))
 
 (deftest csr-route-sanitizes-untrusted-page-metadata-before-proved-arithmetic
-  (let [{:keys [plan schedule]} (route/route! (problem :route (csr-route)) intel-desc)
+  (let [{:keys [plan artifact]} (route/route! (problem :route (csr-route)) intel-desc)
+        schedule (get-in artifact [:attributes :segmented-weighted-reduction-schedule])
         lowered (swr-body/lower-routed-paged plan schedule)
         operations (operation-tree (:operations lowered))
         compute-by-id (into {}
@@ -556,18 +557,44 @@
                                     (when-let [result (:result operation)]
                                       [(:id result) operation])))
                             operations)
+        raw-routed-count (get compute-by-id 'raw-routed-page-count)
         routed-count (get compute-by-id 'routed-page-count)
         computed-length (get compute-by-id 'computed-kv-length)]
     ;; Raw device page offsets and last-page lengths have no overflow contract.  The only marked
     ;; arithmetic consumes clamped SSA values, while invalid raw metadata remains in route-valid
     ;; and therefore masks all writes.
-    (is (= :no-overflow (get-in routed-count [:expression :options :overflow])))
+    (is (= :no-overflow (get-in raw-routed-count [:expression :options :overflow])))
     (is (= ['safe-page-end 'safe-page-begin]
+           (get-in raw-routed-count [:expression :arguments])))
+    (is (= ['raw-routed-page-count (kbody/literal 0 :int)]
            (get-in routed-count [:expression :arguments])))
     (is (= :no-overflow (get-in computed-length [:expression :options :overflow])))
     (is (= 'safe-final-page-length
            (last (get-in computed-length [:expression :arguments]))))
     (is (some? (get compute-by-id 'route-valid)))))
+
+(deftest csr-route-clamps-an-inverted-row-before-certified-length-arithmetic
+  (let [route (attention/csr-paged-route
+               {:page-offsets 'page-offsets :page-indices 'page-indices
+                :last-page-lengths 'last-page-lengths :start-positions 'kv-start-positions
+                :page-index-capacity 1})
+        problem (problem :route route :page-size Integer/MAX_VALUE :physical-pages 1)
+        {:keys [plan artifact]} (route/route! problem intel-desc)
+        schedule (get-in artifact [:attributes :segmented-weighted-reduction-schedule])
+        lowered (swr-body/lower-routed-paged plan schedule)
+        compute-by-id (into {}
+                            (keep (fn [operation]
+                                    (when-let [result (:result operation)]
+                                      [(:id result) operation])))
+                            (operation-tree (:operations lowered)))
+        count-minus-one (get compute-by-id 'computed-kv-length)]
+    ;; An invalid row with begin=1/end=0 has a raw count of -1.  It is clamped to zero before
+    ;; the certified `count - 1` product, even with the largest legal page size.
+    (is (= 'safe-final-page-length
+           (last (get-in count-minus-one [:expression :arguments]))))
+    (is (= 'routed-page-count
+           (get-in count-minus-one [:expression :arguments 0 :arguments 0 :arguments 0])))
+    (is (= :no-overflow (get-in count-minus-one [:expression :options :overflow])))))
 
 (deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
   (let [{:keys [artifact reference? declines]}

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -547,6 +547,28 @@
     (is (str/includes? (:source artifact)
                        "rstr_empty_last_page_valid = (rstr_final_page_length == 0)"))))
 
+(deftest csr-route-sanitizes-untrusted-page-metadata-before-proved-arithmetic
+  (let [{:keys [plan schedule]} (route/route! (problem :route (csr-route)) intel-desc)
+        lowered (swr-body/lower-routed-paged plan schedule)
+        operations (operation-tree (:operations lowered))
+        compute-by-id (into {}
+                            (keep (fn [operation]
+                                    (when-let [result (:result operation)]
+                                      [(:id result) operation])))
+                            operations)
+        routed-count (get compute-by-id 'routed-page-count)
+        computed-length (get compute-by-id 'computed-kv-length)]
+    ;; Raw device page offsets and last-page lengths have no overflow contract.  The only marked
+    ;; arithmetic consumes clamped SSA values, while invalid raw metadata remains in route-valid
+    ;; and therefore masks all writes.
+    (is (= :no-overflow (get-in routed-count [:expression :options :overflow])))
+    (is (= ['safe-page-end 'safe-page-begin]
+           (get-in routed-count [:expression :arguments])))
+    (is (= :no-overflow (get-in computed-length [:expression :options :overflow])))
+    (is (= 'safe-final-page-length
+           (last (get-in computed-length [:expression :arguments]))))
+    (is (some? (get compute-by-id 'route-valid)))))
+
 (deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
   (let [{:keys [artifact reference? declines]}
         (route/route! (problem :visibility (csr-visibility)) intel-desc)]

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -268,9 +268,19 @@
                           program {:target-device :ze:0 :dtype :float}))
         operation (first (get-in scheduled [:equations 0 :operations]))
         artifact (segop-opencl/generate-scheduled-segmap-kernel
-                  operation :dtype :float :target-dialect :opencl-portable
+                  ;; The scheduled device is :ze:0. `r * feat` is ordinary long arithmetic,
+                  ;; so this concrete artifact uses Intel OpenCL's checked-trap contract.
+                  operation :dtype :float :target-dialect :opencl-intel
                   :array-types {'x :float 'out :float}
                   :scalar-types {'rows :long 'feat :long})
+        portable-reason (try
+                          (segop-opencl/generate-scheduled-segmap-kernel
+                           operation :dtype :float :target-dialect :opencl-portable
+                           :array-types {'x :float 'out :float}
+                           :scalar-types {'rows :long 'feat :long})
+                          nil
+                          (catch clojure.lang.ExceptionInfo exception
+                            (:reason (ex-data exception))))
         jvm (par-simd/simd-pass scheduled :min-elements 1)
         execute (eval (list 'fn '[x out rows feat] (:form jvm)))
         x (float-array [1.0 2.0 3.0 4.0])
@@ -288,6 +298,8 @@
     (testing "the device kernel is a verified KernelBody with a nested loop"
       (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
       (is (nil? (get-in artifact [:attributes :kernel-body-decline])))
+      (is (= :kernel-body-c-trap-unsupported portable-reason)
+          "portable OpenCL does not pretend it can preserve checked long arithmetic")
       (is (str/includes? (:source artifact) "for (")))
     (testing "the JVM schedule executes the loop"
       (is (nil? (execute x out 2 2)))


### PR DESCRIPTION
Restores one current-main integer-semantics vertical without documentation churn.\n\n- Normal typed source integral add, subtract, and multiply carry trap semantics; unchecked source forms retain wrapping semantics.\n- KernelBody rejects integral arithmetic with an omitted or invalid overflow policy.\n- The routed attention body explicitly certifies bounded route and cursor arithmetic as no-overflow; widened stencil bound arithmetic is likewise certified.\n- Integer contraction, register-tiled contraction, and scan value algebra decline until their own overflow contracts exist.\n- CUDA/HIP trap lowering is unchanged; every OpenCL dialect continues to decline trap semantics.\n\nFocused checks: KernelBody IR namespace: 23 tests / 121 assertions. Direct source lowering verified checked add/subtract/multiply to trap and unchecked add to wrap. Changed producer namespaces load together.