### PR TITLE
Retire the direct reduce-into backend adapter

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -708,6 +708,10 @@ reduction graph (including cross-block finalization) and write only `out[0]`; ra
 imply a host scalar download. Affine/multi-axis and aliased full contractions remain outside this
 admission boundary. Public graph scalars retain their logical dtype while individual kernel nodes
 may use checked integer narrowing for physical launch bounds.
+The internal direct `reduce-into` spelling enters that same rank-zero typed storage contract;
+its separate backend one-workgroup refinement and dispatch constructor are deleted. Small and
+empty reductions use one terminal phase, while large/dynamic reductions retain the complete
+partial/finalization graph. Pointwise, disjoint-output admission remains explicit.
 Nested scalar folds inside a retained map are now explicit typed scalar-region terms. Monoid-shaped
 folds carry an `AssociativeScan` certificate and an implementation-defined association contract, so
 the JVM may select its multi-accumulator SIMD reduction. General recurrences carry an ordered

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -26,7 +26,6 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
-            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.typed-soac-resident :as resident]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
@@ -344,32 +343,6 @@
     (list 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
           kernel-name arguments)))
 
-(defn- resident-single-reduction
-  "Refine a scalar reduction to the explicit one-workgroup phase required by reduce-into.
-
-   The output identity is changed here, at the semantic operation boundary, rather than passed as
-   an emitter-only alias. One group folds the complete extent, so the caller-owned one-element
-   result is the scheduled output rather than an undersized partial buffer."
-  [operation output]
-  (let [dtype (dtype/canon (:dtype operation))
-        workgroup-size (get-in operation [:grid :block-size])
-        grid (segop/->KernelGrid 1 workgroup-size
-                                (* workgroup-size (dtype/bytes-of dtype)))
-        operator (-> (:reduction operation)
-                     (update :components
-                             (fn [components]
-                               (mapv #(assoc % :result output) components)))
-                     (assoc-in [:attributes :physical-phase] :single))]
-    (assoc operation
-           :level (segop/->SegLevel :block :none)
-           :reduction operator
-           :lambda nil
-           :outputs #{output}
-           :grid grid
-           :phase :single
-           :schedule (segred-body/scalar-workgroup-tree-schedule
-                      operator grid :single))))
-
 (defn- emit-map-void-invocation
   "Render the staging marker from the artifact's logical argument projection. The marker remains
    useful to the host evaluator, but it no longer owns or reconstructs an argument convention."
@@ -474,6 +447,7 @@
                  (and (par/par-scatter-form? form)
                       (:stride (par/extract-par-scatter-info form)))
                  (par/par-reduce-form? form)
+                 (par/par-reduce-into-form? form)
                  (and (croute/par-contract-form? form) (empty? (nth form 2)))
                  ;; A compound source extent normalizes to a preceding typed scalar equation. It
                  ;; cannot be projected as a closed SegMap without losing that SSA definition.
@@ -822,37 +796,11 @@
                           (:kernel-name k)
                           (vec (:arguments r)))))))
 
-            ;; === par/reduce-into — resident terminal SegRed writing a caller-owned scalar ===
-            ;; Unlike the occupancy-capped partial phase used by host-scalar reduction, this is an
-            ;; explicit one-group terminal refinement. The generic executable path preserves that
-            ;; launch for staging and resident replay alike. Emitted by the reduce-fusion pass.
+            ;; A direct resident reduction must retain its complete scheduled typed graph.
             (par/par-reduce-into-form? form)
-            (let [{:keys [out-buf reduce-form]} (par/extract-par-reduce-into-info form)
-                  segred (resident-single-reduction
-                          (par->segred stats reduce-form dtype device-id
-                                      top-scalar-types top-array-types)
-                          out-buf)
-                  kernel (segop-cl/generate-segred-kernel
-                          segred out-buf :dtype dtype :scalar-types top-scalar-types
-                          :array-types top-array-types)
-                  k (register-kernel! kernel :ze-reduces)
-                  dispatch (kdispatch/make
-                            {:id (str "resident-single-reduction-"
-                                      (Integer/toUnsignedString (hash k) 16))
-                             :alternatives [k]
-                             :default-strategy :scalar-workgroup-tree
-                             :selector {:kind :fixed-strategy
-                                        :strategy :scalar-workgroup-tree}
-                             :provenance {:pass :opencl
-                                          :source-dialect :segred
-                                          :operation (:id segred)}
-                             :attributes {:operation-family :scalar-reduction
-                                          :resident-result true}})]
-              (swap! dispatches conj dispatch)
-              ;; Unlike the nil-result host-scalar marker, this path is executable both through
-              ;; staging and resident extraction. Both consume the same KernelCall geometry.
-              (list 'raster.compiler.pipeline/invoke-scheduled-executable!
-                    device-id (:id dispatch) (vec (:arguments k))))
+            (throw (ex-info "resident reduction must enter GPU emission as a complete TypedSOAC graph"
+                            {:reason :resident-reduction-requires-typed-graph
+                             :source form :target-dialect :kernel-graph :fallback :none}))
 
             ;; === par/reduce — SegOp path ===
             (par/par-reduce-form? form)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1179,6 +1179,27 @@
                                  {:destination output :access :write :host-return :effect})
                                outputs)}))
 
+    (par/par-reduce-into-form? expression)
+    (let [{:keys [out-buf reduce-form]} (par/extract-par-reduce-into-info expression)
+          elem-type (or (:raster.type/elem-type (meta expression))
+                        (get array-types out-buf) default-dtype :double)
+          description (operation-description
+                       id symbol
+                       (vary-meta reduce-form assoc :raster.type/elem-type elem-type)
+                       default-dtype array-types)
+          {:keys [product inputs scalars index extent]} description
+          expressions (:results (reduction/fold-region product))]
+      ;; This internal compatibility spelling owns storage, not a second reduction algebra.
+      ;; Alias/coordinate cases outside the pointwise scalar schedule must decline explicitly.
+      (when (and (symbol? out-buf) (not (contains? inputs out-buf))
+                 (every? #(pointwise-input? expressions % index) inputs))
+        {:kind :segmented-reduce :id id :sym symbol
+         :segment-axes [] :reduce-index index :reduce-extent extent
+         :results [(effect-result-id id 0)] :product product
+         :inputs inputs :outputs #{out-buf} :scalars (disj scalars out-buf)
+         :effect-only? true :host-binding symbol
+         :result-storage [{:destination out-buf :access :write :host-return :buffer}]}))
+
     (par/par-reduce-form? expression)
     (let [{:keys [acc init idx bound body elem-type]} (par/extract-par-reduce-info expression)
           io (extract-io body idx [symbol] :accumulator acc)
@@ -1336,6 +1357,7 @@
     (par/par-map-form? expression) (nth expression 3)
     (par/par-map2-form? expression) (nth expression 4)
     (par/par-reduce-form? expression) (nth expression 4)
+    (par/par-reduce-into-form? expression) (nth expression 5)
     (or (par/par-scan-form? expression) (par/par-scan-exclusive-form? expression))
     (nth expression 5)
     (par/par-stencil-form? expression) (nth expression 7)
@@ -1351,6 +1373,7 @@
                    (par/par-map-form? expression) 3
                    (par/par-map2-form? expression) 4
                    (par/par-reduce-form? expression) 4
+                   (par/par-reduce-into-form? expression) 5
                    (or (par/par-scan-form? expression)
                        (par/par-scan-exclusive-form? expression)) 5
                    (par/par-stencil-form? expression) 7

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -254,16 +254,20 @@
                  {:raster.type/elem-type :float})
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
-      (is (= 'raster.compiler.pipeline/invoke-scheduled-executable!
-             (first (:form result))))
-      (is (= '[a obuf scale n] (nth (:form result) 3)))
+      (let [invocation (some #(when (and (seq? %)
+                                        (= 'raster.compiler.pipeline/invoke-scheduled-executable!
+                                           (first %))) %)
+                              (tree-seq coll? seq (:form result)))]
+        (is invocation)
+        (is (= '[a obuf scale n] (nth invocation 3))))
       (is (= 1 (count (:dispatches result))))
-      (is (= :scalar-workgroup-tree
+      (is (= :scheduled-graph
              (:default-strategy (first (:dispatches result)))))
-      (is (= '[a obuf scale _n_bound]
-             (mapv :name (:abi (first (:kernels result))))))
-      (is (= [1] (get-in result [:kernels 0 :launch :group-count])))
-      (is (= :single (get-in result [:kernels 0 :attributes :phase])))))))
+      (is (= [:block-local :cross-block]
+             (mapv #(get-in % [:attributes :phase]) (:kernels result))))
+      (is (= 'obuf (second (:arguments (last (:kernels result))))))
+      (is (= [1] (get-in result [:kernels 1 :launch :group-count])))
+      (is (zero? (get-in result [:stats :segop-relowered] 0)))))))
 
 (deftest opencl-pass-full-contraction-reduction-uses-a-complete-executable
   (let [product (with-meta '(* (aget A i) (aget B i)) {:raster.type/tag 'float})

--- a/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
+++ b/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
@@ -120,9 +120,36 @@
                 (is (= 456.0 (double (aget ^floats actual 1))) "only out[0] is written")))
             (finally (fixture/close! program))))))))
 
-(defn- run-staged! [target]
-  (let [kernel-dispatch (first (:dispatches (emitted 'n)))
-        register! (requiring-resolve
+(defn- emitted-reduce-into [n combine identity]
+  (opencl/opencl-pass
+   (with-meta
+     (list 'raster.par/reduce-into 'out 'acc identity 'i n
+           (list combine 'acc '(* (aget x i) (aget y i))))
+     {:raster.type/elem-type :float})
+   :device-id :ze:0 :dtype :float :compile-spirv? false
+   :array-types {'x :float 'y :float 'out :float} :scalar-types {'n :long}))
+
+(deftest direct-reduce-into-reuses-typed-storage-and-monoid-scheduling
+  (doseq [[combine identity] [['+ 0.0] ['* 1.0]]
+          [n phases] [[0 [:single]] [8 [:single]]
+                      [1025 [:block-local :cross-block]] ['n [:block-local :cross-block]]]]
+    (let [result (emitted-reduce-into n combine identity)
+          graph (dispatch/default-alternative (first (:dispatches result)))]
+      (is (= :typed-soac (get-in result [:stats :direct-scheduling :route])))
+      (is (= phases (mapv #(get-in % [:operation :attributes :phase]) (:nodes graph))))
+      (is (= ['out] (mapv :id (:outputs graph))))
+      (is (= 1 (get-in graph [:outputs 0 :elements])))
+      (is (zero? (get-in result [:stats :segop-relowered] 0))))))
+
+(deftest direct-reduce-into-rejects-unproved-storage-and-coordinates
+  (doseq [body ['(+ acc (aget out i)) '(+ acc (aget x (* i 2)))]]
+    (is (nil? (frontend/form->program
+               (list 'let* ['result (list 'raster.par/reduce-into 'out 'acc 0.0 'i 8 body)]
+                     'out)
+               {:dtype :float :array-types {'x :float 'out :float}})))))
+
+(defn- run-staged-dispatch! [target kernel-dispatch combine identity]
+  (let [register! (requiring-resolve
                    (symbol (if (= target :ocl:0)
                              "raster.gpu.ocl-runtime" "raster.gpu.ze-runtime")
                            "register-kernel-dispatch!"))]
@@ -133,8 +160,14 @@
             out (float-array [123.0 456.0])]
         (is (identical? out (gpu/invoke-staged-executable!
                             target (:id kernel-dispatch) [x y out (long n)])))
-        (is (= [(* n 0.5) 456.0] (vec out))
+        (is (= [(float (reduce combine identity (repeat n 0.5))) 456.0] (vec out))
             "ordinary staged invocation preserves the unwritten output tail")))))
+
+(defn- run-staged! [target]
+  (doseq [[result combine identity] [[(emitted 'n) + 0.0]
+                                     [(emitted-reduce-into 'n '+ 0.0) + 0.0]
+                                     [(emitted-reduce-into 'n '* 1.0) * 1.0]]]
+    (run-staged-dispatch! target (first (:dispatches result)) combine identity)))
 
 (deftest opencl-rank-zero-contraction-writes-the-resident-result
   (if @opencl-probe/opencl-available?


### PR DESCRIPTION
## Summary

Remove the direct `reduce-into` backend's one-workgroup refinement and private dispatch construction. The internal spelling now enters the existing rank-zero TypedSOAC segmented-reduction/storage contract and emits the complete scheduled reduction graph.

- Small/empty extents use a terminal phase; large/dynamic extents use partial plus cross-block finalization.
- Preserve the original certified monoid and caller-owned output, without a new IR or emitter.
- Admit pointwise input coordinates and disjoint output storage; unsupported cases do not retain the removed backend adapter.
- Add sum/product schedule regressions, explicit admission rejection checks, and staged numerical/tail-preservation coverage to the automatic OpenCL CPU gate.

## Validation

- Focused backend/reduction tests: 31 tests / 206 assertions passed; final expanded reduction namespace: 10 tests / 89 assertions passed.
- Neighboring frontend/resident/route batch: 810 passing assertions, one SIMD test could not load FloatVector because the initial console lacked the vector module. Fresh-process route tests with the normal test JVM configuration subsequently passed: 54 tests / 505 assertions.
- Independent read-only review: no concrete defects found.
- Local GPU gates explicitly skip because device initialization is unavailable; full suite, numerical OpenCL CPU execution and CUDA/HIP compilation are CI gates.
