### PR TITLE
Unify rank-zero contractions with complete typed reduction graphs

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -702,6 +702,12 @@ TypedSOAC subset directly. Certified inclusive and exclusive scans also cross th
 algorithm and scheduled-program boundary, retaining explicit destination, result-layout, and
 graph-owned temporary-storage contracts. Migration is complete when hardware-costed multi-consumer
 fusion, the remaining parallel forms, and covered backend compatibility re-lowerings are deleted.
+Full contractions with one pointwise reduction axis and disjoint caller-owned output now use the
+same TypedSOAC segmented reduction with an empty segment space. They lower to the complete scalar
+reduction graph (including cross-block finalization) and write only `out[0]`; rank zero does not
+imply a host scalar download. Affine/multi-axis and aliased full contractions remain outside this
+admission boundary. Public graph scalars retain their logical dtype while individual kernel nodes
+may use checked integer narrowing for physical launch bounds.
 Nested scalar folds inside a retained map are now explicit typed scalar-region terms. Monoid-shaped
 folds carry an `AssociativeScan` certificate and an implementation-defined association contract, so
 the JVM may select its multi-accumulator SIMD reduction. General recurrences carry an ordered

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -36,6 +36,18 @@
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]))
 
+(defn- host-scalar-result?
+  [program equation]
+  (let [value (get-in program [:values (first (:results equation))])
+        algorithm (:algorithm equation)]
+    (and (= [] (:shape value))
+         (not (resident/resident-scalar-value? value))
+         ;; A rank-zero tensor written to caller-owned storage still returns a buffer,
+         ;; not an implicitly downloaded host scalar.
+         (or (nil? algorithm)
+             (not-any? #(soac-dialect/result-storage (soac-dialect/facts algorithm) (second %))
+                       (soac-dialect/equations algorithm))))))
+
 ;; Buffer semantics of the emitted kernel-invoke marker: invoke-registered-kernel
 ;; WRITES its `out` arg in place (arg 2 of [kname inputs out scalars n]) and
 ;; RETURNS it, so the binding sym is a pure alias of the out buffer. Declared in
@@ -462,6 +474,7 @@
                  (and (par/par-scatter-form? form)
                       (:stride (par/extract-par-scatter-info form)))
                  (par/par-reduce-form? form)
+                 (and (croute/par-contract-form? form) (empty? (nth form 2)))
                  ;; A compound source extent normalizes to a preceding typed scalar equation. It
                  ;; cannot be projected as a closed SegMap without losing that SSA definition.
                  (and (par/par-map-form? form)
@@ -1078,17 +1091,8 @@
                                                                                raster.compiler.ir.segop.SegRed %)
                                                                              (:operations equation)))
                                                             :ze-reduces)
-                                                          (boolean
-                                                           (and equation
-                                                                (not (resident/resident-scalar-value?
-                                                                      (get-in parallel-program
-                                                                              [:values (first (:results equation))])))
-                                                                (= [] (get-in parallel-program
-                                                                              [:values
-                                                                               (first
-                                                                                (:results
-                                                                                 equation))
-                                                                               :shape]))))))
+                                                          (boolean (host-scalar-result?
+                                                                    parallel-program equation))))
                                                        (binding [*bound-segops*
                                                                  (when parallel-program
                                                                    (parallel-program/operations-for-binding
@@ -1132,10 +1136,8 @@
                                            (equation-graph/make-for-equation
                                             parallel-program equation))
                                           :ze-reduces
-                                          (boolean
-                                           (= [] (get-in parallel-program
-                                                         [:values (first (:results equation))
-                                                          :shape])))))
+                                          (boolean (host-scalar-result?
+                                                    parallel-program equation))))
                                        (binding [*bound-segops* (:operations equation)
                                                  *bound-algorithm*
                                                  (when parallel-program

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -798,7 +798,7 @@
                              :expected scalar-arguments
                              :actual (vec (sort-by pr-str (keys scalar-groups)))})))
         _ (doseq [[argument pairs] scalar-groups]
-            (when-not (apply = (map (comp :kernel-dtype first) pairs))
+            (when-not (apply = (map (comp :dtype first) pairs))
               (throw (ex-info "kernel graph scalar has inconsistent emitted ABI dtypes"
                               {:reason :kernel-graph-scalar-dtype
                                :argument argument :slots (mapv first pairs)}))))
@@ -816,7 +816,12 @@
         scalar-abi (mapv (fn [argument]
                            (let [slots (mapv first (get scalar-groups argument))
                                  declared (some #(when (= argument (:id %)) %) declared-scalars)
-                                 kernel-dtype (or (:kernel-dtype (first slots)) (:dtype declared))
+                                 ;; A graph is not a physical kernel. Each node preserves its
+                                 ;; own checked conversion (e.g. long parameter versus int bound).
+                                 physical-types (distinct (map :kernel-dtype slots))
+                                 kernel-dtype (if (= 1 (count physical-types))
+                                                (first physical-types)
+                                                (or (:dtype declared) (:dtype (first slots))))
                                  logical-dtype (or (:dtype declared)
                                                    (get scalar-types argument)
                                                    kernel-dtype)

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -89,8 +89,12 @@
         (doseq [[slot argument] (filterv (fn [[slot _]] (= :scalar (:kind slot)))
                                          (mapv vector (:abi artifact) (:arguments artifact)))]
           (if-let [public-slot (get public-scalars argument)]
-            (when-not (= (select-keys slot [:dtype :kernel-dtype])
-                         (select-keys public-slot [:dtype :kernel-dtype]))
+            (when-not (and (= (:dtype slot) (:dtype public-slot))
+                           (or (= (:kernel-dtype slot) (:kernel-dtype public-slot))
+                               ;; GraphCall performs checked integral conversion per node.
+                               ;; Other precision changes still need an explicit numerical policy.
+                               (every? #{:int :long}
+                                       [(:kernel-dtype slot) (:kernel-dtype public-slot)])))
               (throw (ex-info "kernel artifact scalar dtype differs from its graph interface"
                               {:reason :kernel-graph-artifact-scalar-dtype
                                :node id :argument argument

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -6,6 +6,7 @@
    Driver allocation, registration, recording and events remain runtime concerns."
   (:require [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]))
 
@@ -103,7 +104,13 @@
       (when-not (and (map? value) (contains? value :type) (contains? value :value))
         (throw (ex-info "graph symbolic scalar requires an explicitly typed runtime value"
                         {:compiler-value compiler-value :slot slot :value value})))
-      value)
+      (if (= (:type value) (:kernel-dtype slot))
+        value
+        (if (every? #{:int :long} [(:type value) (:kernel-dtype slot)])
+          (executable/physical-runtime-scalar slot (:value value))
+          (throw (ex-info "graph scalar requires an unsupported physical conversion"
+                          {:reason :kernel-graph-call-scalar-conversion
+                           :slot slot :value value})))))
     (let [value (resolve-integer scalar-values compiler-value)]
       {:type (:kernel-dtype slot)
        :value (cast-scalar (:kernel-dtype slot) value)})))
@@ -154,7 +161,7 @@
    symbolic scalar values. Derived integer arguments such as a block-count CeilDiv are resolved
    from the typed scalar environment and receive the ABI slot's integer type."
   [graph buffers scalar-values]
-  (let [graph (kgraph/validate! graph)
+  (let [graph (executable/validate! graph)
         declared (declared-buffer-ids graph)
         scalar-values (validate-scalar-values! graph (or scalar-values {}))]
     (when-not (= declared (set (keys buffers)))

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -355,7 +355,7 @@
   (let [axes (:segment-axes value)
         indices (mapv first axes)]
     (and (reduce-attributes? (dissoc value :segment-axes))
-         (vector? axes) (seq axes)
+         (vector? axes)
          (every? #(and (vector? %) (= 2 (count %))
                        (symbol? (first %)) (extent? (second %)))
                  axes)

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -499,7 +499,9 @@
           segment-axes (:segment-axes attributes)
           reduced-index (:index attributes)
           reduced-extent (:extent attributes)
-          dense-coordinate (flat-segment-coordinate segment-axes reduced-index reduced-extent)
+          dense-coordinate (if (seq segment-axes)
+                             (flat-segment-coordinate segment-axes reduced-index reduced-extent)
+                             reduced-index)
           substitutions
           (into (zipmap capture-parameters captures)
                 (map (fn [parameter array]
@@ -515,13 +517,29 @@
                    :result result})
                 (range) accumulators (:identities attributes) (:dtypes attributes)
                 physical-results)
-          operator (reduction/make
-                    {:components components
-                     :index reduced-index
-                     :step (reduction/->ReductionRegion [] step-results {})
-                     :algebra {:components (:algebra attributes)}
-                     :attributes {:source :typed-soac :equation equation-id
-                                  :segmented true}})
+          operator (if (empty? segment-axes)
+                     (do
+                       (when-not (= 1 (count components))
+                         (throw (ex-info "rank-zero reduction requires one scalar component"
+                                         {:reason :typed-soac-rank-zero-reduction-components
+                                          :equation equation-id})))
+                       (let [{:keys [accumulator neutral dtype result]} (first components)]
+                         (reduction/scalar
+                          {:accumulator accumulator :neutral neutral :dtype dtype :result result
+                           :index reduced-index :step-result (first step-results)
+                           :algebra (first (:algebra attributes))
+                           :attributes (cond-> {:source :typed-soac :equation equation-id}
+                                         (:result-transform attributes)
+                                         (assoc :result-region
+                                                (scalar-region-lower/from-typed-result-transform
+                                                 (:result-transform attributes))))})))
+                     (reduction/make
+                      {:components components
+                       :index reduced-index
+                       :step (reduction/->ReductionRegion [] step-results {})
+                       :algebra {:components (:algebra attributes)}
+                       :attributes {:source :typed-soac :equation equation-id
+                                    :segmented true}}))
           values (:values facts)
           stable-captures (set (get-in attributes [:attributes :stable-array-captures]))
           inputs (set/union (set arrays) stable-captures)
@@ -564,11 +582,18 @@
                                 {:reason :typed-soac-segmented-reduce-input
                                  :equation equation-id :input input
                                  :value (get values input)}))))]
-      [(segop/->SegRed equation-id space
+      (if (empty? segment-axes)
+        (lower-reduce-description
+         {:id equation-id :sym (first physical-results)
+          :reduction operator :segment-axes [] :bound reduced-extent :idx reduced-index
+          :inputs inputs :outputs (set physical-results) :scalars scalars
+          :elem-type output-dtype}
+         device-id :dtype output-dtype)
+        [(segop/->SegRed equation-id space
                        (segop/->SegLevel :thread :virtual)
                        operator nil inputs (set physical-results) scalars planned-grid
                        (if contraction? :contraction :segmented)
-                       contraction-schedule output-dtype)])))
+                       contraction-schedule output-dtype)]))))
 
 (defn typed-product-reduce-program?
   "Whether a validated one-equation TypedSOAC program is a product reduction."

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -265,7 +265,7 @@
           (list head bindings stripped)))
       :else nil)))
 
-(declare store-region)
+(declare store-region pointwise-input?)
 
 (defn- counted-store-loop
   "Recognize a counted loop of stores inside an effect-map body.

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1227,7 +1227,16 @@
       ;; The direct slice is scalar segmented-reduction algebra plus an optional closed typed
       ;; result transform. Staged quantization carries additional schedule/load contracts and must
       ;; not be admitted by dropping those facts.
-      (when (and (seq free-axes) (seq contract-axes)
+      (when (and (seq contract-axes)
+                 (or (seq free-axes)
+                     ;; The first rank-zero tensor reduction uses the ordinary pointwise
+                     ;; scalar tree. Affine/multi-axis loads need their own coordinate witness.
+                     (and (= 1 (count contract-axes)) (nil? epilogue)
+                          (not-any? #(= out (:sym %)) (:operands facts))
+                          (every? #(pointwise-input?
+                                    (:results (reduction/fold-region (:reduction facts)))
+                                    (:sym %) (ffirst contract-axes))
+                                  (:operands facts))))
                  ;; Decode lambdas, declared physical maps, staged accumulators and output
                  ;; conversions are not scalar fold syntax. Keep them on the certified
                  ;; contraction route until TypedSOAC represents those facts explicitly.
@@ -1830,7 +1839,7 @@
     :stencil (and (= 1 (count (:result-storage description)))
                   (symbol? (get-in description [:result-storage 0 :destination])))
     :reduce true
-    :segmented-reduce (and (seq (:segment-axes description))
+    :segmented-reduce (and (vector? (:segment-axes description))
                            (symbol? (get-in description [:result-storage 0 :destination])))
     :product-reduce (and (seq (:segment-axes description))
                          (seq (:result-components description))
@@ -2163,11 +2172,17 @@
   [{:keys [id segment-axes reduce-index reduce-extent inputs scalars product results
            result-transform]}]
   (let [component (first (:components product))
-        stable (vec (sort-by pr-str inputs))
+        expressions (:results (reduction/fold-region product))
+        arrays (if (empty? segment-axes)
+                 (vec (sort-by pr-str
+                               (filter #(pointwise-input? expressions % reduce-index) inputs)))
+                 [])
+        elements (element-symbols (count arrays))
+        stable (vec (sort-by pr-str (set/difference (set inputs) (set arrays))))
         captures (vec (sort-by pr-str (distinct (concat stable scalars))))
         capture-parameters (capture-symbols (count captures))
         step-results (mapv #(util/subst-syms (zipmap captures capture-parameters) %)
-                           (:results (reduction/fold-region product)))
+                           (elementize expressions arrays elements reduce-index))
         algebra (scan/certify-reassociation
                  {:acc (:accumulator component)
                   :init (:neutral component)
@@ -2184,9 +2199,9 @@
                  :dtypes [(:dtype component)]
                  :algebra [algebra]
                  :result-transform result-transform}
-                [] captures
+                arrays captures
                 (dialect/lambda-form
-                 (vec (concat [(:accumulator component)] capture-parameters))
+                 (vec (concat [(:accumulator component)] elements capture-parameters))
                  step-results)))))
 
 (defn- product-reduce-equation

--- a/src/raster/compiler/passes/parallel/typed_soac_resident.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_resident.clj
@@ -23,24 +23,16 @@
       (throw (ex-info "resident realization received an unknown TypedSOAC equation"
                       {:reason :typed-soac-resident-equation :equation equation}))))
 
-(defn- parameter-parts
-  [{:keys [kind attributes arrays parameters]}]
-  (let [accumulator-count (if (= :reduce kind)
-                            (count (:accumulators attributes))
-                            0)
-        array-count (count arrays)
-        accumulator-end accumulator-count
-        element-end (+ accumulator-count array-count)]
-    {:accumulators (subvec (vec parameters) 0 accumulator-end)
-     :elements (subvec (vec parameters) accumulator-end element-end)
-     :capture-parameters (subvec (vec parameters) element-end)}))
-
 (defn- emit-equation
   [{:keys [kind id results attributes arrays captures parameters locals body-results]}]
   (list '= id (vec results)
         (list (symbol (name kind)) attributes (vec arrays) (vec captures)
               (dialect/lambda-form (vec parameters) (dialect/emit-locals locals)
                                    (vec body-results)))))
+
+(defn- parameter-parts
+  [info]
+  (dialect/parameter-layout (emit-equation info)))
 
 (defn- result-transform-inputs
   [attributes]
@@ -129,7 +121,8 @@
                                        (util/subst-syms capture-substitutions init)))
                             (:locals info))
         global-bodies (mapv #(util/subst-syms capture-substitutions %) (:body-results info))
-        bound (set (concat accumulators elements [(get-in info [:attributes :index])]))
+        bound (set (concat accumulators elements [(get-in info [:attributes :index])]
+                           (map first (get-in info [:attributes :segment-axes]))))
         stable-before (set (get-in info [:attributes :attributes :stable-array-captures]))
         referenced-values (->> (concat (mapcat #(util/free-syms (:init %) bound) global-locals)
                                        (mapcat #(util/free-syms % bound) global-bodies)

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1717,10 +1717,13 @@
                       {:dispatch-id dispatch-id :result-slots (mapv first result-pairs)})))
     (with-gpu-session* device-id
       (fn [session]
-        (doseq [{:keys [key value dtype elements resident? read?]} groups]
+        (doseq [{:keys [key value dtype elements resident? read? write?]} groups]
           (if resident?
             (register-buffer! session key value {:ownership :borrowed})
-            (alloc! session {key [dtype elements (when read? value)]})))
+            ;; Write access is not a proof that every supplied element is overwritten:
+            ;; kernels may write a prefix or guarded subset. Full-capacity copy-back must
+            ;; preserve the rest until a verified coverage contract permits eliding upload.
+            (alloc! session {key [dtype elements (when (or read? write?) value)]})))
         (let [handle (bind-kernel-executable! session
                                               [:staged-executable dispatch-id]
                                               executable arguments)]

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -265,14 +265,14 @@
       (is (= [1] (get-in result [:kernels 0 :launch :group-count])))
       (is (= :single (get-in result [:kernels 0 :attributes :phase])))))))
 
-(deftest opencl-pass-full-contraction-reduction-uses-ordered-marker
+(deftest opencl-pass-full-contraction-reduction-uses-a-complete-executable
   (let [product (with-meta '(* (aget A i) (aget B i)) {:raster.type/tag 'float})
         form (list 'raster.par/contract 'O [] '[[i 8]] product)
         result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float)
         kernel (first (:kernels result))]
-    (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
-           (first (:form result))))
-    (is (= '[A B nil 8] (nth (:form result) 2)))
+    (is (= 'raster.compiler.pipeline/invoke-scheduled-executable!
+           (first (second (second (:form result))))))
+    (is (= '[A B O] (nth (second (second (:form result))) 3)))
     (is (= '[A B O _n_bound] (mapv :name (:abi kernel))))
     (is (= [:operand :operand :result :bound] (mapv :role (:abi kernel))))))
 

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -246,7 +246,7 @@
                          :default-strategy :two-stage
                          :selector {:kind :fixed-strategy :strategy :two-stage}})
         x (float-array [1.0 2.0 3.0])
-        out (float-array 3)
+        out (float-array [123.0 456.0 789.0])
         calls (atom [])
         session (atom {:device-id :probe})]
     (with-redefs-fn
@@ -285,7 +285,11 @@
           (is (= [:staged-executable-pointer 0] (first bound-arguments)))
           (is (= [:staged-executable-pointer 1] (second bound-arguments)))
           (is (= {:type :long :value 3} (nth bound-arguments 2))))
-        (is (= 2 (count (filter #(= :alloc (first %)) @calls))))
+        (let [allocations (filter #(= :alloc (first %)) @calls)
+              output-spec (get (second (second allocations)) [:staged-executable-pointer 1])]
+          (is (= 2 (count allocations)))
+          (is (identical? out (nth output-spec 2))
+              "write-only ABI access does not prove full overwrite of caller storage"))
         (is (= 1 (count (filter #(= :download (first %)) @calls))))))))
 
 (deftest staged-graph-capacities-fail-before-opening-a-device-session

--- a/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
+++ b/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
@@ -1,0 +1,131 @@
+(ns raster.compiler.passes.parallel.full-reduction-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.arrays :as arrays]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.core :refer [deftm]]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.link :as link]
+            [raster.gpu.descriptor-fixture :as fixture]
+            [raster.gpu.device-probe :as opencl-probe]))
+
+(deftm dot-into!
+  [x :- (Array float) y :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/contract out [] [[i n]]
+    (* (arrays/aget x i) (arrays/aget y i)) :init (float 0.0)))
+
+(defn- emitted [n]
+  (let [source (list 'let* ['result (list 'raster.par/contract 'out [] [['i n]]
+                                        '(* (aget x i) (aget y i)))] 'out)
+        scheduled (:form (pipeline/schedule-parallel-form
+                          source {:dtype :float :target-device :ze:0
+                                  :array-types {'x :float 'y :float 'out :float}
+                                  :scalar-types {'n :long}}))]
+    (opencl/opencl-pass scheduled :dtype :float :compile-spirv? false)))
+
+(deftest rank-zero-contractions-use-the-complete-reduction-graph
+  (doseq [[n phases] [[0 1] [8 1] [1025 2] ['n 2]]]
+    (let [result (emitted n)
+          graph (dispatch/default-alternative (first (:dispatches result)))]
+      (is (= phases (count (:nodes graph))))
+      (is (= ['out] (mapv :id (:outputs graph))))
+      (is (= 1 (:elements (first (:outputs graph)))))
+      (is (some #{'raster.compiler.pipeline/invoke-scheduled-executable!} (flatten (:form result))))
+      (is (not-any? #{'raster.gpu.ze-runtime/invoke-registered-reduction-kernel 'clojure.core/aget}
+                    (flatten (:form result))))
+      (is (zero? (get-in result [:stats :segop-relowered] 0))))))
+
+(deftest graph-scalars-retain-logical-types-with-checked-node-narrowing
+  (let [graph (dispatch/default-alternative (first (:dispatches (emitted 'n))))
+        buffers (into {} (map (fn [b] [(:id b) (Object.)]))
+                      (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
+        call (graph-call/make graph buffers {'n {:type :long :value 1025}})
+        uses (for [node (:nodes call)
+                   [slot argument value] (map vector (get-in node [:call :artifact :abi])
+                                              (get-in node [:call :artifact :arguments])
+                                              (get-in node [:call :arguments]))
+                   :when (= 'n argument)]
+               [(:kernel-dtype slot) (:type value) (:value value)])]
+    (is (= graph (executable/validate! graph)))
+    (is (= #{[:int :int 1025] [:long :long 1025]} (set uses)))
+    (is (thrown? ArithmeticException
+                 (graph-call/make graph buffers {'n {:type :long :value (inc (long Integer/MAX_VALUE))}})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (graph-call/make graph buffers {'n {:type :long :value -1}})))
+    (let [retyped (-> graph
+                      (update :scalars #(mapv (fn [s] (assoc s :dtype :double)) %))
+                      (update :abi #(mapv (fn [slot]
+                                            (if (= :scalar (:kind slot))
+                                              (assoc slot :dtype :double :kernel-dtype :double)
+                                              slot)) %)))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar dtype differs"
+                            (executable/validate! retyped))))))
+
+(deftest rank-zero-admission-does-not-discard-unproved-coordinate-or-alias-contracts
+  (doseq [contract ['(raster.par/contract out [] [[i 4] [j 6]] (aget x (+ (* i 6) j)))
+                    '(raster.par/contract out [] [[i 8]] (aget x (* i 2)))
+                    '(raster.par/contract out [] [[i 8]] (aget out i))]]
+    (is (nil? (frontend/form->program (list 'let* ['result contract] 'out)
+                                     {:dtype :float :array-types {'x :float 'out :float}})))))
+
+(deftest public-rank-zero-contraction-is-resident
+  (doseq [target [:ocl:0 :ze:0]]
+    (let [descriptor (pipeline/compile-gpu-program #'dot-into! target :dtype :float)]
+      (is (= [:executable] (mapv :convention (:steps descriptor))))
+      (is (empty? (:allocs descriptor))))))
+
+(deftest rank-zero-and-resident-scalar-reductions-compose
+  (let [result (route/attempt
+                '(let* [a (raster.par/contract out [] [[i n]] (* (aget x i) (aget y i)))
+                        total (raster.par/reduce acc 0.0 j n (+ acc (aget x j)))
+                        b (raster.par/map-void! k n (aset z k (* total (aget x k))))]
+                   [out b])
+                :float {'x :float 'y :float 'out :float 'z :float}
+                {:resident-reductions? true})]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= 1 (get-in result [:stats :resident-reductions])))
+    (is (get-in result [:stats :typed-validated]))))
+
+(deftest jvm-rank-zero-contraction-preserves-caller-owned-storage
+  (doseq [n [0 8 1025]]
+    (let [x (float-array (max 1 n) 1.0)
+          y (float-array (max 1 n) 0.5)
+          out (float-array [123.0 456.0])]
+      (is (identical? out (dot-into! x y out (long n))))
+      (is (= [(* n 0.5) 456.0] (vec out))))))
+
+(defn- run-device! [target]
+  (let [descriptor (pipeline/compile-gpu-program #'dot-into! target :dtype :float)]
+    (gpu/with-gpu-session [session target]
+      (doseq [n [0 8 1025]]
+        (let [x (float-array (map #(float (- (mod % 7) 3)) (range (max 1 n))))
+              y (float-array (repeat (max 1 n) 0.5))
+              out (float-array [123.0 456.0])
+              arguments [x y out (long n)]
+              expected (reduce + 0.0 (map #(* (double %1) %2) (take n x) (take n y)))
+              program (fixture/instantiate! session descriptor arguments
+                                            {'x :input 'y :input 'out :output})]
+          (try
+            (link/upload! (:executable program)
+                          (get-in program [:lowering :certificate :bindings 'out]) out)
+            (dotimes [_ 2]
+              (let [actual (get (fixture/run! program arguments) 'out)]
+                (is (= expected (double (aget ^floats actual 0))))
+                (is (= 456.0 (double (aget ^floats actual 1))) "only out[0] is written")))
+            (finally (fixture/close! program))))))))
+
+(deftest opencl-rank-zero-contraction-writes-the-resident-result
+  (if @opencl-probe/opencl-available?
+    (run-device! :ocl:0)
+    (opencl-probe/opencl-skip! "rank-zero contraction graph")))
+
+(deftest level-zero-rank-zero-contraction-writes-the-resident-result
+  (if @gpu-probe/gpu-available?
+    (run-device! :ze:0)
+    (gpu-probe/gpu-skip! "rank-zero contraction graph")))

--- a/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
+++ b/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
@@ -120,12 +120,28 @@
                 (is (= 456.0 (double (aget ^floats actual 1))) "only out[0] is written")))
             (finally (fixture/close! program))))))))
 
+(defn- run-staged! [target]
+  (let [kernel-dispatch (first (:dispatches (emitted 'n)))
+        register! (requiring-resolve
+                   (symbol (if (= target :ocl:0)
+                             "raster.gpu.ocl-runtime" "raster.gpu.ze-runtime")
+                           "register-kernel-dispatch!"))]
+    (register! kernel-dispatch)
+    (doseq [n [0 8 1025]]
+      (let [x (float-array (max 1 n) 1.0)
+            y (float-array (max 1 n) 0.5)
+            out (float-array [123.0 456.0])]
+        (is (identical? out (gpu/invoke-staged-executable!
+                            target (:id kernel-dispatch) [x y out (long n)])))
+        (is (= [(* n 0.5) 456.0] (vec out))
+            "ordinary staged invocation preserves the unwritten output tail")))))
+
 (deftest opencl-rank-zero-contraction-writes-the-resident-result
   (if @opencl-probe/opencl-available?
-    (run-device! :ocl:0)
+    (do (run-device! :ocl:0) (run-staged! :ocl:0))
     (opencl-probe/opencl-skip! "rank-zero contraction graph")))
 
 (deftest level-zero-rank-zero-contraction-writes-the-resident-result
   (if @gpu-probe/gpu-available?
-    (run-device! :ze:0)
+    (do (run-device! :ze:0) (run-staged! :ze:0))
     (gpu-probe/gpu-skip! "rank-zero contraction graph")))


### PR DESCRIPTION
## Summary

Route eligible rank-zero `par/contract` forms through the existing TypedSOAC segmented-reduction and complete scalar reduction graph. Preserve caller-owned `out[0]`, including empty input and cross-block finalization; tensor rank alone no longer requests a host scalar download.

- Admit only one pointwise reduction axis with disjoint output and no epilogue; retain compatibility for affine/multi-axis/aliased cases.
- Reuse canonical TypedSOAC lambda layout during resident rewriting, including mixed tensor/scalar reduction programs.
- Keep graph scalars logically typed while checking per-node int/long physical conversion (including overflow). Other precision mismatches remain rejected.
- Add public compilation, JVM, graph replay, buffer-tail preservation, and gated OpenCL/Level Zero numerical tests.
- Review caught an ordinary staging bug: write-only access did not prove full overwrite, yet staging downloaded full capacity from uninitialized output storage. Staging now preserves writable host arrays on upload; resident buffers stay borrowed. Added staged numerical tail-preservation regressions. Upload elision requires a future explicit coverage proof.

## Validation

- Focused REPL batches: 152 tests, 984 assertions, zero failures/errors.
- `git diff --check` clean.
- Local device tests explicitly skipped: no requested OpenCL device; Level Zero initialization unavailable. CI OpenCL CPU gate must provide numerical execution evidence.
- Full suite and native emitter checks delegated to CI to keep the laptop feedback loop light.
- Initial CI exposed a forward declaration masked by REPL reload; fixed and cold-loaded successfully. All seven checks subsequently passed before the review-driven staging repair; the repaired head must pass again.

This is a bounded legacy-path retirement, not a claim that all full contractions or peak schedules are unified.
