### PR TITLE
Require commutativity for the reordering product-reduction tree

### DIFF
--- a/design/test-feedback.md
+++ b/design/test-feedback.md
@@ -108,3 +108,10 @@ unwraps arbitrary unary calls or resolves static fields by their unqualified nam
 handwritten exclusive-scan generator has been removed (no Raster/pretrained/finetune callers).
 The retained product leaf still needs destination-dtype literal range validation and migration
 to the common KernelBody emitter; source-constant evaluation alone does not complete that work.
+
+Before that migration, the lane-strided product tree is gated by one IR-owned algebra check
+at scheduling and emission: both associativity and commutativity must be explicitly declared.
+Its lane folds and halving tree permute elements. Associativity alone cannot justify that
+schedule (affine-function composition is a counterexample). Noncommutative products remain
+representable but need an order-preserving schedule; they now decline instead of silently
+being reordered. This checks declared contracts, not arbitrary mathematical proofs.

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -429,15 +429,7 @@
   [segred & {:keys [kernel-name-prefix scalar-types array-types]
              :or {kernel-name-prefix "product_reduce" scalar-types {} array-types {}}}]
   (let [operator (reduction/validate! (:reduction segred))
-        schedule (reduction/validate-schedule! (:schedule segred))
-        _ (when-not (= :segmented-workgroup-tree (:strategy schedule))
-            (throw (ex-info "product reduction schedule has no OpenCL lowering"
-                            {:reason :product-reduction-schedule-not-emittable
-                             :strategy (:strategy schedule)})))
-        _ (when-not (true? (get-in operator [:algebra :associative?]))
-            (throw (ex-info "parallel product schedule requires an explicit associative algebra"
-                            {:reason :product-reduction-not-associative
-                             :algebra (:algebra operator)})))
+        schedule (reduction/validate-product-tree! operator (:schedule segred))
         components (:components operator)
         element (reduction/element-region operator)
         combine (reduction/combine-region operator)

--- a/src/raster/compiler/ir/reduction.clj
+++ b/src/raster/compiler/ir/reduction.clj
@@ -175,6 +175,25 @@
                       {:reason :product-reduction-attributes :attributes attributes}))))
   reduction)
 
+(defn validate-product-tree!
+  "Validate the algebra required by the lane-strided, halving-tree product schedule.
+   This schedule permutes elements, so associativity alone is insufficient. These are explicit
+   caller-supplied algebra contracts, not a proof of arbitrary combine expressions."
+  [operator schedule]
+  (validate! operator)
+  (validate-schedule! schedule)
+  (when-not (= :segmented-workgroup-tree (:strategy schedule))
+    (throw (ex-info "product tree requires the segmented-workgroup-tree schedule"
+                    {:reason :product-reduction-schedule-not-emittable
+                     :strategy (:strategy schedule)})))
+  (doseq [[property reason] [[:associative? :product-reduction-not-associative]
+                            [:commutative? :product-reduction-not-commutative]]]
+    (when-not (true? (get-in operator [:algebra property]))
+      (throw (ex-info "reordering product tree requires explicit associativity and commutativity"
+                      {:reason reason :required property :algebra (:algebra operator)
+                       :strategy (:strategy schedule) :fallback :none}))))
+  schedule)
+
 (defn make
   [{:keys [components index step element-bindings element-results combine-parameters
            combine-bindings combine-results algebra attributes]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -946,6 +946,7 @@
                            :component-dtypes (reduction/dtypes reduction)
                            :scratch-bytes-per-lane (:bytes-per-lane product-grid-info)
                            :slm-budget (:slm-budget product-grid-info)}})))
+        _ (when product? (reduction/validate-product-tree! reduction product-schedule))
         execution (execution-plan/reduce-execution bound grid-1)]
     (if product?
       [(segop/->SegRed (:id description) space (segop/->SegLevel :block :virtual)

--- a/test/raster/compiler/ir/reduction_test.clj
+++ b/test/raster/compiler/ir/reduction_test.clj
@@ -65,6 +65,30 @@
     (is (= {:acc 'acc :init 0.0 :lambda '(+ acc (aget values i))}
            (reduction/scalar-op operator)))))
 
+(deftest lane-strided-tree-cannot-schedule-associativity-alone
+  ;; Affine-function composition is associative, not commutative. The existing two-lane tree
+  ;; groups e0,e2 then e1,e3 instead of preserving e0,e1,e2,e3.
+  (let [compose (fn [[a b] [c d]] [(* a c) (+ (* a d) b)])
+        [e0 e1 e2 e3 :as values] [[1 1] [2 0] [1 3] [1 0]]]
+    (is (not= (reduce compose [1 0] values)
+              (compose (compose e0 e2) (compose e1 e3)))))
+  (let [node (soac/par-form->soac '_ argmax-product-form 7 :dtype :float)
+        scheduled (first (soac-lower/lower-soac node :cpu:0 :dtype :float))]
+    (doseq [[field expected] [[:associative? :product-reduction-not-associative]
+                             [:commutative? :product-reduction-not-commutative]]
+            flag [false nil]]
+      (let [operator (assoc-in (:reduction node) [:algebra field] flag)]
+        ;; Both initial schedule construction and emission of a changed retained operator must
+        ;; check the same contract; callers cannot bypass it with an already-built schedule.
+        (doseq [attempt [#(soac-lower/lower-soac (assoc node :reduction operator) :cpu:0 :dtype :float)
+                         #(segop-opencl/generate-product-reduction-kernel
+                           (assoc scheduled :reduction operator)
+                           :scalar-types {'nrows :int 'width :int}
+                           :array-types {'values :float})]]
+          (try (attempt) (is false "unsupported algebra must decline")
+               (catch clojure.lang.ExceptionInfo e
+                 (is (= expected (:reason (ex-data e)))))))))))
+
 (deftest scalar-parallel-reduction-requires-the-registered-typed-identity
   (try
     (reduction/scalar


### PR DESCRIPTION
## Summary
- Move the product tree algebra check into Reduction IR and invoke it at both schedule construction and emission.
- Require explicitly true associativity and commutativity: strided lane folds plus the halving tree permute elements.
- Missing/false contracts decline rather than silently reorder; noncommutative products remain representable for a future order-preserving schedule.
- No new kernel, target-specific semantic API or inferred algebra claims.

## Validation
- 61 focused tests, 297 assertions, zero failures/errors in the reusable JVM.
- Counterexample uses associative noncommutative affine composition to demonstrate the ordering distinction.
- Tests reject missing/false properties both during construction and when the retained operator changes after scheduling.
- Existing row-gather composition and typed frontend tests pass; OpenCL unavailable locally (explicit skip).
- Independent read-only review found no blocker; all full/native/device checks delegated to CI.

## Next
Migrate tuple product reduction emission to common KernelBody using per-component typed carries and workgroup scratch, preserving ABI and coupled tuple updates. Destination-dtype literal validation belongs at that typed boundary.