### PR TITLE
Measure public compiler and resident replay routes with explicit baselines

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,6 +25,8 @@
          :exec-fn cognitect.test-runner.api/test
          :exec-args {:excludes [:perf]}}
   :ci-timed {:main-opts ["-m" "raster.ci.timed-runner" "-e" ":perf"]}
+  ;; Combine with :test for the normal compiler JVM options; explicitly opt in to timing.
+  :production-canary {:main-opts ["-m" "raster.perf.production-canary"]}
   ;; The perf-regression ratchet — INCLUDES only ^:perf, opposite of :test. Local
   ;; only (Valhalla+GPU). `-M:perf` gates against the committed baseline;
   ;; `-M:perf --update-baseline` re-seeds after an intended speedup.

--- a/design/test-feedback.md
+++ b/design/test-feedback.md
@@ -60,3 +60,42 @@ and transfer/allocation costs. Keep a small stable-machine canary set outside or
 run broader differential workloads against external libraries periodically. Missing measurements
 or hardware are missing evidence, not successful performance gates. Never update a baseline
 merely to accept a slowdown.
+
+## Opt-in production-route canaries
+
+`clojure -M:test:production-canary /path/to/options.edn` runs either `:case :cpu`
+(Raster AOT sum-of-squares) or `:case :gemm` (public compiled/lower, instantiate, resident
+LinkPlan replay of a 64×64×64 contraction). Example options:
+
+```clojure
+{:case :gemm :target :ocl:0
+ :environment-tag "machine-name; driver-version; power-mode"
+ :compiler-revision "exact-commit-and-any-local-patch-label"
+ :baseline "/path/to/reviewed-gemm-baseline.edn"
+ :output "/path/to/new-gemm-measurement.edn"}
+```
+
+Both routes validate against independent numerical references before measuring. CI executes
+the CPU route and, in the OpenCL lane, the resident GEMM route with timing replaced by one
+replay: these are correctness checks, not performance gates. There is no GPU timing claim
+when hardware is unavailable.
+
+The GPU metric is **host-synchronized warm resident replay**, including runtime submission
+overhead, not device-only kernel latency or peak GEMM throughput. Compilation and binding
+are reported separately; upload/download are outside timed replay. This tiny shape catches
+route/runtime regressions but does not establish SOTA performance. Device-event profiling of
+equation-first prepared programs is not yet supported by `link/measure!`.
+
+The comparison identity includes shape, dtype, numerical policy, device/host/JVM signatures,
+timing scope and an explicit machine/driver tag. Compiler revision and emitted executable
+signatures are evidence, not comparison keys: a source change must not bypass the old baseline.
+Missing baselines, incomparable environments, noisy measurements and invalid measurements
+exit nonzero. A stationary median above 115% of baseline also fails. Review repeated initial
+measurements and explicitly designate a separate baseline file; the runner never seeds or
+updates it. Compilation/binding timings are diagnostic, not yet regression-gated.
+
+Known public-boundary follow-up discovered by this canary: a direct returned scheduled
+contraction currently retains a synthetic result name instead of resolving its common ABI
+`:result` buffer. The canary uses explicit `write C; return C`; fix result alias propagation
+without weakening resident-plan validation. Also review cast-wrapped zero identities, which
+currently decline the register-tiled route even though they are numerically zero.

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -1,0 +1,139 @@
+(ns raster.perf.production-canary
+  "Opt-in canaries of the public Raster compiler and resident replay paths.
+   No timing assertion runs in ordinary CI and no run creates/updates its own baseline."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [raster.arrays :as arrays]
+            [raster.core :refer [deftm]]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.gpu.compiled :as compiled]
+            [raster.gpu.dispatch-tuning :as tuning]
+            [raster.gpu.link :as link]
+            [raster.runtime.hardware :as hardware]
+            [raster.runtime.microbench :as microbench]))
+
+(deftm sumsq [x :- (Array double) n :- Long] :- Double
+  (raster.par/reduce acc 0.0 i n
+    (+ acc (* (arrays/aget x i) (arrays/aget x i)))))
+
+(deftm gemm64! [A :- (Array float) B :- (Array float) C :- (Array float)] :- (Array float)
+  (let [_ (raster.par/contract C [[i 64] [j 64]] [[k 64]]
+            (* (arrays/aget A (+ (* i 64) k)) (arrays/aget B (+ (* k 64) j)))
+            :init 0.0)]
+    C))
+
+(defn- valid-measurement? [result]
+  (let [median (get-in result [:measurement :median-ns])]
+    (and (true? (:validated? result)) (number? median)
+         (Double/isFinite (double median)) (pos? median))))
+
+(defn verdict
+  "Compare like-for-like stationary measurements. Source/schedule changes stay comparable;
+   they belong in evidence, not in an identity that could silently bypass a regression."
+  [baseline result]
+  (cond
+    (not (valid-measurement? result)) :invalid-measurement
+    (not (true? (get-in result [:measurement :stationary?]))) :nonstationary
+    (nil? baseline) :unbaselined
+    (not= (:identity baseline) (:identity result)) :incomparable
+    (not (and (valid-measurement? baseline)
+              (true? (get-in baseline [:measurement :stationary?])))) :invalid-baseline
+    (<= (get-in result [:measurement :median-ns])
+        (* 1.15 (get-in baseline [:measurement :median-ns]))) :pass
+    :else :regression))
+
+(defn- identity-for [workload target dtype shape timing-source environment-tag]
+  (when-not (and (string? environment-tag) (not-empty environment-tag))
+    (throw (ex-info "canary requires an explicit stable-machine/driver :environment-tag" {})))
+  (hardware/init!)
+  {:version 1 :workload workload :target target :dtype dtype :shape shape
+   :timing-source timing-source :cache-state :warm-resident
+   :environment-tag environment-tag
+   :device (hardware/device-signature target)
+   :host (hardware/device-signature :cpu:0)
+   :java-version (System/getProperty "java.vm.version")})
+
+(defn- measure [thunk]
+  (microbench/do-bench thunk :warmup-ms 500 :budget-ms 800 :cv-threshold 0.08))
+
+(defn cpu! [{:keys [environment-tag compiler-revision]}]
+  (let [identity (identity-for :sumsq-aot :cpu:0 :double [1048576] :host-call environment-tag)
+        x (double-array (map #(/ (double (mod % 16)) 16.0) (range 1048576)))
+        expected (reduce (fn [s v] (+ s (* v v))) 0.0 x)
+        start (System/nanoTime)
+        f (pipeline/compile-aot #'sumsq :dtype :double)
+        compile-ns (- (System/nanoTime) start)
+        sink (volatile! nil)
+        thunk #(vreset! sink (f x (long (alength x))))]
+    (when-not (= expected (double (thunk)))
+      (throw (ex-info "production CPU canary failed independent numerical reference" {})))
+    {:identity (assoc identity :numerical-policy :double)
+     :compiler-revision compiler-revision :compile-ns compile-ns :validated? true
+     :measurement (measure thunk)}))
+
+(defn gemm-arguments []
+  [(float-array (map #(float (/ (- (mod % 13) 6) 8.0)) (range 4096)))
+   (float-array (map #(float (/ (- (mod % 11) 5) 8.0)) (range 4096)))
+   (float-array 4096)])
+
+(defn gemm-reference [^floats a ^floats b]
+  (float-array
+   (for [i (range 64) j (range 64)]
+     (float (reduce + 0.0
+                    (for [k (range 64)]
+                      (* (double (aget a (+ (* i 64) k))) (double (aget b (+ (* k 64) j))))))))))
+
+(defn prepare-gemm [target args]
+  (compiled/lower #'gemm64! args {:target target :dtype :float :on-non-resident :throw
+                                 :constants ['A 'B]}))
+
+(defn gemm! [{:keys [environment-tag target compiler-revision] :or {target :ocl:0}}]
+  (let [identity (identity-for :gemm64-resident target :float [64 64 64]
+                               :host-synchronized-replay environment-tag)
+        args (gemm-arguments)
+        expected (vec (gemm-reference (first args) (second args)))
+        started (System/nanoTime)
+        prepared (prepare-gemm target args)
+        compile-ns (- (System/nanoTime) started)
+        started (System/nanoTime)
+        c (compiled/instantiate! prepared)
+        bind-ns (- (System/nanoTime) started)]
+    (try
+      (let [resident (:executable c)
+            _ (link/run! resident)
+            output (some #(when (= 'C (:sym %)) %) (:out-tree c))
+            _ (when-not output
+                (throw (ex-info "GEMM canary has no semantic C output" {})))
+            actual (vec (link/download resident (:node output)))
+            _ (when-not (= expected actual)
+                (throw (ex-info "production GEMM canary failed independent numerical reference"
+                                {:expected-head (take 8 expected) :actual-head (take 8 actual)})))
+            alternatives (keep :dispatch (get-in prepared [:descriptor :steps]))]
+        {:identity (assoc identity :numerical-policy (get-in prepared [:schedule :precision]))
+         :compiler-revision compiler-revision
+         :compile-ns compile-ns :bind-ns bind-ns :validated? true
+         :schedule (:schedule prepared)
+         :execution (compiled/ir c)
+         :candidate-strategies (mapv #(mapv dispatch/alternative-strategy (:alternatives %))
+                                     alternatives)
+         :candidate-signatures (mapv #(mapv tuning/executable-signature (:alternatives %))
+                                     alternatives)
+         :measurement (measure #(link/run! resident))})
+      (finally (compiled/close! c)))))
+
+(defn -main [options-file]
+  (let [{:keys [case baseline output] :as opts} (edn/read-string (slurp options-file))]
+    (when-not (and (string? (:compiler-revision opts)) (not-empty (:compiler-revision opts)))
+      (throw (ex-info "canary requires :compiler-revision for auditable results" {})))
+    (when (and baseline output
+               (= (.getCanonicalPath (io/file baseline)) (.getCanonicalPath (io/file output))))
+      (throw (ex-info "canary output must not overwrite its baseline" {})))
+    (let [result ((clojure.core/case case :cpu cpu! :gemm gemm!
+                       (throw (ex-info "canary :case must be :cpu or :gemm" {}))) opts)
+          baseline (when (and baseline (.exists (io/file baseline)))
+                     (edn/read-string (slurp baseline)))
+          result (assoc result :verdict (verdict baseline result))]
+      (when output (io/make-parents output) (spit output (pr-str result)))
+      (prn result)
+      (System/exit (if (= :pass (:verdict result)) 0 2)))))

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -1,0 +1,38 @@
+(ns raster.perf.production-canary-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.perf.production-canary :as canary]
+            [raster.runtime.microbench :as microbench]
+            [raster.gpu.device-probe :as probe]))
+
+(defn- once-only [f & _]
+  (f)
+  {:median-ns 100 :stationary? true})
+
+(deftest explicit-baseline-and-comparability
+  (let [sample {:identity {:workload :example :environment-tag "fixture"}
+                :validated? true :measurement {:median-ns 100 :stationary? true}}]
+    (is (= :pass (canary/verdict sample sample)))
+    (is (= :regression (canary/verdict sample (assoc-in sample [:measurement :median-ns] 116))))
+    (is (= :unbaselined (canary/verdict nil sample)))
+    (is (= :incomparable (canary/verdict sample (assoc-in sample [:identity :environment-tag] "other"))))
+    (is (= :nonstationary (canary/verdict sample (assoc-in sample [:measurement :stationary?] false))))
+    (is (= :invalid-baseline (canary/verdict (assoc sample :validated? false) sample)))
+    (doseq [v [nil 0 -1 ##NaN ##Inf]]
+      (is (= :invalid-measurement
+             (canary/verdict sample (assoc-in sample [:measurement :median-ns] v)))))))
+
+(deftest cpu-canary-executes-the-public-aot-route
+  ;; Real compilation and independent reference; no wall-time assertion in CI.
+  (with-redefs [microbench/do-bench once-only]
+    (let [result (canary/cpu! {:environment-tag "ci-correctness-only"})]
+      (is (:validated? result))
+      (is (= :sumsq-aot (get-in result [:identity :workload]))))))
+
+(deftest opencl-resident-gemm-canary-numerics
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "production canary resident GEMM numerics")
+    (with-redefs [microbench/do-bench once-only]
+      (let [result (canary/gemm! {:target :ocl:0 :environment-tag "ci-correctness-only"})]
+        (is (:validated? result))
+        (is (= :host-synchronized-replay (get-in result [:identity :timing-source])))
+        (is (seq (:execution result)))))))

--- a/test/raster/perf/regression_gate_test.clj
+++ b/test/raster/perf/regression_gate_test.clj
@@ -1,5 +1,9 @@
 (ns raster.perf.regression-gate-test
-  "B0.5 — the perf-regression RATCHET. The one gate that catches wall-time
+  "Historical raw-Clojure timing control, NOT a Raster compiler or generated GEMM gate.
+   For production-route canaries use raster.perf.production-canary and design/test-feedback.md.
+   The historical methodology description below must not be interpreted as compiler coverage.
+
+   B0.5 — the perf-regression RATCHET. The one gate that catches wall-time
    regressions the structural proxies (buffer counts, split-k policy, tile-fits-budget)
    cannot see: a GEMM-leaf rewrite, epilogue fusion, or cost-guided fusion can keep
    every proxy identical while regressing µs. This closes that blind spot.
@@ -83,7 +87,7 @@
                  (format "%.1f%%" (* 100.0 (dec (/ (double median-ns) (double prev)))))))))))
 
 ;; --- Canary 1 (device-free): a C2-vectorizable double reduction ---
-;; Guards the JVM-SIMD lowering path and proves the ratchet end-to-end without a device.
+;; Raw Clojure control only: does not call Raster's JVM-SIMD lowering path.
 ;; A tight sum-of-products over a fixed array — the shape C2 SuperWord vectorizes; a
 ;; regression here (e.g. a boxing or a lost FloatVector selection) shows as µs growth.
 (deftest ^:perf cpu-simd-reduce-canary


### PR DESCRIPTION
## Summary
- Add opt-in Raster AOT and public compiled/lower → resident LinkPlan GEMM canaries, with independent numerical references.
- Keep compilation/binding separate from warm host-synchronized replay; record numerical policy and emitted executable signatures.
- Never seed or overwrite a baseline implicitly. Missing/noisy/incomparable results cannot pass.
- Ordinary CI checks CPU numerics and OpenCL resident numerics without wall-time thresholds. Correct the historical raw-loop canary coverage claim.

## Validation
- Focused reusable-JVM tests: 3 tests, 14 assertions, zero failures/errors.
- Local OpenCL unavailable: numerical device gate explicitly skipped; CircleCI OpenCL CPU lane must validate it.
- Public GPU lowering and executable signature generation exercised without device execution.

## Scope
This is small-shape route/runtime regression infrastructure, not evidence of SOTA GEMM. Direct scheduled-result aliasing and cast-wrapped zero identities are recorded follow-ups; this canary explicitly returns C.