### PR TITLE
Retain typed product locals through scheduling and index lowering

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -454,8 +454,10 @@ retained emitter and a host oracle on CPU OpenCL (empty/short/tail rows, ties, N
 and joins the hardware-free CUDA/HIP compile gates. This is not a throughput benchmark.
 
 It is deliberately not yet a production route: it accepts one segment axis, int32 row/column
-bounds, explicitly retained region-binding types and long-width address expressions. Computed
-local address bindings still decline. Caller-supplied storage shapes are not a source/storage
+bounds, retained region-binding types and long-width address expressions. TypedSOAC local dtypes
+now survive SegRed projection and scalar SSA substitution, so computed local address bindings and
+typed integral constants use those same facts rather than a reconstructed type map. Contradictory
+candidate overrides decline. Caller-supplied storage shapes are not a source/storage
 certificate (`:source-storage-certified? false`); exact graph/source/body storage closure must be
 added before selection. Zero-row calls retain the existing zero-group rejection and need planner
 elision; zero-width rows produce the neutral tuple. Next: close those obligations over the public

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1,0 +1,83 @@
+# Compiler unification campaign
+
+Authorized scope: complete the four stages below in order. Each production migration must retain
+its numerical, ABI, ownership and resource contracts; isolated emitter coverage is not a completed
+vertical. The north star remains the architectural specification.
+
+## 1. Close product reduction production lowering — active
+
+- Landed #382: shared typed multi-result scalar-region lowering.
+- Landed #383: candidate row-product KernelBody, CPU OpenCL differential execution, CUDA/HIP
+  compilation. Production still uses the retained source emitter.
+- Implemented in this slice: preserve TypedSOAC local dtypes through SegRed and subsequent
+  scalar/index lowering; compare both direct and local-address candidates on CPU OpenCL.
+- Certify the exact semantic source, storage boundaries and public bindings against the graph.
+- Exercise ordinary public compilation, resident execution and hidden/multiple tuple results.
+- Cover required axis/bound variants and zero-row planning; reject unsupported cases explicitly.
+- Select the certified body and delete the old product algorithm emitter once its coverage is
+  replaced. Keep necessary target instruction lowering.
+
+Exit: public product workloads use the typed route without reconstructed facts or source assembly.
+
+## 2. Retire the remaining compatibility paths — queued
+
+Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
+before treating a definition as live or dead:
+
+| Priority | Boundary | Representative acceptance |
+|---|---|---|
+| 1 | General contraction fallback in `contract_route` / `segop_opencl` | General/scientific contractions, exact decline inventory |
+| 2 | Unscheduled effect maps in `opencl_pass` / `par_opencl` | Resident mutation, aliasing, nil/buffer returns |
+| 3 | Strided scatter/gather source emission | Block transfers, collision and view contracts |
+| 4 | Active-ID compaction | ABM firms, stable output order and count/capacity |
+| 5 | Compound-local algorithm emission | Structured loop dependencies, storage and barriers |
+| 6 | Staged/quantized contractions | Decode/lift algebra, typed accumulators and overflow |
+
+Audit apparent unused wrappers separately. A source oracle is not a production fallback; removing
+one must not erase its independent numerical evidence. Track JVM and C/SIMD compatibility as well
+as GPU paths, using the same production corpus and retained TypedSOAC facts.
+
+Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
+production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
+the entire compiler unified from one successful vertical.
+
+## 3. General fusion and bounded specialization — queued
+
+- Validate shared scalar-region composition, coupled reductions and post-reduction transforms.
+- Audit recompute/materialize choices on fan-out, effects, aliases and observable results.
+- Apply retained static structural facts before fusion, shape/layout/target facts before scheduling,
+  and typed constant/range simplification afterward.
+- Preserve ordered arithmetic and AD/effect boundaries. Use guards and bounded specialization
+  caches; do not unroll large numerical iteration spaces merely because their sizes are known.
+
+Exit: representative scientific and model expressions compile with explained fusion/placement
+choices, differential correctness, and measured kernel/allocation/compile-cost changes.
+
+## 4. Measure generated production kernels and selection — queued
+
+Begin with existing production canaries, not independent handwritten builders:
+
+- `test/raster/perf/production_canary.clj`: public AOT sumsq and resident generated GEMM;
+  GPU replay currently measures host-synchronized latency, not pure device throughput.
+- `bench/soac_contract_bench.clj`: contraction ladder; verify its entry point before reuse.
+- `bench/resident_gemm_cold_bench.clj`: useful cold/warm methodology, but its source-oracle builder
+  must be replaced before it counts as generated-production evidence.
+
+Measure GEMM, quantized projections, reductions and attention with matched shape, dtype, numerical
+policy, warmup and transfer boundaries. Record compiler/tuning time, kernel count, allocations,
+peak storage, transferred bytes and execution time. External comparisons and heavier experiments
+stay outside the local hot loop. Use device events where available and label CPU OpenCL results as
+CPU results. No SOTA claim follows from successful vendor compilation alone.
+
+Use the measurements to shortlist legal schedules and validate selective autotuning/cache replay.
+If comparable accelerator hardware is unavailable, complete harnesses and correctness gates but
+leave accelerator competitiveness explicitly unmeasured.
+
+Exit: reproducible production measurements identify wins/regressions and explain schedule choices;
+claims are limited to tested hardware and workloads. Discuss the results before stages 5–6.
+
+## Working loop
+
+One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
+compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
+with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/passes/parallel/index_expression.clj
+++ b/src/raster/compiler/passes/parallel/index_expression.clj
@@ -154,7 +154,8 @@
    This is the graph-launch counterpart of scalar KernelBody lowering, not source type inference."
   [expression scope leaf-dtype expected-dtype decline!]
   (letfn [(source-dtype [form]
-            (or (some-> (or (:raster.type/tag (meta form)) (:tag (meta form)))
+            (or (when (instance? raster.compiler.ir.kernel_body.Literal form) (:type form))
+                (some-> (or (:raster.type/tag (meta form)) (:tag (meta form)))
                         dtype/dtype-for-scalar-tag dtype/canon)
                 (when (symbol? form) (some-> (leaf-dtype form) dtype/canon))
                 (when (integer? form)
@@ -175,6 +176,15 @@
               (cond
                 (integer? form)
                 (coerce form (source-dtype form) expected form)
+
+                (instance? raster.compiler.ir.kernel_body.Literal form)
+                (let [{:keys [value type]} form]
+                  (when-not (and (contains? #{:int :long} type) (integer? value)
+                                 (scalar-range/literal value type))
+                    (decline! :index-literal
+                              "typed index literal requires a representable int or long"
+                              {:expression form}))
+                  (coerce (body/index-cast value type :exact) type expected form))
 
                 (symbol? form)
                 (if (contains? scope form)

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -8,6 +8,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
@@ -20,6 +21,20 @@
 (defn- decline! [rule message data]
   (throw (ex-info message (assoc data :reason :product-kernel-body-declined
                                  :missing-rule rule :fallback :none))))
+
+(defn- region-binding-types
+  "Read retained TypedSOAC local tags. Explicit candidate facts may fill omissions, not override."
+  [region supplied]
+  (reduce (fn [facts id]
+            (if-let [retained (some-> (types/sym-type-tag id) dtype/dtype-for-scalar-tag)]
+              (do
+                (when (and (get supplied id) (not= retained (get supplied id)))
+                  (decline! :binding-dtype-conflict
+                            "candidate binding dtype disagrees with its retained source type"
+                            {:binding id :retained retained :supplied (get supplied id)}))
+                (assoc facts id retained))
+              facts))
+          (or supplied {}) (take-nth 2 (:bindings region))))
 
 (defn lower
   "Lower one row-segmented SegRed with retained input shapes and scalar/region binding dtypes.
@@ -37,6 +52,10 @@
         {row :name rows :bound} (first segments)
         {column :name width :bound} (segop/seg-space-reduced-dim (:space segred))
         components (:components operator)
+        element-binding-types (region-binding-types (reduction/element-region operator)
+                                                     element-binding-types)
+        combine-binding-types (region-binding-types (reduction/combine-region operator)
+                                                     combine-binding-types)
         types (mapv :dtype components)
         wg (:workgroup-size source-schedule)
         inputs (vec (sort-by name (:inputs segred)))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -429,7 +429,18 @@
                               {:binding id :expression expression}))
                   (let [lowered (checked-lower (util/subst-syms substitutions expression)
                                                (get binding-types id) environment)
-                        result (:result lowered)]
+                        result (:result lowered)
+                        ;; References to fresh SSA locals must carry the same retained type as
+                        ;; their definition, including when they become storage coordinates.
+                        ;; Index lowering must not rediscover this from an enclosing result.
+                        ;; Half and internal predicate values have no JVM scalar tag. Their
+                        ;; dtype stays in the existing typed SSA environment, not a guessed tag.
+                        tag (when-not (= :predicate (:type lowered))
+                              (:scalar-tag (dtype/info (:type lowered))))
+                        result (if (and (symbol? result) tag)
+                                 (with-meta result
+                                   (assoc (meta result) :raster.type/tag tag))
+                                 result)]
                     {:operations (into operations (:operations lowered))
                      :substitutions (assoc substitutions id result)
                      :environment (cond-> environment

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -628,13 +628,18 @@
                        [parameter (list 'clojure.core/aget array coordinate)])
                      array-parameters arrays))
           element-bindings
-          (vec (mapcat (fn [{:keys [id init]}]
-                         [id (util/subst-syms substitutions init)])
+          (vec (mapcat (fn [{:keys [id dtype init]}]
+                         [(with-meta id (assoc (meta id) :raster.type/tag
+                                               (dtype/scalar-tag-for-dtype dtype)))
+                          (util/subst-syms substitutions init)])
                        (:locals element)))
           element-results (mapv #(util/subst-syms substitutions %)
                                 (:body-results element))
           combine-bindings
-          (vec (mapcat (fn [{:keys [id init]}] [id init]) (:locals combine)))
+          (vec (mapcat (fn [{:keys [id dtype init]}]
+                         [(with-meta id (assoc (meta id) :raster.type/tag
+                                               (dtype/scalar-tag-for-dtype dtype))) init])
+                       (:locals combine)))
           facts (soac-dialect/facts program)
           physical-results (soac-dialect/physical-results facts equation)
           result-by-component (zipmap (:result-components attributes) physical-results)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -323,8 +323,10 @@
            (write-artifact! directory suffix "candidate-product-reduction"
                             (body-target/emit-artifact
                              "candidate_product_argmax"
-                             (product-body/schedule (product-fixtures/argmax-segred)
-                                                    product-fixtures/options)
+                             (product-body/schedule (product-fixtures/typed-local-address-segred)
+                                                    (dissoc product-fixtures/options
+                                                            :element-binding-types
+                                                            :combine-binding-types))
                              dialect))
            (write-artifact! directory suffix "pipelined-attention" pipelined)
            (write-artifact! directory suffix "swizzled-pipelined-attention"

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -226,7 +226,12 @@
 
 (deftest compile-gpu-program-extracts-a-real-contraction-as-an-ordered-resident-executable
   (let [descriptor (pipeline/compile-gpu-program #'resident-contract-descriptor-probe
-                                                 :ze:0 :dtype :float)
+                                                 :ze:0 :dtype :float
+                                                 ;; This test checks the direct contraction ABI,
+                                                 ;; not a mixed-precision graph's leading casts.
+                                                 ;; Other tests may register a matrix-capable
+                                                 ;; synthetic target in the shared registry.
+                                                 :schedule {:precision :f32-scalar})
         step (first (:steps descriptor))
         executable (:artifact step)
         args [(float-array 64) (float-array 64)]
@@ -237,7 +242,7 @@
                              (:argument-specs step))
         {:keys [buffers scalar-values]} (kexec/graph-bindings executable call-arguments)
         ;; `graph-bindings` exposes only the public interface.  The graph runner owns the
-        ;; XMX staging allocations; a direct KernelGraphCall test supplies equivalent mock
+        ;; private allocations; a direct KernelGraphCall test supplies equivalent mock
         ;; values for each declared private temporary.
         temporary-buffers (into {}
                                 (map (fn [id] [id [:temporary-buffer id]]))

--- a/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
@@ -32,9 +32,14 @@
           old (reference/generate-product-reduction-kernel segred
                 :scalar-types (:scalar-types fixtures/options)
                 :array-types (:array-types fixtures/options))
+          retained-options (dissoc fixtures/options :element-binding-types :combine-binding-types)
           new (target/emit-artifact "candidate_product_argmax"
-                                   (product/schedule segred fixtures/options) :opencl-portable)]
-      (doseq [artifact [old new]] (register! (:kernel-name artifact) artifact))
+                                   (product/schedule (fixtures/typed-argmax-segred) retained-options)
+                                   :opencl-portable)
+          local (target/emit-artifact "candidate_product_local_address"
+                                     (product/schedule (fixtures/typed-local-address-segred)
+                                                       retained-options) :opencl-portable)]
+      (doseq [artifact [old new local]] (register! (:kernel-name artifact) artifact))
       (doseq [[nrows width] (cons [0 1] (map #(vector 5 %) [0 1 7 32 33 65]))]
         (let [rows (vec (take nrows [(vec (repeat width (float 2)))
                     (mapv #(float (mod % 7)) (range width))
@@ -62,8 +67,7 @@
                                 (execute! (bind-call (call/make artifact
                                                                (mapv bindings (:arguments artifact))))))
                               (vec (read! output))
-                              (finally (free! output))))) [old new])]
-              (is (= (if (zero? nrows) [-77] (mapv argmax rows))
-                     (first results) (second results))
+                              (finally (free! output))))) [old new local])]
+              (is (apply = (cons (if (zero? nrows) [-77] (mapv argmax rows)) results))
                   (str "rows " nrows ", width " width)))
             (finally (free! input))))))))

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -3,21 +3,28 @@
             [clojure.walk :as walk]
             [raster.compiler.backend.gpu.kernel-body-target :as target]
             [raster.compiler.backend.gpu.segop-opencl :as reference]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.reduction-test :as fixtures]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.product-reduction-body :as product]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
 
-(defn argmax-segred []
+(defn- argmax-form []
   (let [form (vec fixtures/argmax-product-form)
         ;; This fixture supplies retained address widths explicitly, like analyzed source.
         form (update-in form [6 1]
                         (fn [[op array coordinate]]
                           (list op array
                                 (walk/postwalk
-                                 #(if (seq? %) (with-meta % {:tag 'long}) %) coordinate))))
-        node (soac/par-form->soac '_ (apply list form) 7 :dtype :float)]
+                                 #(if (seq? %) (with-meta % {:tag 'long}) %) coordinate))))]
+    (apply list form)))
+
+(defn argmax-segred []
+  (let [node (soac/par-form->soac '_ (argmax-form) 7 :dtype :float)]
     (assoc-in (first (soac-lower/lower-soac node :cpu:0 :dtype :float))
               [:schedule :workgroup-size] 32)))
 
@@ -27,6 +34,53 @@
    :scalar-types {'nrows :int 'width :int}
    :element-binding-types {'candidate :float}
    :combine-binding-types {'left-nan :int 'right-nan :int 'better :int}})
+
+(defn typed-argmax-segred []
+  (let [tag-bindings (fn [bindings dtypes]
+                       (vec (mapcat (fn [[id init]]
+                                      [(with-meta id {:raster.type/tag
+                                                      (dtype/scalar-tag-for-dtype (get dtypes id))})
+                                       init]) (partition 2 bindings))))
+        ;; Supply the facts normally attached by the walker; the frontend deliberately does not
+        ;; infer types from these raw test S-expressions.
+        form (-> (vec (argmax-form))
+                 (update 6 tag-bindings (:element-binding-types options))
+                 (update 9 tag-bindings (:combine-binding-types options))
+                 (update 2 #(mapv (fn [[id neutral type]]
+                                    [id (constant/literal-or-original neutral) type]) %)))
+        program (frontend/form->program
+                 (list 'let* ['effect (apply list form)] 'effect)
+                 {:dtype :float :array-types {'values :float 'indices :int}
+                  :scalar-types (:scalar-types options)})]
+    (assoc-in (first (soac-lower/lower-typed-product-reduce program :cpu:0 :dtype :float))
+              [:schedule :workgroup-size] 32)))
+
+(defn typed-local-address-segred []
+  (let [segred (typed-argmax-segred)
+        ;; Use the semantic reduction index, not a spelling inferred from generated code.
+        index (get-in segred [:reduction :index])]
+    (update-in segred [:reduction :element :bindings]
+               (fn [bindings]
+                 (into [(with-meta 'offset {:raster.type/tag 'long}) (list 'long index)]
+                       (mapcat (fn [[id init]] [id (util/subst-syms {index 'offset} init)])
+                               (partition 2 bindings)))))))
+
+(deftest typed-product-projection-retains-local-types-without-caller-reconstruction
+  (let [segred (typed-argmax-segred)
+        tags (fn [region]
+               (into {} (map #(vector % (:raster.type/tag (meta %))))
+                     (take-nth 2 (get-in segred [:reduction region :bindings]))))
+        inferred-options (dissoc options :element-binding-types :combine-binding-types)]
+    (is (= {'candidate 'float} (tags :element)))
+    (is (= {'left-nan 'int 'right-nan 'int 'better 'int} (tags :combine)))
+    (is (string? (:source (target/emit-artifact "typed_product_argmax"
+                                              (product/schedule segred inferred-options)
+                                              :opencl-portable))))
+    (try
+      (product/schedule segred (assoc-in options [:combine-binding-types 'better] :float))
+      (is false "retained source types cannot be overridden by candidate options")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :binding-dtype-conflict (:missing-rule (ex-data e))))))))
 
 (deftest row-product-emits-through-shared-target-pipeline
   (let [segred (argmax-segred)

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -105,3 +105,47 @@
                         :results [(let* [a 9] a) a]}
                       [:int :int] {'a :int} {})]
     (is (= [(body/literal 9 :int) (body/literal 3 :int)] (:results result)))))
+
+(deftest typed-index-lowering-consumes-local-ssa-facts
+  (let [decline! (fn [rule message data] (throw (ex-info message (assoc data :rule rule))))
+        lower (:lower-region
+               (scalar/make-lowerer
+                {:arrays #{'x} :array-types {'x :float} :scalar-types {'i :int}
+                 :lower-index (fn [expression scope]
+                                (index/lower-typed expression scope {'i :int} :long decline!))
+                 :decline! decline!}))]
+    (doseq [[init expected-kind] [['(long i) "ScalarCompute"] [0 nil]]]
+      (let [result (lower {:bindings ['offset init] :results '[(aget x offset)]}
+                          [:float] {'offset :long} {})
+            load (peek (:operations result))
+            coordinate (first (:coordinates load))]
+        (is (= :float (get-in load [:result :type])))
+        (if expected-kind
+          (do
+            (is (= expected-kind (.getSimpleName (class (first (:operations result))))))
+            (is (= 'long (:raster.type/tag (meta coordinate)))))
+          (is (= (body/index-cast 0 :long :exact) coordinate)))))
+    (let [result (lower '{:bindings [offset 0] :results [(aget x (long offset))]}
+                        [:float] {'offset :int} {})]
+      (is (= (body/index-cast (body/index-cast 0 :int :exact) :long :exact)
+             (first (:coordinates (peek (:operations result)))))))
+    (doseq [[value type] [[2147483648 :int] [0.5 :float]]]
+      (try
+        (lower {:bindings ['offset value] :results '[(aget x offset)]}
+               [:float] {'offset type} {})
+        (is false "malformed typed index constants must decline")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :index-literal (:rule (ex-data e)))))))))
+
+(deftest kernel-only-dtypes-do-not-require-a-jvm-tag
+  (let [lower (:lower-region
+               (scalar/make-lowerer
+                {:arrays #{'x} :array-types {'x :half} :scalar-types {}
+                 :lower-index (fn [coordinate _] coordinate)
+                 :decline! (fn [rule message data]
+                             (throw (ex-info message (assoc data :rule rule))))}))
+        result (lower '{:bindings [h (aget x 0)] :results [h h]} [:half :half] {'h :half} {})]
+    (is (= [:half :half] (:types result)))
+    (is (= 1 (count (:operations result))))
+    (is (apply = (:results result)))
+    (is (= :half (get-in result [:operations 0 :result :type])))))


### PR DESCRIPTION
## Scope
Continue campaign stage 1. Production product routing is unchanged; source/storage certification is still required.

## Changes
- Preserve canonical TypedSOAC local dtype tags when projecting product element/combine regions to SegRed.
- Retain those facts on fresh scalar SSA references, including computed addresses, instead of reconstructing local types at emission.
- Read retained product binding facts by default and reject contradictory candidate overrides.
- Accept validated typed integer literals in exact index lowering.
- Preserve half-precision locals without inventing a JVM scalar tag.
- Add a four-stage campaign ledger and record the remaining compatibility/performance inventory.

## Validation
64 focused tests, 294 assertions, zero failures/errors. Actual CPU PoCL differential execution compares the retained source emitter, the TypedSOAC-projected candidate, and a computed-local-address candidate against a host oracle. Coverage includes empty/short/tail rows, ties, NaNs, infinities, poisoned outputs, invalid type evidence, and half locals. CUDA/HIP fixture now uses retained TypedSOAC facts and local addressing; full suites run on CI.

Independent review caught the half-tag regression; fixed and regression-tested. No throughput claim, production flip, or storage-certificate claim.