### PR TITLE
Measure CI load and test costs before rebalancing shards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
       - run:
           name: Run deterministic test shard
           command: scripts/ci-test-shard.sh
+      - store_artifacts:
+          path: test-results
+          destination: test-timings
 
   emit-gpu-compile-fixtures:
     executor: clojure-java24
@@ -177,6 +180,9 @@ jobs:
       - run:
           name: Run OpenCL-gated tests on the CPU OpenCL device
           command: scripts/ci-opencl-cpu.sh
+      - store_artifacts:
+          path: test-results
+          destination: test-timings
 
   deploy:
     executor: clojure-java24

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _site/
 # local dev sandbox for the cljs/browser port (not shipped; testing strategy TBD)
 /cljs-sandbox/
 raster_qmm_gpu_lnl.bin
+/test-results/

--- a/deps.edn
+++ b/deps.edn
@@ -19,11 +19,12 @@
          ;; GPU → not a representative perf machine). Run it with -M:perf on the
          ;; Valhalla+Arc box. See raster.perf.regression-gate-test. NOTE: the
          ;; exclusion must be set on BOTH invocation paths — `-M:test` reads
-         ;; :main-opts (-e :perf); CircleCI runs `-X:test` which reads :exec-fn +
+         ;; :main-opts (-e :perf); `-X:test` reads :exec-fn +
          ;; :exec-args, so the same exclusion goes there as {:excludes [:perf]}.
          :main-opts ["-m" "cognitect.test-runner" "-e" ":perf"]
          :exec-fn cognitect.test-runner.api/test
          :exec-args {:excludes [:perf]}}
+  :ci-timed {:main-opts ["-m" "raster.ci.timed-runner" "-e" ":perf"]}
   ;; The perf-regression ratchet — INCLUDES only ^:perf, opposite of :test. Local
   ;; only (Valhalla+GPU). `-M:perf` gates against the committed baseline;
   ;; `-M:perf --update-baseline` re-seeds after an intended speedup.

--- a/design/test-feedback.md
+++ b/design/test-feedback.md
@@ -1,0 +1,51 @@
+# Test feedback and performance evidence
+
+The fast loop is focused tests in a correctly configured reusable JVM. Full correctness tests
+run in isolated CI processes. Do not parallelize test vars inside one JVM: tests redefine Vars
+and share runtime/dispatch state. Keep local JVM concurrency bounded by available memory.
+
+## Measure before repartitioning
+
+`scripts/ci-test-shard.sh` currently balances four processes by source bytes, not observed cost.
+On CI run 6675, the test phases took 143, 221, 242 and 566 seconds. This shows an imbalance; it
+does not identify which tests are redundant or prove that the compiler itself became slower.
+
+Both the general shards and OpenCL CPU job now use `raster.ci.timed-runner`, a scoped timing
+wrapper around the existing Cognitect runner. Test selection, metadata exclusions, fixtures,
+assertion reporting and failure summaries remain unchanged. Each process publishes
+`test-results/timings.edn` as a CI artifact, including:
+
+- per-namespace load and test nanoseconds;
+- per-test-var execution nanoseconds (nested inside namespace time, **not additive**);
+- observed load/test order and JVM version.
+
+Load time includes dependencies first reached by that namespace. Do not treat one sample as an
+intrinsic namespace cost: compare multiple runs, preserve process startup overhead separately,
+and remeasure after partition changes. Timing instrumentation is diagnostic, not a noisy CI
+wall-time regression assertion.
+
+Landing order:
+
+1. Collect load/test timings without dropping coverage.
+2. Rebalance processes using measured costs and verify every namespace remains assigned once.
+3. Isolate measured corpus/compiled-training bottlenecks; split indivisible work with an explicit
+   completeness check if necessary.
+4. Avoid repeating device-free structural tests in the OpenCL lane, while preserving actual
+   numerical device execution and explicit capability gates.
+5. Share repeated immutable, option-keyed compile fixtures only where tests do not redefine or
+   mutate compiler state. Preserve independent numerical and source-code oracles.
+
+## What current performance evidence does not establish
+
+Passing correctness, route/allocation checks and nvcc/hipcc compilation does not establish GPU
+speed or parity with vendor GEMM implementations. The current `:perf` canary times a plain
+Clojure loop, not a Raster-compiled function. The retained cold GEMM benchmark invokes the
+independent source oracle rather than the production TypedSOAC route. Neither is a sufficient
+performance regression gate for the current compiler-generated GEMM implementation.
+
+Next performance work must benchmark the public compilation/LinkPlan route with explicit
+shape, dtype, selected schedule, target/driver identity, cold compilation, warm device execution,
+and transfer/allocation costs. Keep a small stable-machine canary set outside ordinary CI, then
+run broader differential workloads against external libraries periodically. Missing measurements
+or hardware are missing evidence, not successful performance gates. Never update a baseline
+merely to accept a slowdown.

--- a/scripts/ci-opencl-cpu.sh
+++ b/scripts/ci-opencl-cpu.sh
@@ -28,4 +28,4 @@ for file in "${files[@]}"; do
 done
 
 echo "running ${#files[@]} OpenCL-gated namespaces on ${RASTER_OCL_DEVICE_TYPE} device(s)"
-exec clojure -M:test "${args[@]}"
+exec clojure -M:test:ci-timed "${args[@]}"

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -97,4 +97,4 @@ for namespace in "${namespaces[@]}"; do
   runner_args+=("-n" "${namespace}")
 done
 
-clojure -M:test "${runner_args[@]}"
+clojure -M:test:ci-timed "${runner_args[@]}"

--- a/test/raster/ci/timed_runner.clj
+++ b/test/raster/ci/timed_runner.clj
@@ -1,0 +1,75 @@
+(ns raster.ci.timed-runner
+  "CI-only timing instrumentation for explicit namespace selections around the existing
+   Cognitect runner; fixtures, test reporting and failure semantics remain owned by that runner
+   and clojure.test. Use the ordinary runner for help, regex or default discovery."
+  (:require [clojure.java.io :as io]
+            [clojure.test :as test]
+            [clojure.tools.cli :as cli]
+            [cognitect.test-runner :as runner]))
+
+(def ^:dynamic *loading?* false)
+
+(defn measured
+  [timings path f]
+  (let [start (System/nanoTime)]
+    (try (f)
+         (finally
+           (swap! timings update-in path (fnil + 0)
+                  (- (System/nanoTime) start))))))
+
+(defn run-timed!
+  [options report-file]
+  (let [started (System/nanoTime)
+        timings (atom {:schema-version 1 :namespaces {} :vars {}
+                       :load-order [] :test-order []})
+        selected (:namespace options)
+        require* clojure.core/require
+        test-ns* test/test-ns
+        test-var* test/test-var]
+    (when-not (seq selected)
+      (throw (ex-info "timed CI runner requires explicit namespace selection" {})))
+    (try
+      (with-redefs [clojure.core/require
+                    (fn [& args]
+                      (if (and (not *loading?*) (= 1 (count args))
+                               (contains? selected (first args)))
+                        (binding [*loading?* true]
+                          (swap! timings update :load-order conj (first args))
+                          (measured timings [:namespaces (first args) :load-ns]
+                                    #(apply require* args)))
+                        (apply require* args)))
+                    test/test-ns
+                    (fn [n]
+                      (swap! timings update :test-order conj (ns-name (the-ns n)))
+                      (measured timings [:namespaces (ns-name (the-ns n)) :test-ns]
+                                #(test-ns* n)))
+                    test/test-var
+                    (fn [v]
+                      (let [{:keys [ns name]} (meta v)]
+                        (if (and (:test (meta v)) (contains? selected (ns-name ns)))
+                          (measured timings [:vars (symbol (str (ns-name ns)) (str name))]
+                                    #(test-var* v))
+                          (test-var* v))))]
+        (runner/test options))
+      (finally
+        (try
+          (io/make-parents report-file)
+          (spit report-file
+                (pr-str (assoc @timings :elapsed-ns (- (System/nanoTime) started)
+                               :java-version (System/getProperty "java.version"))))
+          (println "CI namespace/var timings:" (str report-file))
+          (catch Exception error
+            ;; Diagnostics must not mask the compiler/test exception we are diagnosing.
+            (binding [*out* *err*]
+              (println "Could not write CI timing diagnostics:" (.getMessage error)))))))))
+
+(defn -main [& args]
+  (let [{:keys [options errors]} (cli/parse-opts args runner/cli-options)
+        report (or (System/getenv "RASTER_TEST_TIMING_REPORT")
+                   "test-results/timings.edn")]
+    (when (or (seq errors) (:test-help options))
+      (throw (ex-info "invalid timed CI runner arguments" {:errors errors})))
+    (try
+      (let [{:keys [fail error]} (run-timed! options report)]
+        (System/exit (if (zero? (+ fail error)) 0 1)))
+      (finally (shutdown-agents)))))

--- a/test/raster/ci/timed_runner_test.clj
+++ b/test/raster/ci/timed_runner_test.clj
@@ -1,0 +1,50 @@
+(ns raster.ci.timed-runner-test
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [cognitect.test-runner :as runner]
+            [raster.ci.timed-runner :as timed]))
+
+(deftest timing-preserves-results-and-records-exceptions
+  (let [times (atom {})]
+    (is (= :result (timed/measured times [:ok] (constantly :result))))
+    (is (thrown-with-msg? Exception #"probe"
+                          (timed/measured times [:error]
+                                          #(throw (Exception. "probe")))))
+    (is (every? #(and (integer? %) (not (neg? %))) (vals @times)))
+    (is (= #{:ok :error} (set (keys @times))))))
+
+(deftest runner-delegates-selection-and-preserves-failure-summary
+  (let [file (java.io.File/createTempFile "raster-timings-" ".edn")
+        options {:namespace #{'raster.ci.timed-runner-test} :exclude #{:perf}}
+        summary {:test 3 :pass 2 :fail 1 :error 0}
+        seen (atom nil)]
+    (try
+      (with-redefs [runner/test (fn [actual] (reset! seen actual) summary)]
+        (is (= summary (timed/run-timed! options file))))
+      (is (= options @seen))
+      (is (= 1 (:schema-version (edn/read-string (slurp file)))))
+      (finally (io/delete-file file)))))
+
+(deftest load-errors-still-publish-the-timing-report
+  (let [file (java.io.File/createTempFile "raster-timings-error-" ".edn")]
+    (try
+      (with-redefs [runner/test (fn [_] (throw (Exception. "load failed")))]
+        (is (thrown-with-msg? Exception #"load failed"
+                              (timed/run-timed! {:namespace #{'raster.ci.timed-runner-test}}
+                                                file))))
+      (is (= 1 (:schema-version (edn/read-string (slurp file)))))
+      (finally (io/delete-file file)))))
+
+(deftest timing-output-failure-does-not-mask-test-outcomes
+  (let [file (java.io.File/createTempFile "raster-timings-parent-" ".edn")
+        impossible-report (io/file file "timings.edn")
+        options {:namespace #{'raster.ci.timed-runner-test}}]
+    (try
+      (with-redefs [runner/test (constantly {:test 1 :pass 1 :fail 0 :error 0})]
+        (is (= {:test 1 :pass 1 :fail 0 :error 0}
+               (timed/run-timed! options impossible-report))))
+      (with-redefs [runner/test (fn [_] (throw (Exception. "original failure")))]
+        (is (thrown-with-msg? Exception #"original failure"
+                              (timed/run-timed! options impossible-report))))
+      (finally (io/delete-file file)))))


### PR DESCRIPTION
## Summary

Collect namespace load/test and test-var timings around the existing Cognitect runner in all four general CI shards and the OpenCL CPU lane. Publish EDN artifacts, including observed namespace order and JVM version.

This does **not** change shard assignment, skip additional tests, or parallelize vars in a shared JVM. It supplies the evidence needed to rebalance safely: the last completed suite had shard test phases of 143/221/242/566 seconds despite roughly equal source bytes.

The wrapper delegates selection, exclusions, fixtures, reporting and failure summaries. Report I/O failures are explicit diagnostics and cannot mask test outcomes. It is a CI-only entry for explicit namespace selections; the original runner remains available for general use.

Document test cleanup priorities and current performance-evidence gaps: the raw-Clojure CPU canary and independent-source GEMM benchmark are not regression gates for production Raster-generated kernels.

## Validation

- Focused runner/manifest tests: 5 tests, 158 assertions, no failures/errors.
- Shell syntax checks and diff whitespace checks pass.
- Read-only agent review checked selection, global-state interactions and failure semantics. Its diagnostic I/O concern is fixed and tested.
- Full suite runs in CI; no local compiler-heavy JVM was started for this slice.
