### PR TITLE
Certify product reduction source refinement and correct its launch grid

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -462,6 +462,11 @@ certificate (`:source-storage-certified? false`); exact graph/source/body storag
 added before selection. Zero-row calls retain the existing zero-group rejection and need planner
 elision; zero-width rows produce the neutral tuple. Next: close those obligations over the public
 TypedSOAC route, switch only certified candidates, then delete the retained source emitter.
+The retained product `KernelGrid` now describes its actual segment-count launch and tuple scratch,
+not the scalar width-reduction grid formerly used only to seed workgroup sizing. The candidate
+checks that grid against the selected tree. `validate-source!` additionally replays the body and
+ABI refinement against an independently supplied SegRed; neither check substitutes for the pending
+graph/storage proof.
 
 TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
 axes, one innermost reduction axis, typed accumulator products, dense element operands and stable

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -11,6 +11,8 @@ vertical. The north star remains the architectural specification.
   compilation. Production still uses the retained source emitter.
 - Implemented in this slice: preserve TypedSOAC local dtypes through SegRed and subsequent
   scalar/index lowering; compare both direct and local-address candidates on CPU OpenCL.
+- Source closure follow-up: align the retained product KernelGrid with the segment-count launch,
+  validate scratch/workgroup agreement, and replay the body refinement against the retained source.
 - Certify the exact semantic source, storage boundaries and public bindings against the graph.
 - Exercise ordinary public compilation, resident execution and hidden/multiple tuple results.
 - Cover required axis/bound variants and zero-row planning; reject unsupported cases explicitly.
@@ -36,6 +38,9 @@ before treating a definition as live or dead:
 Audit apparent unused wrappers separately. A source oracle is not a production fallback; removing
 one must not erase its independent numerical evidence. Track JVM and C/SIMD compatibility as well
 as GPU paths, using the same production corpus and retained TypedSOAC facts.
+CI also exposed target-registry leakage from test fixtures: matrix-capable synthetic targets can
+change another test's automatic precision route. The direct contraction ABI test now requests its
+FP32 policy explicitly; broader fixture isolation remains a cleanup item.
 
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -58,6 +58,12 @@
                                                      combine-binding-types)
         types (mapv :dtype components)
         wg (:workgroup-size source-schedule)
+        scratch-bytes (* wg (reduce + (map dtype/bytes-of types)))
+        expected-grid {:num-blocks rows :block-size wg :shared-mem-bytes scratch-bytes}
+        _ (when-not (= expected-grid (select-keys (:grid segred) (keys expected-grid)))
+            (decline! :source-grid
+                      "product source grid must agree with its segment launch and tuple scratch"
+                      {:expected expected-grid :actual (:grid segred)}))
         inputs (vec (sort-by name (:inputs segred)))
         outputs (vec (keep :result components))
         scalars (vec (sort-by name (set/union (set (:scalars segred))
@@ -185,7 +191,7 @@
                   [(body/->Yield [])] [])]))
           :schedule {:strategy :product-workgroup-tree :workgroup-size wg}
           :launch (launch/spec {:workgroup-size [wg] :group-count [(launch/runtime-value '_n_bound)]
-                                :shared-memory-bytes (* wg (reduce + (map dtype/bytes-of types)))})
+                                :shared-memory-bytes scratch-bytes})
           :provenance {:dialect :kernel-body :source-dialect :segred :segop-id (:id segred)}
           :attributes {:kind :product-reduction :component-dtypes types}})]
     {:kernel-body kernel-body :rows rows :inputs inputs :outputs outputs :scalars scalars}))
@@ -207,3 +213,20 @@
                                      (:components (:reduction segred)))}
       :provenance {:dialect :kernel-body :source-dialect :segred :segop-id (:id segred)}
       :attributes {:candidate-only true :source-storage-certified? false}})))
+
+(defn validate-source!
+  "Replay the deterministic body refinement against an independently retained SegRed.
+
+   This closes source, schedule, scalar/effect ABI and tuple evaluation correspondence. It is
+   deliberately not a storage-capacity proof: options still carry the caller's storage extents.
+   Production selection additionally needs the exact enclosing graph/storage certificate."
+  [candidate source options]
+  (scheduled/validate! candidate)
+  (when-not (= source (:source candidate))
+    (decline! :source-identity "product candidate does not retain the supplied source" {}))
+  (let [expected (schedule source options)]
+    (when-not (= expected candidate)
+      (decline! :source-refinement
+                "product body or contracts differ from the retained source refinement"
+                {:source (:id source)})))
+  candidate)

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -934,7 +934,10 @@
                      {:name idx :bound bound}))
         planned-grid (phase-grid :reduce device-id bound dtype)
         product-grid-info (when product? (product-grid device-id planned-grid reduction))
-        grid-1 (or (:grid product-grid-info) planned-grid)
+        grid-1 (cond-> (or (:grid product-grid-info) planned-grid)
+                 ;; Product schedules own one workgroup per segment. The scalar reduction's
+                 ;; capped width-based grid is only a workgroup-size seed, not their launch.
+                 product? (assoc :num-blocks (segop/seg-space-num-segments-expr space)))
         product-schedule
         (when product?
           (let [workgroup-size (:block-size grid-1)

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -7,6 +7,7 @@
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.reduction-test :as fixtures]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.product-reduction-body :as product]
@@ -23,10 +24,15 @@
                                  #(if (seq? %) (with-meta % {:tag 'long}) %) coordinate))))]
     (apply list form)))
 
+(defn- small-workgroup [segred]
+  (-> segred
+      (assoc-in [:schedule :workgroup-size] 32)
+      (assoc-in [:grid :block-size] 32)
+      (assoc-in [:grid :shared-mem-bytes] 256)))
+
 (defn argmax-segred []
   (let [node (soac/par-form->soac '_ (argmax-form) 7 :dtype :float)]
-    (assoc-in (first (soac-lower/lower-soac node :cpu:0 :dtype :float))
-              [:schedule :workgroup-size] 32)))
+    (small-workgroup (first (soac-lower/lower-soac node :cpu:0 :dtype :float)))))
 
 (def options
   {:array-types {'values :float}
@@ -52,8 +58,7 @@
                  (list 'let* ['effect (apply list form)] 'effect)
                  {:dtype :float :array-types {'values :float 'indices :int}
                   :scalar-types (:scalar-types options)})]
-    (assoc-in (first (soac-lower/lower-typed-product-reduce program :cpu:0 :dtype :float))
-              [:schedule :workgroup-size] 32)))
+    (small-workgroup (first (soac-lower/lower-typed-product-reduce program :cpu:0 :dtype :float)))))
 
 (defn typed-local-address-segred []
   (let [segred (typed-argmax-segred)
@@ -140,3 +145,41 @@
       (is false "unretained compound address widths must not be guessed")
       (catch clojure.lang.ExceptionInfo e
         (is (= :index-expression (:missing-rule (ex-data e))))))))
+
+(deftest source-product-grid-is-the-actual-segment-schedule
+  (doseq [source [(argmax-segred) (typed-argmax-segred)]]
+    (is (= 'nrows (get-in source [:grid :num-blocks])))
+    (doseq [[field bad] [[:num-blocks 'width] [:block-size 64] [:shared-mem-bytes 128]]]
+      (try
+        (product/schedule (assoc-in source [:grid field] bad) options)
+        (is false (str "contradictory grid " field " must decline"))
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :source-grid (:missing-rule (ex-data e)))))))))
+
+(deftest source-refinement-is-replayed-not-asserted-by-a-candidate-label
+  (let [source (typed-argmax-segred)
+        options (dissoc options :element-binding-types :combine-binding-types)
+        candidate (product/schedule source options)]
+    (is (= candidate (product/validate-source! candidate source options)))
+    (doseq [forged [(assoc-in candidate [:numerics :policy] :different-tree)
+                    (assoc-in candidate [:body :operations 0 :upper]
+                              (body/index-cast 0 :long :exact))
+                    (assoc-in candidate [:body :operations 0 :iter-args 1 :initial]
+                              (body/literal 0 :int))]]
+      (try
+        (product/validate-source! forged source options)
+        (is false "a well-typed but different computation must not retain the source witness")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :source-refinement (:missing-rule (ex-data e)))))))
+    (try
+      (product/validate-source! candidate (assoc source :id :other-equation) options)
+      (is false "a caller-supplied source, not the candidate's own label, closes identity")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :source-identity (:missing-rule (ex-data e))))))
+    (try
+      (product/validate-source!
+       candidate source
+       (assoc-in options [:array-shapes 'values] [(launch/sum (launch/product 'nrows 'width) 1)]))
+      (is false "changed independent storage facts require a different refinement")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :source-refinement (:missing-rule (ex-data e))))))))


### PR DESCRIPTION
## Summary
- Make product SegRed grids describe the actual one-workgroup-per-segment launch and tuple scratch.
- Replay KernelBody refinement against an independently retained source and options; reject well-typed semantic mutations.
- Keep production selection gated on the remaining graph/storage certificate. This is not yet a production route flip.

## Validation
- 62 focused tests, 315 assertions passed including CPU PoCL execution before the final additional regression assertion.
- Final source-refinement namespace: 7 tests, 49 assertions, zero failures/errors.
- Read-only review found no blocker; added its independent-storage-fact mutation regression.
- Full test and cross-vendor compile gates delegated to CI.