### PR TITLE
Unify checked constant identities across algebra proofs and GPU schedules

### DIFF
--- a/design/test-feedback.md
+++ b/design/test-feedback.md
@@ -97,5 +97,8 @@ updates it. Compilation/binding timings are diagnostic, not yet regression-gated
 The canary directly returns its scheduled contraction: result alias propagation resolves the
 common ABI's `:result` buffer without weakening resident-plan validation. This also covers
 the public-boundary defect discovered while introducing the canary.
-Remaining follow-up: review cast-wrapped zero identities, which
-currently decline the register-tiled route even though they are numerically zero.
+Primitive literal casts now pass through one checked constant boundary shared by scan/reduction
+certification, SegRed identity emission and matrix schedule legality. It evaluates supported
+Clojure casts rather than stripping them, and compares integer/floating values exactly. Unknown
+or failing conversions provide no evidence. The canary uses `(float 0.0)` to exercise this
+path; original initializer expressions remain in the retained IR.

--- a/src/raster/compiler/core/numeric_constant.clj
+++ b/src/raster/compiler/core/numeric_constant.clj
@@ -1,0 +1,54 @@
+(ns raster.compiler.core.numeric-constant
+  "Checked evidence for numeric literals and primitive literal casts, not general evaluation.
+   Cast recognition belongs to op-descriptor. Unknown/effectful forms and failing conversions
+   yield no evidence; callers must retain or decline them, never erase the conversion."
+  (:require [raster.compiler.core.op-descriptor :as descriptor]))
+
+(defn value
+  "Return {:value number} for a supported constant, nil otherwise. Primitive casts use
+   Clojure's checked source semantics, including floating rounding and range failures.
+   No arbitrary function resolution, eval, or inference registry is involved."
+  [expression]
+  (cond
+    (or (integer? expression) (float? expression)) {:value expression}
+    (symbol? expression)
+    (case expression
+      Float/POSITIVE_INFINITY {:value Float/POSITIVE_INFINITY}
+      Float/NEGATIVE_INFINITY {:value Float/NEGATIVE_INFINITY}
+      Double/POSITIVE_INFINITY {:value Double/POSITIVE_INFINITY}
+      Double/NEGATIVE_INFINITY {:value Double/NEGATIVE_INFINITY}
+      nil)
+    (and (seq? expression) (= 2 (count expression)))
+    (when-let [tag (descriptor/cast-result-tag (first expression))]
+      (when-let [operand (value (second expression))]
+        (try
+          {:value (case tag
+                    byte (byte (:value operand))
+                    int (int (:value operand))
+                    long (long (:value operand))
+                    float (float (:value operand))
+                    double (double (:value operand)))}
+          (catch IllegalArgumentException _ nil)
+          (catch ArithmeticException _ nil))))
+    :else nil))
+
+(defn literal-or-original
+  "Fold only a checked constant; retain every unsupported expression verbatim."
+  [expression]
+  (if-let [constant (value expression)] (:value constant) expression))
+
+(defn equivalent?
+  "Compare proven numeric values without rounding an integer to a float for comparison.
+   NaN is never an identity. Signed-zero policy remains the algebra/schedule's responsibility."
+  [left right]
+  (let [l (value left) r (value right)]
+    (when (and l r)
+      (let [a (:value l) b (:value r)
+            nonfinite? #(and (float? %) (not (Double/isFinite (double %))))
+            exact-decimal #(if (float? %) (java.math.BigDecimal. (double %)) (bigdec %))]
+        (if (or (nonfinite? a) (nonfinite? b))
+          (and (nonfinite? a) (nonfinite? b) (== a b))
+          (zero? (.compareTo ^java.math.BigDecimal (exact-decimal a) (exact-decimal b))))))))
+
+(defn zero-value? [expression]
+  (boolean (equivalent? expression 0)))

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -23,6 +23,7 @@
    symbols is how a transpose rewrite risked a silent miscompile."
   (:require [clojure.walk :as walk]
             [raster.compiler.core.op-descriptor :as od]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as contract-stages]
             [raster.compiler.ir.reduction :as reduction]))
@@ -379,7 +380,7 @@
       (not (contains? '#{+ clojure.core/+ raster.numeric/+} combine))
       {:ok false :reason :non-plus-combine :combine combine}
 
-      (not (and (number? neutral) (zero? neutral)))
+      (not (constant/zero-value? neutral))
       {:ok false :reason :non-zero-matrix-init :init neutral}
 
       (nil? (body-product-of element (map :sym operands)))

--- a/src/raster/compiler/ir/scan.clj
+++ b/src/raster/compiler/ir/scan.clj
@@ -6,6 +6,7 @@
    only when the body is an associative combine of the prior accumulator and an accumulator-free
    element expression. This boundary proves that property before SegScan scheduling."
   (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.passes.scalar.effects :as effects]
             [raster.compiler.core.util :as util]))
@@ -15,19 +16,13 @@
 (defn associative-scan? [x]
   (and x (= "raster.compiler.ir.scan.AssociativeScan" (.getName (class x)))))
 
-(def ^:private cast-dtypes
-  {'float :float, 'clojure.core/float :float
-   'double :double, 'clojure.core/double :double
-   'int :int, 'clojure.core/int :int
-   'long :long, 'clojure.core/long :long})
-
 (defn- acc-ref?
   [expr acc reduction-dtype]
   (or (= expr acc)
       (and (seq? expr)
            (= 2 (count expr))
            (= (dtype/canon reduction-dtype)
-              (some-> (get cast-dtypes (first expr)) dtype/canon))
+              (some-> (descriptor/cast-result-tag (first expr)) keyword dtype/canon))
            (= acc (second expr)))))
 
 (defn- contains-symbol?
@@ -36,27 +31,6 @@
     (= expr target) true
     (coll? expr) (boolean (some #(contains-symbol? % target) expr))
     :else false))
-
-(defn- literal-value
-  [expr _reduction-dtype]
-  (if (and (seq? expr)
-           (= 2 (count expr))
-           ;; Casts around literal identities are representation spelling, not accumulator
-           ;; evidence. Compare the literal exactly in the reduction domain below; unlike
-           ;; acc-ref?, accepting `(double 0.0)` for an explicitly float scan cannot change which
-           ;; value is carried or hide a cross-dtype accumulator.
-           (contains? cast-dtypes (first expr))
-           (number? (second expr)))
-    (second expr)
-    expr))
-
-(defn- identity-equivalent?
-  [left right reduction-dtype]
-  (let [left (literal-value left reduction-dtype)
-        right (literal-value right reduction-dtype)]
-    (if (and (number? left) (number? right))
-      (== left right)
-      (= left right))))
 
 (defn- pure-element?
   [expr]
@@ -110,7 +84,7 @@
                         {:reason (reason operation "element-impure-or-unknown")
                          :element element :body lambda :reduction-op reduction-op})))
       (let [identity (descriptor/typed-reduce-identity combine dtype)]
-        (when-not (identity-equivalent? init identity dtype)
+        (when-not (constant/equivalent? init identity)
           (throw (ex-info "parallel reduction with a non-identity init requires a distinct schedule"
                           {:reason (reason operation "nonidentity-init")
                            :combine combine :init init :identity identity :dtype dtype})))
@@ -140,8 +114,8 @@
        (= (:dtype declared) (:dtype derived))
        (= (some-> (:combine declared) name symbol)
           (some-> (:combine derived) name symbol))
-       (identity-equivalent? (:init declared) (:init derived) (:dtype declared))
-       (identity-equivalent? (:identity declared) (:identity derived) (:dtype declared))))
+       (constant/equivalent? (:init declared) (:init derived))
+       (constant/equivalent? (:identity declared) (:identity derived))))
 
 (defn certify
   "Certify `scan-op` as a parallel associative scan or throw a structured conversion decline.

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -6,6 +6,7 @@
   all inspectable compiler values.  A backend may decline an instruction family it cannot lower,
   but it must consume this body rather than reconstructing the schedule from the source form."
   (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
@@ -20,9 +21,6 @@
 
 (defn- additive? [combine]
   (contains? '#{+ clojure.core/+ raster.numeric/+} combine))
-
-(defn- zero-init? [init]
-  (and (number? init) (zero? init)))
 
 (defn- compiler-id? [value]
   (or (symbol? value) (keyword? value)))
@@ -334,7 +332,7 @@
        (not (additive? combine))
        (decline :non-plus-combine {:combine combine})
 
-       (not (zero-init? neutral))
+       (not (constant/zero-value? neutral))
        (decline :non-zero-matrix-init {:init neutral})
 
        (nil? (facts/body-product-of element (map :sym operands)))

--- a/src/raster/compiler/passes/parallel/register_tiled_body.clj
+++ b/src/raster/compiler/passes/parallel/register_tiled_body.clj
@@ -6,6 +6,7 @@
    microtile and 2-D launch explicit so every C-family target consumes the same scheduled value."
   (:require [clojure.walk :as walk]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
@@ -170,7 +171,7 @@
             (decline! :non-plus-combine
                       "register-tiled contraction combine must be +"
                       {:combine combine}))
-        _ (when-not (and (number? neutral) (zero? neutral))
+        _ (when-not (constant/zero-value? neutral)
             (decline! :non-zero-matrix-init
                       "register-tiled contraction requires a zero reduction identity"
                       {:neutral neutral}))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -9,6 +9,7 @@
    explicitly; scheduled graphs have no source-shaped target fallback."
   (:require [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.types :as types]
@@ -226,20 +227,6 @@
       (recur (util/subst-syms (util/binding-env bindings) (first body))))
     expression))
 
-(defn- literal-value
-  [value]
-  (if (and (seq? value)
-           (= 2 (count value))
-           (descriptor/cast-op? (first value))
-           (number? (second value)))
-    (second value)
-    (case value
-      Double/POSITIVE_INFINITY Double/POSITIVE_INFINITY
-      Double/NEGATIVE_INFINITY Double/NEGATIVE_INFINITY
-      Float/POSITIVE_INFINITY Float/POSITIVE_INFINITY
-      Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
-      value)))
-
 (defn scalar-plan
   "Project one scalar SegRed into an explicit combine operator, identity and element expression."
   [segred]
@@ -265,7 +252,7 @@
                 {:segred-id (:id segred) :declared declared :derived derived}))
     ;; Retain the concrete neutral spelling after proving it equivalent to the typed registry
     ;; identity. KernelBody consumers need a literal, while the certificate remains the proof.
-    {:operator operator :identity (literal-value init) :element (:element derived)
+    {:operator operator :identity (constant/literal-or-original init) :element (:element derived)
      :accumulator acc}))
 
 (defn capped-group-count
@@ -558,7 +545,7 @@
                            (every? #(contraction-facts/operand-axis-map coordinate-proof %)
                                    (:operands coordinate-proof))
                            (= element (:element view))
-                           (= (literal-value identity) (literal-value (:neutral view)))
+                           (constant/equivalent? identity (:neutral view))
                            (= operator (intrinsics/canonical (:combine view)))
                            (= (dtype/canon dtype) (dtype/canon (:dtype view))))
               (decline! :contraction-coordinate-proof
@@ -571,7 +558,7 @@
             (decline! :floating-minmax-semantics
                       "portable scalar reduction needs an explicit NaN and signed-zero policy for min/max"
                       {:segred-id (:id segred) :operator operator}))
-        identity (literal-value identity)
+        identity (constant/literal-or-original identity)
         _ (when-not (number? identity)
             (decline! :literal-identity
                       "KernelBody scalar reduction requires a numeric identity"

--- a/test/raster/compiler/core/numeric_constant_test.clj
+++ b/test/raster/compiler/core/numeric_constant_test.clj
@@ -1,0 +1,25 @@
+(ns raster.compiler.core.numeric-constant-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.numeric-constant :as constant]))
+
+(deftest primitive-casts-are-evaluated-not-stripped
+  (doseq [tag '[byte int long float double clojure.core/float clojure.core/long]]
+    (is (constant/zero-value? (list tag 0))))
+  (is (= {:value (float 2147483647)} (constant/value '(float 2147483647))))
+  (is (not (constant/equivalent? '(float 2147483647) 2147483647)))
+  (is (not (constant/equivalent? (list 'double Long/MAX_VALUE) Long/MAX_VALUE)))
+  (is (constant/equivalent? '(double (float 1)) 1))
+  (is (= (Double/doubleToRawLongBits -0.0)
+         (Double/doubleToRawLongBits (:value (constant/value '(double -0.0)))))))
+
+(deftest no-evidence-for-unknown-or-failing-forms
+  (doseq [form ['(int Double/POSITIVE_INFINITY) '(byte 256) '(unknown 0)
+               '(float x) '(float 0 1) '(do (effect!) 0) 'x nil]]
+    (is (nil? (constant/value form)))
+    (is (= form (constant/literal-or-original form)))
+    (is (not (constant/equivalent? form form)))))
+
+(deftest infinities-and-nan
+  (is (constant/equivalent? 'Float/POSITIVE_INFINITY Double/POSITIVE_INFINITY))
+  (is (not (constant/equivalent? 'Float/POSITIVE_INFINITY 'Double/NEGATIVE_INFINITY)))
+  (is (not (constant/equivalent? ##NaN ##NaN))))

--- a/test/raster/compiler/ir/scan_test.clj
+++ b/test/raster/compiler/ir/scan_test.clj
@@ -3,6 +3,20 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.scan :as scan]))
 
+(deftest rounded-or-failing-casts-do-not-prove-integer-identities
+  (doseq [[dtype init] [[:int '(float 2147483647)]
+                       [:long (list 'double Long/MAX_VALUE)]
+                       [:long (double Long/MAX_VALUE)]
+                       [:int '(int Double/POSITIVE_INFINITY)]]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"non-identity init"
+          (scan/certify {:acc 'acc :init init :lambda '(min acc x)} dtype)))))
+
+(deftest checked-nested-casts-retain-the-original-init
+  (let [init '(double (float 0.0))
+        certificate (scan/certify {:acc 'acc :init init :lambda '(+ acc x)} :double)]
+    (is (= init (:init certificate)))
+    (is (scan/associative-scan? certificate))))
+
 (deftest associative-scan-certification
   (let [facts (scan/certify {:acc 'acc :init 0.0
                              :lambda '(+ acc (clojure.core/aget values i))}

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -48,6 +48,15 @@
     (is (= :dot-operand (get-in kernel [:fragments 8 :layout :kind])))
     (is (= :mma-frag (get-in kernel [:fragments 0 :layout :kind])))))
 
+(deftest checked-zero-identities-reach-the-matrix-schedule
+  (doseq [init '[(float 0.0) (double (float 0))]]
+    (let [proof (facts/contraction-facts (matrix-form 128 128 128 init) :dtype :half)
+          planned (schedule/plan-matrix-body proof nil nil)]
+      (is (:ok (facts/dense-matrix-view proof)))
+      (is (:ok planned))
+      (is (body/kernel-body? (:body planned)))
+      (is (= init (:neutral (facts/scalar-reduction-view proof)))))))
+
 (deftest matrix-fragment-boundaries-are-a-legality-policy
   (testing "K=24 meets the old 16-byte pitch test but cannot form a final K16 instruction"
     (let [planned (schedule/plan-matrix-body

--- a/test/raster/compiler/passes/parallel/register_tiled_body_test.clj
+++ b/test/raster/compiler/passes/parallel/register_tiled_body_test.clj
@@ -14,7 +14,7 @@
   {:block-m 4 :block-n 4 :block-k 2 :thread-m 2 :thread-n 2})
 
 (defn- contraction
-  [& [epilogue]]
+  [& [epilogue init]]
   (facts/from-components
    {:out 'C
     :free-axes [['i 8] ['j 8]]
@@ -22,7 +22,8 @@
     :body '(raster.numeric/*
             (clojure.core/aget A (clojure.core/+ (clojure.core/* i 8) k))
             (clojure.core/aget B (clojure.core/+ (clojure.core/* k 8) j)))
-    :opts (cond-> {} epilogue (assoc :epilogue epilogue))
+    :opts (cond-> {} epilogue (assoc :epilogue epilogue)
+                  (some? init) (assoc :init init))
     :dtype :float}))
 
 (defn- operation-kinds
@@ -33,6 +34,13 @@
              (when (instance? raster.compiler.ir.kernel_body.ForLoop operation)
                (operation-kinds (:operations operation)))))
    operations))
+
+(deftest checked-zero-identities-reach-the-register-tiled-body
+  (doseq [init '[0.0 (float 0.0) (double (float 0))]]
+    (let [proof (contraction nil init)
+          emitted (segop-emit/generate-register-tiled-kernel-body proof 'C :tile small-tile)]
+      (is (body/kernel-body? (:kernel-body emitted)))
+      (is (= init (:neutral (facts/scalar-reduction-view proof)))))))
 
 (deftest cooperative-register-tile-is-a-verified-scalar-kernel-body
   (let [kernel-body (:kernel-body

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -20,7 +20,7 @@
 (deftm gemm64! [A :- (Array float) B :- (Array float) C :- (Array float)] :- (Array float)
   (raster.par/contract C [[i 64] [j 64]] [[k 64]]
     (* (arrays/aget A (+ (* i 64) k)) (arrays/aget B (+ (* k 64) j)))
-    :init 0.0))
+    :init (float 0.0)))
 
 (defn- valid-measurement? [result]
   (let [median (get-in result [:measurement :median-ns])]


### PR DESCRIPTION
## Summary
- Replace cast stripping with one checked numeric-literal boundary using canonical cast descriptors and actual Clojure conversion semantics.
- Compare floating/integer values exactly: do not round integer extrema during identity comparison.
- Share this evidence between scan/reduction certificates, SegRed identity emission, dense-matrix classification, register tiling and matrix schedules.
- Retain original initializer expressions. Unsupported/throwing forms provide no evidence.
- Remove the duplicate scan cast table and local literal/zero helpers.

## Evidence
- Reproduced incorrect certificates for int min initialized with (float 2147483647), and long min initialized with (double Long/MAX_VALUE). Both now decline.
- Public cast-zero GEMM canary now exposes regtiled and portable-segred candidates, previously only portable. This is route evidence, not a speedup measurement.
- Warm and cold focused runs: 89 tests, 563 assertions, zero failures/errors.
- Local OpenCL unavailable, explicitly skipped. CI must run the actual OpenCL CPU canary.
- Independent read-only review found no correctness blocker.

## Scope
No new type inference, function registry or kernel implementation. Signed-zero algebra policy is unchanged. No automatic baseline updates or SOTA performance claim.