### PR TITLE
Resolve scheduled return aliases through the executable ABI

### DIFF
--- a/design/test-feedback.md
+++ b/design/test-feedback.md
@@ -94,8 +94,8 @@ exit nonzero. A stationary median above 115% of baseline also fails. Review repe
 measurements and explicitly designate a separate baseline file; the runner never seeds or
 updates it. Compilation/binding timings are diagnostic, not yet regression-gated.
 
-Known public-boundary follow-up discovered by this canary: a direct returned scheduled
-contraction currently retains a synthetic result name instead of resolving its common ABI
-`:result` buffer. The canary uses explicit `write C; return C`; fix result alias propagation
-without weakening resident-plan validation. Also review cast-wrapped zero identities, which
+The canary directly returns its scheduled contraction: result alias propagation resolves the
+common ABI's `:result` buffer without weakening resident-plan validation. This also covers
+the public-boundary defect discovered while introducing the canary.
+Remaining follow-up: review cast-wrapped zero identities, which
 currently decline the register-tiled route even though they are numerically zero.

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1530,6 +1530,8 @@
    bare nil (the silent-empty-graph footgun)."
   ([form] (extract-gpu-program form nil))
   ([form kernel-info-fn]
+   (extract-gpu-program form kernel-info-fn nil))
+  ([form kernel-info-fn dispatch-info-fn]
    (if-not (and (seq? form) (#{'let* 'let} (first form)))
      {::non-resident {:why :not-a-let-form :form (when (seq? form) (first form))}}
      (let [bindings (partition 2 (second form))
@@ -1577,8 +1579,14 @@
              (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
              (if-let [s (parse-gpu-step sym expr)]
                (let [ordered-result
-                     (when (and (:arguments s) kernel-info-fn)
-                       (let [abi (:abi (kernel-info-fn (:kernel-name s)))
+                     (when (:arguments s)
+                       (let [abi (if (and (:dispatch-id s) dispatch-info-fn)
+                                   ;; Graph schedules have no single kernel name. Their validated
+                                   ;; common ABI owns the return value just as it owns binding.
+                                   (some-> (dispatch-info-fn (:dispatch-id s))
+                                           kdispatch/default-alternative kexec/abi)
+                                   (when kernel-info-fn
+                                     (:abi (kernel-info-fn (:kernel-name s)))))
                              result-indexes (keep-indexed
                                              (fn [i slot]
                                                (when (= :result (:role slot)) i))
@@ -1865,7 +1873,7 @@
         reg-entry (requiring-resolve (symbol (str runtime-ns) "kernel-registry-entry"))
         dispatch-entry (requiring-resolve
                         (symbol (str runtime-ns) "kernel-dispatch-registry-entry"))
-        extracted (extract-gpu-program form reg-entry)
+        extracted (extract-gpu-program form reg-entry dispatch-entry)
         prog (if-let [nr (::non-resident extracted)]
                (if (= on-non-resident :throw)
                  (throw (ex-info

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -11,11 +11,45 @@
    form extracted to a (wrong) step with no ::non-resident."
   (:require [clojure.test :refer [deftest testing is]]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.kernel-abi :as kabi]))
 
 (def ^:private nr-key :raster.compiler.pipeline/non-resident)
 
 (defn- why [form] (get-in (pipeline/extract-gpu-program form) [nr-key :why]))
+
+(deftest scheduled-results-use-the-dispatch-common-abi
+  (let [artifact (kart/make
+                  {:kernel-name "alias_fixture"
+                   :source "__kernel void alias_fixture(__global const float* x, __global float* out) {}"
+                   :abi [(kabi/slot 'x :input :float :role :operand)
+                         (kabi/slot 'out :output :float :role :result)]
+                   :arguments '[x out]
+                   :launch (klaunch/spec {:workgroup-size [1] :group-count [1]})
+                   :effects {:kind :map :reads ['x] :writes ['out]}
+                   :attributes {:strategy :fixture}})
+        dispatch (kdispatch/make {:id "alias-dispatch" :alternatives [artifact]
+                                  :default-strategy :fixture :selector {:kind :fixed-strategy :strategy :fixture}})
+        lookup (fn [id] (when (= "alias-dispatch" id) dispatch))
+        kernel-lookup (fn [_] (throw (ex-info "must not resolve a graph through a kernel name" {})))
+        direct (pipeline/extract-gpu-program
+                 '(let* [returned (raster.compiler.pipeline/invoke-scheduled-executable!
+                                   :ocl:0 "alias-dispatch" [A C])]
+                    returned)
+                 kernel-lookup lookup)
+        chained (pipeline/extract-gpu-program
+                  '(let* [returned (raster.compiler.pipeline/invoke-scheduled-executable!
+                                    :ocl:0 "alias-dispatch" [A C])
+                          final (raster.compiler.pipeline/invoke-scheduled-executable!
+                                 :ocl:0 "alias-dispatch" [returned D])]
+                     final)
+                  kernel-lookup lookup)]
+    (is (= 'C (:result direct)))
+    (is (= 'D (:result chained)))
+    (is (= '[C D] (:arguments (second (:steps chained)))))
+    (is (every? #(= :executable (:convention %)) (:steps chained)))))
 
 (deftest map-void-arity
   (doseq [head '[raster.gpu.ze-runtime/invoke-registered-map-void-kernel

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -18,10 +18,9 @@
     (+ acc (* (arrays/aget x i) (arrays/aget x i)))))
 
 (deftm gemm64! [A :- (Array float) B :- (Array float) C :- (Array float)] :- (Array float)
-  (let [_ (raster.par/contract C [[i 64] [j 64]] [[k 64]]
-            (* (arrays/aget A (+ (* i 64) k)) (arrays/aget B (+ (* k 64) j)))
-            :init 0.0)]
-    C))
+  (raster.par/contract C [[i 64] [j 64]] [[k 64]]
+    (* (arrays/aget A (+ (* i 64) k)) (arrays/aget B (+ (* k 64) j)))
+    :init 0.0))
 
 (defn- valid-measurement? [result]
   (let [median (get-in result [:measurement :median-ns])]

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -28,6 +28,12 @@
       (is (:validated? result))
       (is (= :sumsq-aot (get-in result [:identity :workload]))))))
 
+(deftest direct-contraction-result-is-a-public-resident-buffer
+  (let [p (canary/prepare-gemm :ocl:0 (canary/gemm-arguments))]
+    (is (= 'C (get-in p [:descriptor :result-sym])))
+    (is (= ['C] (mapv :sym (:out-tree p))))
+    (is (every? #(= :executable (:convention %)) (get-in p [:descriptor :steps])))))
+
 (deftest opencl-resident-gemm-canary-numerics
   (if-not @probe/opencl-available?
     (probe/opencl-skip! "production canary resident GEMM numerics")


### PR DESCRIPTION
## Summary
- Generic scheduled executable markers carry a dispatch ID, not a kernel name. Resolve their return role using the validated common executable ABI.
- Reuse existing alias propagation for direct returns and downstream reads; preserve resident-plan validation and extractor compatibility arities.
- Exercise a direct returned contraction in the production canary, plus a device-free public lowering regression and chained-result extractor regression.

## Validation
- Warm and cold focused runs: 12 tests, 49 assertions, zero failures/errors.
- OpenCL absent locally; CircleCI OpenCL CPU lane covers actual numerical replay.
- Independent read-only review found no correctness blocker.
- No new kernel implementation, inference registry, or output-name heuristic.