### PR TITLE
Route scalar SegRed through verified scheduled graphs

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -42,6 +42,17 @@
   [id dtype elements role]
   (kgraph/buffer id dtype elements :device role))
 
+(defn- ordered-public-buffers
+  "Preserve the supplied public argument order, independently of matrix lhs/rhs order.
+   Only reorder locally derived buffer descriptions; do not copy facts from the source witness."
+  [buffers arguments]
+  (let [positions (zipmap arguments (range))]
+    (when-not (every? #(contains? positions (:id %)) buffers)
+      (throw (ex-info "matrix schedule buffer is absent from its public interface"
+                      {:reason :gemm-public-buffer-interface
+                       :buffers buffers :arguments arguments})))
+    (vec (sort-by #(get positions (:id %)) buffers))))
+
 (defn- value-use
   [buffer access]
   (kgraph/->ValueUse buffer access))
@@ -805,10 +816,12 @@
                       split-k? (conj (graph-buffer partials :float partial-elements :temporary)))]
     (let [stage-graph
           (kgraph/make
-           {:inputs (into [(graph-buffer a :float a-elements :input)
-                           (graph-buffer b :float b-elements :input)]
-                          (map #(graph-buffer (:id %) (:dtype %) (:elements %) :input))
-                          epilogue-buffers)
+           {:inputs (ordered-public-buffers
+                     (into [(graph-buffer a :float a-elements :input)
+                            (graph-buffer b :float b-elements :input)]
+                           (map #(graph-buffer (:id %) (:dtype %) (:elements %) :input))
+                           epilogue-buffers)
+                     arguments)
             :outputs [(graph-buffer c :float c-elements :output)]
             :temporaries temporaries
             :scalars (kgraph/interface-scalars abi arguments)
@@ -876,8 +889,10 @@
                    :schedule {:kind :matrix-instruction-tiling :tile tile}})
         stage-graph
         (kgraph/make
-         {:inputs [(graph-buffer a :float a-elements :input)
-                   (graph-buffer b :float b-elements :input)]
+         {:inputs (ordered-public-buffers
+                   [(graph-buffer a :float a-elements :input)
+                    (graph-buffer b :float b-elements :input)]
+                   arguments)
           :outputs [(graph-buffer c :float c-elements :output)]
           :temporaries [(graph-buffer a16 :half a-elements :temporary)
                         (graph-buffer b16 :half b-elements :temporary)]

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -24,6 +24,7 @@
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -327,6 +328,30 @@
     (kabi/validate-reduction-arguments! abi arguments)
     (list 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
           kernel-name arguments)))
+
+(defn- resident-single-reduction
+  "Refine a scalar reduction to the explicit one-workgroup phase required by reduce-into.
+
+   The output identity is changed here, at the semantic operation boundary, rather than passed as
+   an emitter-only alias. One group folds the complete extent, so the caller-owned one-element
+   result is the scheduled output rather than an undersized partial buffer."
+  [operation output]
+  (let [dtype (dtype/canon (:dtype operation))
+        workgroup-size (get-in operation [:grid :block-size])
+        grid (segop/->KernelGrid 1 workgroup-size
+                                (* workgroup-size (dtype/bytes-of dtype)))
+        operator (update (:reduction operation) :components
+                         (fn [components]
+                           (mapv #(assoc % :result output) components)))]
+    (assoc operation
+           :level (segop/->SegLevel :block :none)
+           :reduction operator
+           :lambda nil
+           :outputs #{output}
+           :grid grid
+           :phase :single
+           :schedule (segred-body/scalar-workgroup-tree-schedule
+                      operator grid :single))))
 
 (defn- emit-map-void-invocation
   "Render the staging marker from the artifact's logical argument projection. The marker remains
@@ -684,19 +709,37 @@
                           (:kernel-name k)
                           (vec (:arguments r)))))))
 
-            ;; === par/reduce-into — resident SegRed writing a caller-supplied 1-elem buffer ===
-            ;; Same SegRed kernel as par/reduce (it already has an `output` param), but the
-            ;; resident invoke carries the output buffer (4-arg) so it stays device-resident
-            ;; instead of round-tripping a host scalar. Emitted by the reduce-fusion pass.
+            ;; === par/reduce-into — resident terminal SegRed writing a caller-owned scalar ===
+            ;; Unlike the occupancy-capped partial phase used by host-scalar reduction, this is an
+            ;; explicit one-group terminal refinement. The generic executable path preserves that
+            ;; launch for staging and resident replay alike. Emitted by the reduce-fusion pass.
             (par/par-reduce-into-form? form)
             (let [{:keys [out-buf reduce-form]} (par/extract-par-reduce-into-info form)
-                  segred (par->segred stats reduce-form dtype device-id
+                  segred (resident-single-reduction
+                          (par->segred stats reduce-form dtype device-id
                                       top-scalar-types top-array-types)
+                          out-buf)
                   kernel (segop-cl/generate-segred-kernel
                           segred out-buf :dtype dtype :scalar-types top-scalar-types
                           :array-types top-array-types)
-                  k (register-kernel! kernel :ze-reduces)]
-              (emit-reduction-invocation k out-buf))
+                  k (register-kernel! kernel :ze-reduces)
+                  dispatch (kdispatch/make
+                            {:id (str "resident-single-reduction-"
+                                      (Integer/toUnsignedString (hash k) 16))
+                             :alternatives [k]
+                             :default-strategy :scalar-workgroup-tree
+                             :selector {:kind :fixed-strategy
+                                        :strategy :scalar-workgroup-tree}
+                             :provenance {:pass :opencl
+                                          :source-dialect :segred
+                                          :operation (:id segred)}
+                             :attributes {:operation-family :scalar-reduction
+                                          :resident-result true}})]
+              (swap! dispatches conj dispatch)
+              ;; Unlike the nil-result host-scalar marker, this path is executable both through
+              ;; staging and resident extraction. Both consume the same KernelCall geometry.
+              (list 'raster.compiler.pipeline/invoke-scheduled-executable!
+                    device-id (:id dispatch) (vec (:arguments k))))
 
             ;; === par/reduce — SegOp path ===
             (par/par-reduce-form? form)

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -401,18 +401,49 @@
   ;; would otherwise misfire the "offset"→int heuristic). Form-meta types are the base.
   (let [supplied-program0 (when (parallel-program/parallel-program? form)
                             (parallel-program/validate! form segop/segop-node?))
+        retained-operations (mapcat :operations (:equations supplied-program0))
+        retained-buffer-ids
+        (set (mapcat #(concat (segop/operation-inputs %)
+                              (segop/operation-outputs %))
+                     retained-operations))
+        retained-equation-ids
+        (set (mapcat #(concat (:operands %) (:results %)) (:equations supplied-program0)))
+        ;; Host-only scalar SSA has no SegOp by construction. Classify every equation-boundary
+        ;; value not named by a physical buffer role as scalar; this preserves compound-extent
+        ;; leaves across compatibility re-entry while rank-zero resident buffers remain buffers.
+        retained-scalar-ids
+        (set/union (set (mapcat segop/operation-scalars retained-operations))
+                   (set/difference retained-equation-ids retained-buffer-ids))
+        retained-role-overlap (set/intersection retained-buffer-ids retained-scalar-ids)
+        _ (when (seq retained-role-overlap)
+            (throw (ex-info "retained schedule gives values contradictory ABI roles"
+                            {:reason :parallel-program-parameter-role-conflict
+                             :values retained-role-overlap})))
         retained-scalar-types
-        (into {}
-              (keep (fn [[id value]]
-                      (when (and (symbol? id) (empty? (:shape value)))
-                        [id (:dtype value)])))
-              (:values supplied-program0))
+        (when supplied-program0
+          (parallel-program/known-value-types supplied-program0 retained-scalar-ids))
         retained-array-types
+        (when supplied-program0
+          (parallel-program/known-value-types supplied-program0 retained-buffer-ids))
+        scalar-type-conflicts
         (into {}
-              (keep (fn [[id value]]
-                      (when (and (symbol? id) (seq (:shape value)))
-                        [id (:dtype value)])))
-              (:values supplied-program0))
+              (keep (fn [[id retained]]
+                      (when-let [provided (get scalar-types id)]
+                        (when-not (= (dtype/canon retained) (dtype/canon provided))
+                          [id {:retained retained :provided provided}]))))
+              retained-scalar-types)
+        array-type-conflicts
+        (into {}
+              (keep (fn [[id retained]]
+                      (when-let [provided (get array-types id)]
+                        (when-not (= (dtype/canon retained) (dtype/canon provided))
+                          [id {:retained retained :provided provided}]))))
+              retained-array-types)
+        _ (when (or (seq scalar-type-conflicts) (seq array-type-conflicts))
+            (throw (ex-info "caller type facts contradict the retained scheduled program"
+                            {:reason :parallel-program-type-conflict
+                             :scalar-conflicts scalar-type-conflicts
+                             :array-conflicts array-type-conflicts})))
         ;; A compatibility ParallelProgram predates the direct TypedSOAC value identities used by
         ;; graph storage. Re-enter once through its retained source instead of preserving a second
         ;; backend contract whose operations and SSA results can name different physical values.
@@ -443,8 +474,8 @@
            {:target-device device-id :dtype dtype
             ;; A compatibility re-entry may need to rebuild structure, but it may never discard
             ;; types already retained by the prior middle-end boundary.
-            :scalar-types (merge retained-scalar-types scalar-types)
-            :array-types (merge retained-array-types array-types)})
+            :scalar-types (merge scalar-types retained-scalar-types)
+            :array-types (merge array-types retained-array-types)})
 
           (and (nil? supplied-program) (form/binding-form? form))
           (segop-lower-pass/schedule-source-program

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -20,10 +20,12 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
@@ -340,9 +342,11 @@
         workgroup-size (get-in operation [:grid :block-size])
         grid (segop/->KernelGrid 1 workgroup-size
                                 (* workgroup-size (dtype/bytes-of dtype)))
-        operator (update (:reduction operation) :components
-                         (fn [components]
-                           (mapv #(assoc % :result output) components)))]
+        operator (-> (:reduction operation)
+                     (update :components
+                             (fn [components]
+                               (mapv #(assoc % :result output) components)))
+                     (assoc-in [:attributes :physical-phase] :single))]
     (assoc operation
            :level (segop/->SegLevel :block :none)
            :reduction operator
@@ -395,8 +399,29 @@
   ;; DECLARED types from derive-param-types (opts) override the name-heuristic fallback in the
   ;; kernel generators — e.g. `features` (Long→int) and `gain-offset` (Double→float, whose name
   ;; would otherwise misfire the "offset"→int heuristic). Form-meta types are the base.
-  (let [supplied-program (when (parallel-program/parallel-program? form)
-                           (parallel-program/validate! form segop/segop-node?))
+  (let [supplied-program0 (when (parallel-program/parallel-program? form)
+                            (parallel-program/validate! form segop/segop-node?))
+        retained-scalar-types
+        (into {}
+              (keep (fn [[id value]]
+                      (when (and (symbol? id) (empty? (:shape value)))
+                        [id (:dtype value)])))
+              (:values supplied-program0))
+        retained-array-types
+        (into {}
+              (keep (fn [[id value]]
+                      (when (and (symbol? id) (seq (:shape value)))
+                        [id (:dtype value)])))
+              (:values supplied-program0))
+        ;; A compatibility ParallelProgram predates the direct TypedSOAC value identities used by
+        ;; graph storage. Re-enter once through its retained source instead of preserving a second
+        ;; backend contract whose operations and SSA results can name different physical values.
+        compatibility-program? (and supplied-program0
+                                    (some? (:source supplied-program0))
+                                    (not= :typed-soac
+                                          (get-in supplied-program0
+                                                  [:provenance :source-dialect])))
+        supplied-program (when-not compatibility-program? supplied-program0)
         direct-mini-program?
         (and (nil? supplied-program)
              (or (par/par-rng-fill-form? form)
@@ -404,6 +429,7 @@
                       (:stride (par/extract-par-gather-info form)))
                  (and (par/par-scatter-form? form)
                       (:stride (par/extract-par-scatter-info form)))
+                 (par/par-reduce-form? form)
                  ;; A compound source extent normalizes to a preceding typed scalar equation. It
                  ;; cannot be projected as a closed SegMap without losing that SSA definition.
                  (and (par/par-map-form? form)
@@ -411,6 +437,15 @@
                             (:bound (par/extract-par-map-info form)))))))
         direct-schedule
         (cond
+          compatibility-program?
+          (segop-lower-pass/schedule-source-program
+           (:source supplied-program0)
+           {:target-device device-id :dtype dtype
+            ;; A compatibility re-entry may need to rebuild structure, but it may never discard
+            ;; types already retained by the prior middle-end boundary.
+            :scalar-types (merge retained-scalar-types scalar-types)
+            :array-types (merge retained-array-types array-types)})
+
           (and (nil? supplied-program) (form/binding-form? form))
           (segop-lower-pass/schedule-source-program
            form {:target-device device-id :dtype dtype
@@ -482,7 +517,9 @@
             k))
 
         emit-scheduled-graph!
-        (fn [scheduled]
+        (fn emit-scheduled-graph!
+          ([scheduled] (emit-scheduled-graph! scheduled nil false))
+          ([scheduled stat-key host-scalar-result?]
           ;; KernelDispatch is already the verified selection value above both a single artifact
           ;; and a graph.  A one-alternative dispatch therefore gives scheduled equations the same
           ;; registry/selection seam as tuned GEMM without introducing a second graph registry.
@@ -508,11 +545,42 @@
             (swap! kernels into (mapv :operation (:nodes emitted)))
             (swap! dispatches conj dispatch)
             (swap! stats update :kernel-graphs inc)
+            (when stat-key (swap! stats update stat-key inc))
             ;; Staging and resident extraction consume the same registered dispatch and complete
             ;; ordered executable ABI. The device id chooses only the runtime; it is not part of
             ;; the executable's semantic call interface.
-            (list 'raster.compiler.pipeline/invoke-scheduled-executable!
-                  device-id (:id dispatch) (vec (:arguments emitted)))))
+            (let [invocation-arguments
+                  (if host-scalar-result?
+                    (let [result-indexes
+                          (keep-indexed (fn [index slot]
+                                          (when (= :result (:role slot)) index))
+                                        (:abi emitted))
+                          _ (when-not (= 1 (count result-indexes))
+                              (throw (ex-info
+                                      "host scalar graph requires exactly one result ABI slot"
+                                      {:reason :scheduled-host-scalar-result
+                                       :result-indexes (vec result-indexes)
+                                       :abi (:abi emitted)})))
+                          result-index (first result-indexes)
+                          result-slot (nth (:abi emitted) result-index)
+                          result-id (nth (:arguments emitted) result-index)
+                          result-buffer (some #(when (= result-id (:id %)) %)
+                                              (:outputs emitted))
+                          constructor ({:float 'float-array :double 'double-array}
+                                       (dtype/canon (:dtype result-slot)))]
+                      (when-not (and result-buffer (= 1 (:elements result-buffer)) constructor)
+                        (throw (ex-info
+                                "scheduled host scalar result must be one FP32/FP64 graph element"
+                                {:reason :scheduled-host-scalar-result
+                                 :slot result-slot :buffer result-buffer})))
+                      (assoc (vec (:arguments emitted)) result-index (list constructor 1)))
+                    (vec (:arguments emitted)))
+                  invocation
+                  (list 'raster.compiler.pipeline/invoke-scheduled-executable!
+                        device-id (:id dispatch) invocation-arguments)]
+              (if host-scalar-result?
+                (list 'clojure.core/aget invocation 0)
+                invocation)))))
 
         transform
         (fn transform [form]
@@ -743,17 +811,10 @@
 
             ;; === par/reduce — SegOp path ===
             (par/par-reduce-form? form)
-            (let [{:keys [bound]} (par/extract-par-reduce-info form)]
-              (if (and (number? bound) (< bound min-elements))
-                (do (swap! stats update :fallback inc)
-                    (par/expand-par-reduce form))
-                (let [segred (par->segred stats form dtype device-id
-                                          top-scalar-types top-array-types)
-                      kernel (segop-cl/generate-segred-kernel
-                              segred nil :dtype dtype :scalar-types top-scalar-types
-                              :array-types top-array-types)
-                      k (register-kernel! kernel :ze-reduces)]
-                  (emit-reduction-invocation k nil))))
+            (throw (ex-info
+                    "scalar reduction must enter GPU emission as a complete TypedSOAC graph"
+                    {:reason :scalar-reduction-requires-typed-graph
+                     :source form :target-dialect :kernel-graph :fallback :none}))
 
             ;; Typed segmented product reduction. The portable schedule is one deterministic
             ;; workgroup tree per segment; mixed result components remain separate ABI buffers.
@@ -940,12 +1001,58 @@
             (let [[let-sym bindings & body-exprs] form
                   pairs (partition 2 bindings)
                   new-bindings (vec (mapcat (fn [[sym expr]]
-                                              (let [scheduled
+                                              (let [equation
                                                     (when parallel-program
-                                                      (parallel-program/kernel-graph-for-binding
-                                                       parallel-program sym expr))]
+                                                      (parallel-program/equation-for-binding
+                                                       parallel-program sym expr))
+                                                    scheduled
+                                                    (let [typed-equation?
+                                                          (and (:algorithm equation)
+                                                               (= :typed-soac
+                                                                  (get-in parallel-program
+                                                                          [:provenance
+                                                                           :source-dialect])))
+                                                          scalar-reduction?
+                                                          (and (seq (:operations equation))
+                                                               (every?
+                                                                #(and (instance?
+                                                                       raster.compiler.ir.segop.SegRed %)
+                                                                      (reduction/scalar?
+                                                                       (:reduction %)))
+                                                                (:operations equation)))]
+                                                      (if (and typed-equation?
+                                                               (or scalar-reduction?
+                                                                   (get-in equation
+                                                                           [:attributes
+                                                                            :kernel-graph])))
+                                                        (:graph
+                                                         (equation-graph/make-for-equation
+                                                          parallel-program equation))
+                                                        (get-in equation
+                                                                [:attributes :kernel-graph])))]
                                                 [sym (if scheduled
-                                                       (emit-scheduled-graph! scheduled)
+                                                       (do
+                                                         (when (and equation
+                                                                    (every? #(instance?
+                                                                              raster.compiler.ir.segop.SegRed %)
+                                                                            (:operations equation)))
+                                                           (swap! stats update :segop-reused
+                                                                  (fnil inc 0)))
+                                                         (emit-scheduled-graph!
+                                                          scheduled
+                                                          (when (and equation
+                                                                     (every? #(instance?
+                                                                               raster.compiler.ir.segop.SegRed %)
+                                                                             (:operations equation)))
+                                                            :ze-reduces)
+                                                          (boolean
+                                                           (and equation
+                                                                (= [] (get-in parallel-program
+                                                                              [:values
+                                                                               (first
+                                                                                (:results
+                                                                                 equation))
+                                                                               :shape]))))))
                                                        (binding [*bound-segops*
                                                                  (when parallel-program
                                                                    (parallel-program/operations-for-binding
@@ -957,15 +1064,47 @@
                                                          (transform expr)))]))
                                             pairs))
                   new-body (mapv (fn [expr]
-                                   (binding [*bound-segops*
-                                             (when parallel-program
-                                               (parallel-program/operations-for-source
-                                                parallel-program expr))
-                                             *bound-algorithm*
-                                             (when parallel-program
-                                               (parallel-program/algorithm-for-source
-                                                parallel-program expr))]
-                                     (transform expr)))
+                                   (let [equation
+                                         (when parallel-program
+                                           (parallel-program/equation-for-source
+                                            parallel-program expr))
+                                         ;; The compatibility discoverer gives value-producing
+                                         ;; body expressions an internal result identity rather
+                                         ;; than a source binding. Its exact algorithm/SegOps can
+                                         ;; therefore be graph-validated directly even though the
+                                         ;; enclosing program predates typed provenance.
+                                         typed-equation?
+                                         (and (:algorithm equation)
+                                              (or (= :typed-soac
+                                                     (get-in parallel-program
+                                                             [:provenance :source-dialect]))
+                                                  (= :body (first (:site equation)))))
+                                         scalar-reduction?
+                                         (and (seq (:operations equation))
+                                              (every?
+                                               #(and (instance?
+                                                      raster.compiler.ir.segop.SegRed %)
+                                                     (reduction/scalar?
+                                                      (:reduction %)))
+                                               (:operations equation)))]
+                                     (if (and typed-equation? scalar-reduction?)
+                                       (do
+                                         (swap! stats update :segop-reused (fnil inc 0))
+                                         (emit-scheduled-graph!
+                                          (:graph
+                                           (equation-graph/make-for-equation
+                                            parallel-program equation))
+                                          :ze-reduces
+                                          (boolean
+                                           (= [] (get-in parallel-program
+                                                         [:values (first (:results equation))
+                                                          :shape])))))
+                                       (binding [*bound-segops* (:operations equation)
+                                                 *bound-algorithm*
+                                                 (when parallel-program
+                                                   (parallel-program/algorithm-for-source
+                                                    parallel-program expr))]
+                                         (transform expr)))))
                                  body-exprs)]
               (with-meta (apply list let-sym new-bindings new-body) (meta form)))
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -27,6 +27,7 @@
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
+            [raster.compiler.passes.parallel.typed-soac-resident :as resident]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -1048,6 +1049,7 @@
                                                                (every?
                                                                 #(and (instance?
                                                                        raster.compiler.ir.segop.SegRed %)
+                                                                      (empty? (segop/seg-space-segment-dims (:space %)))
                                                                       (reduction/scalar?
                                                                        (:reduction %)))
                                                                 (:operations equation)))]
@@ -1078,6 +1080,9 @@
                                                             :ze-reduces)
                                                           (boolean
                                                            (and equation
+                                                                (not (resident/resident-scalar-value?
+                                                                      (get-in parallel-program
+                                                                              [:values (first (:results equation))])))
                                                                 (= [] (get-in parallel-program
                                                                               [:values
                                                                                (first
@@ -1115,6 +1120,7 @@
                                               (every?
                                                #(and (instance?
                                                       raster.compiler.ir.segop.SegRed %)
+                                                     (empty? (segop/seg-space-segment-dims (:space %)))
                                                      (reduction/scalar?
                                                       (:reduction %)))
                                                (:operations equation)))]

--- a/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
@@ -6,7 +6,6 @@
    scalar equations remain explicit host-only steps. OpenCL, CUDA, and HIP differ only at the
    KernelBody source dialect boundary."
   (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
-            [clojure.set :as set]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emission]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
@@ -38,42 +37,6 @@
                           {:value id}))
                  [id (:dtype value)])))
         (distinct (mapcat segop/operation-scalars operations))))
-
-(defn- scheduled-body
-  [parallel-program equation]
-  (let [algorithm (:algorithm equation)
-        ;; A graph is emitted one equation at a time, but storage extents may be named by a
-        ;; preceding pure TypedSOAC scalar equation.  Keep the checked launch projection on the
-        ;; narrowed body so later graph re-derivation (including emitted-equation validation)
-        ;; observes exactly the same authoritative definition.
-        preceding-equations
-        (take-while #(not= (:id %) (:id equation)) (:equations parallel-program))
-        ;; A later host scalar may depend on a prior numerical result.  The closed slice names
-        ;; that omitted result as an input, but it must still retain every earlier host equation
-        ;; so the emitted program can bind the slice back to the exact outer execution prefix.
-        scalar-prefix (vec (filter #(true? (get-in % [:attributes :host-only]))
-                                   preceding-equations))
-        equations (conj scalar-prefix equation)]
-    (program/make
-     {:dialect :segop
-      :source nil
-      :values (:values parallel-program)
-      ;; The body is a normal, dependency-closed Program slice: preceding host scalar equations
-      ;; execute before—and therefore prove—the one emitted numerical equation.  Revalidation
-      ;; never consults an asserted extent map in descriptive attributes.
-      :inputs (program/infer-inputs equations)
-      :equations equations
-      :outputs (:results equation)
-      :effects (reduce set/union #{} (map :effects equations))
-      :diagnostics []
-      :provenance {:source-dialect :typed-soac
-                   :pass :parallel-program-c-family}
-      :attributes {:host-control :explicit-typed-algorithm}
-      :operation? segop/segop-node?
-      :algorithm? (fn [candidate retained]
-                    (and (= retained (soac/validate! retained))
-                         (= (:operands candidate) (:inputs (soac/facts retained)))
-                         (= (:results candidate) (soac/outputs retained))))})))
 
 (defn- emit-graph
   [scheduled-graph values operations opts]
@@ -151,20 +114,14 @@
       equation
 
       (soac/program-form? algorithm)
-      (let [body (scheduled-body parallel-program equation)
+      (let [{:keys [body graph]} (equation-graph/make-for-equation
+                                  parallel-program equation)
             ;; Multi-phase schedules retain family-independent decisions (algebra, phase
             ;; decomposition, tuning choice) on their certified graph. Rebuilding the physical
             ;; dataflow remains generic, but those schedule facts must survive to target lowering.
-            graph-contract (get-in equation [:attributes :kernel-graph])
-            scheduled-graph (equation-graph/make
-                             algorithm body
-                             (cond-> {}
-                               graph-contract
-                               (assoc :provenance (:provenance graph-contract)
-                                      :attributes (:attributes graph-contract))))
             operations (:operations equation)
             contraction-facts (contraction-facts-by-operation algorithm operations)
-            emitted (emit-graph scheduled-graph (:values body) operations
+            emitted (emit-graph graph (:values body) operations
                                 (cond-> (assoc opts
                                                :scheduled-equation-algorithm algorithm
                                                :scheduled-equation-body body)

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -609,13 +609,13 @@
    body without a device. It throws only structured `:segred-kernel-body-declined` exceptions for
    unsupported scalar regions; verified-body or emitter failures remain compiler errors."
   [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect
-                            graph-node kernel-graph]
+                            graph-node kernel-graph coordinate-proof]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
   (let [scheduled
         (segred-body/schedule segred out-sym
                              {:dtype dtype :array-types array-types
-                              :scalar-types scalar-types})
+                              :scalar-types scalar-types :coordinate-proof coordinate-proof})
         _ (when (not= (some? graph-node) (some? kernel-graph))
             (throw (ex-info "scalar reduction graph certification requires both node and graph"
                             {:reason :segred-graph-context
@@ -684,7 +684,7 @@
    phase contract. Unsupported scalar regions fail with their structured KernelBody decline;
    no target may recover semantics by reparsing a source-shaped lambda."
   [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect
-                            graph-node kernel-graph]
+                            graph-node kernel-graph coordinate-proof]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
   (when (seq (segop/seg-space-segment-dims (:space segred)))
@@ -696,7 +696,7 @@
     (generate-segred-kernel-body
      segred out-sym :dtype dtype :kernel-name-prefix kernel-name-prefix
      :scalar-types scalar-types :array-types array-types :target-dialect target-dialect
-     :graph-node graph-node :kernel-graph kernel-graph)
+     :graph-node graph-node :kernel-graph kernel-graph :coordinate-proof coordinate-proof)
     (catch clojure.lang.ExceptionInfo exception
       (when-not (segred-body/declined? exception) (throw exception))
       (let [decline (assoc (ex-data exception) :fallback :none)]

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -603,62 +603,36 @@
                    :schedule schedule}})))
 
 (defn generate-segred-kernel-body
-  "Lower an eligible scalar SegRed through verified KernelBody and a thin C-family dialect.
+  "Schedule and emit an eligible scalar SegRed through the canonical KernelBody target.
 
    This function is public so CUDA/HIP compiler fixtures can validate the exact same scheduled
    body without a device. It throws only structured `:segred-kernel-body-declined` exceptions for
    unsupported scalar regions; verified-body or emitter failures remain compiler errors."
-  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect
+                            graph-node kernel-graph]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
-  (let [{:keys [kernel-body operator identity arrays scalars output bound]}
-        (segred-body/lower segred out-sym :dtype dtype :array-types array-types
-                           :scalar-types scalar-types)
-        dtype (or (:dtype segred) dtype)
+  (let [scheduled
+        (segred-body/schedule segred out-sym
+                             {:dtype dtype :array-types array-types
+                              :scalar-types scalar-types})
+        _ (when (not= (some? graph-node) (some? kernel-graph))
+            (throw (ex-info "scalar reduction graph certification requires both node and graph"
+                            {:reason :segred-graph-context
+                             :graph-node graph-node :kernel-graph kernel-graph})))
+        _ (when graph-node
+            (scheduled-body/validate-against-node! scheduled graph-node kernel-graph))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
-        parameter-names (into {output "output" '_n_bound "_n_bound"}
-                              (map (fn [id] [id (ce/c-symbol id)]))
-                              (concat arrays scalars))
-        source (kernel-body-opencl/emit-scalar-kernel
-                kernel-name kernel-body
-                {:target-dialect target-dialect :parameter-names parameter-names})
-        scalar-dtype (fn [id]
-                       (or (get scalar-types id)
-                           (get scalar-types (symbol (name id)))
-                           (throw (ex-info "kernel scalar parameter has no declared dtype"
-                                           {:reason :kernel-scalar-dtype-unknown :symbol id
-                                            :declared (vec (keys scalar-types))}))))
-        result-name (or out-sym 'output)
-        abi (kabi/validate!
-             (vec (concat
-                   (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand
-                                    :aliasing :no-write-alias)
-                        arrays)
-                   [(kabi/slot result-name :output dtype :c-name "output" :role :result)]
-                   (map #(kabi/slot % :scalar (scalar-dtype %)
-                                    :c-name (ce/c-symbol %) :role :parameter)
-                        scalars)
-                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
-        c-op ({:+ "+" :* "*" :min "fmin" :max "fmax"} operator)]
-    (kart/make
-     {:kernel-name kernel-name
-      :target (kernel-body-c-dialect/target (kernel-body-c-dialect/resolve! target-dialect))
-      :source source
-      :abi abi
-      :arguments (vec (concat arrays [out-sym] scalars [bound]))
-      :launch (:launch kernel-body)
-      :temporaries []
-      :effects {:kind :pure-reduction}
-      :provenance {:dialect :segred :segop-id (:id segred)}
-      :attributes {:array-params arrays
-                   :scalar-params scalars
-                   :dtype dtype
-                   :n-phases 2
-                   :identity-val identity
-                   :c-op c-op
-                   :kernel-body kernel-body
-                   :emission-route :kernel-body
-                   :target-dialect target-dialect}})))
+        output (some #(when (= :result (:role %)) (:id %))
+                     (get-in scheduled [:body :parameters]))
+        parameter-names (merge
+                         (into {}
+                               (map (fn [parameter]
+                                      [(:id parameter) (ce/c-symbol (:id parameter))]))
+                               (get-in scheduled [:body :parameters]))
+                         {output "output" '_n_bound "_n_bound"})]
+    (kernel-body-target/emit-artifact
+     kernel-name scheduled target-dialect {:parameter-names parameter-names})))
 
 (defn generate-scheduled-segmap-kernel
   "Emit one scheduled SegMap through the single KernelBody-first C-family boundary.
@@ -706,10 +680,11 @@
 (defn generate-segred-kernel
   "Emit a scheduled full reduction exclusively through target-neutral KernelBody.
 
-   The artifact carries the complete ordered ABI, symbolic launch, workgroup scratch and two-phase
-   reduction protocol. Unsupported scalar regions fail with their structured KernelBody decline;
+   The artifact carries the complete ordered ABI, symbolic launch, workgroup scratch and exact
+   phase contract. Unsupported scalar regions fail with their structured KernelBody decline;
    no target may recover semantics by reparsing a source-shaped lambda."
-  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect
+                            graph-node kernel-graph]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
   (when (seq (segop/seg-space-segment-dims (:space segred)))
@@ -720,7 +695,8 @@
   (try
     (generate-segred-kernel-body
      segred out-sym :dtype dtype :kernel-name-prefix kernel-name-prefix
-     :scalar-types scalar-types :array-types array-types :target-dialect target-dialect)
+     :scalar-types scalar-types :array-types array-types :target-dialect target-dialect
+     :graph-node graph-node :kernel-graph kernel-graph)
     (catch clojure.lang.ExceptionInfo exception
       (when-not (segred-body/declined? exception) (throw exception))
       (let [decline (assoc (ex-data exception) :fallback :none)]
@@ -1041,38 +1017,41 @@
         emitted
         (kgraph/map-operations
          graph
-         (fn [{:keys [id operation]}]
+         (fn [{:keys [id operation] :as node}]
            (let [outputs (vec (:outputs operation))]
              (when-not (= 1 (count outputs))
                (throw (ex-info "scalar SegRed graph node requires exactly one scheduled output"
                                {:reason :kernel-graph-reduction-output
                                 :target :opencl-c :node id :outputs outputs})))
-             (kart/certify-scheduled-operation
-              (if (seq (segop/seg-space-segment-dims (:space operation)))
-                (let [facts (or (get contraction-facts (:id operation))
-                                (throw (ex-info
-                                        "segmented reduction lacks verified contraction facts"
-                                        {:reason :kernel-graph-segmented-reduction-facts
-                                         :operation (:id operation) :fallback :none})))
-                      descriptor (hw/descriptor-for target-device)
-                      planned (contraction-schedule/plan-portable-body
-                               facts operation descriptor
-                               {:array-types array-types :scalar-types scalar-types})]
-                  (when-not (:ok planned)
-                    (throw (ex-info
-                            "segmented reduction has no portable KernelBody schedule"
-                            {:reason :kernel-graph-segmented-reduction-body
-                             :operation (:id operation) :schedule-decline planned
-                             :fallback :none})))
+             (if (seq (segop/seg-space-segment-dims (:space operation)))
+               (let [facts (or (get contraction-facts (:id operation))
+                               (throw (ex-info
+                                       "segmented reduction lacks verified contraction facts"
+                                       {:reason :kernel-graph-segmented-reduction-facts
+                                        :operation (:id operation) :fallback :none})))
+                     descriptor (hw/descriptor-for target-device)
+                     planned (contraction-schedule/plan-portable-body
+                              facts operation descriptor
+                              {:array-types array-types :scalar-types scalar-types})]
+                 (when-not (:ok planned)
+                   (throw (ex-info
+                           "segmented reduction has no portable KernelBody schedule"
+                           {:reason :kernel-graph-segmented-reduction-body
+                            :operation (:id operation) :schedule-decline planned
+                            :fallback :none})))
+                 (kart/certify-scheduled-operation
                   (generate-contraction-kernel-artifact
                    (:body planned) :target-dialect target-dialect
-                   :kernel-name-prefix "graph_contraction"))
-                (generate-segred-kernel
-                 operation (first outputs)
-                 :dtype (:dtype operation)
-                 :scalar-types scalar-types :array-types array-types
-                 :target-dialect target-dialect))
-              operation))))]
+                   :kernel-name-prefix "graph_contraction")
+                  operation))
+               ;; Scalar reductions are certified against their complete graph context before
+               ;; projection. Do not add the older artifact-only operation wrapper outside it.
+               (generate-segred-kernel
+                operation (first outputs)
+                :dtype (:dtype operation)
+                :scalar-types scalar-types :array-types array-types
+                :target-dialect target-dialect
+                :graph-node node :kernel-graph graph)))))]
     (finalize-emitted-graph
      emitted
      (kernel-body-c-dialect/target (kernel-body-c-dialect/resolve! target-dialect))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -621,7 +621,7 @@
                             {:reason :segred-graph-context
                              :graph-node graph-node :kernel-graph kernel-graph})))
         _ (when graph-node
-            (scheduled-body/validate-against-node! scheduled graph-node kernel-graph))
+            (segred-body/validate-against-node! scheduled graph-node kernel-graph))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         output (some #(when (= :result (:role %)) (:id %))
                      (get-in scheduled [:body :parameters]))

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -231,6 +231,18 @@
                              :value compiler-value :indexes (vec indexes) :values values})))
           (first values))))))
 
+(defn realize-launch
+  "Realize an artifact's launch from a complete ABI-ordered runtime argument vector.
+
+   This deliberately does not construct a KernelCall: compatibility staging may reserve the
+   artifact's result pointer itself, but it must still honor the exact symbolic launch (including
+   occupancy caps) before that allocation exists. Scalar representation and pointer checks remain
+   the caller's responsibility and KernelCall performs them for resident execution."
+  [artifact arguments]
+  (let [artifact (kart/validate! artifact)
+        arguments (kabi/validate-arguments! (:abi artifact) arguments)]
+    (klaunch/realize (:launch artifact) (argument-resolver artifact arguments))))
+
 (defn resolve-value
   "Resolve one compiler value through a checked call's artifact/runtime argument relation. This
    is used for artifact attributes such as a contraction's logical output extent; backends still
@@ -251,7 +263,9 @@
    (let [artifact (kart/validate! artifact)
          arguments (kabi/validate-arguments! (:abi artifact) arguments)
          resolver (or resolve-value (argument-resolver artifact arguments))
-         realized (klaunch/realize (:launch artifact) resolver)
+         realized (if resolve-value
+                    (klaunch/realize (:launch artifact) resolver)
+                    (realize-launch artifact arguments))
          geometry (if group-count
                     (klaunch/geometry
                      {:workgroup-size (:workgroup-size realized)

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -110,6 +110,10 @@
     (throw (ex-info "kernel int scalar argument is outside its physical ABI range"
                     {:reason :kernel-scalar-range :slot slot :value value
                      :minimum Integer/MIN_VALUE :maximum Integer/MAX_VALUE})))
+  (when (and (= :bound (:role slot))
+             (or (not (integer? (:value value))) (neg? (:value value))))
+    (throw (ex-info "kernel extent bound must be a non-negative integer"
+                    {:reason :kernel-bound-range :slot slot :value value})))
   value)
 
 (defn- resident-view
@@ -262,6 +266,11 @@
   ([artifact arguments {:keys [group-count resolve-value]}]
    (let [artifact (kart/validate! artifact)
          arguments (kabi/validate-arguments! (:abi artifact) arguments)
+         ;; Extent/range checks precede launch realization.  Otherwise a negative bound can first
+         ;; fail as an incidental zero-sized grid—or, for a clamped schedule, realize a valid grid.
+         _ (doseq [[slot value] (map vector (:abi artifact) arguments)
+                   :when (= :scalar (:kind slot))]
+             (scalar-value! slot value))
          resolver (or resolve-value (argument-resolver artifact arguments))
          realized (if resolve-value
                     (klaunch/realize (:launch artifact) resolver)

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -174,8 +174,14 @@
   (case dtype
     :int (if (integer? value)
            (Math/toIntExact (long value))
-           (int value))
-    :long (long value)
+           (throw (ex-info "kernel integral scalar requires an integer value"
+                           {:reason :kernel-executable-integral-scalar
+                            :dtype dtype :value value})))
+    :long (if (integer? value)
+            (long value)
+            (throw (ex-info "kernel integral scalar requires an integer value"
+                            {:reason :kernel-executable-integral-scalar
+                             :dtype dtype :value value})))
     :float (float value)
     :double (double value)
     (throw (ex-info "kernel executable has no runtime scalar representation for ABI dtype"
@@ -200,8 +206,12 @@
                                    :slot slot :expected kernel-dtype
                                    :actual (:type value) :value value})))
                 (:value value))
-              value)]
-    {:type kernel-dtype :value (cast-runtime-scalar kernel-dtype raw)}))
+              value)
+        physical (cast-runtime-scalar kernel-dtype raw)]
+    (when (and (= :bound (:role slot)) (neg? physical))
+      (throw (ex-info "kernel extent bound must be non-negative"
+                      {:reason :kernel-bound-range :slot slot :value raw})))
+    {:type kernel-dtype :value physical}))
 
 (defn typed-runtime-arguments
   "Normalize raw caller scalars to the explicit values required by KernelCall/KernelGraphCall.

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -13,6 +13,7 @@
 (defrecord Product [factors])
 (defrecord AlignUp [value alignment])
 (defrecord Minimum [values])
+(defrecord Maximum [values])
 (defrecord LaunchSpec [workgroup-size group-count shared-memory-bytes])
 (defrecord LaunchGeometry [workgroup-size group-count shared-memory-bytes])
 
@@ -81,6 +82,13 @@
     (throw (ex-info "minimum requires one or more non-nil values" {:values values})))
   (->Minimum (vec values)))
 
+(defn maximum
+  "The maximum of one or more integer expressions."
+  [& values]
+  (when-not (and (seq values) (every? some? values))
+    (throw (ex-info "maximum requires one or more non-nil values" {:values values})))
+  (->Maximum (vec values)))
+
 (defn launch-spec? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.LaunchSpec" x))
 
@@ -107,6 +115,9 @@
 
 (defn- minimum? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.Minimum" x))
+
+(defn- maximum? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.Maximum" x))
 
 (declare index-expr? index-cast? validate-spec! spec)
 
@@ -140,6 +151,7 @@
     (align-up? x) (and (expression? (:value x))
                        (integer? (:alignment x)) (pos? (:alignment x)))
     (minimum? x) (and (seq (:values x)) (every? expression? (:values x)))
+    (maximum? x) (and (seq (:values x)) (every? expression? (:values x)))
     (index-expr? x) (and (contains? index-operations (:op x))
                          (valid-index-arity? (:op x) (:arguments x))
                          (every? expression? (:arguments x)))
@@ -173,6 +185,7 @@
     (align-up? x) (and (resolvable-expression? (:value x))
                        (integer? (:alignment x)) (pos? (:alignment x)))
     (minimum? x) (and (seq (:values x)) (every? resolvable-expression? (:values x)))
+    (maximum? x) (and (seq (:values x)) (every? resolvable-expression? (:values x)))
     (or (index-expr? x) (index-cast? x)) (expression? x)
     :else (some? x)))
 
@@ -201,6 +214,7 @@
               (product? value) (promote (map infer (:factors value)))
               (align-up? value) (promote [(infer (:value value)) :int])
               (minimum? value) (promote (map infer (:values value)))
+              (maximum? value) (promote (map infer (:values value)))
 
               (index-expr? value)
               (let [types (set (map infer (:arguments value)))]
@@ -249,6 +263,7 @@
     (product? expression) (reduce into #{} (map expression-references (:factors expression)))
     (align-up? expression) (expression-references (:value expression))
     (minimum? expression) (reduce into #{} (map expression-references (:values expression)))
+    (maximum? expression) (reduce into #{} (map expression-references (:values expression)))
     (index-expr? expression)
     (reduce into #{} (map expression-references (:arguments expression)))
     (index-cast? expression) (expression-references (:argument expression))
@@ -275,7 +290,7 @@
                   ;; back into an invalid opaque identity and stop transitive extent expansion.
                   (or (runtime-value? replacement) (ceil-div? replacement)
                       (floor-div? replacement) (sum? replacement) (product? replacement)
-                      (align-up? replacement) (minimum? replacement)
+                      (align-up? replacement) (minimum? replacement) (maximum? replacement)
                       (index-expr? replacement) (index-cast? replacement))
                   (rebind replacement)
                   :else (->RuntimeValue replacement)))
@@ -287,6 +302,7 @@
               (product? value) (assoc value :factors (mapv rebind (:factors value)))
               (align-up? value) (assoc value :value (rebind (:value value)))
               (minimum? value) (assoc value :values (mapv rebind (:values value)))
+              (maximum? value) (assoc value :values (mapv rebind (:values value)))
               (index-expr? value) (assoc value :arguments (mapv rebind (:arguments value)))
               (index-cast? value) (assoc value :argument (rebind (:argument value)))
               :else (get bindings value value)))]
@@ -331,6 +347,7 @@
            (floor-div? x)
            (sum? x)
            (minimum? x)
+           (maximum? x)
            ;; Rebinding an opaque dimension to an exact typed scalar definition may expose a
            ;; checked KernelBody index node at the root. The same nodes are already accepted
            ;; inside compound dimensions and must remain legal after substitution.
@@ -489,6 +506,8 @@
                   (long alignment)))
                (minimum? expression)
                (reduce min (map resolve* (:values expression)))
+               (maximum? expression)
+               (reduce max (map resolve* (:values expression)))
                ;; KernelBody index algebra may reach a launch dimension when a scheduled body
                ;; projects its own extent expressions into the launch spec. Evaluate it here with
                ;; the same exact-overflow discipline rather than asking the runtime binder to

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -472,7 +472,8 @@
               ;; first surface bound would schedule only a prefix of the reduction.
               red-bound (:bound (segop/seg-space-reduced-dim (:space semantic-operation)))
               sr (scalar-contraction-phase semantic-operation out-sym dtype red-bound)
-              k (sco/generate-segred-kernel sr out-sym :dtype dtype)
+              k (sco/generate-segred-kernel
+                 sr out-sym :dtype dtype :coordinate-proof contract-facts)
               attrs (:attributes k)]
           {:strategy :full-reduce
            :invoke :reduction

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -37,6 +37,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]))
 
 (defn par-contract-form?
@@ -143,7 +144,8 @@
    reuse a contraction input by compiler identity without adding a second ABI slot. Default single-launch
    leaves must also supply matching 1-3D workgroup/grid data; validation closes those fields and the
    ordered compiler values into a KernelArtifact. Full reductions already arrive as a verified
-   artifact and retain their distinct two-phase invoke protocol, whose scheduler owns geometry.
+   artifact and retain their distinct host-terminal invoke protocol; staging realizes that
+   artifact's own symbolic geometry.
 
    Returns the descriptor with `:arguments`, the compiler values in exact ABI order, and an
    executable `:artifact` for every route."
@@ -207,8 +209,9 @@
       (nil? out-elems)
       (throw (ex-info "contract descriptor: :out-elems is required (the artifact sizes the output with it)"
                       {:strategy strategy}))
-      ;; A single-launch descriptor preserves the schedule's actual dimensionality. The reduction
-      ;; invoke computes its own two-phase geometry, so it legitimately carries neither.
+      ;; A single-launch descriptor preserves the schedule's actual dimensionality. A reduction
+      ;; descriptor already carries its complete artifact launch, so this compatibility descriptor
+      ;; legitimately duplicates neither field.
       (and (not= :reduction invoke)
            (not (and (vector? wg) (vector? grid)
                      (<= 1 (count wg) 3)
@@ -216,7 +219,7 @@
       (throw (ex-info "contract descriptor: :wg and :grid must have matching 1-3D geometry"
                       {:strategy strategy :wg wg :grid grid}))
       (and (= :reduction invoke) (or (some? wg) (some? grid)))
-      (throw (ex-info "contract descriptor: :invoke :reduction must not carry :wg/:grid (the invoke owns the two-phase launch)"
+      (throw (ex-info "contract descriptor: :invoke :reduction must not duplicate its artifact launch in :wg/:grid"
                       {:strategy strategy :wg wg :grid grid}))
       (and (= :reduction invoke) (nil? reduce-bound))
       (throw (ex-info "contract descriptor: :invoke :reduction requires :reduce-bound"
@@ -297,6 +300,34 @@
                     {:reason :epilogue-unsupported-by-this-leaf :strategy (:strategy d)
                      :declines (vec (:declines d))})))
   d)
+
+(defn- scalar-contraction-phase
+  "Refine the zero-free-axis contraction cell to the scalar SegRed schedule it executes.
+
+   Typed contraction lowering initially carries the candidate schedule used by tensor-valued
+   contractions. A scalar output has no matrix/register-tiled candidate: it is one block-local
+   workgroup-tree phase followed by the compatibility host combine. Replace the irrelevant
+   thread/virtual level and hardware-family schedule with that exact physical phase before target
+   emission."
+  [operation output dtype reduced-bound]
+  (let [workgroup-size (or (get-in operation [:grid :block-size]) 256)
+        grid (segop/->KernelGrid
+              (or (get-in operation [:grid :num-blocks])
+                  (klaunch/ceil-div reduced-bound workgroup-size))
+              workgroup-size
+              (* workgroup-size (dtype/bytes-of dtype)))
+        operator (update (:reduction operation) :components
+                         (fn [components]
+                           (mapv #(assoc % :result output) components)))]
+    (assoc operation
+           :level (segop/->SegLevel :block :virtual)
+           :reduction operator
+           :lambda nil
+           :outputs #{output}
+           :grid grid
+           :phase :block-local
+           :schedule (segred-body/scalar-workgroup-tree-schedule
+                      operator grid :block-local))))
 
 (defn route-contraction
   "Route a contraction form through verified facts, an applied hardware schedule and a target leaf.
@@ -420,23 +451,22 @@
       ;; algebra: (n free, 0 contract) = map, (n, n) = contraction, (0, n) = REDUCTION. The
       ;; SegSpace then has only the reduced dim — exactly the 1-D shape (seg-space-1d?) that
       ;; generate-segred-kernel's two-phase tree reduction already consumes, so no new emitter.
-      ;; Its launch protocol differs (two phases + a host-side final combine), so the descriptor
-      ;; says so with :invoke :reduction rather than pretending it is a 2-D kernel launch.
+      ;; Its launch protocol differs (one scheduled partial phase plus a host-side terminal
+      ;; combine), so the descriptor says so with :invoke :reduction rather than pretending it is
+      ;; a 2-D kernel launch.
         (zero? n-free)
-        (let [sr (or scheduled-operation
-                     (cl/contract-form->segred
-                      (compatibility-form! contract-form :full-reduce)
-                      :dtype dtype :facts contract-facts))
-              ;; A zero-free-axis contraction is physically the nonterminal phase consumed by the
-              ;; registered host-combine protocol. The old contraction/segmented tags carried no
-              ;; scalar reduction schedule and are outside the canonical SegRed phase vocabulary.
-              sr (if (and (empty? (segop/seg-space-segment-dims (:space sr)))
-                          (not (contains? #{:single :block-local :cross-block} (:phase sr))))
-                   (assoc sr :phase :block-local)
-                   sr)
+        (let [semantic-operation
+              (or scheduled-operation
+                  (cl/contract-form->segred
+                   (compatibility-form! contract-form :full-reduce)
+                   :dtype dtype :facts contract-facts))
+              ;; The SegSpace is authoritative here. In particular, two or more contraction axes
+              ;; have already been flattened to their checked row-major product; selecting the
+              ;; first surface bound would schedule only a prefix of the reduction.
+              red-bound (:bound (segop/seg-space-reduced-dim (:space semantic-operation)))
+              sr (scalar-contraction-phase semantic-operation out-sym dtype red-bound)
               k (sco/generate-segred-kernel sr out-sym :dtype dtype)
-              attrs (:attributes k)
-              red-bound (second (first contract-axes))]
+              attrs (:attributes k)]
           {:strategy :full-reduce
            :invoke :reduction
            :artifact k
@@ -444,7 +474,6 @@
            :array-params (:array-params attrs)
            :abi (:abi k) :arguments (:arguments k)
            :dtype dtype :out-dtype dtype :out-elems 1
-           :n-phases (:n-phases attrs)
          ;; CARRY THE COMBINE for descriptor inspection as well as in the artifact attributes.
          ;; The staging runtime reads the artifact attributes for its host-side final combine.
            :c-op (:c-op attrs) :identity-val (:identity-val attrs)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -427,6 +427,13 @@
                      (cl/contract-form->segred
                       (compatibility-form! contract-form :full-reduce)
                       :dtype dtype :facts contract-facts))
+              ;; A zero-free-axis contraction is physically the nonterminal phase consumed by the
+              ;; registered host-combine protocol. The old contraction/segmented tags carried no
+              ;; scalar reduction schedule and are outside the canonical SegRed phase vocabulary.
+              sr (if (and (empty? (segop/seg-space-segment-dims (:space sr)))
+                          (not (contains? #{:single :block-local :cross-block} (:phase sr))))
+                   (assoc sr :phase :block-local)
+                   sr)
               k (sco/generate-segred-kernel sr out-sym :dtype dtype)
               attrs (:attributes k)
               red-bound (second (first contract-axes))]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -311,14 +311,21 @@
    emission."
   [operation output dtype reduced-bound]
   (let [workgroup-size (or (get-in operation [:grid :block-size]) 256)
+        group-count (if-let [existing (get-in operation [:grid :num-blocks])]
+                      (segred-body/launch-group-count existing reduced-bound workgroup-size)
+                      ;; The compatibility front door has no concrete device descriptor. State a
+                      ;; conservative portable occupancy cap instead of leaving the schedule
+                      ;; implicit or accepting an arbitrary caller expression.
+                      (segred-body/capped-group-count 256 reduced-bound workgroup-size))
         grid (segop/->KernelGrid
-              (or (get-in operation [:grid :num-blocks])
-                  (klaunch/ceil-div reduced-bound workgroup-size))
+              group-count
               workgroup-size
               (* workgroup-size (dtype/bytes-of dtype)))
-        operator (update (:reduction operation) :components
-                         (fn [components]
-                           (mapv #(assoc % :result output) components)))]
+        operator (-> (:reduction operation)
+                     (update :components
+                             (fn [components]
+                               (mapv #(assoc % :result output) components)))
+                     (assoc-in [:attributes :physical-phase] :block-local))]
     (assoc operation
            :level (segop/->SegLevel :block :virtual)
            :reduction operator

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -350,7 +350,7 @@
    consume the same scheduled body vocabulary.  Quantization remains an operand/decode concern,
    not a buffer-ownership or graph-composition concern."
   [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts operation-id
-                           candidate-families scheduled-operation]
+                           candidate-families scheduled-operation array-types scalar-types]
                     :or {dtype :half prefer-peak? false}}]
   (let [contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
         contract-form (or contract-form (:form contract-facts))
@@ -386,9 +386,19 @@
                             {:reason :contraction-candidate-families
                              :families candidate-families
                              :allowed contraction-families})))
-        tensorize-plan (memoize #(route-2free-1contract out-sym dtype desc tile
-                                                        epilogue contract-facts operation-id
-                                                        candidate-families))]
+        mixed-core-storage?
+        (some (fn [operand]
+                (when-let [stored (or (get array-types (:sym operand))
+                                      (get array-types (symbol (name (:sym operand)))))]
+                  (not= (dtype/canon dtype) (dtype/canon stored))))
+              (:operands contract-facts))
+        tensorize-plan
+        (memoize
+         #(if mixed-core-storage?
+            {::declines [{:leaf :dpas :reason :mixed-operand-storage}
+                         {:leaf :regtiled :reason :mixed-operand-storage}]}
+            (route-2free-1contract out-sym dtype desc tile
+                                  epilogue contract-facts operation-id candidate-families)))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The
     ;; failure mode it guards is a LAUNCH-time arity mismatch (valid C, wrong number of bound args),
     ;; which has bitten twice; validating at generation makes it a loud compile-time error instead.
@@ -523,7 +533,21 @@
                        (cl/contract-form->segred
                         (compatibility-form! contract-form :portable-segred)
                         :dtype dtype :facts contract-facts))
-                portable (contraction-schedule/plan-portable-body contract-facts sr desc)
+                portable (contraction-schedule/plan-portable-body
+                          contract-facts sr desc
+                          {:array-types (or array-types {}) :scalar-types (or scalar-types {})})
+                _ (when (and (not (:ok portable))
+                             (or mixed-core-storage?
+                                 (some #(contains? #{:float :double}
+                                                   (some-> (get scalar-types %) dtype/canon))
+                                       (:scalars sr))))
+                    (throw (ex-info
+                            "mixed storage or floating captures require a typed portable contraction schedule"
+                            {:reason :no-legal-contraction-family
+                             :operation operation-id :families candidate-families
+                             :declines [{:leaf :portable-kernel-body
+                                         :reason (:reason portable) :data (:detail portable)}]
+                             :fallback :none})))
                 emitted (when (:ok portable)
                           (sco/generate-contraction-kernel-body (:body portable)))
                 {:keys [kernel-name source array-params scalar-params abi
@@ -686,6 +710,14 @@
                                 (assoc options
                                        :dtype dtype
                                        :facts facts
+                                       :array-types (into {} (map (fn [id]
+                                                                  [id (get-in (soac-dialect/facts program)
+                                                                              [:values id :dtype])]))
+                                                          (:inputs operation))
+                                       :scalar-types (into {} (map (fn [id]
+                                                                   [id (get-in (soac-dialect/facts program)
+                                                                               [:values id :dtype])]))
+                                                           (:scalars operation))
                                        :scheduled-operation operation
                                        :candidate-families families
                                        :operation-id operation-id)))
@@ -909,10 +941,11 @@
                                      (get-in candidate [:artifact :arguments]))
           :when (and (= :scalar (:kind slot))
                      (not (public-interface-slot? slot)))]
-    (when-not (and (contains? #{:int :long} (:kernel-dtype slot))
-                   (klaunch/expression? compiler-value)
-                   (every? public-scalars
-                           (klaunch/expression-references compiler-value)))
+    (when-not (or (contains? public-scalars compiler-value)
+                  (and (contains? #{:int :long} (:kernel-dtype slot))
+                       (klaunch/expression? compiler-value)
+                       (every? public-scalars
+                               (klaunch/expression-references compiler-value))))
       (throw (ex-info
               "typed contraction candidate has a private scalar outside its semantic ABI"
               {:reason :typed-contraction-dispatch-unbound-private-scalar

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1213,6 +1213,10 @@
       (not (:ok matrix-view))
       {:alternatives [] :decline (dissoc matrix-view :ok)}
 
+      (some #(and (= (:out facts) (:name %)) (= :inout (:kind %))) abi)
+      {:alternatives []
+       :decline {:reason :mixed-dpas-inout-result-transform-not-lowered}}
+
       (and (:batched? matrix-view) (seq (:epilogue matrix-view)))
       {:alternatives []
        :decline {:reason :batched-matrix-result-transform-not-lowered}}

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -76,6 +76,7 @@
                                   (conj (mapv second axes) (:body contract-facts))))
         core-scalar-ids (set/difference core-symbols core-operand-ids axis-indices
                                         #{(:out contract-facts)})
+        dimension-scalars (reduce set/union #{} (map (comp util/free-syms second) axes))
         ;; The scheduled TypedSOAC operation exposes its complete physical boundary, including
         ;; result-transform captures. Core contraction loads and epilogue loads have different
         ;; layout/dtype rules, so partition those roles from the verified facts instead of
@@ -100,10 +101,14 @@
         _ (when-not (and (dtype/known? dtype)
                          (integer? workgroup-size) (pos? workgroup-size)
                          (zero? (bit-and workgroup-size (dec workgroup-size)))
-                         (every? #(= dtype (array-dtype %)) arrays)
-                         (every? #(contains? #{:int :long} (dtype/canon (scalar-dtype %))) scalars))
+                         (every? #(or (= dtype (array-dtype %))
+                                      (and (contains? #{:float :double} dtype)
+                                           (contains? #{:float :double} (array-dtype %)))) arrays)
+                         (every? #(dtype/known? (scalar-dtype %)) scalars)
+                         (every? #(contains? #{:int :long} (dtype/canon (scalar-dtype %)))
+                                 dimension-scalars))
             (decline! :storage-contract
-                      "portable contraction requires uniform operand dtype and integral dimensions"
+                      "portable contraction requires compatible operand storage and integral dimensions"
                       {:dtype dtype :arrays arrays :array-types array-types
                        :scalars scalars :scalar-types scalar-types
                        :workgroup-size workgroup-size}))
@@ -118,7 +123,27 @@
                        :indices (mapv (juxt :sym :idx) (:operands contract-facts))}))
         reduced-index (:name reduced-dim)
         axis-symbols (set (concat (map :name segment-dims) [reduced-index]))
-        index-scope (into axis-symbols scalars)
+        index-scope (into axis-symbols
+                          (filter #(contains? #{:int :long} (dtype/canon (scalar-dtype %))) scalars))
+        ;; Physical coordinates are wide. Preserve the scalar ABI's retained widths and insert
+        ;; exact widening at index uses rather than pretending every dimension was an int.
+        wide-indices? (boolean (some #(= :long (dtype/canon (scalar-dtype %))) scalars))
+        widen-builtin #(if wide-indices? (body/index-cast % :long :exact) %)
+        widen-index (fn widen-index [expression]
+                      (cond
+                        (not wide-indices?) expression
+                        (integer? expression) (body/index-cast expression :long :exact)
+                        (symbol? expression)
+                        (if (and (not (contains? axis-symbols expression))
+                                 (= :int (dtype/canon (scalar-dtype expression))))
+                          (body/index-cast expression :long :exact)
+                          expression)
+                        (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
+                        (apply body/expression (:op expression)
+                               (map widen-index (:arguments expression)))
+                        :else expression))
+        lower-index (fn [expression scope]
+                      (widen-index (lower-index expression scope)))
         segment-count-source (segop/seg-space-num-segments-expr space)
         segment-count (lower-index segment-count-source index-scope)
         launch-segment-count (index-expression/to-launch-expression segment-count decline!)
@@ -159,6 +184,8 @@
                   ;; by their own retained source facts.
                   :declared-result-dtype dtype
                   :arrays (set arrays) :scalars (set scalars)
+                  :array-types (into {} (map (fn [id] [id (array-dtype id)])) arrays)
+                  :scalar-types (into {} (map (fn [id] [id (scalar-dtype id)])) scalars)
                   :coordinate-lower element-coordinate-lower
                   :load-predicate active-mask
                   :load-other (body/literal identity dtype)})
@@ -183,10 +210,11 @@
         parameters
         (vec (concat
               (map (fn [array]
-                     (let [extent (physical-extent array)]
+                     (let [extent (physical-extent array)
+                           storage-dtype (array-dtype array)]
                        (body/->KernelParameter
-                        array :input dtype [extent] :global
-                        (layout/row-major [extent] dtype) :operand)))
+                        array :input storage-dtype [extent] :global
+                        (layout/row-major [extent] storage-dtype) :operand)))
                    arrays)
               [(body/->KernelParameter output (if destination-read? :inout :output) dtype
                                        [segment-count] :global
@@ -221,17 +249,20 @@
                          (body/->IndexCompute
                           segment-index
                           (body/expression :add
-                                           (body/expression :mul group-index workgroup-size)
-                                           local-index))]
+                                           (body/expression :mul
+                                                            (widen-builtin group-index)
+                                                            (widen-builtin workgroup-size))
+                                           (widen-builtin local-index)))]
                         decomposition))
          :masks [(body/->Mask active-mask
-                              [(body/predicate :lt segment-index '_nseg)])]
+                              [(body/predicate :lt segment-index
+                                               (widen-builtin '_nseg))])]
          :operations
          (vec
           (concat
            [(body/->ForLoop
-             (body/value reduced-index :int)
-             0 reduced-bound 1
+             (body/value reduced-index (if wide-indices? :long :int))
+             (widen-builtin 0) reduced-bound 1
              [(body/->LoopArg (body/value accumulator dtype)
                               (body/literal identity dtype))]
              (vec (concat

--- a/src/raster/compiler/passes/parallel/index_expression.clj
+++ b/src/raster/compiler/passes/parallel/index_expression.clj
@@ -248,6 +248,7 @@
         :floor-div (apply launch/floor-div arguments)
         :ceil-div (apply launch/ceil-div arguments)
         :min (apply launch/minimum arguments)
+        :max (apply launch/maximum arguments)
         (decline! :launch-index-expression
                   "kernel index operation is not a non-negative launch extent"
                   {:expression expression :operation (:op expression)})))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -130,6 +130,41 @@
               bindings))
           {} equations))
 
+(defn body-for-equation
+  "Return the dependency-closed scheduled program slice for one numerical equation.
+
+   A graph is emitted one equation at a time, but storage extents may be defined by preceding
+   typed host-scalar equations.  This is the single narrowing operation used by equation-first
+   target emission and compatibility backend entry; neither may discard or reconstruct that
+   prefix independently."
+  [parallel-program equation]
+  (let [parallel-program (program/validate! parallel-program segop/segop-node?)
+        retained (some #(when (= (:id %) (:id equation)) %) (:equations parallel-program))
+        _ (when-not (= retained equation)
+            (fail! :scheduled-equation-membership
+                   "scheduled equation is not an exact member of its parallel program"
+                   {:equation (:id equation)}))
+        preceding (take-while #(not= (:id %) (:id equation)) (:equations parallel-program))
+        scalar-prefix (vec (filter #(true? (get-in % [:attributes :host-only])) preceding))
+        equations (conj scalar-prefix equation)]
+    (program/make
+     {:dialect :segop
+      :source nil
+      :values (:values parallel-program)
+      :inputs (program/infer-inputs equations)
+      :equations equations
+      :outputs (:results equation)
+      :effects (reduce set/union #{} (map :effects equations))
+      :diagnostics []
+      :provenance {:source-dialect :typed-soac
+                   :pass :scheduled-equation-graph}
+      :attributes {:host-control :explicit-typed-algorithm}
+      :operation? segop/segop-node?
+      :algorithm? (fn [candidate algorithm]
+                    (and (= algorithm (soac/validate! algorithm))
+                         (= (:operands candidate) (:inputs (soac/facts algorithm)))
+                         (= (:results candidate) (soac/outputs algorithm))))})))
+
 (defn- typed-host-scalar-equation?
   [values equation algorithm]
   (when-let [[result _] (scalar-result-expression equation)]
@@ -304,3 +339,20 @@
        ;; retained ParallelProgram prefix, not descriptive KernelGraph attributes.  A schedule
        ;; validator that needs them must receive and revalidate that exact program slice.
        :attributes attributes}))))
+
+(defn make-for-equation
+  "Derive the exact scheduled KernelGraph for one TypedSOAC numerical equation.
+
+   The equation's optional graph contract contributes only already-validated schedule provenance
+   and attributes; dataflow, storage and scalar closure are always reconstructed from the retained
+   algorithm and its dependency-closed program slice."
+  [parallel-program equation]
+  (let [body (body-for-equation parallel-program equation)
+        algorithm (:algorithm equation)
+        graph-contract (get-in equation [:attributes :kernel-graph])]
+    {:body body
+     :graph (make algorithm body
+                  (cond-> {}
+                    graph-contract
+                    (assoc :provenance (:provenance graph-contract)
+                           :attributes (:attributes graph-contract))))}))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -18,8 +18,10 @@
   [reason message data]
   (throw (ex-info message (assoc data :reason reason :pass :scheduled-equation-graph))))
 
+(declare integral-scalar-value?)
+
 (defn- value-elements
-  [derived-scalars value]
+  [values derived-scalars value]
   (let [dimension-value (fn [dimension]
                           ;; AbstractValue uses `(value id)` to distinguish a compound stable
                           ;; value ID from shape syntax. KernelGraph owns explicit integer
@@ -28,7 +30,17 @@
                                    (= 'value (first dimension))
                                    (= 2 (count dimension)))
                             (second dimension)
-                            dimension))
+                            (if (and (seq? dimension)
+                                     (not (contains? '#{extent unknown-dimension} (first dimension))))
+                              (let [decline! (fn [rule message data] (fail! rule message data))
+                                    scope (set (filter #(integral-scalar-value? (get values %))
+                                                       (util/free-syms dimension)))
+                                    ;; This is AbstractValue dimension algebra, not a host
+                                    ;; scalar expression. Its operations are mathematical extents
+                                    ;; (scan's n+1), so no source arithmetic dtype is inferred.
+                                    index (index-expression/lower dimension scope decline!)]
+                                (index-expression/to-launch-expression index decline!))
+                              dimension)))
         shape (mapv dimension-value (:shape value))
         elements (cond
                    (empty? shape) 1
@@ -45,6 +57,16 @@
   (and value
        (empty? (:shape value))
        (contains? #{:int :long} (some-> (:dtype value) dtype/canon))))
+
+(defn- unknown-shape? [value]
+  (some #(and (seq? %) (= 'unknown-dimension (first %))) (:shape value)))
+
+(defn- required-write-extent
+  "Cover every logical write to shared physical storage; an unknown write prevents refinement."
+  [values derived-scalars result-values]
+  (when (and (seq result-values) (every? #(and % (not (unknown-shape? %))) result-values))
+    (let [extents (vec (distinct (map #(value-elements values derived-scalars %) result-values)))]
+      (if (= 1 (count extents)) (first extents) (apply launch/maximum extents)))))
 
 (defn- scalar-result-expression
   "Return one closed typed scalar result with lambda parameters replaced by its stable captures.
@@ -138,7 +160,9 @@
    target emission and compatibility backend entry; neither may discard or reconstruct that
    prefix independently."
   [parallel-program equation]
-  (let [parallel-program (program/validate! parallel-program segop/segop-node?)
+  (let [;; The enclosing program may also contain scheduled structured loops. Validate its
+        ;; envelope here; the extracted numerical slice below has strict SegOp legality.
+        parallel-program (program/validate! parallel-program)
         retained (some #(when (= (:id %) (:id equation)) %) (:equations parallel-program))
         _ (when-not (= retained equation)
             (fail! :scheduled-equation-membership
@@ -211,7 +235,7 @@
              "scheduled storage lacks an AbstractValue"
              {:value id}))
     {:dtype (:dtype value)
-     :elements (value-elements derived-scalars value)
+     :elements (value-elements values derived-scalars value)
      :memory-space (or (:memory-space value) :device)}))
 
 (defn- algorithm-boundary?
@@ -318,9 +342,29 @@
                                        operations))
          temporary-ids (set/difference operation-values inputs outputs)
          values (:values scheduled)
+         result-storage-values
+         (reduce
+          (fn [by-storage equation]
+            (reduce (fn [by-storage [logical physical]]
+                      (update by-storage physical (fnil conj [])
+                              (get-in (soac/facts algorithm) [:values logical])))
+                    by-storage
+                    (map vector (nth equation 2) (soac/physical-results algorithm equation))))
+          {} retained-equations)
          buffer-specs (into {}
                             (map (fn [id] [id (storage-spec values derived-scalars id)]))
                             (set/union inputs outputs temporary-ids))
+         ;; An aliased destination can have unknown capacity while the typed result has a
+         ;; precise written extent (e.g. an exclusive scan writes n+1 elements). That semantic
+         ;; extent is the required capacity, not a claim about the allocation's full size.
+         buffer-specs (reduce-kv
+                       (fn [specs id result-values]
+                         (if-let [extent (and (contains? specs id)
+                                              (unknown-shape? (get values id))
+                                              (required-write-extent values derived-scalars result-values))]
+                           (assoc-in specs [id :elements] extent)
+                           specs))
+                       buffer-specs result-storage-values)
          scalars (public-scalars scheduled operations buffer-specs)]
      (graph/from-segops
       operations

--- a/src/raster/compiler/passes/parallel/segfoldmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segfoldmap_body.clj
@@ -379,6 +379,7 @@
     "Product" (canonical-operation :mul (:factors expression))
     "Sum" (canonical-operation :add (:terms expression))
     "Minimum" (canonical-operation :min (:values expression))
+    "Maximum" (canonical-operation :max (:values expression))
     "CeilDiv" (canonical-operation :ceil-div [(:value expression) (:divisor expression)])
     "FloorDiv" (canonical-operation :floor-div [(:value expression) (:divisor expression)])
     "AlignUp" (canonical-operation :align-up [(:value expression) (:alignment expression)])

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -65,7 +65,7 @@
    NB success/failure is carried in an explicit `{:ok …}`/`{:err …}` rather than a truthy value: a
    SOAC node is a RECORD, and records satisfy `map?` and are always truthy, so a compact
    `or`/`if-let` version silently misread every successful lowering as a decline marker."
-  [sym form device-id dtype array-types]
+  [sym form device-id dtype array-types scalar-types]
   (when (seq? form)
     (let [par? (par/par-form? form)
           decline (fn [stage e] (when (contains? fatal-reasons (:reason (ex-data e))) (throw e))
@@ -99,7 +99,8 @@
                           (typed-frontend/form->program
                            (list 'let* [sym form] sym)
                            {:dtype (or dtype :double)
-                            :array-types array-types}))
+                            :array-types array-types
+                            :scalar-types scalar-types}))
               segops (attempt #(if algorithm
                                  (soac-lower/lower-typed-reduce
                                   algorithm (or device-id :cpu:0) :dtype (or dtype :double))
@@ -127,15 +128,20 @@
     :else (unknown-vector-shape)))
 
 (defn- value-contract
-  [id node dtype array-types result?]
+  [id node dtype array-types scalar-types result?]
   (let [array-ids (set/union (or (soac/soac-inputs node) #{})
                              (or (soac/soac-outputs node) #{}))
         shape (cond
                 result? (result-shape node)
+                ;; A scalar reduction's indexed reads are certified over its reduction extent.
+                ;; Retain that minimum physical capacity instead of the compatibility `?` shape;
+                ;; graph staging can then prove the input is large enough without guessing.
+                (and (contains? array-ids id) (soac/soac-reduce? node)) [(:bound node)]
                 (contains? array-ids id) (unknown-vector-shape)
                 :else [])
-        value-dtype (or (get array-types id)
-                        (when (symbol? id) (get array-types (symbol (name id))))
+        declared-types (if (contains? array-ids id) array-types scalar-types)
+        value-dtype (or (get declared-types id)
+                        (when (symbol? id) (get declared-types (symbol (name id))))
                         (:elem-type node)
                         dtype
                         :double)]
@@ -145,21 +151,27 @@
                 :effects #{}})))
 
 (defn- equation
-  [equation-id site sym source {:keys [soac algorithm segops kernel-graph]} dtype array-types]
-  (let [;; Body-position equations currently have no ParallelProgram result ID; retain the typed
-        ;; algorithm only where its result has an authoritative envelope identity.
-        algorithm (when (= :binding (first site)) algorithm)
+  [equation-id site sym source {:keys [soac algorithm segops kernel-graph]}
+   dtype array-types scalar-types]
+  (let [;; A scalar reduction is value-producing even in body position. Give that expression the
+        ;; same internal SSA envelope as a source binding: whether an algorithm can be scheduled
+        ;; must not depend on surface syntax. Effect-only body operations still have no result.
+        value-producing? (or (= :binding (first site))
+                             (and (soac/soac-reduce? soac)
+                                  (empty? (:segment-axes soac))
+                                  (reduction/scalar? (:reduction soac))))
+        algorithm (when value-producing? algorithm)
         operands (-> (soac/node-all-free-syms soac) (disj sym) (->> (sort-by str) vec))
-        result-ids (if (= :binding (first site)) [sym] [])
+        result-ids (if value-producing? [sym] [])
         effects (cond-> #{:memory/read}
                   (seq (soac/soac-outputs soac)) (conj :memory/write))
         operand-values (into {}
                              (map (fn [id]
-                                    [id (value-contract id soac dtype array-types false)]))
+                                    [id (value-contract id soac dtype array-types scalar-types false)]))
                              operands)
         result-values (into {}
                             (map (fn [id]
-                                   [id (value-contract id soac dtype array-types true)]))
+                                   [id (value-contract id soac dtype array-types scalar-types true)]))
                             result-ids)
         eq (program/->ProgramEquation
             equation-id site source operands result-ids algorithm (vec segops) effects
@@ -193,6 +205,50 @@
                        :id id :definition defined :use inferred}))))
   definition)
 
+(defn- declare-scheduled-temporaries
+  "Declare physical SSA storage introduced by a multi-phase schedule.
+
+   Both typed whole-program lowering and compatibility discovery use this one rule. A backend must
+   never learn a partial buffer's dtype or extent from its generated name."
+  [values equations]
+  (reduce
+   (fn [values equation]
+     (let [values
+           (reduce (fn [values temporary]
+                     (let [id (:id temporary)]
+                       (if (contains? values id)
+                         values
+                         (assoc values id
+                                (av/tensor
+                                 {:dtype (:dtype temporary)
+                                  :shape (soac-dialect/extent-shape (:elements temporary))
+                                  :representation {:kind :plain}
+                                  :memory-space (:memory-space temporary)})))))
+                   values
+                   (get-in equation [:attributes :kernel-graph :temporaries]))]
+       (reduce
+        (fn [values operation]
+          (if (and (instance? raster.compiler.ir.segop.SegRed operation)
+                   (= :block-local (:phase operation)))
+            (let [grid (:grid operation)
+                  reduced-bound (-> operation :space segop/seg-space-reduced-dim :bound)
+                  partial-extent
+                  (segred-body/launch-group-count
+                   (:num-blocks grid) reduced-bound (:block-size grid))]
+              (reduce (fn [values id]
+                        (if (contains? values id)
+                          values
+                          (assoc values id
+                                 (av/tensor
+                                  {:dtype (:dtype operation)
+                                   :shape (soac-dialect/extent-shape partial-extent)
+                                   :representation {:kind :plain}
+                                   :memory-space :device}))))
+                      values (:outputs operation)))
+            values))
+        values (:operations equation))))
+   values equations))
+
 (defn- build-program
   [source lowered-equations declined device-id dtype]
   (let [{:keys [equations values]}
@@ -204,7 +260,12 @@
                  ;; Source binders and pre-existing buffers may share a spelling in imperative IR.
                  ;; Give equation results their own SSA-like IDs so a scalar binding can never
                  ;; collide with an array operand of the same name.
-                 results (mapv (fn [source-id] [:binding source-id]) source-results)
+                 ;; A body-position result is already an internal compiler identity and has no
+                 ;; user binding whose successive definitions need disambiguation. Keeping that
+                 ;; symbol also matches the typed reduction component's physical result contract.
+                 results (if (= :body (first (:site equation)))
+                           source-results
+                           (mapv (fn [source-id] [:binding source-id]) source-results))
                  values-with-operands
                  (reduce (fn [values [source-id value-id]]
                            ;; A mapped operand already has the defining equation's authoritative
@@ -234,6 +295,7 @@
                  (update :environment into (map vector source-results results)))))
          {:environment {} :values {} :equations []}
          lowered-equations)
+        values (declare-scheduled-temporaries values equations)
         result-ids (set (mapcat :results equations))
         operand-ids (set (mapcat :operands equations))
         inputs (->> (set/difference operand-ids result-ids) (sort-by str) vec)
@@ -349,45 +411,7 @@
           ;; A multi-phase schedule introduces physical SSA values that do not exist in the
           ;; functional algorithm. They still require explicit contracts; an emitter must never
           ;; infer their dtype or extent from a generated name.
-          scheduled-values
-          (reduce
-           (fn [values equation]
-             (let [values
-                   (reduce (fn [values temporary]
-                             (let [id (:id temporary)]
-                               (if (contains? values id)
-                                 values
-                                 (assoc values id
-                                        (av/tensor
-                                         {:dtype (:dtype temporary)
-                                          :shape (soac-dialect/extent-shape
-                                                  (:elements temporary))
-                                          :representation {:kind :plain}
-                                          :memory-space (:memory-space temporary)})))))
-                           values
-                           (get-in equation [:attributes :kernel-graph :temporaries]))]
-               (reduce
-                (fn [values operation]
-                  (if (and (instance? raster.compiler.ir.segop.SegRed operation)
-                           (= :block-local (:phase operation)))
-                    (let [grid (:grid operation)
-                          reduced-bound (-> operation :space segop/seg-space-reduced-dim :bound)
-                          partial-extent
-                          (segred-body/launch-group-count
-                           (:num-blocks grid) reduced-bound (:block-size grid))]
-                      (reduce (fn [values id]
-                                (if (contains? values id)
-                                  values
-                                  (assoc values id
-                                         (av/tensor
-                                          {:dtype (:dtype operation)
-                                           :shape (soac-dialect/extent-shape partial-extent)
-                                           :representation {:kind :plain}
-                                           :memory-space :device}))))
-                              values (:outputs operation)))
-                    values))
-                values (:operations equation))))
-           (:values form) equations)
+          scheduled-values (declare-scheduled-temporaries (:values form) equations)
           ;; Scheduled operations are not exempt from SSA validation merely because they are
           ;; records nested inside an equation. Every physical operand/result—including generated
           ;; partial arrays and aliased destinations—must have an AbstractValue contract.
@@ -450,6 +474,7 @@
             device-id (:target-device opts)
             dtype (:dtype opts)
             array-types (:array-types opts)
+            scalar-types (:scalar-types opts)
             lowered (atom 0)
             graphs-lowered (atom 0)
           ;; Every par form the middle end could NOT represent, as data. Previously these went to
@@ -457,7 +482,7 @@
           ;; anyone diagnosing why a kernel took the legacy path.
             declined (atom [])
             attempt (fn [sym init]
-                      (let [r (lower-attempt sym init device-id dtype array-types)]
+                      (let [r (lower-attempt sym init device-id dtype array-types scalar-types)]
                         (when-let [d (:declined r)] (swap! declined conj d))
                         (when (:segops r) r)))
             binding-equations
@@ -466,7 +491,8 @@
                (when-let [lowered-values (attempt sym init)]
                  (swap! lowered inc)
                  (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
-                 (equation idx [:binding sym] sym init lowered-values dtype array-types)))
+                 (equation idx [:binding sym] sym init lowered-values
+                           dtype array-types scalar-types)))
              pairs)
           ;; Also check body expressions for par forms
             body-equations
@@ -477,7 +503,7 @@
                    (swap! lowered inc)
                    (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
                    (equation (+ (count pairs) idx) [:body idx] tmp-sym expr
-                             lowered-values dtype array-types))))
+                             lowered-values dtype array-types scalar-types))))
              body-exprs)
             equations (vec (concat binding-equations body-equations))]
         {:form (build-program (list* let-sym bindings-vec body-exprs)

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -35,20 +35,60 @@
 
 (def ^:private scalar-phases #{:single :block-local :cross-block})
 
+(defn scalar-workgroup-tree-schedule
+  "Construct the canonical schedule carried by one ordinary scalar SegRed phase.
+
+   This is shared by semantic-to-SegOp lowering and the zero-free contraction compatibility
+   projection. The source operation therefore states the workgroup tree that KernelBody later
+   verifies; KernelBody scheduling does not manufacture a second, implicit schedule."
+  [operator grid phase]
+  (let [operator (reduction/validate! operator)
+        workgroup-size (:block-size grid)
+        accumulator-dtype (dtype/canon (:dtype (first (:components operator))))
+        shared-memory-bytes (* workgroup-size (dtype/bytes-of accumulator-dtype))
+        terminal? (contains? #{:single :cross-block} phase)]
+    (reduction/schedule
+     {:strategy :scalar-workgroup-tree
+      :workgroup-size workgroup-size
+      :stages [:lane-fold :workgroup-tree (if terminal? :terminal-store :partial-store)]
+      :tuning-space {}
+      :numerical-mode (select-keys (if (scan/associative-scan? (:algebra operator))
+                                     (:algebra operator)
+                                     (first (:components (:algebra operator))))
+                                   [:order :reassociation :overflow])
+      :attributes {:phase phase
+                   :group-count (:num-blocks grid)
+                   :shared-memory-bytes shared-memory-bytes}})))
+
 (defn- validate-scalar-segred!
   "Validate the complete semantic/schedule subset implemented by the portable workgroup tree."
   [segred out-sym array-types]
   (when-not (instance? raster.compiler.ir.segop.SegRed segred)
     (throw (ex-info "scalar reduction scheduling requires a SegRed"
                     {:reason :raster/bug :operation segred})))
-  (let [operator (reduction/validate! (:reduction segred))
+  (let [operator (try
+                   (reduction/validate! (:reduction segred))
+                   (catch clojure.lang.ExceptionInfo exception
+                     (decline! :scalar-product-reduction
+                               "portable scalar SegRed requires a canonical ProductReduction"
+                               {:operation (:id segred) :reduction (:reduction segred)
+                                :reduction-error (ex-data exception)})))
         dimensions (segop/seg-space-segment-dims (:space segred))
         phase (:phase segred)
         outputs (vec (:outputs segred))
         component (first (:components operator))
         accumulator-dtype (dtype/canon (:dtype component))
-        workgroup-size (or (get-in segred [:grid :block-size]) 256)
+        grid (:grid segred)
+        workgroup-size (:block-size grid)
         num-blocks (get-in segred [:grid :num-blocks])
+        shared-memory-bytes (get-in segred [:grid :shared-mem-bytes])
+        schedule (try
+                   (reduction/validate-schedule! (:schedule segred))
+                   (catch clojure.lang.ExceptionInfo exception
+                     (decline! :scalar-workgroup-tree-schedule
+                               "portable scalar SegRed requires an explicit reduction schedule"
+                               {:operation (:id segred) :schedule (:schedule segred)
+                                :schedule-error (ex-data exception)})))
         result-region (get-in operator [:attributes :result-region])
         output (or out-sym (first outputs))
         declared-type (fn [id]
@@ -69,6 +109,10 @@
       (decline! :zero-segment-dimensions
                 "portable scalar SegRed cannot schedule a segmented result space"
                 {:operation (:id segred) :segment-dimensions dimensions}))
+    (when-not (nil? (:lambda segred))
+      (decline! :fused-map-representation
+                "scalar SegRed requires its element expression in ProductReduction, not map-lambda"
+                {:operation (:id segred) :map-lambda (:lambda segred)}))
     (when-not (contains? scalar-phases phase)
       (decline! :scalar-reduction-phase
                 "portable scalar SegRed has an unsupported reduction phase"
@@ -77,6 +121,11 @@
       (decline! :single-physical-output
                 "portable scalar SegRed requires one stable physical output identity"
                 {:operation (:id segred) :outputs outputs :requested-output out-sym}))
+    (when-not (= (first outputs) output)
+      (decline! :physical-output-remap
+                "scalar SegRed emission cannot silently replace its semantic output identity"
+                {:operation (:id segred) :semantic-output (first outputs)
+                 :requested-output out-sym}))
     (when-not (contains? #{:float :double} accumulator-dtype)
       (decline! :uniform-scalar-storage
                 "portable scalar SegRed supports FP32 or FP64 storage and accumulation"
@@ -94,6 +143,38 @@
       (decline! :workgroup-size
                 "portable scalar SegRed requires a positive power-of-two workgroup"
                 {:operation (:id segred) :workgroup-size workgroup-size}))
+    (let [expected-level (if (= :block-local phase)
+                           (segop/->SegLevel :block :virtual)
+                           (segop/->SegLevel :block :none))
+          expected-shared-memory (* workgroup-size (dtype/bytes-of accumulator-dtype))
+          expected-stages [:lane-fold :workgroup-tree
+                           (if (contains? #{:single :cross-block} phase)
+                             :terminal-store :partial-store)]]
+      (when-not (= expected-level (:level segred))
+        (decline! :phase-level
+                  "scalar SegRed phase and execution level disagree"
+                  {:operation (:id segred) :phase phase
+                   :expected expected-level :actual (:level segred)}))
+      (when-not (= expected-shared-memory shared-memory-bytes)
+        (decline! :grid-shared-memory
+                  "scalar SegRed grid shared memory differs from its workgroup tree"
+                  {:operation (:id segred) :expected expected-shared-memory
+                   :actual shared-memory-bytes}))
+      (when-not (= {:strategy :scalar-workgroup-tree
+                    :workgroup-size workgroup-size
+                    :stages expected-stages
+                    :phase phase
+                    :group-count num-blocks
+                    :shared-memory-bytes expected-shared-memory}
+                   {:strategy (:strategy schedule)
+                    :workgroup-size (:workgroup-size schedule)
+                    :stages (:stages schedule)
+                    :phase (get-in schedule [:attributes :phase])
+                    :group-count (get-in schedule [:attributes :group-count])
+                    :shared-memory-bytes (get-in schedule [:attributes :shared-memory-bytes])})
+        (decline! :schedule-grid
+                  "scalar SegRed schedule does not describe its emitted grid/workgroup tree"
+                  {:operation (:id segred) :phase phase :grid grid :schedule schedule})))
     (when (and (contains? #{:single :cross-block} phase) (not= 1 num-blocks))
       (decline! :terminal-phase-groups
                 "terminal scalar SegRed phases must launch exactly one workgroup"
@@ -104,7 +185,7 @@
                 {:operation (:id segred) :phase phase :result-region result-region}))
     {:operator operator :component component :dtype accumulator-dtype
      :workgroup-size workgroup-size :phase phase :output output
-     :result-region result-region}))
+     :result-region result-region :schedule schedule}))
 
 (defn- retained-expression-dtype
   "Read the walker/TypedClojure result fact carried by a scalar expression.
@@ -215,6 +296,11 @@
          (pos? (second grid-expression)))
     (launch/minimum (second grid-expression)
                     (launch/ceil-div bound workgroup-size))
+
+    ;; A compatibility or prior scheduling pass may already have constructed canonical launch IR.
+    ;; Preserve that inspectable expression instead of accepting only its historical source form.
+    (and (not (integer? grid-expression)) (launch/expression? grid-expression))
+    grid-expression
 
     :else
     (decline! :launch-grid
@@ -515,17 +601,35 @@
           :indices [(body/->IndexBinding 'group-index :group 0)
                     (body/->IndexBinding 'group-count :group-count 0)
                     (body/->IndexBinding 'local-index :local 0)
+                    ;; Widen schedule arithmetic before multiplying or adding. An int32 bound may
+                    ;; equal Integer/MAX_VALUE; inactive final-group lanes must not overflow while
+                    ;; merely forming the coordinate that the loop predicate excludes.
+                    (body/->IndexCompute
+                     'wide-bound (body/index-cast '_n_bound :long :exact))
+                    (body/->IndexCompute
+                     'wide-group-index (body/index-cast 'group-index :long :exact))
+                    (body/->IndexCompute
+                     'wide-group-count (body/index-cast 'group-count :long :exact))
+                    (body/->IndexCompute
+                     'wide-local-index (body/index-cast 'local-index :long :exact))
                     (body/->IndexCompute
                      'group-chunk
-                     (body/expression :ceil-div '_n_bound 'group-count))
+                     ;; For a positive extent, 1 + (n-1)/groups is overflow-free.
+                     (body/expression
+                      :add 1
+                      (body/expression :floor-div
+                                       (body/expression :sub 'wide-bound 1)
+                                       'wide-group-count)))
                     (body/->IndexCompute
-                     'group-start (body/expression :mul 'group-index 'group-chunk))
+                     'group-start (body/expression :mul 'wide-group-index 'group-chunk))
                     (body/->IndexCompute
-                     'group-end
-                     (body/expression :min '_n_bound
-                                      (body/expression :add 'group-start 'group-chunk)))
+                     'group-length
+                     (body/expression :min 'group-chunk
+                                      (body/expression :sub 'wide-bound 'group-start)))
                     (body/->IndexCompute
-                     'global-index (body/expression :add 'group-start 'local-index))]
+                     'global-index (body/expression :add 'group-start 'wide-local-index))
+                    (body/->IndexCompute
+                     'group-end (body/expression :add 'group-start 'group-length))]
           :masks (vec (concat
                        [(body/->Mask :lane-zero [(body/predicate :eq 'local-index 0)])]
                        (map (fn [stride]
@@ -535,7 +639,7 @@
                                         (iterate #(quot % 2) (quot workgroup-size 2))))))
           :operations (vec (concat
                             [(body/->ForLoop
-                              (body/value element-index :int)
+                              (body/value element-index :long)
                               'global-index 'group-end workgroup-size
                               [(body/->LoopArg (body/value lane-accumulator dtype)
                                                (body/literal identity dtype))]
@@ -660,6 +764,7 @@
                    :segop-id (:id segred) :phase phase}
       :attributes {:array-params arrays
                    :scalar-params scalars
+                   :strategy :scalar-workgroup-tree
                    :dtype (dtype/canon (:dtype segred))
                    :phase phase
                    :group-count output-elements
@@ -674,8 +779,13 @@
   "Close scalar SegRed output geometry over its complete KernelGraph context."
   [scheduled node kernel-graph]
   (let [scheduled (scheduled-body/validate-against-node! scheduled node kernel-graph)
-        output-use (first (filter #(contains? #{:write :read-write} (:access %))
-                                  (:uses node)))
+        source (:source scheduled)
+        semantic-output (first (:outputs source))
+        physical-result (get-in scheduled [:attributes :physical-result])
+        output-use (some #(when (and (= semantic-output (:buffer %))
+                                     (contains? #{:write :read-write} (:access %)))
+                            %)
+                         (:uses node))
         output-buffer (some #(when (= (:buffer output-use) (:id %)) %)
                             (concat (:inputs kernel-graph) (:outputs kernel-graph)
                                     (:temporaries kernel-graph)))
@@ -687,8 +797,13 @@
                                % {'_n_bound (:value bound-binding)})
                              (:shape output-parameter))
         output-elements (get-in scheduled [:attributes :output-elements])
-        group-count (get-in (scheduled-body/realized-launch scheduled) [:group-count 0])]
-    (when-not (and output-use output-buffer output-parameter bound-binding
+        realized-launch (scheduled-body/realized-launch scheduled)
+        group-count (get-in realized-launch [:group-count 0])
+        workgroup-size (get-in source [:grid :block-size])
+        shared-memory-bytes (get-in source [:grid :shared-mem-bytes])]
+    (when-not (and (= 1 (count (:outputs source)))
+                   (= semantic-output physical-result (:id output-parameter))
+                   output-use output-buffer output-parameter bound-binding
                    (= [output-elements] realized-shape)
                    (= output-elements group-count)
                    (= output-elements (:elements output-buffer)))
@@ -697,4 +812,16 @@
                 {:node (:id node) :output-use output-use :output-buffer output-buffer
                  :output-parameter output-parameter :realized-shape realized-shape
                  :output-elements output-elements :group-count group-count}))
+    (when-not (and (= (:phase source) (get-in scheduled [:effects :phase]))
+                   (= (:phase source) (get-in scheduled [:legality :phase]))
+                   (= (:phase source) (get-in scheduled [:attributes :phase]))
+                   (= workgroup-size (get-in scheduled [:body :schedule :workgroup-size]))
+                   (= [workgroup-size] (:workgroup-size realized-launch))
+                   (= shared-memory-bytes (:shared-memory-bytes realized-launch)))
+      (decline! :schedule-projection
+                "scalar SegRed certificate changes its source phase or workgroup-tree geometry"
+                {:node (:id node) :phase (:phase source)
+                 :effects (:effects scheduled) :legality (:legality scheduled)
+                 :attributes (:attributes scheduled) :launch realized-launch
+                 :grid (:grid source)}))
     scheduled))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -13,6 +13,7 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.reduction :as reduction]
@@ -326,7 +327,7 @@
     expression))
 
 (defn- widen-index-expression
-  "Make array-coordinate arithmetic uniformly 64-bit without changing public scalar ABI types."
+  "Make certified contraction-coordinate arithmetic uniformly 64-bit."
   [expression value-types]
   (cond
     (integer? expression) (body/index-cast expression :long :exact)
@@ -510,7 +511,7 @@
 
   `array-types` and `scalar-types` are authoritative ABI facts. Tensor element storage and the
    accumulator remain uniform; integral scalar parameters may participate in index expressions."
-  [segred out-sym & {:keys [dtype array-types scalar-types]
+  [segred out-sym & {:keys [dtype array-types scalar-types coordinate-proof]
                      :or {dtype :double array-types {} scalar-types {}}}]
   (let [{validated-dtype :dtype output :output result-region :result-region}
         (validate-scalar-segred! segred out-sym array-types)
@@ -538,6 +539,28 @@
                       {:segred-id (:id segred) :dtype dtype :bound bound
                        :workgroup-size workgroup-size :arrays arrays :scalars scalars}))
         {:keys [operator identity element]} (scalar-plan segred)
+        contraction-coordinate-proof?
+        (when coordinate-proof
+          (let [view (when (contraction-facts/facts? coordinate-proof)
+                       (contraction-facts/scalar-reduction-view coordinate-proof))
+                [proof-index proof-bound] (:flat-contract-axis coordinate-proof)
+                operand-ids (set (map :sym (:operands coordinate-proof)))]
+            (when-not (and view
+                           (zero? (:n-free coordinate-proof))
+                           (= [index bound] [proof-index proof-bound])
+                           (= (set arrays) operand-ids)
+                           (every? #(contraction-facts/operand-axis-map coordinate-proof %)
+                                   arrays)
+                           (= element (:element view))
+                           (= (literal-value identity) (literal-value (:neutral view)))
+                           (= operator (intrinsics/canonical (:combine view)))
+                           (= (dtype/canon dtype) (dtype/canon (:dtype view))))
+              (decline! :contraction-coordinate-proof
+                        "affine scalar-contraction coordinates disagree with retained facts"
+                        {:segred-id (:id segred) :facts coordinate-proof
+                         :index index :bound bound :arrays arrays
+                         :operator operator :identity identity :element element}))
+            true))
         _ (when (contains? #{:min :max} operator)
             (decline! :floating-minmax-semantics
                       "portable scalar reduction needs an explicit NaN and signed-zero policy for min/max"
@@ -563,12 +586,19 @@
           :scalar-types (into {} (map (fn [id] [id (scalar-dtype id)])) scalars)
           :coordinate-lower
           (fn [source-coordinate]
-            (widen-index-expression
-             (index-expression/lower
-              (util/subst-syms {index element-index} source-coordinate)
-              (conj (set scalars) element-index)
-              decline!)
-             (assoc scalar-types element-index :long)))})
+            ;; The first complete vertical proves every input has at least `bound` elements.
+            ;; That proves only the pointwise coordinate. Affine/gathered reads need an explicit
+            ;; view extent plus a range proof; admitting `i+offset` from expression syntax would
+            ;; turn an n-element capacity check into a false memory-safety certificate.
+            (if contraction-coordinate-proof?
+              ;; Verified contraction facts prove every operand's AxisMap and physical extent.
+              (widen-index-expression
+               (index-expression/lower
+                (util/subst-syms {index element-index} source-coordinate)
+                (conj (set scalars) element-index)
+                decline!)
+               (assoc scalar-types element-index :long))
+              (when (= index source-coordinate) element-index)))})
         group-count (if (= :block-local (:phase segred))
                       (launch/rebind-expression
                        (launch-group-count (get-in segred [:grid :num-blocks])
@@ -741,7 +771,7 @@
    (let [{:keys [kernel-body operator identity arrays scalars output bound group-count result-region]}
         (lower segred out-sym
                :dtype (:dtype options) :array-types (:array-types options)
-               :scalar-types scalar-types)
+               :scalar-types scalar-types :coordinate-proof (:coordinate-proof options))
         arguments (mapv (fn [parameter]
                           (if (= '_n_bound (:id parameter)) bound (:id parameter)))
                         (:parameters kernel-body))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -15,7 +15,9 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.scan :as scan]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
@@ -30,6 +32,79 @@
 (defn declined?
   [exception]
   (= :segred-kernel-body-declined (:reason (ex-data exception))))
+
+(def ^:private scalar-phases #{:single :block-local :cross-block})
+
+(defn- validate-scalar-segred!
+  "Validate the complete semantic/schedule subset implemented by the portable workgroup tree."
+  [segred out-sym array-types]
+  (when-not (instance? raster.compiler.ir.segop.SegRed segred)
+    (throw (ex-info "scalar reduction scheduling requires a SegRed"
+                    {:reason :raster/bug :operation segred})))
+  (let [operator (reduction/validate! (:reduction segred))
+        dimensions (segop/seg-space-segment-dims (:space segred))
+        phase (:phase segred)
+        outputs (vec (:outputs segred))
+        component (first (:components operator))
+        accumulator-dtype (dtype/canon (:dtype component))
+        workgroup-size (or (get-in segred [:grid :block-size]) 256)
+        num-blocks (get-in segred [:grid :num-blocks])
+        result-region (get-in operator [:attributes :result-region])
+        output (or out-sym (first outputs))
+        declared-type (fn [id]
+                        (some-> (or (get array-types id)
+                                    (get array-types
+                                         (when (or (symbol? id) (keyword? id))
+                                           (symbol (name id)))))
+                                dtype/canon))
+        input-types (mapv (fn [input]
+                            (or (declared-type input) accumulator-dtype))
+                          (:inputs segred))
+        output-type (or (declared-type output) accumulator-dtype)]
+    (when-not (reduction/scalar? operator)
+      (decline! :scalar-product-reduction
+                "portable scalar SegRed scheduling requires one ProductReduction component"
+                {:operation (:id segred) :components (count (:components operator))}))
+    (when (seq dimensions)
+      (decline! :zero-segment-dimensions
+                "portable scalar SegRed cannot schedule a segmented result space"
+                {:operation (:id segred) :segment-dimensions dimensions}))
+    (when-not (contains? scalar-phases phase)
+      (decline! :scalar-reduction-phase
+                "portable scalar SegRed has an unsupported reduction phase"
+                {:operation (:id segred) :phase phase :supported scalar-phases}))
+    (when-not (and (= 1 (count outputs)) (some? (first outputs)) (some? output))
+      (decline! :single-physical-output
+                "portable scalar SegRed requires one stable physical output identity"
+                {:operation (:id segred) :outputs outputs :requested-output out-sym}))
+    (when-not (contains? #{:float :double} accumulator-dtype)
+      (decline! :uniform-scalar-storage
+                "portable scalar SegRed supports FP32 or FP64 storage and accumulation"
+                {:operation (:id segred) :accumulator-dtype accumulator-dtype}))
+    (when-not (and (= accumulator-dtype (dtype/canon (:dtype segred)))
+                   (= accumulator-dtype output-type)
+                   (every? #{accumulator-dtype} input-types))
+      (decline! :uniform-scalar-storage
+                "portable scalar SegRed requires uniform storage and accumulator dtypes"
+                {:operation (:id segred) :segred-dtype (:dtype segred)
+                 :accumulator-dtype accumulator-dtype :input-dtypes input-types
+                 :output-dtype output-type}))
+    (when-not (and (integer? workgroup-size) (pos? workgroup-size)
+                   (zero? (bit-and workgroup-size (dec workgroup-size))))
+      (decline! :workgroup-size
+                "portable scalar SegRed requires a positive power-of-two workgroup"
+                {:operation (:id segred) :workgroup-size workgroup-size}))
+    (when (and (contains? #{:single :cross-block} phase) (not= 1 num-blocks))
+      (decline! :terminal-phase-groups
+                "terminal scalar SegRed phases must launch exactly one workgroup"
+                {:operation (:id segred) :phase phase :num-blocks num-blocks}))
+    (when (and (= :block-local phase) result-region)
+      (decline! :nonterminal-result-transform
+                "a completed reduction transform may run only in a terminal SegRed phase"
+                {:operation (:id segred) :phase phase :result-region result-region}))
+    {:operator operator :component component :dtype accumulator-dtype
+     :workgroup-size workgroup-size :phase phase :output output
+     :result-region result-region}))
 
 (defn- retained-expression-dtype
   "Read the walker/TypedClojure result fact carried by a scalar expression.
@@ -285,7 +360,6 @@
                                       "scalar arithmetic requires its retained walker/TypedClojure result dtype"
                                       {:expression expression :operator operator}))
                         typed-inputs (mapv #(lower % nil) arguments)
-                        input-dtypes (mapv :dtype typed-inputs)
                         result-dtype retained-dtype]
                     (when (dtype/integral? result-dtype)
                       (decline! :integral-scalar-arithmetic
@@ -321,11 +395,13 @@
 (defn lower
   "Lower an eligible scalar SegRed to one verified portable workgroup-tree KernelBody.
 
-   `array-types` and `scalar-types` are authoritative ABI facts. Tensor element storage and the
+  `array-types` and `scalar-types` are authoritative ABI facts. Tensor element storage and the
    accumulator remain uniform; integral scalar parameters may participate in index expressions."
   [segred out-sym & {:keys [dtype array-types scalar-types]
                      :or {dtype :double array-types {} scalar-types {}}}]
-  (let [dtype (or (:dtype segred) dtype)
+  (let [{validated-dtype :dtype output :output result-region :result-region}
+        (validate-scalar-segred! segred out-sym array-types)
+        dtype (or validated-dtype (:dtype segred) dtype)
         index (:name (segop/seg-space-reduced-dim (:space segred)))
         bound (:bound (segop/seg-space-reduced-dim (:space segred)))
         ;; Direct compatibility-front-door reductions can arrive before target scheduling. Keep
@@ -338,13 +414,10 @@
                                   (get scalar-types (symbol (name id))) dtype))
         array-dtype (fn [id] (or (get array-types id)
                                  (get array-types (symbol (name id))) dtype))
-        bound-dimension (if (or (symbol? bound) (keyword? bound) (vector? bound))
-                          (launch/runtime-value bound)
-                          bound)
+        bound-dimension '_n_bound
         _ (when-not (and (contains? #{:float :double} (dtype/canon dtype))
                          (integer? workgroup-size) (pos? workgroup-size)
                          (zero? (bit-and workgroup-size (dec workgroup-size)))
-                         (launch/dimension-expression? bound-dimension)
                          (every? #(= (dtype/canon dtype) (dtype/canon (array-dtype %))) arrays)
                          (every? #(dtype/known? (dtype/canon (scalar-dtype %))) scalars))
             (decline! :uniform-scalar-storage
@@ -377,9 +450,8 @@
              (util/subst-syms {index element-index} source-coordinate)
              (conj (set scalars) element-index)
              decline!))})
-        output (or out-sym 'output)
         group-count (if-let [grid-expression (get-in segred [:grid :num-blocks])]
-                      (launch-group-count grid-expression bound workgroup-size)
+                      (launch-group-count grid-expression bound-dimension workgroup-size)
                       (launch/ceil-div bound-dimension workgroup-size))
         scratch 'workgroup-reduction-scratch
         barrier (fn [] (body/->WorkgroupBarrier
@@ -410,12 +482,11 @@
                      % :input dtype ['_n_bound] :global
                      (layout/row-major ['_n_bound] dtype) :operand)
                    arrays)
-              [(body/->KernelParameter output :output dtype ['partial-count] :global
-                                       (layout/row-major ['partial-count] dtype) :result)]
+              [(body/->KernelParameter output :output dtype [group-count] :global
+                                       (layout/row-major [group-count] dtype) :result)]
               (map #(body/->KernelParameter % :scalar (scalar-dtype %) [] nil nil :parameter)
                    scalars)
               [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))
-        result-region (get-in segred [:reduction :attributes :result-region])
         _ (when (and result-region (seq (:operands result-region)))
             (decline! :full-reduction-result-operands
                       "full-reduction result transforms cannot address tensor operands"
@@ -502,4 +573,128 @@
      :arrays arrays
      :scalars scalars
      :output output
-     :bound bound}))
+     :bound bound
+     :group-count group-count
+     :result-region result-region}))
+
+(defn- logical-bound-dtype
+  [bound scalar-types]
+  (let [references (launch/expression-references bound)
+        scalar-dtype (fn [id]
+                       (or (get scalar-types id)
+                           (get scalar-types (when (or (symbol? id) (keyword? id))
+                                               (symbol (name id))))
+                           ;; Compatibility reductions predate GraphScalar. Their only omitted
+                           ;; shape representation was the historical physical int bound.
+                           (when (= references #{id}) :int)))]
+    (try
+      (launch/typed-expression-dtype bound scalar-dtype)
+      (catch clojure.lang.ExceptionInfo exception
+        (decline! :phase-bound-dtype
+                  "scalar SegRed phase bound lacks a complete checked integer type"
+                  {:bound bound :scalar-types scalar-types
+                   :type-error (ex-data exception)})))))
+
+(defn schedule
+  "Refine one scalar SegRed phase into a complete target-neutral ScheduledKernelBody.
+
+   The exact SegRed is the semantic source. `_n_bound` is target-private int storage bound to the
+   phase's exact logical extent; a wider public extent carries an explicit checked-range proof.
+   Each artifact writes exactly its launch group count, while only terminal phases may apply the
+   typed completed-result transform."
+  ([segred options]
+   (schedule segred nil options))
+  ([segred out-sym {:keys [scalar-types] :as options}]
+   (let [{:keys [kernel-body operator identity arrays scalars output bound group-count result-region]}
+        (lower segred out-sym
+               :dtype (:dtype options) :array-types (:array-types options)
+               :scalar-types scalar-types)
+        arguments (mapv (fn [parameter]
+                          (if (= '_n_bound (:id parameter)) bound (:id parameter)))
+                        (:parameters kernel-body))
+        bound-dtype (logical-bound-dtype bound scalar-types)
+        scalar-bindings
+        (mapv (fn [[parameter argument]]
+                (let [kernel-dtype (dtype/canon (:dtype parameter))
+                      logical-dtype (if (= '_n_bound (:id parameter))
+                                      bound-dtype kernel-dtype)]
+                  {:parameter (:id parameter) :value argument
+                   :dtype logical-dtype :kernel-dtype kernel-dtype
+                   :conversion (if (= logical-dtype kernel-dtype)
+                                 :identity :checked-range)}))
+              (filterv (fn [[parameter _]] (= :scalar (:kind parameter)))
+                       (map vector (:parameters kernel-body) arguments)))
+        phase (:phase segred)
+        output-elements (launch/rebind-expression group-count {'_n_bound bound})
+        c-op ({:+ "+" :* "*" :min "fmin" :max "fmax"} operator)
+        result-dtype (dtype/canon (or (:result-dtype result-region) (:dtype segred)))]
+    (scheduled-body/make
+     {:source segred
+      :body kernel-body
+      :arguments arguments
+      :scalar-bindings scalar-bindings
+      :effects {:kind :scalar-reduction-phase
+                :phase phase
+                :uses (scheduled-body/derive-uses kernel-body arguments)}
+      :legality {:kind :scalar-segred-workgroup-tree
+                 :product-components 1
+                 :segment-dimensions 0
+                 :phase phase
+                 :workgroup-size (get-in kernel-body [:schedule :workgroup-size])
+                 :power-of-two-workgroup true
+                 :terminal (contains? #{:single :cross-block} phase)
+                 :certified-monoid (get-in segred [:reduction :algebra])
+                 :identity identity
+                 :uniform-dtype (dtype/canon (:dtype segred))}
+      :numerics (cond-> {:mode :reassociated
+                         :policy :certified-workgroup-tree
+                         :rounding :implementation-defined
+                         :accumulator-dtype (dtype/canon (:dtype segred))}
+                  result-region
+                  (assoc :result-transform
+                         {:kind :typed-scalar-region
+                          :policy :same-typed-ssa-evaluation-order
+                          :input-dtype (dtype/canon (:dtype segred))
+                          :result-dtype result-dtype}))
+      :provenance {:dialect :kernel-body :source-dialect :segred
+                   :segop-id (:id segred) :phase phase}
+      :attributes {:array-params arrays
+                   :scalar-params scalars
+                   :dtype (dtype/canon (:dtype segred))
+                   :phase phase
+                   :group-count output-elements
+                   :output-elements output-elements
+                   :physical-result output
+                   ;; Compatibility staging still combines partials on the host and consumes these
+                   ;; values. They are projections of the proved monoid, not emitter inference.
+                   :identity-val identity
+                   :c-op c-op}}))))
+
+(defn validate-against-node!
+  "Close scalar SegRed output geometry over its complete KernelGraph context."
+  [scheduled node kernel-graph]
+  (let [scheduled (scheduled-body/validate-against-node! scheduled node kernel-graph)
+        output-use (first (filter #(contains? #{:write :read-write} (:access %))
+                                  (:uses node)))
+        output-buffer (some #(when (= (:buffer output-use) (:id %)) %)
+                            (concat (:inputs kernel-graph) (:outputs kernel-graph)
+                                    (:temporaries kernel-graph)))
+        output-parameter (some #(when (= :result (:role %)) %)
+                               (get-in scheduled [:body :parameters]))
+        bound-binding (some #(when (= '_n_bound (:parameter %)) %)
+                            (:scalar-bindings scheduled))
+        realized-shape (mapv #(launch/rebind-expression
+                               % {'_n_bound (:value bound-binding)})
+                             (:shape output-parameter))
+        output-elements (get-in scheduled [:attributes :output-elements])
+        group-count (get-in (scheduled-body/realized-launch scheduled) [:group-count 0])]
+    (when-not (and output-use output-buffer output-parameter bound-binding
+                   (= [output-elements] realized-shape)
+                   (= output-elements group-count)
+                   (= output-elements (:elements output-buffer)))
+      (decline! :output-elements
+                "scalar SegRed output extent differs from its launch or KernelGraph storage"
+                {:node (:id node) :output-use output-use :output-buffer output-buffer
+                 :output-parameter output-parameter :realized-shape realized-shape
+                 :output-elements output-elements :group-count group-count}))
+    scheduled))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -386,7 +386,7 @@
    accumulator dtype; this pass never invents a final narrowing conversion. A typed region owner
    may provide `declared-result-dtype` for the outer expression only; nested calls still require
    their own retained facts."
-  [expression {:keys [index coordinate dtype arrays scalars scalar-types coordinate-lower
+  [expression {:keys [index coordinate dtype arrays array-types scalars scalar-types coordinate-lower
                       load-predicate load-other declared-result-dtype]}]
   (let [dtype (dtype/canon dtype)
         operations (atom [])
@@ -440,14 +440,17 @@
                                 "KernelBody reduction cannot prove this array load coordinate"
                                 {:expression expression :array array :coordinate source-coordinate
                                  :index index :arrays arrays}))
-                    (let [result (fresh "element-load")]
+                    (let [result (fresh "element-load")
+                          load-dtype (dtype/canon (get array-types array dtype))
+                          other (or load-other (body/literal 0 load-dtype))]
                       (emit! (body/->ScalarLoad
-                              (body/value result dtype) array [lowered-coordinate]
+                              (body/value result load-dtype) array [lowered-coordinate]
                               load-predicate
                               (when load-predicate
-                                (or load-other (body/literal 0 dtype)))
+                                (if (= load-dtype (:type other)) other
+                                    (body/literal (:value other) load-dtype)))
                               :cached)
-                             result dtype)))
+                             result load-dtype)))
 
                   (and (seq? expression) (descriptor/cast-op? (first expression))
                        (= 2 (count expression)))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -147,9 +147,7 @@
                            (segop/->SegLevel :block :virtual)
                            (segop/->SegLevel :block :none))
           expected-shared-memory (* workgroup-size (dtype/bytes-of accumulator-dtype))
-          expected-stages [:lane-fold :workgroup-tree
-                           (if (contains? #{:single :cross-block} phase)
-                             :terminal-store :partial-store)]]
+          expected-schedule (scalar-workgroup-tree-schedule operator grid phase)]
       (when-not (= expected-level (:level segred))
         (decline! :phase-level
                   "scalar SegRed phase and execution level disagree"
@@ -160,21 +158,11 @@
                   "scalar SegRed grid shared memory differs from its workgroup tree"
                   {:operation (:id segred) :expected expected-shared-memory
                    :actual shared-memory-bytes}))
-      (when-not (= {:strategy :scalar-workgroup-tree
-                    :workgroup-size workgroup-size
-                    :stages expected-stages
-                    :phase phase
-                    :group-count num-blocks
-                    :shared-memory-bytes expected-shared-memory}
-                   {:strategy (:strategy schedule)
-                    :workgroup-size (:workgroup-size schedule)
-                    :stages (:stages schedule)
-                    :phase (get-in schedule [:attributes :phase])
-                    :group-count (get-in schedule [:attributes :group-count])
-                    :shared-memory-bytes (get-in schedule [:attributes :shared-memory-bytes])})
+      (when-not (= expected-schedule schedule)
         (decline! :schedule-grid
-                  "scalar SegRed schedule does not describe its emitted grid/workgroup tree"
-                  {:operation (:id segred) :phase phase :grid grid :schedule schedule})))
+                  "scalar SegRed schedule is not the exact canonical workgroup-tree schedule"
+                  {:operation (:id segred) :phase phase :grid grid
+                   :expected expected-schedule :schedule schedule})))
     (when (and (contains? #{:single :cross-block} phase) (not= 1 num-blocks))
       (decline! :terminal-phase-groups
                 "terminal scalar SegRed phases must launch exactly one workgroup"
@@ -183,6 +171,11 @@
       (decline! :nonterminal-result-transform
                 "a completed reduction transform may run only in a terminal SegRed phase"
                 {:operation (:id segred) :phase phase :result-region result-region}))
+    (when-not (= phase (get-in operator [:attributes :physical-phase]))
+      (decline! :physical-phase
+                "scalar SegRed reduction must state the exact physical phase it inhabits"
+                {:operation (:id segred) :phase phase
+                 :reduction-physical-phase (get-in operator [:attributes :physical-phase])}))
     {:operator operator :component component :dtype accumulator-dtype
      :workgroup-size workgroup-size :phase phase :output output
      :result-region result-region :schedule schedule}))
@@ -274,39 +267,55 @@
     {:operator operator :identity (literal-value init) :element (:element derived)
      :accumulator acc}))
 
+(defn capped-group-count
+  "Construct the canonical non-empty occupancy-capped scalar-reduction grid."
+  [cap bound workgroup-size]
+  (when-not (and (integer? cap) (pos? cap))
+    (decline! :launch-grid "scalar reduction occupancy cap must be positive"
+              {:cap cap :bound bound :workgroup-size workgroup-size}))
+  (launch/maximum 1 (launch/minimum cap (launch/ceil-div bound workgroup-size))))
+
 (defn launch-group-count
-  "Translate SegRed's historical capped-grid expression into inspectable launch IR.
+  "Translate SegRed's exact occupancy cap into a non-empty inspectable launch expression.
 
    `compute-launch-params` predates KernelLaunch and represents the reduction grid as
    `(min occupancy-cap (int (Math/ceil (/ (double bound) block-size))))`.  Do not carry that
    executable host form into KernelBody: recognize the exact producer contract and rebuild it
-   from the authoritative SegSpace bound and workgroup size."
+   from the authoritative SegSpace bound and workgroup size. The outer maximum gives an empty
+   reduction one workgroup, whose inactive lanes reduce to the certified identity."
   [grid-expression bound workgroup-size]
-  (cond
-    (and (integer? grid-expression) (pos? grid-expression))
-    grid-expression
-
-    (symbol? grid-expression)
-    (launch/runtime-value grid-expression)
-
-    (and (seq? grid-expression)
-         (contains? '#{min clojure.core/min} (first grid-expression))
-         (= 3 (count grid-expression))
-         (integer? (second grid-expression))
-         (pos? (second grid-expression)))
-    (launch/minimum (second grid-expression)
-                    (launch/ceil-div bound workgroup-size))
-
-    ;; A compatibility or prior scheduling pass may already have constructed canonical launch IR.
-    ;; Preserve that inspectable expression instead of accepting only its historical source form.
-    (and (not (integer? grid-expression)) (launch/expression? grid-expression))
-    grid-expression
-
-    :else
-    (decline! :launch-grid
-              "KernelBody scalar reduction requires an explicit or canonical capped SegRed grid"
-              {:grid-expression grid-expression :bound bound
-               :workgroup-size workgroup-size})))
+  (let [historical-groups
+        (list 'int
+              (list 'Math/ceil
+                    (list '/ (list 'double bound) (double workgroup-size))))
+        historical-cap
+        (when (and (seq? grid-expression)
+                   (contains? '#{min clojure.core/min} (first grid-expression))
+                   (= 3 (count grid-expression))
+                   (integer? (second grid-expression))
+                   (pos? (second grid-expression))
+                   (= historical-groups (nth grid-expression 2)))
+          (second grid-expression))
+        ;; KernelLaunch records are maps. Recognize only the exact canonical shape rather than
+        ;; accepting an arbitrary expression that happens to agree with a forged body.
+        canonical-cap
+        (when (= "raster.compiler.ir.kernel_launch.Maximum"
+                 (some-> grid-expression class .getName))
+          (let [[one capped] (:values grid-expression)]
+            (when (and (= 1 one)
+                       (= "raster.compiler.ir.kernel_launch.Minimum"
+                          (some-> capped class .getName)))
+              (let [[cap groups] (:values capped)]
+                  (when (and (integer? cap) (pos? cap)
+                           (= groups (launch/ceil-div bound workgroup-size)))
+                  cap)))))
+        cap (or historical-cap canonical-cap)]
+    (if cap
+      (capped-group-count cap bound workgroup-size)
+      (decline! :launch-grid
+                "KernelBody scalar reduction requires its canonical occupancy-capped group count"
+                {:grid-expression grid-expression :bound bound
+                 :workgroup-size workgroup-size}))))
 
 (defn- strip-index-cast
   [expression]
@@ -315,6 +324,24 @@
            (= 2 (count expression)))
     (second expression)
     expression))
+
+(defn- widen-index-expression
+  "Make array-coordinate arithmetic uniformly 64-bit without changing public scalar ABI types."
+  [expression value-types]
+  (cond
+    (integer? expression) (body/index-cast expression :long :exact)
+    (symbol? expression)
+    (if (= :long (dtype/canon (get value-types expression :int)))
+      expression
+      (body/index-cast expression :long :exact))
+    (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
+    (apply body/expression (:op expression)
+           (map #(widen-index-expression % value-types) (:arguments expression)))
+    (instance? raster.compiler.ir.kernel_body.IndexCast expression)
+    (if (= :long (dtype/canon (:dtype expression)))
+      expression
+      (body/index-cast expression :long :exact))
+    :else expression))
 
 (defn- cast-policy
   [source target]
@@ -511,6 +538,10 @@
                       {:segred-id (:id segred) :dtype dtype :bound bound
                        :workgroup-size workgroup-size :arrays arrays :scalars scalars}))
         {:keys [operator identity element]} (scalar-plan segred)
+        _ (when (contains? #{:min :max} operator)
+            (decline! :floating-minmax-semantics
+                      "portable scalar reduction needs an explicit NaN and signed-zero policy for min/max"
+                      {:segred-id (:id segred) :operator operator}))
         identity (literal-value identity)
         _ (when-not (number? identity)
             (decline! :literal-identity
@@ -532,13 +563,18 @@
           :scalar-types (into {} (map (fn [id] [id (scalar-dtype id)])) scalars)
           :coordinate-lower
           (fn [source-coordinate]
-            (index-expression/lower
-             (util/subst-syms {index element-index} source-coordinate)
-             (conj (set scalars) element-index)
-             decline!))})
-        group-count (if-let [grid-expression (get-in segred [:grid :num-blocks])]
-                      (launch-group-count grid-expression bound-dimension workgroup-size)
-                      (launch/ceil-div bound-dimension workgroup-size))
+            (widen-index-expression
+             (index-expression/lower
+              (util/subst-syms {index element-index} source-coordinate)
+              (conj (set scalars) element-index)
+              decline!)
+             (assoc scalar-types element-index :long)))})
+        group-count (if (= :block-local (:phase segred))
+                      (launch/rebind-expression
+                       (launch-group-count (get-in segred [:grid :num-blocks])
+                                           bound workgroup-size)
+                       {bound bound-dimension})
+                      1)
         scratch 'workgroup-reduction-scratch
         barrier (fn [] (body/->WorkgroupBarrier
                         :workgroup #{:workgroup} :acquire-release (body/full-participation)))
@@ -614,12 +650,9 @@
                      'wide-local-index (body/index-cast 'local-index :long :exact))
                     (body/->IndexCompute
                      'group-chunk
-                     ;; For a positive extent, 1 + (n-1)/groups is overflow-free.
-                     (body/expression
-                      :add 1
-                      (body/expression :floor-div
-                                       (body/expression :sub 'wide-bound 1)
-                                       'wide-group-count)))
+                     ;; Ceil-div is defined for zero, so an empty reduction reaches the tree with
+                     ;; one inactive, identity-valued workgroup and never forms `n - 1`.
+                     (body/expression :ceil-div 'wide-bound 'wide-group-count))
                     (body/->IndexCompute
                      'group-start (body/expression :mul 'wide-group-index 'group-chunk))
                     (body/->IndexCompute
@@ -683,14 +716,10 @@
 
 (defn- logical-bound-dtype
   [bound scalar-types]
-  (let [references (launch/expression-references bound)
-        scalar-dtype (fn [id]
+  (let [scalar-dtype (fn [id]
                        (or (get scalar-types id)
                            (get scalar-types (when (or (symbol? id) (keyword? id))
-                                               (symbol (name id))))
-                           ;; Compatibility reductions predate GraphScalar. Their only omitted
-                           ;; shape representation was the historical physical int bound.
-                           (when (= references #{id}) :int)))]
+                                               (symbol (name id))))))]
     (try
       (launch/typed-expression-dtype bound scalar-dtype)
       (catch clojure.lang.ExceptionInfo exception
@@ -730,8 +759,12 @@
                        (map vector (:parameters kernel-body) arguments)))
         phase (:phase segred)
         output-elements (launch/rebind-expression group-count {'_n_bound bound})
-        c-op ({:+ "+" :* "*" :min "fmin" :max "fmax"} operator)
+        c-op ({:+ "+" :* "*"} operator)
         result-dtype (dtype/canon (or (:result-dtype result-region) (:dtype segred)))]
+    (when-not c-op
+      (decline! :certified-monoid
+                "portable scalar reduction has no emitted combine spelling"
+                {:operation (:id segred) :operator operator}))
     (scheduled-body/make
      {:source segred
       :body kernel-body
@@ -776,10 +809,14 @@
                    :c-op c-op}}))))
 
 (defn validate-against-node!
-  "Close scalar SegRed output geometry over its complete KernelGraph context."
+  "Close scalar SegRed over its exact source, body, launch, and KernelGraph storage facts."
   [scheduled node kernel-graph]
   (let [scheduled (scheduled-body/validate-against-node! scheduled node kernel-graph)
         source (:source scheduled)
+        _ (when-not (instance? raster.compiler.ir.segop.SegRed source)
+            (decline! :schedule-source
+                      "scalar reduction storage closure requires an exact SegRed source"
+                      {:source source :node (:id node)}))
         semantic-output (first (:outputs source))
         physical-result (get-in scheduled [:attributes :physical-result])
         output-use (some #(when (and (= semantic-output (:buffer %))
@@ -791,6 +828,13 @@
                                     (:temporaries kernel-graph)))
         output-parameter (some #(when (= :result (:role %)) %)
                                (get-in scheduled [:body :parameters]))
+        parameters (get-in scheduled [:body :parameters])
+        arguments (:arguments scheduled)
+        bindings (into {} (map (fn [[parameter argument]] [(:id parameter) argument]))
+                       (map vector parameters arguments))
+        buffers (into {} (map (juxt :id identity))
+                      (distinct (concat (:inputs kernel-graph) (:outputs kernel-graph)
+                                        (:temporaries kernel-graph))))
         bound-binding (some #(when (= '_n_bound (:parameter %)) %)
                             (:scalar-bindings scheduled))
         realized-shape (mapv #(launch/rebind-expression
@@ -801,6 +845,30 @@
         group-count (get-in realized-launch [:group-count 0])
         workgroup-size (get-in source [:grid :block-size])
         shared-memory-bytes (get-in source [:grid :shared-mem-bytes])]
+    (doseq [[parameter argument] (map vector parameters arguments)
+            :when (not= :scalar (:kind parameter))]
+      (let [buffer (get buffers argument)
+            realized-shape (mapv #(launch/rebind-expression % bindings)
+                                 (:shape parameter))
+            realized-elements (case (count realized-shape)
+                                0 1
+                                1 (first realized-shape)
+                                (apply launch/product realized-shape))
+            source-elements (if (= :result (:role parameter))
+                              output-elements
+                              (:bound (segop/seg-space-reduced-dim (:space source))))]
+        (when-not (= (dtype/canon (:dtype parameter)) (some-> buffer :dtype dtype/canon))
+          (decline! :storage-dtype
+                    "scalar SegRed pointer dtype differs from its KernelGraph buffer"
+                    {:node (:id node) :parameter (:id parameter) :argument argument
+                     :parameter-dtype (:dtype parameter) :buffer buffer}))
+        (when-not (and buffer
+                       (= source-elements realized-elements (:elements buffer)))
+          (decline! :storage-extent
+                    "scalar SegRed pointer extent differs across source, body, and graph"
+                    {:node (:id node) :parameter (:id parameter) :argument argument
+                     :source-elements source-elements :body-elements realized-elements
+                     :buffer buffer}))))
     (when-not (and (= 1 (count (:outputs source)))
                    (= semantic-output physical-result (:id output-parameter))
                    output-use output-buffer output-parameter bound-binding
@@ -824,4 +892,15 @@
                  :effects (:effects scheduled) :legality (:legality scheduled)
                  :attributes (:attributes scheduled) :launch realized-launch
                  :grid (:grid source)}))
+    (let [array-types (into {} (map (juxt :id :dtype)) (vals buffers))
+          scalar-types (into {} (map (juxt :id :dtype)) (:scalars kernel-graph))
+          expected (schedule source semantic-output
+                             {:dtype (:dtype source)
+                              :array-types array-types
+                              :scalar-types scalar-types})]
+      (when-not (= expected scheduled)
+        (decline! :schedule-source
+                  "scalar SegRed scheduled body is not the exact refinement of its source"
+                  {:node (:id node) :source (:id source)
+                   :expected-body (:body expected) :actual-body (:body scheduled)})))
     scheduled))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -549,8 +549,11 @@
                            (zero? (:n-free coordinate-proof))
                            (= [index bound] [proof-index proof-bound])
                            (= (set arrays) operand-ids)
+                           ;; Facts retain every load occurrence. Validate each occurrence rather
+                           ;; than looking up by symbol, which would select only the first read of
+                           ;; an array and could hide a later unproved coordinate.
                            (every? #(contraction-facts/operand-axis-map coordinate-proof %)
-                                   arrays)
+                                   (:operands coordinate-proof))
                            (= element (:element view))
                            (= (literal-value identity) (literal-value (:neutral view)))
                            (= operator (intrinsics/canonical (:combine view)))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -929,7 +929,8 @@
                        grid-1 :product product-schedule dtype)]
       (case (:strategy execution)
         :single
-        (let [grid (single-block-grid grid-1)]
+        (let [grid (single-block-grid grid-1)
+              reduction (assoc-in reduction [:attributes :physical-phase] :single)]
           [(segop/->SegRed (:id description)
                            space
                            (segop/->SegLevel :block :none)
@@ -947,7 +948,9 @@
         :two-phase
         (let [level-1 (segop/->SegLevel :block :virtual)
               partials-sym (gensym "partials_")
-              phase-1-reduction (update reduction :attributes dissoc :result-region)
+              phase-1-reduction (-> reduction
+                                    (update :attributes dissoc :result-region)
+                                    (assoc-in [:attributes :physical-phase] :block-local))
               result-region (get-in reduction [:attributes :result-region])
               fold-symbols (reduce set/union #{}
                                    (map util/free-syms

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -929,17 +929,20 @@
                        grid-1 :product product-schedule dtype)]
       (case (:strategy execution)
         :single
-        [(segop/->SegRed (:id description)
-                         space
-                         (segop/->SegLevel :block :none)
-                         reduction
-                         map-lambda
-                         (:inputs description)
-                         (:outputs description)
-                         (:scalars description)
-                         (single-block-grid grid-1)
-                         :single nil
-                         dtype)]
+        (let [grid (single-block-grid grid-1)]
+          [(segop/->SegRed (:id description)
+                           space
+                           (segop/->SegLevel :block :none)
+                           reduction
+                           map-lambda
+                           (:inputs description)
+                           (:outputs description)
+                           (:scalars description)
+                           grid
+                           :single
+                           (segred-body/scalar-workgroup-tree-schedule
+                            reduction grid :single)
+                           dtype)])
 
         :two-phase
         (let [level-1 (segop/->SegLevel :block :virtual)
@@ -953,13 +956,16 @@
               fold-scalars (if result-region
                              (set/intersection (set (:scalars description)) fold-symbols)
                              (:scalars description))
-              phase-1 (segop/->SegRed (:id description) space level-1
-                                      phase-1-reduction map-lambda
-                                      (:inputs description)
-                                      #{partials-sym}
-                                      fold-scalars
-                                      grid-1 :block-local nil
-                                      dtype)
+              phase-1 (segop/->SegRed
+                       (:id description) space level-1
+                       phase-1-reduction map-lambda
+                       (:inputs description)
+                       #{partials-sym}
+                       fold-scalars
+                       grid-1 :block-local
+                       (segred-body/scalar-workgroup-tree-schedule
+                        phase-1-reduction grid-1 :block-local)
+                       dtype)
               phase-2-idx (gensym "j_")
               phase-2-bound (segred-body/launch-group-count
                              (:num-blocks grid-1) bound (:block-size grid-1))
@@ -985,12 +991,15 @@
                 :algebra (:algebra reduction)
                 :attributes (assoc (:attributes reduction)
                                    :physical-phase :cross-block)})
-              phase-2 (segop/->SegRed [:reduction-phase (:id description) :cross-block]
-                                      phase-2-space level-2
-                                      phase-2-reduction nil
-                                      #{partials-sym} #{(:sym description)}
-                                      result-scalars grid-2 :cross-block nil
-                                      dtype)]
+              phase-2 (segop/->SegRed
+                       [:reduction-phase (:id description) :cross-block]
+                       phase-2-space level-2
+                       phase-2-reduction nil
+                       #{partials-sym} #{(:sym description)}
+                       result-scalars grid-2 :cross-block
+                       (segred-body/scalar-workgroup-tree-schedule
+                        phase-2-reduction grid-2 :cross-block)
+                       dtype)]
           [phase-1 phase-2])))))
 
 ;; ================================================================

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1884,11 +1884,10 @@
                     (keep (fn [{:keys [id]}]
                             (when (= :constant (get roles id)) id)))
                     (:inputs selected)))
-            ;; A resident SegRed is deliberately a single-workgroup schedule. KernelGraphs own
-            ;; their complete launch geometry and therefore cannot accept this artifact override.
-            group-count (when (and (= :reduce convention)
-                                   (= :kernel-artifact (kexec/kind selected)))
-                          [1])]
+            ;; Launch geometry belongs to the selected executable. A resident scalar reduction
+            ;; that needs one group must arrive as an explicit :single SegRed refinement; the
+            ;; binder cannot reinterpret an occupancy-capped partial-reduction artifact.
+            group-count nil]
         (bind-selected-executable
          device-id selected ordered-args phase constant-buffer-ids group-count))
 

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1655,6 +1655,33 @@
               (vswap! groups conj {:key key :value value :dtype actual-dtype
                                    :elements elements :resident? resident?
                                    :indexes [index] :read? read? :write? write?}))))))
+    (when (= :kernel-graph (kexec/kind executable))
+      (let [{:keys [buffers scalar-values]} (kexec/graph-bindings executable typed-arguments)
+            capacity-of (fn [value]
+                          (if (dtype/dtype-for-jvm-array value)
+                            (java.lang.reflect.Array/getLength value)
+                            (:n-elements value)))
+            ;; `(extent id)` is an intentionally opaque, resolver-owned graph leaf. Supply the
+            ;; concrete capacity fact here rather than destructuring it into fictitious scalars.
+            extent-values (into {}
+                                (map (fn [[id value]] [(list 'extent id) (capacity-of value)]))
+                                buffers)
+            resolver-values (merge scalar-values extent-values)]
+        (doseq [{:keys [id elements] :as graph-buffer}
+                (concat (:inputs executable) (:outputs executable))
+                :when (some? elements)
+                :let [value (get buffers id)
+                      actual-elements (capacity-of value)
+                      expected-elements (kgcall/resolve-integer resolver-values elements)]]
+          (when (neg? expected-elements)
+            (throw (ex-info "staged graph buffer extent must be non-negative"
+                            {:reason :staged-graph-buffer-extent
+                             :buffer id :elements elements :resolved expected-elements})))
+          (when (> expected-elements actual-elements)
+            (throw (ex-info "staged graph buffer extent exceeds its supplied capacity"
+                            {:reason :staged-graph-buffer-capacity
+                             :buffer id :elements elements :resolved expected-elements
+                             :capacity actual-elements :graph-buffer graph-buffer}))))))
     (let [groups @groups
           key-by-index (reduce (fn [result {:keys [key indexes]}]
                                  (reduce #(assoc %1 %2 key) result indexes))

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -551,6 +551,15 @@
 (defn device-buffer? [x]
   (instance? OclBuffer x))
 
+(defn- known-buffer-capacity
+  "Return a device allocation's element capacity when Raster owns that fact.
+
+   A raw MemorySegment accepted by the low-level compatibility API is an opaque cl_mem handle. Its
+   Java segment size describes only the handle representation, never the allocation behind it."
+  [value]
+  (when (device-buffer? value)
+    (:n-elements ^OclBuffer value)))
+
 (defn- physical-pointer-dtypes [arrays]
   (mapv #(cond
            (device-buffer? %) (:dtype ^OclBuffer %)
@@ -1394,11 +1403,10 @@
                              (long (first group-count)) 1)]
               (doseq [[slot value] pointer-pairs
                       :when (= :result (:role slot))]
-                (let [capacity (cond
-                                 (device-buffer? value) (:n-elements ^OclBuffer value)
-                                 (instance? MemorySegment value)
-                                 (quot (.byteSize ^MemorySegment value)
-                                       (dt/bytes-of (:dtype slot))))]
+                ;; A raw MemorySegment here is an opaque cl_mem handle, not the allocation it
+                ;; names. Its byteSize is the handle representation size and says nothing about
+                ;; device capacity. Only OclBuffer carries a checked element count.
+                (let [capacity (known-buffer-capacity value)]
                   (when (and capacity (< (long capacity) required))
                     (throw (ex-info "resident reduction result buffer is smaller than its scheduled group count"
                                     {:kernel-name kernel-name :slot slot
@@ -1412,11 +1420,8 @@
                 (throw (ex-info "resident contraction output extent must be non-negative"
                                 {:kernel-name kernel-name :out-elems out-elems})))
               (doseq [[slot value] pointer-pairs :when (= :result (:role slot))]
-                (let [capacity (cond
-                                 (device-buffer? value) (:n-elements ^OclBuffer value)
-                                 (instance? MemorySegment value)
-                                 (quot (.byteSize ^MemorySegment value) (dt/bytes-of (:dtype slot))))]
-                  (when (< (long capacity) out-elems)
+                (let [capacity (known-buffer-capacity value)]
+                  (when (and capacity (< (long capacity) out-elems))
                     (throw (ex-info "contraction output buffer is smaller than its artifact extent"
                                     {:kernel-name kernel-name :slot slot :out-elems out-elems
                                      :buffer-elements capacity})))))))

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1388,12 +1388,21 @@
                               {:kernel-name kernel-name :slot slot :value-type (type value)}))))
         _ (kabi/validate-physical-pointer-dtypes!
            abi (physical-pointer-dtypes pointer-values))
-        _ (when (= :pure-reduction (get-in registered [:effects :kind]))
-            (doseq [[slot value] pointer-pairs
-                    :when (= :result (:role slot))]
-              (when (and (device-buffer? value) (< (:n-elements ^OclBuffer value) 1))
-                (throw (ex-info "resident reduction result buffer must hold at least one element"
-                                {:kernel-name kernel-name :slot slot :buffer-elements 0})))))
+        reduction-kind (get-in registered [:effects :kind])
+        _ (when (contains? #{:pure-reduction :scalar-reduction-phase} reduction-kind)
+            (let [required (if (= :scalar-reduction-phase reduction-kind)
+                             (long (first group-count)) 1)]
+              (doseq [[slot value] pointer-pairs
+                      :when (= :result (:role slot))]
+                (let [capacity (cond
+                                 (device-buffer? value) (:n-elements ^OclBuffer value)
+                                 (instance? MemorySegment value)
+                                 (quot (.byteSize ^MemorySegment value)
+                                       (dt/bytes-of (:dtype slot))))]
+                  (when (and capacity (< (long capacity) required))
+                    (throw (ex-info "resident reduction result buffer is smaller than its scheduled group count"
+                                    {:kernel-name kernel-name :slot slot
+                                     :required-elements required :buffer-elements capacity})))))))
         _ (when (= :tensor-contraction (get-in registered [:effects :kind]))
             (let [extent-expr (kart/attribute registered :out-elems)
                   out-elems (long (if (number? extent-expr)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2286,12 +2286,21 @@
                               {:kernel-name kernel-name :slot slot :value-type (type value)}))))
         _ (kabi/validate-physical-pointer-dtypes!
            abi (physical-pointer-dtypes pointer-values))
-        _ (when (= :pure-reduction (get-in registered [:effects :kind]))
-            (doseq [[slot value] pointer-pairs
-                    :when (= :result (:role slot))]
-              (when (and (device-buffer? value) (< (:n-elements ^DeviceBuffer value) 1))
-                (throw (ex-info "resident reduction result buffer must hold at least one element"
-                                {:kernel-name kernel-name :slot slot :buffer-elements 0})))))
+        reduction-kind (get-in registered [:effects :kind])
+        _ (when (contains? #{:pure-reduction :scalar-reduction-phase} reduction-kind)
+            (let [required (if (= :scalar-reduction-phase reduction-kind)
+                             (long (first group-count)) 1)]
+              (doseq [[slot value] pointer-pairs
+                      :when (= :result (:role slot))]
+                (let [capacity (cond
+                                 (device-buffer? value) (:n-elements ^DeviceBuffer value)
+                                 (instance? MemorySegment value)
+                                 (quot (.byteSize ^MemorySegment value)
+                                       (dt/bytes-of (:dtype slot))))]
+                  (when (and capacity (< (long capacity) required))
+                    (throw (ex-info "resident reduction result buffer is smaller than its scheduled group count"
+                                    {:kernel-name kernel-name :slot slot
+                                     :required-elements required :buffer-elements capacity})))))))
         _ (when (= :tensor-contraction (get-in registered [:effects :kind]))
             (let [extent-expr (kart/attribute registered :out-elems)
                   out-elems (long (if (number? extent-expr)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1971,6 +1971,40 @@
     (or (some (fn [[slot value]] (when (= :result (:role slot)) value)) pairs)
         output-array)))
 
+(defn- fmax-number
+  [a b]
+  (cond
+    (Double/isNaN (double a)) b
+    (Double/isNaN (double b)) a
+    :else (Math/max (double a) (double b))))
+
+(defn- fmin-number
+  [a b]
+  (cond
+    (Double/isNaN (double a)) b
+    (Double/isNaN (double b)) a
+    :else (Math/min (double a) (double b))))
+
+(defn- combine-scalar-partials
+  "Compatibility terminal combine with the storage dtype's operation-by-operation rounding.
+
+   OpenCL fmin/fmax ignore one NaN operand; Java Math/min/max propagate it, so use the C-family
+   numerical contract explicitly rather than treating their spellings as Java operators."
+  [result-dtype c-op identity-val partials]
+  (let [coerce (if (= :float (dt/canon result-dtype))
+                 (fn [value] (float value))
+                 (fn [value] (double value)))
+        combine (case c-op
+                  "fmax" fmax-number
+                  "fmin" fmin-number
+                  "*" *
+                  "+" +
+                  (throw (ex-info "staged reduction has an unknown certified combine operator"
+                                  {:operator c-op :dtype result-dtype})))]
+    (reduce (fn [acc partial]
+              (coerce (combine (coerce acc) (coerce partial))))
+            (coerce identity-val) partials)))
+
 (defn invoke-registered-reduction-kernel
   "Run a SegRed host-scalar reduction from one complete ordered ABI value vector. The single
    :result value must be nil: staging owns and inserts the workgroup-partial buffer at exactly
@@ -2017,24 +2051,23 @@
             (throw (ex-info "reduction ABI bound binding has the wrong kernel dtype"
                             {:kernel-name kernel-name :slot bound-slot
                              :expected (:kernel-dtype bound-slot) :actual (:type bound-value)})))
-        n (long (if (map? bound-value) (:value bound-value) bound-value))
+        _ (kexec/physical-runtime-scalar bound-slot bound-value)
         result-dtype (:dtype (first result-pair))
         _ (when-not (#{:float :double} result-dtype)
             (throw (ex-info "host partial combine currently supports only float/double SegRed results"
                             {:kernel-name kernel-name :dtype result-dtype})))
-        ;; Native driver/loading begins only after every ABI/value check above.
+        geometry (kcall/realize-launch registered arguments)
+        _ (when-not (= 1 (count (:workgroup-size geometry)))
+            (throw (ex-info "staging scalar reduction requires a one-dimensional artifact launch"
+                            {:kernel-name kernel-name :geometry geometry})))
+        wg (long (first (:workgroup-size geometry)))
+        group-count (long (first (:group-count geometry)))
+        ;; Native driver/loading begins only after every ABI/value/launch check above.
         loaded (ensure-kernel-loaded! kernel-name)
         kernel-handle (:kernel-handle loaded)
-        workgroup-size (registered-1d-workgroup-size loaded)
         identity-val (or (get-in loaded [:attributes :identity-val])
                          (:identity-val loaded) 0.0)
         c-op (or (get-in loaded [:attributes :c-op]) (:c-op loaded) "+")
-        combine (case c-op "fmax" (fn ^double [^double a ^double b] (Math/max a b))
-                      "fmin" (fn ^double [^double a ^double b] (Math/min a b))
-                      "*"    (fn ^double [^double a ^double b] (* a b))
-                      (fn ^double [^double a ^double b] (+ a b)))
-        wg (long (or workgroup-size 256))
-        group-count (max 1 (long (Math/ceil (/ (double n) wg))))
         dtype-size (long (get dtype-byte-sizes result-dtype))
         value-layout (if (= result-dtype :float) ValueLayout/JAVA_FLOAT ValueLayout/JAVA_DOUBLE)
         staged-inputs
@@ -2064,12 +2097,12 @@
     (launch! kernel-handle group-count wg all-args)
     (if (= group-count 1)
       (double (.get dev-partial value-layout 0))
-      (loop [i 0 acc (double identity-val)]
-        (if (< i group-count)
-          (recur (inc i)
-                 (double (combine acc (double (.get dev-partial value-layout
-                                                    (* i dtype-size))))))
-          acc)))))
+      (double
+       (combine-scalar-partials
+        result-dtype c-op identity-val
+        (map (fn [i]
+               (.get dev-partial value-layout (* (long i) dtype-size)))
+             (range group-count)))))))
 
 ;; ================================================================
 ;; Void-map kernel invocation (side-effect-only kernels)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1971,32 +1971,13 @@
     (or (some (fn [[slot value]] (when (= :result (:role slot)) value)) pairs)
         output-array)))
 
-(defn- fmax-number
-  [a b]
-  (cond
-    (Double/isNaN (double a)) b
-    (Double/isNaN (double b)) a
-    :else (Math/max (double a) (double b))))
-
-(defn- fmin-number
-  [a b]
-  (cond
-    (Double/isNaN (double a)) b
-    (Double/isNaN (double b)) a
-    :else (Math/min (double a) (double b))))
-
 (defn- combine-scalar-partials
-  "Compatibility terminal combine with the storage dtype's operation-by-operation rounding.
-
-   OpenCL fmin/fmax ignore one NaN operand; Java Math/min/max propagate it, so use the C-family
-   numerical contract explicitly rather than treating their spellings as Java operators."
+  "Compatibility terminal combine with the storage dtype's operation-by-operation rounding."
   [result-dtype c-op identity-val partials]
   (let [coerce (if (= :float (dt/canon result-dtype))
                  (fn [value] (float value))
                  (fn [value] (double value)))
         combine (case c-op
-                  "fmax" fmax-number
-                  "fmin" fmin-number
                   "*" *
                   "+" +
                   (throw (ex-info "staged reduction has an unknown certified combine operator"
@@ -2051,11 +2032,30 @@
             (throw (ex-info "reduction ABI bound binding has the wrong kernel dtype"
                             {:kernel-name kernel-name :slot bound-slot
                              :expected (:kernel-dtype bound-slot) :actual (:type bound-value)})))
-        _ (kexec/physical-runtime-scalar bound-slot bound-value)
+        physical-bound (kexec/physical-runtime-scalar bound-slot bound-value)
+        n (long (:value physical-bound))
+        _ (doseq [[slot value] non-result-pointers
+                  :let [capacity (if (device-buffer? value)
+                                   (:n-elements ^DeviceBuffer value)
+                                   (java.lang.reflect.Array/getLength value))]]
+            (when (< (long capacity) n)
+              (throw (ex-info "reduction input is shorter than its certified bound"
+                               {:reason :reduction-input-capacity
+                                :kernel-name kernel-name :slot slot
+                               :required-elements n :buffer-elements capacity}))))
         result-dtype (:dtype (first result-pair))
         _ (when-not (#{:float :double} result-dtype)
             (throw (ex-info "host partial combine currently supports only float/double SegRed results"
                             {:kernel-name kernel-name :dtype result-dtype})))
+        attributes (:attributes registered)
+        _ (when-not (contains? attributes :identity-val)
+            (throw (ex-info "staged reduction artifact lacks its certified identity"
+                            {:kernel-name kernel-name :reason :reduction-identity-missing})))
+        _ (when-not (contains? attributes :c-op)
+            (throw (ex-info "staged reduction artifact lacks its certified combine operator"
+                            {:kernel-name kernel-name :reason :reduction-combine-missing})))
+        identity-val (:identity-val attributes)
+        c-op (:c-op attributes)
         geometry (kcall/realize-launch registered arguments)
         _ (when-not (= 1 (count (:workgroup-size geometry)))
             (throw (ex-info "staging scalar reduction requires a one-dimensional artifact launch"
@@ -2065,9 +2065,6 @@
         ;; Native driver/loading begins only after every ABI/value/launch check above.
         loaded (ensure-kernel-loaded! kernel-name)
         kernel-handle (:kernel-handle loaded)
-        identity-val (or (get-in loaded [:attributes :identity-val])
-                         (:identity-val loaded) 0.0)
-        c-op (or (get-in loaded [:attributes :c-op]) (:c-op loaded) "+")
         dtype-size (long (get dtype-byte-sizes result-dtype))
         value-layout (if (= result-dtype :float) ValueLayout/JAVA_FLOAT ValueLayout/JAVA_DOUBLE)
         staged-inputs

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -16,6 +16,7 @@
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.pipeline :as pipeline]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.runtime.hardware :as hw]))
@@ -276,9 +277,9 @@
        (invoke! (:kernel-name kernel) [out q] [{:type :int :value 7}] n)
        (is (every? true? (map-indexed (fn [i v] (= v (+ 7 (aget q i)))) out)))))))
 
-(deftest gpu-segred-staging-captured-scalar-test
+(deftest gpu-segred-graph-captured-scalar-test
   (when-ze
-   (testing "ordered SegRed staging inserts its partial output and binds captured scalars"
+   (testing "the generated two-phase SegRed graph owns its partial and binds captured scalars"
      (require 'raster.gpu.ze-runtime)
      ((resolve 'raster.gpu.ze-runtime/init!))
      (let [n 1024
@@ -291,12 +292,17 @@
            compiled (opencl-pass/opencl-pass
                      form :device-id :ze:0 :dtype :float
                      :scalar-types {'scale :float 'n :int})
-           kernel (first (:kernels compiled))
-           invoke (resolve 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel)
-           register! (resolve 'raster.gpu.ze-runtime/register-kernel!)
-           _ (register! (:kernel-name kernel) kernel)
-           actual (invoke (:kernel-name kernel) [input nil scale n])
+           dispatch (first (:dispatches compiled))
+           output (float-array 1)
+           register! (resolve 'raster.gpu.ze-runtime/register-kernel-dispatch!)
+           _ (register! dispatch)
+           _ (pipeline/invoke-scheduled-executable!
+              :ze:0 (:id dispatch) [input output scale n])
+           actual (aget output 0)
            expected (reduce + 0.0 (map #(* scale (double %)) (seq input)))]
+       (is (= 2 (count (:kernels compiled))))
+       (is (= [:block-local :cross-block]
+              (mapv #(get-in % [:attributes :phase]) (:kernels compiled))))
        (is (< (Math/abs (- (double actual) expected)) 1e-3)
            (str "captured-scalar SegRed expected " expected ", got " actual))))))
 

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -103,7 +103,7 @@
         node (soac/par-form->soac 'result form 901 :dtype :float)
         operation (first (soac-lower/lower-reduce node nil :dtype :float))]
     (segop-emit/generate-segred-kernel-body
-     operation nil :dtype :float :scalar-types {'scale :double}
+     operation nil :dtype :float :scalar-types {'scale :double 'n :long}
      :target-dialect dialect :kernel-name-prefix "workgroup_reduce")))
 
 (defn- contraction-artifact

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -129,6 +129,21 @@
      (:body planned) :target-dialect dialect
      :kernel-name-prefix "portable_contraction")))
 
+(defn- mixed-contraction-artifact
+  [dialect descriptor]
+  (let [form '(raster.par/contract y [[i m]] [[l k]] (* scale (aget x l)))
+        verified (contraction-facts/contraction-facts form :dtype :double)
+        segred (update (contract-lower/contract-form->segred
+                        form :dtype :double :facts verified) :scalars conj 'scale)
+        planned (contraction-schedule/plan-portable-body
+                 verified segred descriptor
+                 {:array-types {'x :float}
+                  :scalar-types {'m :long 'k :int 'scale :float}})]
+    (when-not (:ok planned)
+      (throw (ex-info "mixed contraction compile fixture did not schedule" planned)))
+    (segop-emit/generate-contraction-kernel-body
+     (:body planned) :target-dialect dialect :kernel-name-prefix "mixed_contraction")))
+
 (defn- register-tiled-contraction-source
   [dialect]
   (let [epilogue {:acc 'acc
@@ -309,6 +324,8 @@
                             (reduction-artifact dialect))
            (write-artifact! directory suffix "portable-contraction"
                             (contraction-artifact dialect descriptor))
+           (write-artifact! directory suffix "mixed-contraction"
+                            (mixed-contraction-artifact dialect descriptor))
            (write-artifact! directory suffix "segmented-fold-map"
                             (segmented-fold-map-artifact dialect))
            (write-source! directory suffix "register-tiled-contraction"

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -247,11 +247,16 @@
                  {:raster.type/elem-type :float})
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
-      (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+      (is (= 'raster.compiler.pipeline/invoke-scheduled-executable!
              (first (:form result))))
-      (is (= '[a obuf scale n] (nth (:form result) 2)))
+      (is (= '[a obuf scale n] (nth (:form result) 3)))
+      (is (= 1 (count (:dispatches result))))
+      (is (= :scalar-workgroup-tree
+             (:default-strategy (first (:dispatches result)))))
       (is (= '[a obuf scale _n_bound]
-             (mapv :name (:abi (first (:kernels result)))))))))
+             (mapv :name (:abi (first (:kernels result))))))
+      (is (= [1] (get-in result [:kernels 0 :launch :group-count])))
+      (is (= :single (get-in result [:kernels 0 :attributes :phase]))))))
 
 (deftest opencl-pass-full-contraction-reduction-uses-ordered-marker
   (let [product (with-meta '(* (aget A i) (aget B i)) {:raster.type/tag 'float})

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -165,7 +165,8 @@
       (is (not (str/includes? (:source kernel) "cl_intel_subgroups")))
       ;; Must NOT have CUDA
       (is (not (str/includes? (:source kernel) "__syncthreads()")))
-      (is (= :segred (get-in kernel [:provenance :dialect])))
+      (is (= :kernel-body (get-in kernel [:provenance :dialect])))
+      (is (= :segred (get-in kernel [:provenance :source-dialect])))
       (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
       (let [workgroup-size (first (get-in kernel [:launch :workgroup-size]))]
         (is (pos-int? workgroup-size))
@@ -233,8 +234,11 @@
       (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
              (first (:form result))))
       (is (= '[a nil scale n] (nth (:form result) 2)))
-      (is (= '[a output scale _n_bound]
-             (mapv :name (:abi (first (:kernels result))))))))
+      (let [artifact (first (:kernels result))
+            result-slot (some #(when (= :result (:role %)) %) (:abi artifact))]
+        (is (some? (:name result-slot))
+            "the artifact retains its scheduled physical result identity")
+        (is (= (:name result-slot) (second (:arguments artifact)))))))
   (testing "reduce-into supplies its resident result at the same ordered ABI slot"
     (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
           form (with-meta

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -222,7 +222,7 @@
       (is (= 0 (:ze-maps (:stats result)))))))
 
 (deftest opencl-pass-reduce-test
-  (testing "par/reduce gets replaced with the ordered registered reduction marker"
+  (testing "par/reduce executes its complete scheduled graph and materializes one host scalar"
     (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
           form (with-meta
                  (list 'raster.par/reduce 'acc 0.0 'i 'n (list '+ 'acc product))
@@ -230,15 +230,22 @@
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
       (is (= 1 (:ze-reduces (:stats result))))
-      (is (= 1 (count (:kernels result))))
-      (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
-             (first (:form result))))
-      (is (= '[a nil scale n] (nth (:form result) 2)))
-      (let [artifact (first (:kernels result))
-            result-slot (some #(when (= :result (:role %)) %) (:abi artifact))]
-        (is (some? (:name result-slot))
-            "the artifact retains its scheduled physical result identity")
-        (is (= (:name result-slot) (second (:arguments artifact)))))))
+      (is (= 2 (count (:kernels result))))
+      (let [invocation (some #(when (and (seq? %)
+                                         (= 'raster.compiler.pipeline/invoke-scheduled-executable!
+                                            (first %))) %)
+                             (tree-seq coll? seq (:form result)))
+            dispatch (first (:dispatches result))
+            graph (first (:alternatives dispatch))
+            scalar-read (some #(when (and (seq? %)
+                                          (= 'clojure.core/aget (first %))) %)
+                              (tree-seq coll? seq (:form result)))]
+        (is invocation)
+        (is (= '[a (float-array 1) scale n] (nth invocation 3)))
+        (is (= [:block-local :cross-block]
+               (mapv #(get-in % [:operation :attributes :phase]) (:nodes graph))))
+        (is (= 1 (count (:temporaries graph))))
+        (is (= 'clojure.core/aget (first scalar-read)))))
   (testing "reduce-into supplies its resident result at the same ordered ABI slot"
     (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
           form (with-meta
@@ -256,7 +263,7 @@
       (is (= '[a obuf scale _n_bound]
              (mapv :name (:abi (first (:kernels result))))))
       (is (= [1] (get-in result [:kernels 0 :launch :group-count])))
-      (is (= :single (get-in result [:kernels 0 :attributes :phase]))))))
+      (is (= :single (get-in result [:kernels 0 :attributes :phase])))))))
 
 (deftest opencl-pass-full-contraction-reduction-uses-ordered-marker
   (let [product (with-meta '(* (aget A i) (aget B i)) {:raster.type/tag 'float})

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -53,7 +53,11 @@
         emitted (sg/generate-kernel-graph
                  graph :array-types {'a :double} :scalar-types {'n :long})
         [phase-one phase-two] (mapv :operation (:nodes emitted))
+        source-nodes (:nodes graph)
+        certificates (mapv #(get-in % [:provenance :scheduled-operation])
+                           [phase-one phase-two])
         partials (first (:inputs (second (mapv :operation (:nodes graph)))))
+        result-id (:id (first (:outputs graph)))
         temporary-specs (graph-call/temporary-specs
                          emitted {'n {:type :long :value 1025}})]
     (is (= [(kgraph/scalar 'n :long)] (:scalars graph)))
@@ -72,6 +76,27 @@
           "a target-private derived bound closes over the public logical scalar"))
     (is (= 2 (count (:nodes emitted))))
     (is (every? kart/kernel-artifact? [phase-one phase-two]))
+    (is (= [] (:dependencies (first source-nodes))))
+    (is (= [(:id (first source-nodes))] (:dependencies (second source-nodes))))
+    (is (= [:block-local :cross-block]
+           (mapv #(get-in % [:effects :phase]) [phase-one phase-two])))
+    (is (= [[{:value 'a :access :read} {:value partials :access :write}]
+            [{:value partials :access :read} {:value result-id :access :write}]]
+           (mapv #(get-in % [:effects :uses]) [phase-one phase-two])))
+    (is (= (mapv :operation source-nodes) (mapv :source certificates))
+        "each scheduled body retains its exact scalar SegRed phase")
+    (doseq [[certificate node] (map vector certificates source-nodes)]
+      (is (= certificate (segred-body/validate-against-node! certificate node graph))))
+    (is (= [(first (get-in phase-one [:attributes :kernel-body :launch :group-count]))]
+           (-> phase-one :attributes :kernel-body :parameters second :shape))
+        "the partial output is closed over the actual checked group-count expression")
+    (is (= [1] (-> phase-two :attributes :kernel-body :parameters second :shape)))
+    (is (= [:checked-range :checked-range]
+           (mapv #(->> % :scalar-bindings
+                       (some (fn [binding]
+                               (when (= '_n_bound (:parameter binding))
+                                 (:conversion binding)))))
+                 certificates)))
     (is (str/includes? (:source phase-two) (str (name partials) "[")))
     (is (not (re-find #"\ba\[" (:source phase-two)))
         "the cross-block target kernel must not resurrect the original reduction body")
@@ -457,16 +482,77 @@
       (is (klaunch/launch-spec? (:launch k)))
       (is (= [256] (get-in k [:launch :workgroup-size])))
       (is (= 1024 (get-in k [:launch :shared-memory-bytes])))
-      (is (= {:dialect :segred :segop-id (:id segred)} (:provenance k)))
+      (is (= :kernel-body (get-in k [:provenance :dialect])))
+      (is (= (:id segred) (get-in k [:provenance :segop-id])))
+      (is (= :scheduled-kernel-body (get-in k [:provenance :lowering])))
       (is (= :float (get-in k [:attributes :dtype])))
       (is (= :kernel-body (get-in k [:attributes :emission-route])))
-      (is (some? (get-in k [:attributes :kernel-body])))))
-  (testing "host-scalar staging retains the result position as an explicit nil placeholder"
+      (is (some? (get-in k [:attributes :kernel-body])))
+      (is (nil? (get-in k [:attributes :n-phases]))
+          "one phase artifact does not claim that it owns two phases")))
+  (testing "the artifact retains a physical result identity; only the host marker substitutes nil"
     (let [form '(raster.par/reduce acc 0.0 i n (+ acc (clojure.core/aget a i)))
           s (soac/par-form->soac 'result form 0)
           k (sg/generate-segred-kernel (first (lower/lower-reduce s nil)) nil :dtype :float)]
-      (is (= '[a output _n_bound] (mapv :name (:abi k))))
-      (is (= '[a nil n] (:arguments k))))))
+      (is (= '[a result _n_bound] (mapv :name (:abi k))))
+      (is (= '[a result n] (:arguments k))))))
+
+(deftest scalar-segred-schedule-rejects-a-forged-graph-source
+  (let [source '(let* [result (raster.par/reduce acc 0.0 i n
+                                                 (+ acc (clojure.core/aget a i)))]
+                      result)
+        options {:dtype :double :array-types {'a :double} :scalar-types {'n :long}}
+        typed (:program (typed-route/attempt source :double {'a :double} options))
+        algorithm (get-in typed [:equations 0 :algorithm])
+        scheduled-program (:form (segop-lower/segop-lower-pass typed options))
+        graph (equation-graph/make algorithm scheduled-program)
+        node (last (:nodes graph))
+        operation (:operation node)
+        certificate (segred-body/schedule operation (first (:outputs operation)) options)
+        forged-node (assoc node :operation (assoc operation :id :forged-reduction))
+        forged-storage (update graph :outputs
+                               #(mapv (fn [buffer] (assoc buffer :elements 2)) %))]
+    (is (identical? operation (:source certificate)))
+    (try
+      (segred-body/validate-against-node! certificate forged-node graph)
+      (is false "a boundary-compatible but different SegRed must not reuse the certificate")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :scheduled-kernel-body-source (:reason (ex-data exception))))))
+    (try
+      (segred-body/validate-against-node! certificate node forged-storage)
+      (is false "the graph result allocation must equal the scheduled output group count")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :output-elements (:missing-rule (ex-data exception))))))))
+
+(deftest completed-scalar-reduction-transform-is-terminal-and-numerically-explicit
+  (let [form (with-meta
+               '(raster.par/reduce acc 0.0 i 32 (+ acc (clojure.core/aget a i)))
+               {:raster.type/elem-type :float})
+        base (first (lower/lower-reduce (soac/par-form->soac 'result form 91) nil
+                                        :dtype :float))
+        transform (kernel-body/->ScalarRegion
+                   '[completed scale] '(clojure.core/* completed scale) [] :float)
+        terminal (-> base
+                     (assoc-in [:reduction :attributes :result-region] transform)
+                     (assoc :scalars #{'scale}))
+        certificate (segred-body/schedule
+                     terminal nil {:array-types {'a :float}
+                                   :scalar-types {'scale :float}})]
+    (is (= :single (:phase terminal)))
+    (is (= {:kind :typed-scalar-region
+            :policy :same-typed-ssa-evaluation-order
+            :input-dtype :float :result-dtype :float}
+           (get-in certificate [:numerics :result-transform])))
+    (is (= :certified-workgroup-tree (get-in certificate [:numerics :policy])))
+    (let [nonterminal (assoc terminal :phase :block-local)]
+      (try
+        (segred-body/schedule nonterminal nil
+                             {:array-types {'a :float}
+                              :scalar-types {'scale :float}})
+        (is false "a block-local phase must not apply the completed transform")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :nonterminal-result-transform
+                 (:missing-rule (ex-data exception)))))))))
 
 (deftest mixed-index-scalars-stay-on-the-portable-reduction-route
   (let [form '(raster.par/reduce acc 0.0 i n

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -674,17 +674,21 @@
           (is (= :nonterminal-result-transform
                  (:missing-rule (ex-data exception)))))))))
 
-(deftest mixed-index-scalars-stay-on-the-portable-reduction-route
+(deftest unproved-affine-loads-decline-the-pointwise-reduction-route
   (let [form '(raster.par/reduce acc 0.0 i n
                                  (+ acc (clojure.core/aget a (+ i offset))))
         node (soac/par-form->soac 'result form 22 :dtype :float)
-        operation (first (lower/lower-reduce node nil :dtype :float))
-        artifact (sg/generate-segred-kernel
-                  operation nil :dtype :float :scalar-types {'offset :int 'n :int})]
-    (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
-    (is (= :int (some #(when (= 'offset (:name %)) (:dtype %)) (:abi artifact))))
-    (is (re-find #"rstr_element_index.*offset" (:source artifact)))
-    (is (nil? (get-in artifact [:attributes :kernel-body-decline])))))
+        operation (first (lower/lower-reduce node nil :dtype :float))]
+    (try
+      (sg/generate-segred-kernel
+       operation nil :dtype :float :scalar-types {'offset :int 'n :int})
+      (is false "an n-element buffer does not prove i+offset is in bounds")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :kernel-graph-target-lowering-missing
+               (:reason (ex-data exception))))
+        (is (= :indexed-load
+               (get-in (ex-data exception)
+                       [:kernel-body-decline :missing-rule])))))))
 
 (deftest mixed-floating-reduction-arithmetic-is-explicit-typed-ssa
   (let [product (with-meta

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -263,7 +263,7 @@
   (let [form (list 'raster.par/reduce 'acc 0.0 'j 'n body-expr)
         s (soac/par-form->soac 'result form 0)
         segops (lower/lower-reduce s nil)]
-    (:source (sg/generate-segred-kernel (first segops) 'out :dtype :float))))
+    (:source (sg/generate-segred-kernel (first segops) 'result :dtype :float))))
 
 (defn- emitted-scan-graph
   ([form] (emitted-scan-graph form {}))
@@ -466,15 +466,15 @@
                {:raster.type/elem-type :float})
         s (soac/par-form->soac 'result form 0)
         segred (first (lower/lower-reduce s nil))
-        k (sg/generate-segred-kernel segred 'result-buffer :dtype :float
+        k (sg/generate-segred-kernel segred 'result :dtype :float
                                      :scalar-types {'scale :float 'n :int})]
     (is (kart/kernel-artifact? k))
     (testing "signature, ABI and compiler values have one identical order"
-      (is (= '[a result-buffer scale _n_bound] (mapv :name (:abi k))))
+      (is (= '[a result scale _n_bound] (mapv :name (:abi k))))
       (is (= [:input :output :scalar :scalar] (mapv :kind (:abi k))))
       (is (= [:float :float :float :int] (mapv :kernel-dtype (:abi k))))
       (is (= [:operand :result :parameter :bound] (mapv :role (:abi k))))
-      (is (= '[a result-buffer scale n] (:arguments k)))
+      (is (= '[a result scale n] (:arguments k)))
       (is (= (kabi/signature-shape (:abi k))
              (kabi/source-signature-shape (:kernel-name k) (:source k))))
       (is (= :no-write-alias (get-in k [:abi 0 :aliasing]))))
@@ -497,6 +497,28 @@
       (is (= '[a result _n_bound] (mapv :name (:abi k))))
       (is (= '[a result n] (:arguments k))))))
 
+(deftest one-scalar-segred-schedule-emits-through-every-c-family-fixture
+  (let [operation (first (lower/lower-reduce
+                          (soac/par-form->soac
+                           'result
+                           '(raster.par/reduce acc 0.0 i n
+                                               (+ acc (clojure.core/aget a i)))
+                           90)
+                          nil :dtype :float))]
+    (doseq [[target expected]
+            [[:opencl-portable :opencl-c]
+             [:cuda :cuda-c]
+             [:hip :hip-cpp]]]
+      (testing (name target)
+        (let [artifact (sg/generate-segred-kernel
+                        operation nil :dtype :float :target-dialect target)
+              certificate (get-in artifact [:provenance :scheduled-operation])]
+          (is (= expected (:target artifact)))
+          (is (identical? operation (:source certificate)))
+          (is (= artifact
+                 (scheduled-body/validate-artifact-projection!
+                  certificate artifact))))))))
+
 (deftest scalar-segred-schedule-rejects-a-forged-graph-source
   (let [source '(let* [result (raster.par/reduce acc 0.0 i n
                                                  (+ acc (clojure.core/aget a i)))]
@@ -514,6 +536,14 @@
                                #(mapv (fn [buffer] (assoc buffer :elements 2)) %))]
     (is (identical? operation (:source certificate)))
     (try
+      (sg/generate-segred-kernel operation 'forged-result
+                                 :dtype :double :array-types {'a :double})
+      (is false "production scalar emission cannot replace the semantic output identity")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :physical-output-remap
+               (get-in (ex-data exception)
+                       [:kernel-body-decline :missing-rule])))))
+    (try
       (segred-body/validate-against-node! certificate forged-node graph)
       (is false "a boundary-compatible but different SegRed must not reuse the certificate")
       (catch clojure.lang.ExceptionInfo exception
@@ -522,7 +552,65 @@
       (segred-body/validate-against-node! certificate node forged-storage)
       (is false "the graph result allocation must equal the scheduled output group count")
       (catch clojure.lang.ExceptionInfo exception
+        (is (= :output-elements (:missing-rule (ex-data exception))))))
+    (try
+      (sg/generate-kernel-graph forged-storage
+                                :array-types {'a :double}
+                                :scalar-types {'n :long})
+      (is false "production graph emission must apply the SegRed/node storage validator")
+      (catch clojure.lang.ExceptionInfo exception
         (is (= :output-elements (:missing-rule (ex-data exception))))))))
+
+(deftest scalar-segred-schedule-rejects-forged-phase-and-tree-facts
+  (let [operation (first (lower/lower-reduce
+                          (soac/par-form->soac
+                           'result
+                           '(raster.par/reduce acc 0.0 i 4096
+                                               (+ acc (clojure.core/aget a i)))
+                           92)
+                          nil :dtype :float))
+        options {:array-types {'a :float}}
+        missing-rule
+        (fn [candidate]
+          (try
+            (segred-body/schedule candidate nil options)
+            nil
+            (catch clojure.lang.ExceptionInfo exception
+              (:missing-rule (ex-data exception)))))
+        cases
+        [[:fused-map-representation (assoc operation :lambda '(identity element))]
+         [:phase-level (assoc operation :level (segop/->SegLevel :block :none))]
+         [:grid-shared-memory (assoc-in operation [:grid :shared-mem-bytes] 0)]
+         [:schedule-grid (assoc-in operation [:schedule :workgroup-size] 128)]
+         [:schedule-grid (assoc-in operation [:schedule :attributes :group-count] 1)]]]
+    (doseq [[expected candidate] cases]
+      (testing (name expected)
+        (is (= expected (missing-rule candidate)))))))
+
+(deftest scalar-segred-max-int-bound-uses-wide-overflow-free-schedule-arithmetic
+  (let [operation (first (lower/lower-reduce
+                          (soac/par-form->soac
+                           'result
+                           (list 'raster.par/reduce 'acc 0.0 'i Integer/MAX_VALUE
+                                 '(+ acc (clojure.core/aget a i)))
+                           93)
+                          nil :dtype :float))
+        kernel-body (:kernel-body
+                     (segred-body/lower operation nil
+                                        :dtype :float :array-types {'a :float}))
+        casts (filterv #(instance? raster.compiler.ir.kernel_body.IndexCast
+                                   (:expression %))
+                       (:indices kernel-body))
+        loop (first (filter #(instance? raster.compiler.ir.kernel_body.ForLoop %)
+                            (:operations kernel-body)))
+        index-expressions (into {} (map (juxt :id :expression) (:indices kernel-body)))]
+    (is (= '[wide-bound wide-group-index wide-group-count wide-local-index]
+           (mapv :id casts)))
+    (is (every? #(= :long (get-in % [:expression :dtype])) casts))
+    (is (= :long (get-in loop [:index :type])))
+    (is (= :sub (get-in index-expressions ['group-chunk :arguments 1 :arguments 0 :op]))
+        "ceil-div is expressed as 1+(n-1)/groups, never n+groups-1")
+    (is (= :add (:op (get index-expressions 'group-end))))))
 
 (deftest completed-scalar-reduction-transform-is-terminal-and-numerically-explicit
   (let [form (with-meta
@@ -544,7 +632,11 @@
             :input-dtype :float :result-dtype :float}
            (get-in certificate [:numerics :result-transform])))
     (is (= :certified-workgroup-tree (get-in certificate [:numerics :policy])))
-    (let [nonterminal (assoc terminal :phase :block-local)]
+    (let [nonterminal (assoc terminal
+                             :phase :block-local
+                             :level (segop/->SegLevel :block :virtual)
+                             :schedule (segred-body/scalar-workgroup-tree-schedule
+                                        (:reduction terminal) (:grid terminal) :block-local))]
       (try
         (segred-body/schedule nonterminal nil
                              {:array-types {'a :float}

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -261,9 +261,12 @@
 
 (defn- segred-source [body-expr]
   (let [form (list 'raster.par/reduce 'acc 0.0 'j 'n body-expr)
-        s (soac/par-form->soac 'result form 0)
-        segops (lower/lower-reduce s nil)]
-    (:source (sg/generate-segred-kernel (first segops) 'result :dtype :float))))
+        s (soac/par-form->soac 'result form 0 :dtype :double)
+        segops (lower/lower-reduce s nil)
+        operation (first segops)]
+    (:source (sg/generate-segred-kernel
+              operation (first (:outputs operation)) :dtype :double
+              :array-types {'a :double} :scalar-types {'n :int}))))
 
 (defn- emitted-scan-graph
   ([form] (emitted-scan-graph form {}))
@@ -440,11 +443,11 @@
 
 (deftest segred-devirtualized-aget-lowers-to-subscript
   (testing "the parametric (.invk aget-impl …) shape — the qlinear-k side of #55"
-    (let [aget-invk (with-meta (list '.invk 'raster.arrays/aget_m_floats_long-impl 'a 'j)
+    (let [aget-invk (with-meta (list '.invk 'raster.arrays/aget_m_doubles_long-impl 'a 'j)
                       {:raster.op/original 'raster.arrays/aget
-                       :raster.type/tag 'float})
+                       :raster.type/tag 'double})
           plus-invk (with-meta (list '.invk 'raster.numeric/_plus__m_double_double-impl
-                                     'acc (list 'double aget-invk))
+                                     'acc aget-invk)
                       {:raster.op/original 'raster.numeric/+
                        :raster.type/tag 'double})
           src (segred-source plus-invk)]
@@ -464,17 +467,18 @@
         form (with-meta (list 'raster.par/reduce 'acc 0.0 'i 'n
                               (list '+ (list 'float 'acc) product))
                {:raster.type/elem-type :float})
-        s (soac/par-form->soac 'result form 0)
+        s (soac/par-form->soac 'result form 0 :dtype :float)
         segred (first (lower/lower-reduce s nil))
-        k (sg/generate-segred-kernel segred 'result :dtype :float
+        physical-output (first (:outputs segred))
+        k (sg/generate-segred-kernel segred (first (:outputs segred)) :dtype :float
                                      :scalar-types {'scale :float 'n :int})]
     (is (kart/kernel-artifact? k))
     (testing "signature, ABI and compiler values have one identical order"
-      (is (= '[a result scale _n_bound] (mapv :name (:abi k))))
+      (is (= ['a physical-output 'scale '_n_bound] (mapv :name (:abi k))))
       (is (= [:input :output :scalar :scalar] (mapv :kind (:abi k))))
       (is (= [:float :float :float :int] (mapv :kernel-dtype (:abi k))))
       (is (= [:operand :result :parameter :bound] (mapv :role (:abi k))))
-      (is (= '[a result scale n] (:arguments k)))
+      (is (= ['a physical-output 'scale 'n] (:arguments k)))
       (is (= (kabi/signature-shape (:abi k))
              (kabi/source-signature-shape (:kernel-name k) (:source k))))
       (is (= :no-write-alias (get-in k [:abi 0 :aliasing]))))
@@ -492,10 +496,13 @@
           "one phase artifact does not claim that it owns two phases")))
   (testing "the artifact retains a physical result identity; only the host marker substitutes nil"
     (let [form '(raster.par/reduce acc 0.0 i n (+ acc (clojure.core/aget a i)))
-          s (soac/par-form->soac 'result form 0)
-          k (sg/generate-segred-kernel (first (lower/lower-reduce s nil)) nil :dtype :float)]
-      (is (= '[a result _n_bound] (mapv :name (:abi k))))
-      (is (= '[a result n] (:arguments k))))))
+          s (soac/par-form->soac 'result form 0 :dtype :float)
+          operation (first (lower/lower-reduce s nil))
+          physical-output (first (:outputs operation))
+          k (sg/generate-segred-kernel operation nil :dtype :float
+                                       :scalar-types {'n :int})]
+      (is (= ['a physical-output '_n_bound] (mapv :name (:abi k))))
+      (is (= ['a physical-output 'n] (:arguments k))))))
 
 (deftest one-scalar-segred-schedule-emits-through-every-c-family-fixture
   (let [operation (first (lower/lower-reduce
@@ -503,7 +510,7 @@
                            'result
                            '(raster.par/reduce acc 0.0 i n
                                                (+ acc (clojure.core/aget a i)))
-                           90)
+                           90 :dtype :float)
                           nil :dtype :float))]
     (doseq [[target expected]
             [[:opencl-portable :opencl-c]
@@ -511,7 +518,8 @@
              [:hip :hip-cpp]]]
       (testing (name target)
         (let [artifact (sg/generate-segred-kernel
-                        operation nil :dtype :float :target-dialect target)
+                        operation nil :dtype :float :target-dialect target
+                        :scalar-types {'n :int})
               certificate (get-in artifact [:provenance :scheduled-operation])]
           (is (= expected (:target artifact)))
           (is (identical? operation (:source certificate)))
@@ -533,7 +541,11 @@
         certificate (segred-body/schedule operation (first (:outputs operation)) options)
         forged-node (assoc node :operation (assoc operation :id :forged-reduction))
         forged-storage (update graph :outputs
-                               #(mapv (fn [buffer] (assoc buffer :elements 2)) %))]
+                               #(mapv (fn [buffer] (assoc buffer :elements 2)) %))
+        forged-certificates
+        [(assoc-in certificate [:body :attributes :identity] 1.0)
+         (assoc-in certificate [:body :schedule :reduction-operator] :*)
+         (assoc-in certificate [:numerics :policy] :forged-tree)]]
     (is (identical? operation (:source certificate)))
     (try
       (sg/generate-segred-kernel operation 'forged-result
@@ -552,14 +564,21 @@
       (segred-body/validate-against-node! certificate node forged-storage)
       (is false "the graph result allocation must equal the scheduled output group count")
       (catch clojure.lang.ExceptionInfo exception
-        (is (= :output-elements (:missing-rule (ex-data exception))))))
+        (is (= :storage-extent (:missing-rule (ex-data exception))))))
     (try
       (sg/generate-kernel-graph forged-storage
                                 :array-types {'a :double}
                                 :scalar-types {'n :long})
       (is false "production graph emission must apply the SegRed/node storage validator")
       (catch clojure.lang.ExceptionInfo exception
-        (is (= :output-elements (:missing-rule (ex-data exception))))))))
+        (is (= :storage-extent
+               (get-in (ex-data exception) [:kernel-body-decline :missing-rule])))))
+    (doseq [forged forged-certificates]
+      (try
+        (segred-body/validate-against-node! forged node graph)
+        (is false "a body or numerical certificate cannot be changed independently of source")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :schedule-source (:missing-rule (ex-data exception)))))))))
 
 (deftest scalar-segred-schedule-rejects-forged-phase-and-tree-facts
   (let [operation (first (lower/lower-reduce
@@ -567,7 +586,7 @@
                            'result
                            '(raster.par/reduce acc 0.0 i 4096
                                                (+ acc (clojure.core/aget a i)))
-                           92)
+                           92 :dtype :float)
                           nil :dtype :float))
         options {:array-types {'a :float}}
         missing-rule
@@ -582,10 +601,19 @@
          [:phase-level (assoc operation :level (segop/->SegLevel :block :none))]
          [:grid-shared-memory (assoc-in operation [:grid :shared-mem-bytes] 0)]
          [:schedule-grid (assoc-in operation [:schedule :workgroup-size] 128)]
-         [:schedule-grid (assoc-in operation [:schedule :attributes :group-count] 1)]]]
+         [:schedule-grid (assoc-in operation [:schedule :attributes :group-count] 1)]
+         [:schedule-grid (assoc-in operation [:schedule :numerical-mode :overflow] :wrap)]
+         [:physical-phase (assoc-in operation [:reduction :attributes :physical-phase]
+                                    :cross-block)]]]
     (doseq [[expected candidate] cases]
       (testing (name expected)
-        (is (= expected (missing-rule candidate)))))))
+        (is (= expected (missing-rule candidate)))))
+    (let [grid (assoc (:grid operation) :num-blocks (klaunch/sum 1 1))
+          forged (assoc operation :grid grid
+                          :schedule (segred-body/scalar-workgroup-tree-schedule
+                                     (:reduction operation) grid (:phase operation)))]
+      (is (= :launch-grid (missing-rule forged))
+          "an internally self-consistent but unrelated launch expression is not a proof"))))
 
 (deftest scalar-segred-max-int-bound-uses-wide-overflow-free-schedule-arithmetic
   (let [operation (first (lower/lower-reduce
@@ -593,7 +621,7 @@
                            'result
                            (list 'raster.par/reduce 'acc 0.0 'i Integer/MAX_VALUE
                                  '(+ acc (clojure.core/aget a i)))
-                           93)
+                           93 :dtype :float)
                           nil :dtype :float))
         kernel-body (:kernel-body
                      (segred-body/lower operation nil
@@ -608,15 +636,15 @@
            (mapv :id casts)))
     (is (every? #(= :long (get-in % [:expression :dtype])) casts))
     (is (= :long (get-in loop [:index :type])))
-    (is (= :sub (get-in index-expressions ['group-chunk :arguments 1 :arguments 0 :op]))
-        "ceil-div is expressed as 1+(n-1)/groups, never n+groups-1")
+    (is (= :ceil-div (get-in index-expressions ['group-chunk :op]))
+        "the checked index algebra handles zero without forming n-1 or n+groups-1")
     (is (= :add (:op (get index-expressions 'group-end))))))
 
 (deftest completed-scalar-reduction-transform-is-terminal-and-numerically-explicit
   (let [form (with-meta
                '(raster.par/reduce acc 0.0 i 32 (+ acc (clojure.core/aget a i)))
                {:raster.type/elem-type :float})
-        base (first (lower/lower-reduce (soac/par-form->soac 'result form 91) nil
+        base (first (lower/lower-reduce (soac/par-form->soac 'result form 91 :dtype :float) nil
                                         :dtype :float))
         transform (kernel-body/->ScalarRegion
                    '[completed scale] '(clojure.core/* completed scale) [] :float)
@@ -652,10 +680,10 @@
         node (soac/par-form->soac 'result form 22 :dtype :float)
         operation (first (lower/lower-reduce node nil :dtype :float))
         artifact (sg/generate-segred-kernel
-                  operation nil :dtype :float :scalar-types {'offset :int})]
+                  operation nil :dtype :float :scalar-types {'offset :int 'n :int})]
     (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
     (is (= :int (some #(when (= 'offset (:name %)) (:dtype %)) (:abi artifact))))
-    (is (re-find #"element_index.* \+ offset" (:source artifact)))
+    (is (re-find #"rstr_element_index.*offset" (:source artifact)))
     (is (nil? (get-in artifact [:attributes :kernel-body-decline])))))
 
 (deftest mixed-floating-reduction-arithmetic-is-explicit-typed-ssa

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -25,6 +25,10 @@
                                           (clojure.core/aget B (clojure.core/+ (clojure.core/* l 128) j)))))
 (def ^:private bound (list 'let* ['c cform] 'c))
 
+(deftest attention-jvp-preserves-mixed-contraction-captures
+  (let [v (requiring-resolve 'raster.dl.attention/scaled-dot-product-attn-jvp)]
+    (is (map? (pl/show-pipeline v :target-device :ocl:0 :dtype :float)))))
+
 (deftest a-contraction-is-a-soac-node-carrying-its-facts
   (let [n (soac/par-form->soac 'c cform 1 :dtype :double)]
     (is (soac/contract? n))

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -102,17 +102,26 @@
   ;; descriptor through. That was a no-op: the descriptor did not contain :c-op/:identity-val —
   ;; generate-segred-kernel returned them into a local that route-contraction discarded. The
   ;; consumer-side assertion could not catch it; only this producer-side one can.
-  (testing ":combine max reaches the descriptor as fmax + its identity, not defaulted to +/0.0"
+  (testing "product reaches the descriptor with its identity, not defaulted to +/0.0"
     (let [r (cr/route-contraction
              (list 'raster.par/contract 'O [] [['l 8]]
                    (list 'raster.numeric/* (list 'aget 'a 'l) (list 'aget 'b 'l))
-                   :combine 'max :init 'Double/NEGATIVE_INFINITY)
+                   :combine '* :init 1.0)
              :dtype :double)]
       (is (= :full-reduce (:strategy r)))
-      (is (= "fmax" (:c-op r)))
-      (is (= Double/NEGATIVE_INFINITY (:identity-val r))
-          "the identity must be the op's, not 0.0 — summing max-partials from 0.0 is wrong for
-           all-negative data"))))
+      (is (= "*" (:c-op r)))
+      (is (= 1.0 (:identity-val r))
+          "the product identity must not become the sum identity")))
+  (testing "floating max cannot silently acquire C fmax's different NaN semantics"
+    (try
+      (cr/route-contraction
+       '(raster.par/contract O [] [[l 8]] (* (aget a l) (aget b l))
+                             :combine max :init Double/NEGATIVE_INFINITY)
+       :dtype :double)
+      (is false "requires an explicit floating min/max numerical policy")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :floating-minmax-semantics
+               (get-in (ex-data exception) [:kernel-body-decline :missing-rule])))))))
 
 (deftest fp64-result-transform-uses-the-typed-register-tiled-store
   (testing "an f64 two-free/one-contract result transform executes on the register-tiled leaf"

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.resident-value :as resident-value]
@@ -75,6 +76,26 @@
     (is (= [:resident-x :resident-out] (mapv second (:pointer-pairs plan))))
     (is (= [:float :int] (mapv (comp :type second) (:scalar-pairs plan))))))
 
+(deftest extent-bounds-reject-negative-values-before-launch
+  (let [arguments [:resident-x :resident-out
+                   {:type :float :value 2.0} {:type :int :value -1}]]
+    (try
+      (kcall/make artifact arguments)
+      (is false "a negative semantic extent must not reach launch realization")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :kernel-bound-range (:reason (ex-data exception))))))))
+
+(deftest staged-scalar-normalization-cannot-truncate-an-extent
+  (doseq [[value reason] [[-1 :kernel-bound-range]
+                          [-0.5 :kernel-executable-integral-scalar]
+                          [3.5 :kernel-executable-integral-scalar]]]
+    (try
+      (kexec/typed-runtime-arguments
+       artifact [:resident-x :resident-out 2.0 value])
+      (is false "an extent must remain an exact non-negative integer")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= reason (:reason (ex-data exception))))))))
+
 (deftest scheduling-may-change-groups-but-not-emitted-workgroup
   (let [call (kcall/make artifact args {:group-count [1]})]
     (is (= [1] (get-in call [:geometry :group-count]))))
@@ -100,15 +121,16 @@
   (let [capped
         (kart/make
          {:kernel-name "capped_reduction_launch_test"
-          :source "__kernel void capped_reduction_launch_test(int n) {}"
-          :abi [(kabi/slot 'n :scalar :int :role :bound)]
-          :arguments '[n]
+          :source "__kernel void capped_reduction_launch_test(__global float* out, int n) {}"
+          :abi [(kabi/slot 'out :output :float :role :result)
+                (kabi/slot 'n :scalar :int :role :bound)]
+          :arguments '[out n]
           :launch (klaunch/spec
                    {:workgroup-size [256]
                     :group-count [(klaunch/minimum
                                    17 (klaunch/ceil-div 'n 256))]})})
         geometry (kcall/realize-launch
-                  capped [{:type :int :value Integer/MAX_VALUE}])]
+                  capped [:resident-out {:type :int :value Integer/MAX_VALUE}])]
     (is (= [256] (:workgroup-size geometry)))
     (is (= [17] (:group-count geometry))
         "staging must not reconstruct an uncapped ceil-div launch")))

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -96,6 +96,31 @@
       (is (= workgroup (get-in call [:geometry :workgroup-size])))
       (is (= groups (get-in call [:geometry :group-count]))))))
 
+(deftest launch-realization-preserves-the-artifact-occupancy-cap-at-max-int
+  (let [capped
+        (kart/make
+         {:kernel-name "capped_reduction_launch_test"
+          :source "__kernel void capped_reduction_launch_test(int n) {}"
+          :abi [(kabi/slot 'n :scalar :int :role :bound)]
+          :arguments '[n]
+          :launch (klaunch/spec
+                   {:workgroup-size [256]
+                    :group-count [(klaunch/minimum
+                                   17 (klaunch/ceil-div 'n 256))]})})
+        geometry (kcall/realize-launch
+                  capped [{:type :int :value Integer/MAX_VALUE}])]
+    (is (= [256] (:workgroup-size geometry)))
+    (is (= [17] (:group-count geometry))
+        "staging must not reconstruct an uncapped ceil-div launch")))
+
+(deftest opencl-raw-handles-do-not-claim-device-allocation-capacity
+  (let [capacity (ns-resolve 'raster.gpu.ocl-runtime 'known-buffer-capacity)
+        handle (java.lang.foreign.MemorySegment/ofArray (long-array 1))
+        owned (ocl/->OclBuffer handle handle 1024 4096 :float 64)]
+    (is (nil? (capacity handle))
+        "a MemorySegment accepted as cl_mem describes the handle, not the allocation")
+    (is (= 1024 (capacity owned)))))
+
 (deftest call-rejects-untyped-or-mistyped-scalars
   (testing "runtime scalar typing is part of the call, not a backend guess"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"typed value"

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -288,6 +288,73 @@
         (is (= 2 (count (filter #(= :alloc (first %)) @calls))))
         (is (= 1 (count (filter #(= :download (first %)) @calls))))))))
 
+(deftest staged-graph-capacities-fail-before-opening-a-device-session
+  (let [graph (staged-graph)
+        graph-dispatch (kdispatch/make
+                        {:id "staged-capacity-dispatch"
+                         :alternatives [graph]
+                         :default-strategy :two-stage
+                         :selector {:kind :fixed-strategy :strategy :two-stage}})
+        opened? (atom false)]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" (constantly graph-dispatch)
+           "device-buffer?" (constantly false)))
+       #'gpu/with-gpu-session*
+       (fn [& _] (reset! opened? true) (throw (ex-info "session opened" {})))}
+      (fn []
+        (doseq [[arguments reason]
+                [[[ (float-array 2) (float-array 3) 3]
+                  :staged-graph-buffer-capacity]
+                 [[(float-array 3) (float-array 3) -1]
+                  :staged-graph-buffer-extent]]]
+          (try
+            (gpu/invoke-staged-executable! :probe "staged-capacity-dispatch" arguments)
+            (is false "invalid graph storage must fail in pure preflight")
+            (catch clojure.lang.ExceptionInfo exception
+              (is (= reason (:reason (ex-data exception)))))))
+        (is (false? @opened?))))))
+
+(deftest staged-preflight-resolves-opaque-external-extent-leaves
+  (let [graph (-> (staged-graph)
+                  (assoc-in [:inputs 0 :elements] '(extent x))
+                  (assoc-in [:outputs 0 :elements] '(extent x))
+                  kgraph/validate!)
+        graph-dispatch (kdispatch/make
+                        {:id "staged-opaque-extent-dispatch"
+                         :alternatives [graph]
+                         :default-strategy :two-stage
+                         :selector {:kind :fixed-strategy :strategy :two-stage}})
+        opened? (atom false)
+        invoke (fn [out]
+                 (gpu/invoke-staged-executable!
+                  :probe "staged-opaque-extent-dispatch"
+                  [(float-array 3) out 3]))]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" (constantly graph-dispatch)
+           "device-buffer?" (constantly false)))
+       #'gpu/with-gpu-session*
+       (fn [& _]
+         (reset! opened? true)
+         (throw (ex-info "past pure preflight" {:reason :past-preflight})))}
+      (fn []
+        (try (invoke (float-array 3))
+             (catch clojure.lang.ExceptionInfo exception
+               (is (= :past-preflight (:reason (ex-data exception))))))
+        (is @opened?)
+        (reset! opened? false)
+        (try
+          (invoke (float-array 2))
+          (is false "cross-buffer opaque extent must still validate output capacity")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :staged-graph-buffer-capacity (:reason (ex-data exception))))))
+        (is (false? @opened?))))))
+
 (deftest staged-executable-preserves-pointer-identity-for-in-place-calls
   (let [same (float-array 3)
         calls (atom [])]

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -66,6 +66,12 @@
     (is (= #{'m 'n 'k} (launch/expression-references requested-splits)))
     (is (= 26 (launch/resolve-expression {'m 13 'n 640 'k 262144}
                                          requested-splits))))
+  (let [nonempty-groups (launch/maximum
+                         1 (launch/minimum 256 (launch/ceil-div 'n 256)))]
+    (is (= #{'n} (launch/expression-references nonempty-groups)))
+    (is (= 1 (launch/resolve-expression {'n 0} nonempty-groups)))
+    (is (= 5 (launch/resolve-expression {'n 1025} nonempty-groups)))
+    (is (= 256 (launch/resolve-expression {'n (* 1024 1024)} nonempty-groups))))
   (let [remainder (body/expression :mod 'k 16)]
     (is (launch/expression? remainder))
     (is (= #{'k} (launch/expression-references remainder)))

--- a/test/raster/compiler/ir/parallel_program_test.clj
+++ b/test/raster/compiler/ir/parallel_program_test.clj
@@ -3,10 +3,21 @@
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]))
 
 (def ^:private reduce-source
   '(raster.par/reduce acc 0.0 i n (clojure.core/+ acc (clojure.core/aget values i))))
+
+(deftest physical-write-capacity-covers-every-aliased-result
+  (let [value #(av/tensor {:dtype :float :shape [%]})
+        extent #'equation-graph/required-write-extent]
+    (is (= 100 (launch/resolve-expression {} (extent {} {} [(value 100) (value 10)]))))
+    (is (= 100 (launch/resolve-expression {} (extent {} {} [(value 10) (value 100)]))))
+    (is (= 100 (extent {} {} [(value 100) (value 100)])))
+    (is (nil? (extent {} {} [(value 100) (value '(unknown-dimension out))])))
+    (is (nil? (extent {} {} [nil (value 100)])))))
 
 (defn- lowered-program []
   (:form (segop-lower/segop-lower-pass (list 'let* ['total reduce-source] 'total)
@@ -47,7 +58,7 @@
     (is (= [[:binding 'total]] (:outputs p)))
     (is (= [reduce-source] (mapv :source (:equations p))))
     (is (every? av/abstract-value? (vals (:values p))))
-    (is (= ['?] (:shape (get (:values p) 'values))))
+    (is (= ['n] (:shape (get (:values p) 'values))))
     (is (= [] (:shape (get (:values p) [:binding 'total]))))
     (is (= {'n :int 'values :double}
            (program/declared-value-types (assoc-in p [:values 'n :dtype] :int)

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -327,3 +327,17 @@
           (is (= :double (:actual (ex-data e))))))
       (finally
         (ze/register-kernel! kernel-name {:test-tombstone? true})))))
+
+(deftest scalar-reduction-host-combine-obeys-storage-rounding-and-c-family-nans
+  (let [combine (ns-resolve 'raster.gpu.ze-runtime 'combine-scalar-partials)]
+    (is (= 0.0
+           (double (combine :float "+" 0.0
+                            [16777216.0 1.0 -16777216.0])))
+        "FP32 compatibility combine rounds after every certified operation")
+    (is (= 1.0
+           (double (combine :double "+" 0.0
+                            [16777216.0 1.0 -16777216.0]))))
+    (is (= 3.0 (double (combine :float "fmax" Float/NEGATIVE_INFINITY
+                                [Float/NaN 3.0]))))
+    (is (= 3.0 (double (combine :float "fmin" Float/POSITIVE_INFINITY
+                                [Float/NaN 3.0]))))))

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -325,10 +325,17 @@
           (is (some? e))
           (is (= :float (:expected (ex-data e))))
           (is (= :double (:actual (ex-data e))))))
+      (testing "semantic reduction certificates are required before driver loading"
+        (let [e (try
+                  (ze/invoke-registered-reduction-kernel
+                   kernel-name [(float-array 4) nil 2.0 4])
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+          (is (= :reduction-identity-missing (:reason (ex-data e))))))
       (finally
         (ze/register-kernel! kernel-name {:test-tombstone? true})))))
 
-(deftest scalar-reduction-host-combine-obeys-storage-rounding-and-c-family-nans
+(deftest scalar-reduction-host-combine-obeys-storage-rounding-and-certified-algebra
   (let [combine (ns-resolve 'raster.gpu.ze-runtime 'combine-scalar-partials)]
     (is (= 0.0
            (double (combine :float "+" 0.0
@@ -337,7 +344,5 @@
     (is (= 1.0
            (double (combine :double "+" 0.0
                             [16777216.0 1.0 -16777216.0]))))
-    (is (= 3.0 (double (combine :float "fmax" Float/NEGATIVE_INFINITY
-                                [Float/NaN 3.0]))))
-    (is (= 3.0 (double (combine :float "fmin" Float/POSITIVE_INFINITY
-                                [Float/NaN 3.0]))))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown certified combine"
+          (combine :float "fmax" Float/NEGATIVE_INFINITY [3.0])))))

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -61,7 +61,10 @@
         executable (:artifact step)]
     (is (= [:executable] (mapv :convention (:steps descriptor))))
     (is (= :exclusive (get-in executable [:attributes :scan-mode])))
-    (is (= (kernel-launch/sum 'n 1) (:elements (first (:outputs executable)))))
+    (doseq [n [0 1 513]]
+      (is (= (inc n)
+             (kernel-launch/resolve-expression {'n n}
+                                               (:elements (first (:outputs executable)))))))
     (is (empty? (:allocs descriptor)))))
 
 (deftest resident-segmap-step-carries-one-executable-call-template
@@ -116,11 +119,14 @@
     (is (= {'state :output} (:array-roles descriptor)))
     (is (= :state (:output step)))))
 
-(deftest resident-segred-schedule-is-an-explicit-kernel-call-override
+(deftest resident-segred-keeps-its-complete-two-phase-schedule
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-reduce
                                                  :ze:0 :dtype :float)
-        step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))
-        workgroup-size (first (get-in step [:artifact :launch :workgroup-size]))
+        step (first (filter #(= :executable (:convention %)) (:steps descriptor)))
+        graph (:artifact step)
+        partial (get-in graph [:nodes 0 :operation])
+        terminal (get-in graph [:nodes 1 :operation])
+        workgroup-size (first (get-in partial [:launch :workgroup-size]))
         n (inc (* 2 workgroup-size))
         runtime-params [(float-array n) (float-array n) 0.75 n]
         ordered-values
@@ -129,13 +135,18 @@
                   {:type type :value (value-fn runtime-params)}
                   (keyword (name sym))))
               (:argument-specs step))
-        default-call (kcall/make (:artifact step) ordered-values)
-        resident-call (kcall/make (:artifact step) ordered-values {:group-count [1]})]
-    (is (kart/kernel-artifact? (:artifact step)))
+        scalars (into {} (keep identity)
+                      (map (fn [slot value]
+                             (when (= :scalar (:kind slot)) [(:name slot) (:value value)]))
+                           (:abi graph) ordered-values))]
+    (is (kernel-graph/kernel-graph? graph))
+    (is (= 2 (count (:nodes graph))))
+    (is (= 1 (count (:temporaries graph))))
     (is (= [:input :output :scalar :scalar]
            (mapv :kind (:argument-specs step))))
-    (is (= [3] (get-in default-call [:geometry :group-count])))
-    (is (= [1] (get-in resident-call [:geometry :group-count])))))
+    (is (= 3 (kernel-launch/resolve-expression
+              scalars (first (get-in partial [:launch :group-count])))))
+    (is (= [1] (get-in terminal [:launch :group-count])))))
 
 (deftest resident-map-void-step-carries-a-logical-plan-for-one-physical-call
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-map-void

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -114,6 +114,21 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires :reduce-bound"
                             (route/validate-descriptor (dissoc red :reduce-bound)))))))
 
+(deftest zero-free-contraction-is-a-real-flat-scalar-segred-schedule
+  (let [routed (route/route-contraction
+                '(raster.par/contract O [] [[i 4] [j 6]]
+                                      (aget A (+ (* i 6) j)))
+                :dtype :float)
+        source (get-in routed [:artifact :provenance :scheduled-operation :source])]
+    (is (= 24 (:reduce-bound routed))
+        "the physical bound is the flattened product, not the first surface axis")
+    (is (= 24 (get-in source [:space :dims 0 :bound])))
+    (is (= :block-local (:phase source)))
+    (is (= [:block :virtual] ((juxt :level :virt) (:level source))))
+    (is (= :scalar-workgroup-tree (get-in source [:schedule :strategy])))
+    (is (= (get-in source [:grid :num-blocks])
+           (get-in source [:schedule :attributes :group-count])))))
+
 (deftest signature-parser-handles-the-real-kernels
   (testing "the parser finds every param of a multi-line DPAS signature"
     (let [d (route/route-contraction (mm 256 512 128) :dtype :half)

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -107,7 +107,7 @@
       (is (= '[A B O _n_bound] (mapv :name (:abi red))))
       (is (= '[A B O 8] (:arguments red))))
     (testing "…and the validator enforces each of those, so the protocol cannot drift"
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not carry"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not"
                             (route/validate-descriptor (assoc red :wg [256 1]))))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered :abi is required"
                             (route/validate-descriptor (dissoc red :abi))))

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -133,14 +133,19 @@
 (deftest scalar-contraction-affine-coordinates-require-the-exact-facts-proof
   (let [form '(raster.par/contract O [] [[i 8]] (aget A i))
         facts (contraction-facts/contraction-facts form :dtype :float)
-        forged (assoc-in facts [:operands 0 :idx] '(+ i 1024))
-        failure (try
-                  (route/route-contraction nil :facts forged :dtype :float)
-                  nil
-                  (catch clojure.lang.ExceptionInfo exception exception))]
-    (is (= :kernel-graph-target-lowering-missing (:reason (ex-data failure))))
-    (is (= :contraction-coordinate-proof
-           (get-in (ex-data failure) [:kernel-body-decline :missing-rule])))))
+        forgeries
+        [(assoc-in facts [:operands 0 :idx] '(+ i 1024))
+         ;; Repeated reads of one array are distinct proof obligations; validating only the first
+         ;; occurrence would admit this unproved second coordinate.
+         (update facts :operands conj {:sym 'A :idx '(+ i 1024) :map nil})]]
+    (doseq [forged forgeries]
+      (let [failure (try
+                      (route/route-contraction nil :facts forged :dtype :float)
+                      nil
+                      (catch clojure.lang.ExceptionInfo exception exception))]
+        (is (= :kernel-graph-target-lowering-missing (:reason (ex-data failure))))
+        (is (= :contraction-coordinate-proof
+               (get-in (ex-data failure) [:kernel-body-decline :missing-rule])))))))
 
 (deftest signature-parser-handles-the-real-kernels
   (testing "the parser finds every param of a multi-line DPAS signature"

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -13,6 +13,7 @@
    actually rejects each historical shape."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.contract-route :as route]))
 
 (defn- mm [m n k]
@@ -128,6 +129,18 @@
     (is (= :scalar-workgroup-tree (get-in source [:schedule :strategy])))
     (is (= (get-in source [:grid :num-blocks])
            (get-in source [:schedule :attributes :group-count])))))
+
+(deftest scalar-contraction-affine-coordinates-require-the-exact-facts-proof
+  (let [form '(raster.par/contract O [] [[i 8]] (aget A i))
+        facts (contraction-facts/contraction-facts form :dtype :float)
+        forged (assoc-in facts [:operands 0 :idx] '(+ i 1024))
+        failure (try
+                  (route/route-contraction nil :facts forged :dtype :float)
+                  nil
+                  (catch clojure.lang.ExceptionInfo exception exception))]
+    (is (= :kernel-graph-target-lowering-missing (:reason (ex-data failure))))
+    (is (= :contraction-coordinate-proof
+           (get-in (ex-data failure) [:kernel-body-decline :missing-rule])))))
 
 (deftest signature-parser-handles-the-real-kernels
   (testing "the parser finds every param of a multi-line DPAS signature"

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -40,6 +40,52 @@
         segred (lower/contract-form->segred form :dtype :half :facts verified)]
     (schedule/plan-portable-body verified segred nil)))
 
+(deftest portable-contraction-retains-load-scalar-and-index-widths
+  (let [form '(raster.par/contract y [[i m]] [[l k]] (* scale (aget x l)))
+        verified (facts/contraction-facts form :dtype :double)
+        segred (update (lower/contract-form->segred form :dtype :double :facts verified)
+                       :scalars conj 'scale)
+        plan (schedule/plan-portable-body
+              verified segred nil
+              {:array-types {'x :float}
+               :scalar-types {'m :long 'k :int 'scale :float}})
+        kernel (:body plan)
+        parameters (into {} (map (juxt :id :dtype)) (:parameters kernel))
+        loop (first (:operations kernel))]
+    (is (:ok plan))
+    (is (= kernel (body/validate! kernel)))
+    (is (= :float (get parameters 'x)))
+    (is (= :float (get parameters 'scale)))
+    (is (= :double (get parameters 'y)))
+    (is (= :long (get-in loop [:index :type])))
+    (is (some #(and (= :cast (get-in % [:expression :op]))
+                    (= :double (get-in % [:expression :result-type])))
+              (:operations loop)))
+    (doseq [target [:opencl-intel :cuda :hip]]
+      (is (string? (:source (emit/generate-contraction-kernel-artifact
+                            kernel :target-dialect target)))))))
+
+(deftest mixed-storage-cannot-select-a-uniform-pointer-leaf
+  (let [form '(raster.par/contract C [[i 4] [j 8]] [[l 16]]
+                                 (* (aget A (+ (* i 16) l)) (aget B (+ (* l 8) j))))
+        routed (route/route-contraction form :dtype :double
+                                        :array-types {'A :float 'B :float})
+        kernel (artifact/attribute (:artifact routed) :kernel-body)]
+    (is (= :portable-segred (:strategy routed)))
+    (is (body/kernel-body? kernel))
+    (is (= [:float :float] (mapv :dtype (take 2 (:parameters kernel)))))
+    (with-redefs [schedule/plan-portable-body (fn [& _] {:ok false :reason :test-decline})]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"mixed storage or floating captures require a typed portable"
+           (route/route-contraction form :dtype :double
+                                    :array-types {'A :float 'B :float}))))
+    (doseq [family [:matrix :register-tiled]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"no enabled contraction schedule family"
+           (route/route-contraction form :dtype :double
+                                    :array-types {'A :float 'B :float}
+                                    :candidate-families #{family}))))))
+
 (deftest portable-contraction-is-a-complete-scheduled-kernel-body
   (let [plan (portable-plan)
         kernel (:body plan)

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -11,7 +11,6 @@
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
-            [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.passes.parallel.contraction-schedule :as schedule]
@@ -98,9 +97,11 @@
   (with-redefs [hardware/descriptor-for (constantly nil)]
     (let [contract (matrix-form 128 128 128)
           source (list 'let* ['c contract] 'c)
-          lowered (:form (segop-lower/segop-lower-pass
-                          source {:target-device :ze:0 :dtype :half}))
-          semantic-operation (first (program/operations-for-binding lowered 'c contract))
+          ;; Enter through the production typed scheduler, not the compatibility discovery
+          ;; envelope whose source is deliberately rescheduled at backend re-entry.
+          lowered (:program (segop-lower/schedule-source-program
+                             source {:target-device :ze:0 :dtype :half}))
+          semantic-operation (first (mapcat :operations (:equations lowered)))
           compiled (opencl/opencl-pass lowered :dtype :half :min-elements 0)
           kernel (artifact/attribute (first (:kernels compiled)) :kernel-body)]
       (is (some? semantic-operation))

--- a/test/raster/compiler/passes/parallel/index_expression_test.clj
+++ b/test/raster/compiler/passes/parallel/index_expression_test.clj
@@ -20,6 +20,13 @@
     (is (= :long (launch/typed-expression-dtype projected dtypes)))
     (is (= #{'rows 'width} (launch/expression-references projected)))))
 
+(deftest maximum-round-trips-from-kernel-index-to-launch-algebra
+  (let [projected (index-expression/to-launch-expression
+                   (body/expression :max 1 'rows) fail!)]
+    (is (= #{'rows} (launch/expression-references projected)))
+    (is (= 1 (launch/resolve-expression {'rows 0} projected)))
+    (is (= 7 (launch/resolve-expression {'rows 7} projected)))))
+
 (deftest typed-launch-projection-declines-int-overflow-semantics
   (let [reason (try
                  (index-expression/lower-typed

--- a/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
@@ -15,6 +15,7 @@
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.passes.parallel.segfoldmap-body :as fold-body]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]
@@ -251,6 +252,25 @@
     (is (= #{'nsegments 'width} (get-in graph [:nodes 0 :scalar-uses])))
     (is (= artifact
            (scheduled-body/validate-artifact-projection! certificate artifact)))))
+
+(deftest fold-map-graph-emission-keeps-the-generic-scheduled-body-validator
+  (let [operation (scheduled-operation)
+        graph (kgraph/from-segops
+               [operation]
+               {:inputs #{'values} :outputs #{'out} :dtype :float
+                :buffer-specs {'values {:dtype :float :elements 'elements}
+                               'out {:dtype :float :elements 'elements}}
+                :scalars [(kgraph/scalar 'nsegments :int)
+                          (kgraph/scalar 'width :int)]})]
+    (with-redefs [segred-body/validate-against-node!
+                  (fn [& _]
+                    (throw (ex-info "SegRed validator used for SegFoldMap" {})))]
+      (is (artifact/kernel-artifact?
+           (get-in (segop-opencl/generate-kernel-graph
+                    graph :target-dialect :opencl-portable
+                    :array-types {'values :float 'out :float}
+                    :scalar-types {'nsegments :int 'width :int})
+                   [:nodes 0 :operation]))))))
 
 (deftest malformed-fold-map-contracts-decline-before-a-refinement-witness
   (let [operation (scheduled-operation)

--- a/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
@@ -86,6 +86,12 @@
                     :else [])))
           operations))
 
+(deftest launch-and-kernel-index-maximum-have-one-canonical-storage-form
+  (let [canonical-extent (ns-resolve 'raster.compiler.passes.parallel.segfoldmap-body
+                                     'canonical-extent)]
+    (is (= (canonical-extent (launch/maximum 'n 1))
+           (canonical-extent (body/expression :max 'n 1))))))
+
 (deftest interpreted-segmented-fold-map-preserves-dependent-fold-order
   (let [values (float-array [1.0 3.0, 2.0 2.0])
         out (float-array 4)]
@@ -253,13 +259,14 @@
     (is (= artifact
            (scheduled-body/validate-artifact-projection! certificate artifact)))))
 
-(deftest fold-map-graph-emission-keeps-the-generic-scheduled-body-validator
+(deftest fold-map-graph-emission-never-uses-the-segred-validator
   (let [operation (scheduled-operation)
+        elements (launch/product 'nsegments 'width)
         graph (kgraph/from-segops
                [operation]
                {:inputs #{'values} :outputs #{'out} :dtype :float
-                :buffer-specs {'values {:dtype :float :elements 'elements}
-                               'out {:dtype :float :elements 'elements}}
+                :buffer-specs {'values {:dtype :float :elements elements}
+                               'out {:dtype :float :elements elements}}
                 :scalars [(kgraph/scalar 'nsegments :int)
                           (kgraph/scalar 'width :int)]})]
     (with-redefs [segred-body/validate-against-node!

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1091,6 +1091,36 @@
         (is (= :portable-segred (:leaf (ex-data exception))))
         (is (= :none (:fallback (ex-data exception))))))))
 
+(deftest matrix-graphs-preserve-public-order-independent-of-operand-order
+  (doseq [batched? [false true]]
+    (let [contract (if batched?
+                     '(raster.par/contract C [[b batch] [i m] [j n]] [[l k]]
+                        (* (aget z (+ (* (+ (* b m) i) k) l))
+                           (aget a (+ (* l n) j))))
+                     '(raster.par/contract C [[i m] [j n]] [[l k]]
+                        (* (aget z (+ (* i k) l)) (aget a (+ (* l n) j)))))
+          {:keys [form]} (pipeline/schedule-parallel-form
+                          (list 'let* ['step contract] 'step)
+                          {:target-device :ze:0 :dtype :float
+                           :array-types {'z :float 'a :float 'C :float}
+                           :scalar-types {'batch :int 'm :int 'n :int 'k :int}})
+          scheduled (contract-route/route-typed-contraction-dispatch
+                     (-> form :equations first :algorithm)
+                     (-> form :equations first :operations first)
+                     :dtype :float :precision :mixed-f16-f32
+                     :desc {:backend :ze :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                            :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                            :subgroup-size 16 :max-workgroup-size 1024
+                            :grf-bytes-per-lane 256 :machine-lanes 8192
+                            :shared-local-memory 131072})]
+      (doseq [strategy (if batched? [:xmx-batched] [:xmx-direct :xmx-split-k])]
+        (let [graph (kdispatch/alternative scheduled strategy)
+              refinement (get-in graph [:attributes :scheduled-graph-refinement])]
+          (is (some? graph))
+          (is (= '[a z] (mapv :id (:inputs graph))))
+          (is (= (kernel-graph/boundary-contract (:source refinement))
+                 (kernel-graph/boundary-contract (:graph refinement)))))))))
+
 (deftest dynamic-f32-contraction-owns-its-dpas-graph-alternatives
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1632,6 +1632,35 @@
                kdispatch/alternative-strategy))
         "low occupancy stays direct rather than transforming split partials")))
 
+(deftest mixed-matrix-routing-declines-a-read-write-result-explicitly
+  (let [transform {:acc 'acc :expr '(+ acc (aget C (+ (* i n) j)))
+                   :operands [{:sym 'C :dtype :float
+                               :map {:groups [[['i 'm] ['j 'n]]]}}]
+                   :scalars [] :dtype :float}
+        contract (concat '(raster.par/contract C [[i m] [j n]] [[l k]]
+                              (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))
+                         [:epilogue transform])
+        {:keys [form]} (pipeline/schedule-parallel-form
+                        (list 'let* ['step (apply list contract)] 'step)
+                        {:target-device :ze:0 :dtype :float
+                         :array-types {'A :float 'B :float 'C :float}
+                         :scalar-types {'m :int 'n :int 'k :int}})
+        dispatch (contract-route/route-typed-contraction-dispatch
+                  (-> form :equations first :algorithm)
+                  (-> form :equations first :operations first)
+                  :dtype :float :precision :mixed-f16-f32
+                  :desc {:backend :ze :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                         :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                         :subgroup-size 16 :max-workgroup-size 1024
+                         :grf-bytes-per-lane 256 :machine-lanes 8192
+                         :shared-local-memory 131072})]
+    (is (= [:portable-segred]
+           (mapv kdispatch/alternative-strategy (:alternatives dispatch))))
+    (is (= :mixed-dpas-inout-result-transform-not-lowered
+           (get-in dispatch [:attributes :matrix-graph-decline :reason])))
+    (is (= :inout (:kind (some #(when (= 'C (:name %)) %)
+                               (:abi (kdispatch/default-alternative dispatch))))))))
+
 (deftest resident-reduction-realization-stays-on-the-typed-spine
   (let [source
         '(let* [total (raster.par/reduce acc 0.0 i n

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1025,9 +1025,9 @@
              (mapv :role (drop 3 (:abi alternative)))))
       (is (kernel-graph-call/kernel-graph-call?
            (kernel-graph-call/make alternative {'A :a 'B :b 'C :c}
-                                   {'m {:type :int :value 7}
-                                    'n {:type :int :value 5}
-                                    'k {:type :int :value 3}}))))
+               {'m {:type :long :value 7}
+                'n {:type :long :value 5}
+                'k {:type :long :value 3}}))))
     (try
       (contract-route/route-typed-contraction
        algorithm operation :dtype :double :desc {})

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -235,6 +235,8 @@
                        'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
                       '(raster.par/reduce acc 0.0 i n
                                           (+ acc (clojure.core/aget a i)))
-                      :dtype :float :min-elements 0)]
+                      :dtype :double :min-elements 0
+                      :array-types {'a :double} :scalar-types {'n :long})]
         (is (= 1 (get-in compiled [:stats :ze-reduces])))
-        (is (= 1 (get-in compiled [:stats :segop-relowered])))))))
+        (is (= 1 (get-in compiled [:stats :segop-reused])))
+        (is (nil? (get-in compiled [:stats :segop-relowered])))))))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -118,6 +118,23 @@
     (is (= 1 (get-in compiled [:stats :segop-reused])))
     (is (= 'clojure.core/aget (first (last (:form compiled)))))))
 
+(deftest compatibility-reentry-cannot-overwrite-retained-value-types
+  (let [form '(let* [n 8192]
+                    (raster.par/reduce acc 0.0 i n
+                                       (+ acc (clojure.core/aget X i))))
+        program (:form (slp/segop-lower-pass
+                        form {:target-device :ze:0 :dtype :double
+                              :scalar-types {'n :long}
+                              :array-types {'X :double}}))
+        failure (try
+                  (op/opencl-pass program :device-id :ze:0 :dtype :double :min-elements 0
+                                  :scalar-types {'n :int})
+                  nil
+                  (catch clojure.lang.ExceptionInfo exception exception))]
+    (is (= :parallel-program-type-conflict (:reason (ex-data failure))))
+    (is (= {:retained :long :provided :int}
+           (get-in (ex-data failure) [:scalar-conflicts 'n])))))
+
 (deftest jvm-simd-consumes-the-boundary-too
   (testing "matching map/reduce SegOps are reused rather than independently re-derived"
     (doseq [[label form stat-key]

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -70,7 +70,7 @@
         simd (par-simd/simd-pass
               form :dtype :double :min-elements 0
               :array-types {'X :double} :scalar-types {'n :long})]
-    (is (= 1 (count (:kernels compiled))))
+    (is (= 2 (count (:kernels compiled))))
     (is (= 1 (get-in compiled [:stats :ze-reduces])))
     (is (= 1 (get-in compiled [:stats :segop-reused])))
     (is (nil? (get-in compiled [:stats :segop-relowered])))
@@ -101,17 +101,22 @@
       (is (= 1 (:segop-reused st)) "consumed from the first-class equation")
       (is (nil? (:segop-relowered st))))))
 
-(deftest a-body-position-reduction-keeps-the-existing-resultless-envelope
+(deftest a-body-position-reduction-has-the-same-typed-result-envelope
   (let [form '(let* [n 8192]
                     (raster.par/reduce acc 0.0 i n
                                        (+ acc (clojure.core/aget X i))))
-        program (lowered form)
+        program (:form (slp/segop-lower-pass
+                        form {:target-device :ze:0 :dtype :double
+                              :scalar-types {'n :long}
+                              :array-types {'X :double}}))
         equation (first (:equations program))
-        st (:stats (run program))]
-    (is (empty? (:results equation)))
-    (is (nil? (:algorithm equation)))
-    (is (= 1 (:segop-reused st)))
-    (is (= 1 (:ze-reduces st)))))
+        compiled (run program)]
+    (is (= 1 (count (:results equation))))
+    (is (some? (:algorithm equation)))
+    (is (= 2 (count (:kernels compiled))))
+    (is (= 1 (get-in compiled [:stats :ze-reduces])))
+    (is (= 1 (get-in compiled [:stats :segop-reused])))
+    (is (= 'clojure.core/aget (first (last (:form compiled)))))))
 
 (deftest jvm-simd-consumes-the-boundary-too
   (testing "matching map/reduce SegOps are reused rather than independently re-derived"

--- a/test/raster/dl/einsum_path_test.clj
+++ b/test/raster/dl/einsum_path_test.clj
@@ -194,5 +194,6 @@
              '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i))) :dtype :double)]
       (is (= :full-reduce (:strategy r)))
       (is (= :reduction (:invoke r)))
-      (is (= 2 (:n-phases r)))
+      (is (nil? (:n-phases r))
+          "one scheduled artifact does not claim ownership of a hidden second phase")
       (is (= 1 (:out-elems r))))))

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -219,7 +219,7 @@
   ;; (the resident TypedSOAC realization gives it a device one-element output buffer)
   ;; threw at bind time even though bind-step! already handled :reduce. This pins the
   ;; wiring: scale*sum(a) (a captured reduction scalar) feeding an elementwise scale compiles to
-  ;; [:reduce :map] steps, binds its full ordered ABI,
+  ;; a two-phase reduction graph followed by a map, binds its full ordered ABI,
   ;; and replays with the correct output. (An ESCAPING tail reduce — a loss returned as
   ;; the scalar result — still doesn't bind: that is the remaining #42 leftover, same as
   ;; bind-step!.)
@@ -244,8 +244,9 @@
           cpu (float-array (map #(float (* (double %) s)) (seq a)))
           {:keys [descriptor] :as r} (run-resident probe [a out n scale])
           gpu (:out r)]
-      (let [red-step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))]
-        (is (some? red-step) "resident-consumed par/reduce compiles to a :reduce step")
+      (let [red-step (first (filter #(= :executable (:convention %)) (:steps descriptor)))]
+        (is (some? red-step) "resident-consumed par/reduce compiles to a graph-backed step")
+        (is (= 2 (count (get-in red-step [:artifact :nodes]))))
         (is (= [:input :output :scalar :scalar]
                (mapv :kind (:argument-specs red-step))))
         (is (= [:float :float :float :int]

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -413,7 +413,8 @@
       (try
         (let [program (fixture/instantiate! s descriptor [x out scale n])
               result (get (fixture/run! program [x out scale n]) 'out)
-              red-step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))]
+              red-step (first (filter #(= :executable (:convention %)) (:steps descriptor)))]
+          (is (= 2 (count (get-in red-step [:artifact :nodes]))))
           (is (= [:input :output :scalar :scalar]
                  (mapv :kind (:argument-specs red-step))))
           (is (< (Math/abs (- (double (aget ^floats result 511))


### PR DESCRIPTION
## Outcome

Scalar par/reduce now follows the canonical compiler vertical end to end:

- retained TypedSOAC reduction algebra
- exact two-phase SegRed schedule
- verified target-neutral ScheduledKernelBody
- complete KernelGraph with compiler-owned partial storage
- portable OpenCL/CUDA/HIP C-family emission
- generic staged/resident executable binding

The direct scalar-reduction backend no longer launches one partial kernel and combines it with a custom host implementation. Rank-zero host results are ordinary one-element graph outputs materialized by the wrapper.

## Correctness boundaries

- Reconstructs graph bodies from exact retained equations and validates full schedule/body/source equality.
- Uses overflow-safe launch algebra, including empty reductions and capped group counts.
- Validates external capacities and all runtime bounds before opening a device session.
- Preserves retained ABI roles and dtypes through compatibility re-entry; contradictions fail closed.
- Admits ordinary scalar loads only at the exact reduced coordinate until buffer-view range proofs land.
- Full-contraction affine coordinates require matching ContractionFacts and a verified AxisMap for every load occurrence.
- Floating min/max decline until NaN and signed-zero policy is explicit.

## Validation

- Broad affected gate: 180 tests, 976 assertions, 0 failures/errors.
- Post-review focused gates for scalar consumption, SegRed codegen, and contraction proof forgeries are green.
- GPU-gated Level Zero tests were skipped locally because no Level Zero device was visible; the updated device test now invokes the generated two-phase graph and will run where hardware is exposed.
- Independent static review completed with no remaining blocker.