### PR TITLE
Preserve false/nil specialization inputs and clarify staged partial evaluation

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1090,6 +1090,28 @@ numerical or resource checks. Logical events, measurements, hardware descriptors
 `LinkPlan` and `ExecutionPlan` are the compiler/runtime seam to OpenCL, Level Zero, CUDA/HIP and
 future collective or cluster runtimes.
 
+Partial evaluation complements the SSA-based KernelBody; it does not replace it. The existing
+source fixpoint already combines call/AD expansion, type-aware rewalking, PE and CSE. The explicit
+PE API also accepts known parameters and dimensions. General runtime-driven respecialization is
+the direction of this contract, not a claim that every runtime fact already feeds every pass.
+
+Use binding-time information at three boundaries: specialize static model/simulator structure
+before TypedSOAC fusion; specialize shapes, layouts and hardware choices before scheduling;
+then simplify the chosen KernelBody with typed constant/range facts. Keep large iteration spaces
+as structured loops/SOACs until a schedule makes bounded unrolling profitable. Daphne's repeated
+desugaring, partial evaluation and symbolic simplification are a useful strategy reference; Raster
+must additionally preserve numerical conversion rules, effects and mutable/resident storage.
+Known shape/layout does not imply known buffer contents. Captured contents require immutable or
+versioned ownership evidence; facts learned at binding need guards and a generic fallback.
+For training, values fixed within an invocation may still be differentiation inputs: specialization
+must preserve the declared AD boundary and cannot silently turn trainable parameters into constants.
+
+Extend this incrementally through workload-backed specializations, not another parallel IR or an
+unrestricted host evaluator. Each specialization should carry its assumptions and validation,
+respect code-size/compile-time/search budgets, and enter a bounded versioned artifact cache.
+Measure cold compilation, generated size and warm execution together: eliminating dynamic work
+can still lose end-to-end if compilation or instruction footprint grows too much.
+
 The search state should include both kernel and graph choices. Per-kernel axes
 include tile, vector width, instruction family, workgroup geometry, layout,
 staging, pipeline depth, and reduction strategy. Graph axes include fusion,

--- a/src/raster/compiler/passes/scalar/pe.clj
+++ b/src/raster/compiler/passes/scalar/pe.clj
@@ -484,14 +484,15 @@
   "Partially evaluate a walked deftm body with known parameter values.
 
   params: vector of parameter symbols
-  values: map of {param -> known-value} (nil for unknown)
+  values: map of {param -> known-value}; omitted keys are unknown. Present nil and false
+  are known values. A nil map means no known parameters.
   body: the walked body forms (as from ::deftm-walked-body)
 
   Returns the simplified body forms."
   [params values body]
   (let [const-env (reduce (fn [env p]
-                            (if-let [v (get values p)]
-                              (assoc env p v)
+                            (if (contains? values p)
+                              (assoc env p (get values p))
                               env))
                           {} params)]
     (mapv #(pe % const-env) body)))

--- a/test/raster/compiler/pe_test.clj
+++ b/test/raster/compiler/pe_test.clj
@@ -143,6 +143,15 @@
           result (pe/pe-walked-body '[a b] {} body)]
       (is (= ['(+ a b)] result)))))
 
+(deftest known-false-and-nil-specialize-like-other-values
+  (let [body '[(if flag yes no)]]
+    (doseq [flag [false nil]]
+      (is (= '[no] (pe/pe-walked-body '[flag] {'flag flag} body))))
+    (is (= '[yes] (pe/pe-walked-body '[flag] {'flag true} body)))
+    (is (= body (pe/pe-walked-body '[flag] {} body)))
+    (is (= body (pe/pe-walked-body '[flag] nil body)))
+    (is (= body (pe/pe-walked-body '[flag] {'unrelated false} body)))))
+
 ;; ================================================================
 ;; .invk preservation
 ;; ================================================================


### PR DESCRIPTION
## Summary
- Known false and nil parameter values now reach the existing PE engine; omitted keys remain unknown.
- Add focused regression coverage for false/nil/true, absent values and unrelated keys.
- Document PE as complementary to SSA and TypedSOAC: structural specialization before fusion, shape/layout/target specialization before scheduling, typed cleanup after scheduling.
- Record guard, AD/effect/ownership, compile-time/code-size and bounded-cache constraints informed by local Daphne inspection.

## Validation
20 focused PE and scope-capture tests, 64 assertions, zero failures/errors. No full local suite.

## Scope
This does not add a new general specializer or wire all runtime facts into PE. Existing PE+CSE integration is in the type-aware rewalk path, with separate known-value/dimension APIs. The tuple KernelBody migration remains the next compiler vertical.