### PR TITLE
Lower row product reductions to candidate KernelBody schedules

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -447,9 +447,19 @@ The product workgroup schedule still uses its source emitter; migrating it to Ke
 preserve the simultaneous tuple update, hidden components, independent dtypes and logical ABI.
 The shared scalar lowerer now accepts ordered multi-result regions with explicit retained binding
 types: each local is lowered once to SSA and shared across results, without inferring its type from
-a consuming component. This is a prerequisite, not yet a production product KernelBody route.
-Next: express the lane folds and workgroup tree with typed carries and per-component scratch,
-compare numerically with the retained implementation, then switch the route and delete that oracle.
+a consuming component. The candidate `product-reduction-body` now expresses lane folds, a fixed
+workgroup tree and final stores with typed carries, independent scratch allocations and shared
+scalar/control target emission. Its mixed float/int argmax fixture is compared against both the
+retained emitter and a host oracle on CPU OpenCL (empty/short/tail rows, ties, NaNs and infinities),
+and joins the hardware-free CUDA/HIP compile gates. This is not a throughput benchmark.
+
+It is deliberately not yet a production route: it accepts one segment axis, int32 row/column
+bounds, explicitly retained region-binding types and long-width address expressions. Computed
+local address bindings still decline. Caller-supplied storage shapes are not a source/storage
+certificate (`:source-storage-certified? false`); exact graph/source/body storage closure must be
+added before selection. Zero-row calls retain the existing zero-group rejection and need planner
+elision; zero-width rows produce the neutral tuple. Next: close those obligations over the public
+TypedSOAC route, switch only certified candidates, then delete the retained source emitter.
 
 TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
 axes, one innermost reduction axis, typed accumulator products, dense element operands and stable

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -1,0 +1,190 @@
+(ns raster.compiler.passes.parallel.product-reduction-body
+  "Candidate KernelBody refinement of row-segmented product reductions.
+
+   This applies the existing lane-strided/fixed-tree schedule, not a new reduction algebra.
+   It is not yet selected by production routing. Storage extents and region binding types are
+   explicit caller evidence; unsupported source/index contracts decline without a fallback."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.index-expression :as index]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
+
+(defn- decline! [rule message data]
+  (throw (ex-info message (assoc data :reason :product-kernel-body-declined
+                                 :missing-rule rule :fallback :none))))
+
+(defn lower
+  "Lower one row-segmented SegRed with retained input shapes and scalar/region binding dtypes.
+   Address arithmetic must already carry the long-width facts required by lower-typed."
+  [segred {:keys [array-types array-shapes scalar-types
+                 element-binding-types combine-binding-types]}]
+  (when-not (instance? raster.compiler.ir.segop.SegRed segred)
+    (decline! :source "product body requires a retained SegRed" {:source segred}))
+  (let [operator (reduction/validate! (:reduction segred))
+        source-schedule (reduction/validate-product-tree! operator (:schedule segred))
+        segments (segop/seg-space-segment-dims (:space segred))
+        _ (when-not (= 1 (count segments))
+            (decline! :segment-rank "initial product body requires one row segment axis"
+                      {:segments segments}))
+        {row :name rows :bound} (first segments)
+        {column :name width :bound} (segop/seg-space-reduced-dim (:space segred))
+        components (:components operator)
+        types (mapv :dtype components)
+        wg (:workgroup-size source-schedule)
+        inputs (vec (sort-by name (:inputs segred)))
+        outputs (vec (keep :result components))
+        scalars (vec (sort-by name (set/union (set (:scalars segred))
+                                             (util/free-syms rows) (util/free-syms width))))
+        _ (doseq [id scalars]
+            (when-not (get scalar-types id)
+              (decline! :scalar-dtype "product scalar requires retained dtype" {:scalar id})))
+        _ (doseq [bound [rows width]]
+            (when-not (and (or (integer? bound) (symbol? bound))
+                           (= :int (launch/typed-expression-dtype bound scalar-types))
+                           (or (symbol? bound) (not (neg? bound))))
+              (decline! :bound-dtype
+                        "initial product body requires nonnegative int32 row/column bounds"
+                        {:bound bound})))
+        _ (doseq [id inputs]
+            (when-not (and (get array-types id) (seq (get array-shapes id)))
+              (decline! :input-storage "product input requires retained dtype and extent"
+                        {:input id})))
+        parameters
+        (vec (concat
+              (map (fn [id]
+                     (body/->KernelParameter id :input (get array-types id)
+                                              (get array-shapes id) :global
+                                              (layout/row-major (get array-shapes id)
+                                                                (get array-types id)) :operand))
+                   inputs)
+              (keep (fn [{:keys [result dtype]}]
+                      (when result
+                        (body/->KernelParameter result :output dtype ['_n_bound] :global
+                                                 (layout/row-major ['_n_bound] dtype) :effect)))
+                    components)
+              (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
+                   scalars)
+              [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))
+        index-types (assoc scalar-types row :int column :long)
+        lower-index (fn [expression locals]
+                      (index/lower-typed expression (set/union (set (keys index-types)) locals)
+                                         index-types :long decline!))
+        lowerer (scalar/make-lowerer
+                 {:arrays (set inputs) :array-types array-types :scalar-types scalar-types
+                  :lower-index lower-index :id-prefix "product" :decline! decline!})
+        neutrals (mapv (fn [{:keys [neutral dtype]}]
+                         (if-let [evidence (constant/value neutral)]
+                           (body/literal (:value evidence) dtype)
+                           (decline! :neutral "product neutral requires checked literal evidence"
+                                     {:neutral neutral :dtype dtype}))) components)
+        ids (fn [prefix] (mapv #(symbol (str prefix "-" %)) (range (count components))))
+        carries (ids "product-carry")
+        lane-results (ids "product-lane-result")
+        scratches (ids "product-scratch")
+        combine-region (reduction/combine-region operator)
+        combine
+        (fn [left right]
+          (let [replacements (into {} (mapcat (fn [[l r] lv rv] [[l lv] [r rv]])
+                                              (:parameters combine-region) left right))
+                region (-> combine-region
+                           (update :bindings #(util/subst-syms replacements %))
+                           (update :results #(util/subst-syms replacements %)))
+                env (into {} (concat (map vector left types) (map vector right types)))]
+            ((:lower-region lowerer) region types combine-binding-types env)))
+        element ((:lower-region lowerer) (reduction/element-region operator) types
+                 element-binding-types index-types)
+        lane-update (combine carries (:results element))
+        barrier #(body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                                          (body/full-participation))
+        strides (vec (take-while pos? (iterate #(quot % 2) (quot wg 2))))
+        mask-id #(keyword (str "product-tree-" %))
+        tree
+        (mapcat
+         (fn [stride]
+           (let [left (ids (str "product-left-" stride))
+                 right (ids (str "product-right-" stride))
+                 merged (combine left right)]
+             [(body/->ScalarCompute (body/value (mask-id stride) :predicate)
+                                    (body/scalar-expression :lt :predicate
+                                                            ['product-lane (body/literal stride :int)]))
+              (body/->IfRegion
+               (mask-id stride)
+               (vec (concat
+                     (mapcat (fn [l r scratch type]
+                               [(body/->ScalarLoad (body/value l type) scratch ['product-lane]
+                                                   nil nil :cached)
+                                (body/->ScalarLoad (body/value r type) scratch
+                                                    [(body/expression :add 'product-lane stride)]
+                                                    nil nil :cached)]) left right scratches types)
+                     (:operations merged)
+                     ;; No store precedes any component's evaluation: coupled updates see the
+                     ;; same old tuple on both sides of the combine.
+                     (map #(body/->ScalarStore %1 ['product-lane] %2 nil)
+                          scratches (:results merged))
+                     [(body/->Yield [])]))
+               [(body/->Yield [])] [])
+              (barrier)])) strides)
+        kernel-body
+        (body/make
+         {:id [:product-reduction (:id segred)] :parameters parameters
+          :stable-reads (mapv body/stable-read inputs)
+          :allocations (mapv #(body/->WorkgroupAllocation %1 %2 [wg]
+                                                         (layout/row-major [wg] %2)
+                                                         (dtype/bytes-of %2)) scratches types)
+          :indices [(body/->IndexBinding row :group 0)
+                    (body/->IndexBinding 'product-lane :local 0)]
+          :operations
+          (vec (concat
+                [(body/->ForLoop
+                  (body/value column :long) (body/index-cast 'product-lane :long :exact)
+                  (lower-index width #{}) wg
+                  (mapv #(body/->LoopArg (body/value %1 %2) %3) carries types neutrals)
+                  (vec (concat (:operations element) (:operations lane-update)
+                               [(body/->Yield (:results lane-update))]))
+                  (mapv body/value lane-results types) {})]
+                (map #(body/->ScalarStore %1 ['product-lane] %2 nil) scratches lane-results)
+                [(barrier)] tree
+                [(body/->ScalarCompute (body/value :product-writer :predicate)
+                                       (body/scalar-expression :eq :predicate
+                                                               ['product-lane (body/literal 0 :int)]))
+                 (body/->IfRegion
+                  :product-writer
+                  (conj (vec (mapcat
+                        (fn [{:keys [result dtype]} scratch value]
+                          (when result
+                            [(body/->ScalarLoad (body/value value dtype) scratch [0] nil nil :cached)
+                             (body/->ScalarStore result [row] value nil)]))
+                        components scratches (ids "product-final"))) (body/->Yield []))
+                  [(body/->Yield [])] [])]))
+          :schedule {:strategy :product-workgroup-tree :workgroup-size wg}
+          :launch (launch/spec {:workgroup-size [wg] :group-count [(launch/runtime-value '_n_bound)]
+                                :shared-memory-bytes (* wg (reduce + (map dtype/bytes-of types)))})
+          :provenance {:dialect :kernel-body :source-dialect :segred :segop-id (:id segred)}
+          :attributes {:kind :product-reduction :component-dtypes types}})]
+    {:kernel-body kernel-body :rows rows :inputs inputs :outputs outputs :scalars scalars}))
+
+(defn schedule [segred options]
+  (let [{:keys [kernel-body rows]} (lower segred options)
+        arguments (mapv #(if (= '_n_bound (:id %)) rows (:id %)) (:parameters kernel-body))]
+    (scheduled/make
+     {:source segred :body kernel-body :arguments arguments
+      :scalar-bindings (scheduled/derive-scalar-bindings kernel-body arguments)
+      :effects {:kind :product-reduction :uses (scheduled/derive-uses kernel-body arguments)}
+      :legality {:kind :product-workgroup-tree :algebra (:algebra (:reduction segred))
+                 :source-schedule (:schedule segred) :aliasing :no-write-alias}
+      :numerics {:mode :reassociated :policy :declared-product-tree
+                 :accumulators (mapv (fn [{:keys [id dtype]}]
+                                       {:value id :dtype dtype
+                                        :rounding (if (dtype/fp-dtype? dtype) :nearest-even :exact)
+                                        :policy :declared-product-tree})
+                                     (:components (:reduction segred)))}
+      :provenance {:dialect :kernel-body :source-dialect :segred :segop-id (:id segred)}
+      :attributes {:candidate-only true :source-storage-certified? false}})))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -1,11 +1,12 @@
 (ns raster.compiler.backend.gpu.kernel-body-compile-fixtures
-  "Generate production scheduled KernelBody sources for hardware-free CUDA/HIP CI gates."
+  "Generate production and explicitly labeled candidate KernelBody sources for CUDA/HIP CI gates."
   (:require [clojure.java.io :as io]
             [raster.arrays]
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.gemm :as gemm-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
+            [raster.compiler.backend.gpu.kernel-body-target :as body-target]
             [raster.compiler.backend.gpu.layout-transform :as layout-transform]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
@@ -19,6 +20,8 @@
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
+            [raster.compiler.passes.parallel.product-reduction-body :as product-body]
+            [raster.compiler.passes.parallel.product-reduction-body-test :as product-fixtures]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
@@ -317,6 +320,12 @@
         tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)
         public-artifacts (equation-first-artifacts target descriptor)]
     (into [(write-artifact! directory suffix "cooperative" cooperative)
+           (write-artifact! directory suffix "candidate-product-reduction"
+                            (body-target/emit-artifact
+                             "candidate_product_argmax"
+                             (product-body/schedule (product-fixtures/argmax-segred)
+                                                    product-fixtures/options)
+                             dialect))
            (write-artifact! directory suffix "pipelined-attention" pipelined)
            (write-artifact! directory suffix "swizzled-pipelined-attention"
                             swizzled-pipelined)

--- a/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
@@ -1,0 +1,69 @@
+(ns raster.compiler.passes.parallel.product-reduction-body-device-test
+  "Differential execution of the candidate and retained product schedule on OpenCL."
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.segop-opencl :as reference]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.passes.parallel.product-reduction-body :as product]
+            [raster.compiler.passes.parallel.product-reduction-body-test :as fixtures]
+            [raster.gpu.device-probe :as probe]))
+
+(defn- argmax [xs]
+  (first
+   (reduce (fn [[best-index best] [i x]]
+             (if (or (and (Float/isNaN x) (not (Float/isNaN best)))
+                     (and (not (Float/isNaN best))
+                          (or (> x best) (and (== x best) (< i best-index)))))
+               [i x] [best-index best]))
+           [Integer/MAX_VALUE Float/NEGATIVE_INFINITY]
+           (map-indexed vector xs))))
+
+(deftest candidate-product-tree-agrees-with-reference-and-host
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "candidate product KernelBody numerical comparison")
+    (let [runtime (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve runtime 'register-kernel!)
+          buffer-of-array (ns-resolve runtime 'buffer-of-array)
+          bind-call (ns-resolve runtime 'bind-kernel-call)
+          execute! (ns-resolve runtime 'launch-registered-bound!)
+          read! (ns-resolve runtime 'buffer->array)
+          free! (ns-resolve runtime 'free-buffer!)
+          segred (fixtures/argmax-segred)
+          old (reference/generate-product-reduction-kernel segred
+                :scalar-types (:scalar-types fixtures/options)
+                :array-types (:array-types fixtures/options))
+          new (target/emit-artifact "candidate_product_argmax"
+                                   (product/schedule segred fixtures/options) :opencl-portable)]
+      (doseq [artifact [old new]] (register! (:kernel-name artifact) artifact))
+      (doseq [[nrows width] (cons [0 1] (map #(vector 5 %) [0 1 7 32 33 65]))]
+        (let [rows (vec (take nrows [(vec (repeat width (float 2)))
+                    (mapv #(float (mod % 7)) (range width))
+                    (mapv #(if (odd? %) Float/NaN (float %)) (range width))
+                    (vec (repeat width Float/NEGATIVE_INFINITY))
+                    (vec (repeat width Float/POSITIVE_INFINITY))]))
+              input (buffer-of-array (float-array (if (or (zero? width) (zero? nrows))
+                                                   [0] (mapcat identity rows))) :float)]
+          (try
+            (let [results
+                  (mapv (fn [artifact]
+                          (let [output (buffer-of-array
+                                        (int-array (repeat (max 1 nrows) -77)) :int)
+                                bindings {'values input 'indices output
+                                          'nrows {:type :int :value (count rows)}
+                                          'width {:type :int :value width}}]
+                            (try
+                              (if (zero? nrows)
+                                ;; Both routes reject zero-group launches. The planner must elide
+                                ;; a zero-row operation rather than submit an invalid device call.
+                                (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                     #"group-count dimension must be a positive integer"
+                                                     (call/make artifact
+                                                                (mapv bindings (:arguments artifact)))))
+                                (execute! (bind-call (call/make artifact
+                                                               (mapv bindings (:arguments artifact))))))
+                              (vec (read! output))
+                              (finally (free! output))))) [old new])]
+              (is (= (if (zero? nrows) [-77] (mapv argmax rows))
+                     (first results) (second results))
+                  (str "rows " nrows ", width " width)))
+            (finally (free! input))))))))

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -1,0 +1,88 @@
+(ns raster.compiler.passes.parallel.product-reduction-body-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.segop-opencl :as reference]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.reduction-test :as fixtures]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.product-reduction-body :as product]
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
+
+(defn argmax-segred []
+  (let [form (vec fixtures/argmax-product-form)
+        ;; This fixture supplies retained address widths explicitly, like analyzed source.
+        form (update-in form [6 1]
+                        (fn [[op array coordinate]]
+                          (list op array
+                                (walk/postwalk
+                                 #(if (seq? %) (with-meta % {:tag 'long}) %) coordinate))))
+        node (soac/par-form->soac '_ (apply list form) 7 :dtype :float)]
+    (assoc-in (first (soac-lower/lower-soac node :cpu:0 :dtype :float))
+              [:schedule :workgroup-size] 32)))
+
+(def options
+  {:array-types {'values :float}
+   :array-shapes {'values [(launch/product 'nrows 'width)]}
+   :scalar-types {'nrows :int 'width :int}
+   :element-binding-types {'candidate :float}
+   :combine-binding-types {'left-nan :int 'right-nan :int 'better :int}})
+
+(deftest row-product-emits-through-shared-target-pipeline
+  (let [segred (argmax-segred)
+        scheduled (product/schedule segred options)
+        old (reference/generate-product-reduction-kernel segred
+              :scalar-types (:scalar-types options) :array-types (:array-types options))]
+    (is (= segred (:source scheduled)))
+    (is (= [:float :int] (get-in scheduled [:body :attributes :component-dtypes])))
+    (is (= (:arguments old) (:arguments scheduled)))
+    (is (= (* 8 (get-in segred [:schedule :workgroup-size]))
+           (get-in scheduled [:body :launch :shared-memory-bytes])))
+    (doseq [dialect [:opencl-portable :cuda :hip]]
+      (let [emitted (target/emit-artifact "product_argmax" scheduled dialect)]
+        (is (string? (:source emitted)))
+        (is (= (mapv #(select-keys % [:name :kind :dtype :role]) (:abi old))
+               (mapv #(select-keys % [:name :kind :dtype :role]) (:abi emitted))))))))
+
+(deftest product-candidate-declines-missing-retained-evidence
+  (doseq [[changed expected]
+          [[(dissoc options :array-shapes) :input-storage]
+           [(dissoc options :scalar-types) :scalar-dtype]
+           [(dissoc options :combine-binding-types) :scalar-region-binding-dtype]]]
+    (try
+      (product/schedule (argmax-segred) changed)
+      (is false (str "must decline " expected))
+      (catch clojure.lang.ExceptionInfo e
+        (is (= expected (:missing-rule (ex-data e))))))))
+
+(deftest tuple-storage-and-control-remain-explicit
+  (let [scheduled (product/schedule (argmax-segred) options)
+        kernel (:body scheduled)
+        kind #(.getSimpleName (class %))
+        loop-op (first (:operations kernel))
+        tree-branches (filter #(and (= "IfRegion" (kind %))
+                                    (not= :product-writer (:condition %))) (:operations kernel))]
+    (is (= [:float :int] (mapv (comp :type :binding) (:iter-args loop-op))))
+    (is (= [:float :int] (mapv :dtype (:allocations kernel))))
+    (is (= ['indices] (mapv :id (filter #(= :output (:kind %)) (:parameters kernel))))
+        "the hidden winning-value component has scratch but no public output")
+    (is (= 5 (count tree-branches)))
+    (doseq [branch tree-branches]
+      (is (= ["ScalarStore" "ScalarStore" "Yield"]
+             (mapv kind (take-last 3 (:then-operations branch)))))
+      (is (not-any? #(= "WorkgroupBarrier" (kind %)) (:then-operations branch))))
+    (is (= 6 (count (filter #(= "WorkgroupBarrier" (kind %)) (:operations kernel)))))
+    (is (false? (get-in scheduled [:attributes :source-storage-certified?])))))
+
+(deftest invalid-neutral-or-unretained-address-width-is-rejected
+  (is (thrown? clojure.lang.ExceptionInfo
+               (product/schedule
+                (assoc-in (argmax-segred) [:reduction :components 1 :neutral] 2147483648)
+                options)))
+  (let [node (soac/par-form->soac '_ fixtures/argmax-product-form 7 :dtype :float)
+        untyped (first (soac-lower/lower-soac node :cpu:0 :dtype :float))]
+    (try
+      (product/schedule untyped options)
+      (is false "unretained compound address widths must not be guessed")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :index-expression (:missing-rule (ex-data e))))))))


### PR DESCRIPTION
## Scope
Candidate only: production product-reduction routing and the retained source emitter are unchanged.

## Implementation
- Preserve the existing lane-strided fold and fixed workgroup tree using typed tuple loop carries, independently typed workgroup scratch, scalar SSA, branches, and barriers.
- Reuse shared scalar-region lowering and target emission; no new scalar inference or handwritten algorithm source.
- Retain hidden components and the logical ABI. Compute all tuple components before committing scratch updates.
- Require explicit storage/region type evidence and retained long address arithmetic. The initial candidate supports one segment axis and int32 row/column bounds.

## Validation
- Focused REPL suites: 18 tests, 119 assertions, zero failures/errors.
- Actual CPU PoCL differential execution against the retained emitter and a host oracle: widths 0, 1, 7, 32, 33, 65; ties, NaNs, positive/negative infinity; independently initialized output buffers.
- Both routes retain zero-row launch rejection before submission. Zero-width rows return the neutral tuple.
- OpenCL source syntax checked with Clang; new candidate fixture joins nvcc/hipcc gates. No NVIDIA/AMD hardware execution or throughput claim.
- Independent read-only review found no blocker for this candidate-only slice.

## Deliberate remaining obligations
- Caller storage shapes are not a source/storage certificate: source-storage-certified? is false. Add exact graph/source/body storage validation before production selection.
- Computed local address bindings still decline rather than infer missing types.
- Complete public TypedSOAC routing coverage, then switch certified candidates and delete the retained emitter.

REPL closed; full suites delegated to CI.