### PR TITLE
Share typed scalar-region bindings across tuple results

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -443,6 +443,14 @@ now proves direct analyzed-source-to-TypedSOAC routing, typed schedule reuse and
 fallback. Subgroup/shuffle and multi-workgroup alternatives remain schedule candidates, not new
 semantic primitives.
 
+The product workgroup schedule still uses its source emitter; migrating it to KernelBody must
+preserve the simultaneous tuple update, hidden components, independent dtypes and logical ABI.
+The shared scalar lowerer now accepts ordered multi-result regions with explicit retained binding
+types: each local is lowered once to SSA and shared across results, without inferring its type from
+a consuming component. This is a prerequisite, not yet a production product KernelBody route.
+Next: express the lane folds and workgroup tree with typed carries and per-component scratch,
+compare numerically with the retained implementation, then switch the route and delete that oracle.
+
 TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
 axes, one innermost reduction axis, typed accumulator products, dense element operands and stable
 arbitrarily indexed tensor captures. Its extents participate in the typed program boundary and

--- a/src/raster/compiler/passes/parallel/index_expression.clj
+++ b/src/raster/compiler/passes/parallel/index_expression.clj
@@ -6,6 +6,7 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.scalar-range :as scalar-range]
             [raster.compiler.ir.kernel-launch :as launch]))
 
 (def ^:private operators
@@ -78,6 +79,17 @@
   (let [expression (descriptor/unwrap-int-cast expression)]
     (cond
       (integer? expression) expression
+
+      (instance? raster.compiler.ir.kernel_body.Literal expression)
+      (let [{:keys [value type]} expression]
+        (if (and (contains? #{:byte :int :long} type)
+                 (integer? value) (scalar-range/literal value type))
+          ;; Typed region substitution retains constants as Literal values. Preserve long
+          ;; index arithmetic even when the constant itself happens to fit in an int.
+          (body/index-cast value (if (= :long type) :long :int) :exact)
+          (decline! :index-literal
+                    "index literal must be a representable integral value"
+                    {:expression expression})))
 
       (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
       (apply body/expression (:op expression)

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -65,9 +65,12 @@
 (defn make-lowerer
   "Build a scalar-expression lowerer.
 
-   Returns `{:lower f}` where `f` accepts expression, expected dtype, and a map of typed local
-   values. `decline!` is called as `(decline! rule message data)` so each owning schedule retains
-   an honest, local coverage contract."
+   Returns `{:lower f :lower-region g}`. `f` accepts expression, expected dtype, and a map of typed
+   local values. `g` accepts an ordered {:bindings [...] :results [...]} region, result dtypes,
+   retained binding dtypes, and typed locals; it returns shared SSA operations and ordered results.
+   Neither entry point stores tuple results: the schedule must commit all components together.
+   `decline!` is called as `(decline! rule message data)` so each owning schedule retains an honest,
+   local coverage contract."
   [{:keys [array-types scalar-types arrays index-scope lower-index predicate id-prefix decline!]
     :or {id-prefix "scalar"}}]
   (let [canon-type #(if (= :predicate %) :predicate (dtype/canon %))
@@ -89,6 +92,7 @@
              (some-> (or (:raster.type/tag (meta expression)) (:tag (meta expression)))
                      dtype/dtype-for-scalar-tag)
              (cond
+               (instance? raster.compiler.ir.kernel_body.Literal expression) (:type expression)
                (symbol? expression) (or (get env expression) (get scalar-types expression) expected)
                (number? expression) expected
                (descriptor/aget-call? expression)
@@ -392,4 +396,51 @@
                   (decline! :scalar-expression
                             "scalar expression has an unsupported value"
                             {:expression expression :type (type expression)}))))]
-      {:lower lower})))
+      {:lower lower
+       :lower-region
+       (fn [{:keys [bindings results]} result-types binding-types env]
+         ;; Region locals are evaluated once, in source order. In particular, a product's
+         ;; shared combine bindings must not be beta-expanded separately into every result.
+         ;; Types are retained facts supplied by the caller, never guessed from a consumer.
+         (when-not (and (vector? bindings) (even? (count bindings))
+                        (every? symbol? (take-nth 2 bindings))
+                        (= (count (take-nth 2 bindings))
+                           (count (set (take-nth 2 bindings))))
+                        (vector? results) (= (count results) (count result-types)))
+           (decline! :scalar-region-shape
+                     "scalar region requires distinct ordered bindings and typed results"
+                     {:bindings bindings :results results :result-types result-types}))
+         (let [checked-lower
+               (fn [expression expected local-env]
+                 (let [expected (canon-type expected)
+                       lowered (lower expression expected local-env)]
+                   (when-not (= expected (:type lowered))
+                     (decline! :scalar-region-dtype
+                               "scalar region value disagrees with its retained dtype"
+                               {:expression expression :expected expected
+                                :actual (:type lowered)}))
+                   lowered))
+               {:keys [operations substitutions environment]}
+               (reduce
+                (fn [{:keys [operations substitutions environment]} [id expression]]
+                  (when-not (get binding-types id)
+                    (decline! :scalar-region-binding-dtype
+                              "scalar region binding lacks a retained dtype"
+                              {:binding id :expression expression}))
+                  (let [lowered (checked-lower (util/subst-syms substitutions expression)
+                                               (get binding-types id) environment)
+                        result (:result lowered)]
+                    {:operations (into operations (:operations lowered))
+                     :substitutions (assoc substitutions id result)
+                     :environment (cond-> environment
+                                    (symbol? result) (assoc result (:type lowered)))}))
+                {:operations [] :substitutions {} :environment env}
+                (partition 2 bindings))
+               lowered-results
+               (mapv (fn [expression expected]
+                       (checked-lower (util/subst-syms substitutions expression)
+                                      expected environment))
+                     results result-types)]
+           {:operations (into operations (mapcat :operations lowered-results))
+            :results (mapv :result lowered-results)
+            :types (mapv :type lowered-results)}))})))

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -1,0 +1,107 @@
+(ns raster.compiler.passes.parallel.scalar-region-body-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.index-expression :as index]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
+
+(defn- lowerer []
+  (let [decline! (fn [rule message data] (throw (ex-info message (assoc data :rule rule))))]
+    (scalar/make-lowerer
+     {:array-types {'x :float} :arrays #{'x} :scalar-types {'i :int}
+      :lower-index (fn [expression scope] (index/lower expression (conj scope 'i) decline!))
+      :decline! decline!})))
+
+(defn- mixed-region [lowerer]
+  ((:lower-region lowerer)
+   '{:bindings [candidate (aget x i) better (> candidate old-value)]
+     :results [(if better candidate old-value) (if better i old-index)]}
+   [:float :int] {'candidate :float 'better :predicate}
+   {'old-value :float 'old-index :int}))
+
+(deftest coupled-results-share-bindings-without-sharing-component-types
+  (let [{:keys [operations results types] :as lowered} (mixed-region (lowerer))
+        kernel
+        (body/make
+         {:id :mixed-region
+          :parameters [(body/->KernelParameter 'x :input :float [16] :global
+                                               (layout/row-major [16] :float) :operand)
+                       (body/->KernelParameter 'i :scalar :int [] nil nil :parameter)
+                       (body/->KernelParameter 'old-value :scalar :float [] nil nil :parameter)
+                       (body/->KernelParameter 'old-index :scalar :int [] nil nil :parameter)
+                       (body/->KernelParameter 'values :output :float [1] :global
+                                               (layout/row-major [1] :float) :result)
+                       (body/->KernelParameter 'indices :output :int [1] :global
+                                               (layout/row-major [1] :int) :result)]
+          :stable-reads [(body/stable-read 'x)]
+          :operations (into operations [(body/->ScalarStore 'values [0] (first results) nil)
+                                        (body/->ScalarStore 'indices [0] (second results) nil)])
+          :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+          :provenance {:dialect :test} :attributes {}})]
+    (is (= [:float :int] types))
+    (is (= ["ScalarLoad" "ScalarCompute" "IfRegion" "IfRegion"]
+           (mapv #(.getSimpleName (class %)) operations)))
+    (is (= (:condition (nth operations 2)) (:condition (nth operations 3)))
+        "both components consume the same predicate SSA value")
+    (is (= results (mapv (comp :id first :results) (drop 2 operations))))
+    (is (= [:float :int] (mapv (comp :type first :results) (drop 2 operations))))
+    (doseq [target [:opencl-portable :cuda :hip]]
+      (is (string? (emit/emit-scalar-kernel "mixed_region" kernel {:target-dialect target}))))))
+
+(deftest ordered-bindings-and-fresh-ssa-across-region-instances
+  (let [lower (lowerer)
+        a (mixed-region lower)
+        b (mixed-region lower)
+        constants ((:lower-region lower)
+                   '{:bindings [a 3 b a] :results [b a]}
+                   [:int :int] {'a :int 'b :int} {})]
+    (is (empty? (:operations constants)))
+    (is (= [(body/literal 3 :int) (body/literal 3 :int)] (:results constants)))
+    (is (not-any? (set (:results a)) (:results b)))
+    (is (= {:operations [] :results [] :types []}
+           ((:lower-region lower) {:bindings [] :results []} [] {} {})))))
+
+(deftest missing-and-inconsistent-type-evidence-is-not-inferred-from-consumers
+  (doseq [[region result-types binding-types env rule]
+          [['{:bindings [a (aget x i)] :results [a]} [:float] {} {}
+            :scalar-region-binding-dtype]
+           ['{:bindings [a (aget x i)] :results [a]} [:int] {'a :int} {}
+            :scalar-region-dtype]
+           ['{:bindings [] :results [a]} [:int] {} {'a :float}
+            :scalar-region-dtype]
+           ['{:bindings [a 1 a 2] :results [a]} [:int] {'a :int} {}
+            :scalar-region-shape]
+           ['{:bindings [] :results [1 2]} [:int] {} {} :scalar-region-shape]
+           ['{:bindings [a b b 1] :results [a]} [:int] {'a :int 'b :int} {}
+            :unbound-scalar]]]
+    (try
+      ((:lower-region (lowerer)) region result-types binding-types env)
+      (is false (str "expected " rule))
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= rule (:rule (ex-data exception))))))))
+
+(deftest typed-constant-bindings-retain-comparison-and-index-types
+  (let [lower (:lower-region (lowerer))
+        comparison (lower '{:bindings [threshold 0.5] :results [(> threshold old-value)]}
+                          [:predicate] {'threshold :float} {'old-value :float})
+        indexed (lower '{:bindings [j 0] :results [(aget x j)]}
+                       [:float] {'j :long} {})]
+    (is (= (body/literal 0.5 :float)
+           (get-in comparison [:operations 0 :expression :arguments 0])))
+    (is (= [(body/index-cast 0 :long :exact)]
+           (get-in indexed [:operations 0 :coordinates])))
+    (doseq [[value type] [[0.5 :float] [256 :byte] [2147483648 :int]]]
+      (try
+        (lower {:bindings ['j value] :results '[(aget x j)]} [:float] {'j type} {})
+        (is false "nonintegral or out-of-range index must decline")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :index-literal (:rule (ex-data exception)))))))))
+
+(deftest region-substitution-respects-nested-lexical-bindings
+  (let [lower (:lower-region (lowerer))
+        result (lower '{:bindings [a 3]
+                        :results [(let* [a 9] a) a]}
+                      [:int :int] {'a :int} {})]
+    (is (= [(body/literal 9 :int) (body/literal 3 :int)] (:results result)))))


### PR DESCRIPTION
## Scope
Prerequisite for ProductReduction -> KernelBody, not a production route switch. The existing product emitter remains the oracle until the scheduled replacement has numerical evidence.

## Changes
- Add shared multi-result scalar-region lowering with ordered, single-evaluation bindings and explicit retained binding/result dtypes.
- Preserve typed constants in comparisons and project checked integral literals into index arithmetic without losing long width.
- Reject missing or inconsistent binding evidence instead of inferring types from consuming tuple components.
- Record the remaining lane-fold/tree migration in the north star.

## Validation
- Focused REPL suites: 23 tests, 243 assertions, zero failures/errors.
- New tests cover mixed float/int coupled results, shared predicates/loads, fresh SSA values, lexical shadowing, constant comparisons and indices, and malformed/missing type evidence.
- New mixed-result fixture emits through OpenCL, CUDA and HIP dialects; existing emitter suite includes syntax checks.
- Independent read-only review completed; two constant-substitution findings fixed and retested.
- Full suite delegated to CI. No GPU performance claim or production schedule change. REPL closed to release laptop memory.