### PR TITLE
Preserve typed result-transform captures through resident realization

### DIFF
--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -63,6 +63,9 @@
         target (dtype/canon target)]
     (cond
       (= source target) nil
+      (and (contains? #{:byte :int :long} source) (dtype/fp-dtype? target))
+      [:nearest-even (if (= :half target) :ieee :exact)]
+
       (and (dtype/fp-dtype? source) (dtype/fp-dtype? target)
            (< (dtype/bytes-of source) (dtype/bytes-of target)))
       [:exact :exact]

--- a/src/raster/compiler/passes/parallel/typed_soac_resident.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_resident.clj
@@ -42,6 +42,11 @@
               (dialect/lambda-form (vec parameters) (dialect/emit-locals locals)
                                    (vec body-results)))))
 
+(defn- result-transform-inputs
+  [attributes]
+  (let [{:keys [operands scalars]} (:result-transform attributes)]
+    (map :value (concat operands scalars))))
+
 (defn- use-sites
   [equations]
   (reduce
@@ -50,6 +55,10 @@
        (-> uses
            (into (map (fn [value] [value {:equation id :role :array}]) arrays))
            (into (map (fn [value] [value {:equation id :role :capture}]) captures))
+           ;; The transform has its own typed scalar boundary. Rewriting the primary
+           ;; lambda cannot turn a transform scalar into a resident buffer load.
+           (into (map (fn [value] [value {:equation id :role :result-transform}])
+                      (result-transform-inputs attributes)))
            (cond-> (dialect/value-id? (:extent attributes))
              (conj [(:extent attributes) {:equation id :role :extent}])))))
    [] equations))
@@ -124,7 +133,8 @@
         stable-before (set (get-in info [:attributes :attributes :stable-array-captures]))
         referenced-values (->> (concat (mapcat #(util/free-syms (:init %) bound) global-locals)
                                        (mapcat #(util/free-syms % bound) global-bodies)
-                                       stable-before)
+                                       stable-before
+                                       (result-transform-inputs (:attributes info)))
                                (filter #(contains? values %)) distinct (sort-by pr-str) vec)
         new-parameters (mapv #(symbol (str "%capture" %)) (range (count referenced-values)))
         body-substitutions (zipmap referenced-values new-parameters)
@@ -145,7 +155,8 @@
 (defn realize
   "Return `[program stats]`, realizing every eligible non-escaping scalar reduction.
 
-   A root declines realization when it is a program result or is used as an element array/extent.
+   A root declines realization when it is a program result or is used as an element array,
+   extent, or result-transform input (which requires a separate scalar-load schedule).
    Scalar chains depending on eligible roots must likewise remain internal and capture-only."
   [program]
   (let [program (dialect/validate! program)

--- a/test/raster/compiler/passes/parallel/resident_norm_device_test.clj
+++ b/test/raster/compiler/passes/parallel/resident_norm_device_test.clj
@@ -1,0 +1,50 @@
+(ns raster.compiler.passes.parallel.resident-norm-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.dl.nn :as nn]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.descriptor-fixture :as fixture]
+            [raster.gpu.device-probe :as opencl-probe]))
+
+(deftest public-rmsnorm-has-a-resident-reduction-and-map
+  (doseq [target [:ocl:0 :ze:0]]
+    (let [descriptor (pipeline/compile-gpu-program #'nn/rms-norm-1row! target :dtype :float)
+          reduction (:artifact (first (:steps descriptor)))]
+      (is (= [:executable :map-void] (mapv :convention (:steps descriptor))))
+      (is (graph/kernel-graph? reduction))
+      (is (= 2 (count (:nodes reduction))))
+      (is (= 1 (count (:allocs descriptor))) "only the completed scalar crosses stages"))))
+
+(defn- run-norm! [target]
+  (let [descriptor (pipeline/compile-gpu-program #'nn/rms-norm-1row! target :dtype :float)]
+    (gpu/with-gpu-session [session target]
+      (doseq [width [1 17 513]]
+        (let [x (float-array (map #(float (/ (- (mod % 11) 5) 7.0)) (range width)))
+              weights (float-array (map #(float (/ (inc (mod % 7)) 9.0)) (range width)))
+              output (float-array width)
+              eps 0.0001
+              gain 1.0
+              arguments [x weights output (long width) eps gain]
+              inverse (/ 1.0 (Math/sqrt (+ eps (/ (reduce + (map #(* (double %) %) x)) width))))
+              expected (mapv #(* %1 inverse (+ gain %2)) x weights)
+              program (fixture/instantiate! session descriptor arguments
+                                            {'x :input 'weight :input 'out :output})]
+          (try
+            (dotimes [_ 2]
+              (let [actual (get (fixture/run! program arguments) 'out)]
+                (is (= width (count actual)))
+                (doseq [[want got] (map vector expected actual)]
+                  (is (< (Math/abs (- want got)) 0.00001)))))
+            (finally (fixture/close! program))))))))
+
+(deftest opencl-resident-rmsnorm-matches-reference
+  (if @opencl-probe/opencl-available?
+    (run-norm! :ocl:0)
+    (opencl-probe/opencl-skip! "resident RMSNorm result transform")))
+
+(deftest level-zero-resident-rmsnorm-matches-reference
+  (if @gpu-probe/gpu-available?
+    (run-norm! :ze:0)
+    (gpu-probe/gpu-skip! "resident RMSNorm result transform")))

--- a/test/raster/compiler/passes/parallel/typed_soac_resident_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_resident_test.clj
@@ -1,0 +1,62 @@
+(ns raster.compiler.passes.parallel.typed-soac-resident-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-resident :as resident]))
+
+(defn- fused [source]
+  (first (fusion/fusion-fixpoint
+          (frontend/form->program source
+                                  {:dtype :double :array-types {'x :double 'out :double}
+                                   :scalar-types {'scale :double}}))))
+
+(deftest result-transform-integral-casts-state-their-rounding
+  (doseq [source [:int :long] target [:float :double]]
+    (let [region (body/->ScalarRegion ['acc 'width] (list (symbol (name target)) 'width)
+                                      [] target)
+          result (scalar-region/lower
+                  region {:accumulator 'acc :accumulator-dtype target :store-dtype target
+                          :parameters {'width {:id 'width :kind :scalar :role :parameter
+                                               :dtype source}}})
+          cast (:expression (first (:operations result)))]
+      (is (= :cast (:op cast)))
+      (is (= {:rounding :nearest-even :overflow :exact} (:options cast))))))
+
+(deftest resident-reduction-preserves-the-independent-transform-boundary
+  (let [program (fused
+                 '(let* [total (raster.par/reduce acc 0.0 i n (+ acc (aget x i)))
+                         ^double scaled (* ^double total ^double scale)
+                         result (raster.par/map-void! j n
+                                  (aset out j (* (aget x j) scaled)))]
+                    result))
+        transform-before (get-in (fusion/equation-info (first (dialect/equations program)))
+                                 [:attributes :result-transform])
+        [result stats] (resident/realize program)
+        reduction (fusion/equation-info (first (dialect/equations result)))]
+    (is (some? transform-before))
+    (is (= '[scale] (mapv :value (:scalars transform-before))))
+    (is (= 1 (:resident-reductions stats)))
+    (is (some #{'scale} (:captures reduction)))
+    (is (= transform-before (get-in reduction [:attributes :result-transform])))
+    (is (resident/resident-scalar-value? (get-in (dialect/facts result) [:values 'scaled])))
+    (is (= result (dialect/validate! result)))))
+
+(deftest transform-scalars-do-not-silently-become-resident-pointers
+  (let [program (fused
+                 '(let* [left (raster.par/reduce a 0.0 i n (+ a (aget x i)))
+                         right (raster.par/reduce b 0.0 j n (+ b (* (aget x j) 2.0)))
+                         ^double combined (* ^double right ^double left)
+                         result (raster.par/map-void! k n
+                                  (aset out k (* (aget x k) combined)))]
+                    result))
+        transform-inputs (into #{} (mapcat #(map :value (get-in (fusion/equation-info %)
+                                                                [:attributes :result-transform :scalars])))
+                               (dialect/equations program))
+        [result _] (resident/realize program)]
+    (is (seq transform-inputs))
+    (doseq [value transform-inputs]
+      (is (not (resident/resident-scalar-value? (get-in (dialect/facts result) [:values value])))))
+    (is (= result (dialect/validate! result)))))

--- a/test/raster/dl/train_test.clj
+++ b/test/raster/dl/train_test.clj
@@ -238,6 +238,12 @@
 ;; End-to-end training: XOR classification
 ;; ================================================================
 
+(defn- seeded-he-weights
+  [^java.util.Random rng rows cols]
+  (let [scale (Math/sqrt (/ 6.0 cols))]
+    (double-array (repeatedly (* rows cols)
+                              #(* scale (- (* 2.0 (.nextDouble rng)) 1.0))))))
+
 (deftest xor-training-test
   (testing "MLP learns XOR pattern"
     (let [;; XOR dataset: 4 samples, repeated for enough data
@@ -250,10 +256,13 @@
                          [x1 x2 y] xor-data]
                      [(double-array [x1 x2]) (double-array [y])]))
           in-dim 2 hidden 8 out-dim 1
-          ;; Initialize weights
-          W1 (nn/he-init hidden in-dim)
+          ;; This is a convergence regression, not a random-initialization stress test.
+          ;; Keep both the initial parameters and minibatch order reproducible, without
+          ;; changing its loss/prediction thresholds or retrying until training succeeds.
+          rng (java.util.Random. 42)
+          W1 (seeded-he-weights rng hidden in-dim)
           b1 (double-array hidden)
-          W2 (nn/he-init out-dim hidden)
+          W2 (seeded-he-weights rng out-dim hidden)
           b2 (double-array out-dim)
           ;; Optimizer state
           adam-state {:W1 {:m (double-array (* hidden in-dim))
@@ -299,11 +308,11 @@
               loss-val))
           batch-size 16
           ;; Record loss at epoch 1
-          first-loss (train/train-epoch! model-fn dataset batch-size :shuffle? true)
+          first-loss (train/train-epoch! model-fn dataset batch-size :shuffle? false)
           ;; Train more epochs
           _ (dotimes [_ 198]
-              (train/train-epoch! model-fn dataset batch-size :shuffle? true))
-          last-loss (train/train-epoch! model-fn dataset batch-size :shuffle? true)
+              (train/train-epoch! model-fn dataset batch-size :shuffle? false))
+          last-loss (train/train-epoch! model-fn dataset batch-size :shuffle? false)
           ;; Evaluate on all 4 XOR inputs
           predict (fn [x1 x2]
                     (let [x (double-array [x1 x2])


### PR DESCRIPTION
## Summary

- Preserve the explicit inputs of a reduction's result transform when rebuilding resident captures. The transform is a separate typed region, not part of the primary reduction lambda.
- Decline resident realization for scalars used by another result transform until a scalar-load schedule exists for that boundary.
- Lower integral-to-floating result-transform conversions with explicit nearest-even rounding and the existing KernelBody numerical contract.
- The public `rms-norm-1row!` now compiles to a two-phase resident reduction graph followed by a map, with one resident scalar crossing stages. No RMSNorm-specific kernel or recognition rule is added.
- Make the XOR convergence regression deterministic after CI exposed unseeded initialization/batch-order flakiness. Production training and all convergence thresholds remain unchanged.

## Validation

- Focused route/resident tests: 56 tests, 514 assertions, green.
- Resident transform, public RMSNorm structure, and kernel-call pipeline tests: 13 tests, 72 assertions, green.
- Read-only review found no concrete defects.
- New OpenCL/Level Zero numerical tests cover widths 1, 17, 513 and graph replay against an independent reference. Local device execution was skipped: this sandbox cannot initialize either backend. The namespace automatically joins the existing OpenCL CPU CI gate; numerical execution is not yet claimed.
- Full suite delegated to CI. No SOTA performance claim or workload-specific semantic API.
- The deterministic XOR test passed twice locally (12 assertions).

Parent #370 is squash-merged. This PR is rebased onto `ebf6df9c` and targets main. The rebase preserved the tested file tree; the subsequent XOR test-only repair addresses the sole failure in that rerun. The shared graph-order repair passed 70 targeted tests / 679 assertions plus both public AD/GEMM regressions. Waiting for checks on the repaired head before merging.
