### PR TITLE
Derive product storage contracts from retained equation graphs

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -14,6 +14,10 @@ vertical. The north star remains the architectural specification.
 - Source closure follow-up: align the retained product KernelGrid with the segment-count launch,
   validate scratch/workgroup agreement, and replay the body refinement against the retained source.
 - Certify the exact semantic source, storage boundaries and public bindings against the graph.
+- Graph correspondence follow-up derives product pointer contracts from the exact retained
+  scheduled-equation projection, shared with fold-map. Unknown capacities and unlowered storage
+  representations decline. This does not prove arbitrary indexed accesses in bounds or enable
+  production selection; those obligations remain explicit.
 - Exercise ordinary public compilation, resident execution and hidden/multiple tuple results.
 - Cover required axis/bound variants and zero-row planning; reject unsupported cases explicitly.
 - Select the certified body and delete the old product algorithm emitter once its coverage is

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -16,6 +16,7 @@
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
 
 (defn- decline! [rule message data]
@@ -230,3 +231,62 @@
                 "product body or contracts differ from the retained source refinement"
                 {:source (:id source)})))
   candidate)
+
+(defn graph-options
+  "Derive candidate storage/type facts from an exact retained graph projection.
+
+   Unknown input capacities are not dense-access evidence. This deliberately declines them,
+   rather than inventing rows*width for arbitrary indexed reads. Shapes describe flat physical
+   storage; this is not an index-bounds proof."
+  [node kernel-graph algorithm scheduled-body]
+  (equation-graph/validate-projection! kernel-graph algorithm scheduled-body)
+  (when-not (some #(= node %) (:nodes kernel-graph))
+    (decline! :graph-node "product node must belong to its exact retained graph" {}))
+  (let [source (:operation node)
+        _ (doseq [id (set/union (set (:inputs source)) (set (:outputs source)))]
+            (let [value (get-in scheduled-body [:values id])]
+              (when-not (and (= {:kind :plain} (:representation value))
+                             (nil? (:logical-layout value)))
+                (decline! :graph-storage-representation
+                          "product raw pointers require plain storage with no unlowered layout"
+                          {:value id :representation (:representation value)
+                           :logical-layout (:logical-layout value)}))))
+        buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs kernel-graph) (:outputs kernel-graph)
+                              (:temporaries kernel-graph)))
+        array-shapes
+        (into {}
+              (map (fn [id]
+                     (let [elements (:elements (get buffers id))
+                           references (launch/expression-references elements)]
+                       (when (or (nil? elements) (some seq? references))
+                         (decline! :graph-input-extent
+                                   "product graph input requires a known storage extent"
+                                   {:input id :elements elements}))
+                       [id [elements]])))
+              (:inputs source))]
+    {:array-types (into {} (map (juxt :id :dtype)) (vals buffers))
+     :array-shapes array-shapes
+     :scalar-types (into {} (map (juxt :id :dtype)) (:scalars kernel-graph))}))
+
+(defn validate-against-node!
+  "Close source/body/graph storage correspondence, not arbitrary source index safety.
+
+   Production admission still requires access legality and runtime capacity checks. In particular,
+   this does not promote candidate-only or source-storage-certified attributes."
+  [candidate node kernel-graph algorithm scheduled-body]
+  (let [options (graph-options node kernel-graph algorithm scheduled-body)
+        candidate (scheduled/validate-against-node! candidate node kernel-graph)
+        source (:operation node)
+        rows (segop/seg-space-num-segments-expr (:space source))
+        buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs kernel-graph) (:outputs kernel-graph)
+                              (:temporaries kernel-graph)))]
+    (doseq [{:keys [result dtype]} (get-in source [:reduction :components]) :when result]
+      (let [buffer (get buffers result)]
+        ;; The initial certificate requires exact equality, not an unproved capacity inequality.
+        (when-not (and (= rows (:elements buffer)) (= dtype (:dtype buffer)))
+          (decline! :graph-output-storage
+                    "product output must retain the exact segment extent and component dtype"
+                    {:output result :rows rows :dtype dtype :buffer buffer}))))
+    (validate-source! candidate source options)))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -384,6 +384,21 @@
        ;; validator that needs them must receive and revalidate that exact program slice.
        :attributes attributes}))))
 
+(defn validate-projection!
+  "Require the exact graph projection of an independently retained algorithm and scheduled body.
+   Descriptive graph context is preserved, but cannot supply storage or scalar definitions."
+  [kernel-graph algorithm scheduled-body]
+  (when-not (and algorithm scheduled-body)
+    (fail! :scheduled-equation-projection-context
+           "graph projection requires both retained algorithm and scheduled body" {}))
+  (let [expected (make algorithm scheduled-body
+                       (select-keys kernel-graph [:effects :provenance :attributes]))]
+    (when-not (= expected kernel-graph)
+      (fail! :scheduled-equation-projection
+             "graph differs from its retained algorithm and scheduled body"
+             {:expected expected :actual kernel-graph})))
+  kernel-graph)
+
 (defn make-for-equation
   "Derive the exact scheduled KernelGraph for one TypedSOAC numerical equation.
 

--- a/src/raster/compiler/passes/parallel/segfoldmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segfoldmap_body.clj
@@ -416,20 +416,8 @@
     {}
     (let [host-prefix (vec (take-while #(true? (get-in % [:attributes :host-only]))
                                        (:equations closed-body)))]
-      (let [;; `make` revalidates the complete SegOp program, the retained TypedSOAC boundary,
-            ;; every buffer extent, and graph dataflow. Preserve only descriptive graph context
-            ;; while reconstructing; it cannot contribute a scalar definition.
-            expected-graph
-            (equation-graph/make
-             closed-algorithm closed-body
-             {:effects (:effects kernel-graph)
-              :provenance (:provenance kernel-graph)
-              :attributes (:attributes kernel-graph)})]
-        (when-not (= expected-graph kernel-graph)
-          (throw (ex-info "fold-map graph is not the exact projection of its retained equation body"
-                          {:reason :segfoldmap-storage-proof
-                           :expected expected-graph :actual kernel-graph})))
-        (equation-graph/derived-scalar-expressions (:values closed-body) host-prefix)))))
+      (equation-graph/validate-projection! kernel-graph closed-algorithm closed-body)
+      (equation-graph/derived-scalar-expressions (:values closed-body) host-prefix))))
 
 (defn validate-against-node!
   "Close a fold-map refinement over its exact source grid and graph storage descriptions.

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -6,12 +6,16 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.reduction-test :as fixtures]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.product-reduction-body :as product]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
 
 (defn- argmax-form []
@@ -41,7 +45,7 @@
    :element-binding-types {'candidate :float}
    :combine-binding-types {'left-nan :int 'right-nan :int 'better :int}})
 
-(defn typed-argmax-segred []
+(defn- typed-argmax-program [values]
   (let [tag-bindings (fn [bindings dtypes]
                        (vec (mapcat (fn [[id init]]
                                       [(with-meta id {:raster.type/tag
@@ -57,8 +61,12 @@
         program (frontend/form->program
                  (list 'let* ['effect (apply list form)] 'effect)
                  {:dtype :float :array-types {'values :float 'indices :int}
-                  :scalar-types (:scalar-types options)})]
-    (small-workgroup (first (soac-lower/lower-typed-product-reduce program :cpu:0 :dtype :float)))))
+                  :values values :scalar-types (:scalar-types options)})]
+    program))
+
+(defn typed-argmax-segred []
+  (small-workgroup
+   (first (soac-lower/lower-typed-product-reduce (typed-argmax-program {}) :cpu:0 :dtype :float))))
 
 (defn typed-local-address-segred []
   (let [segred (typed-argmax-segred)
@@ -183,3 +191,92 @@
       (is false "changed independent storage facts require a different refinement")
       (catch clojure.lang.ExceptionInfo e
         (is (= :source-refinement (:missing-rule (ex-data e))))))))
+
+(defn- graph-context [known-input? & [input-options output-options]]
+  (let [algorithm (typed-argmax-program
+                   (if known-input?
+                     {'values (av/tensor {:dtype :float :shape ['nrows 'width]})}
+                     {}))
+        ;; Model a compiler-generated typed program as well as the analyzed-source frontend,
+        ;; which already declines non-plain aget storage before this boundary.
+        algorithm (if input-options
+                    (apply list (update-in (vec algorithm) [1 :values 'values] merge input-options))
+                    algorithm)
+        algorithm (if output-options
+                    (apply list
+                           (-> (vec algorithm)
+                               (update-in [1 :values 'indices] merge output-options)
+                               (update-in [1 :values (first (nth (first (nth algorithm 2)) 2))] merge
+                                          (select-keys output-options
+                                                       [:logical-layout :representation]))))
+                    algorithm)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          (route/program-envelope algorithm)
+                          {:dtype :float :target-device :cpu:0
+                           :array-types (:array-types options)
+                           :scalar-types (:scalar-types options)}))
+        equation (first (:equations scheduled))
+        {:keys [graph body]} (equation-graph/make-for-equation scheduled equation)]
+    {:algorithm (:algorithm equation) :body body :graph graph :node (first (:nodes graph))}))
+
+(deftest graph-storage-facts-are-derived-from-the-retained-program
+  (let [{:keys [algorithm body graph node]} (graph-context true)
+        derived (product/graph-options node graph algorithm body)
+        candidate (product/schedule (:operation node) derived)]
+    (is (= [(launch/product 'nrows 'width)] (get-in derived [:array-shapes 'values])))
+    (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
+    (is (false? (get-in candidate [:attributes :source-storage-certified?]))
+        "storage correspondence alone does not prove arbitrary indexed reads safe")
+    (doseq [forged [(assoc-in graph [:inputs 0 :elements] 1)
+                    (assoc-in graph [:inputs 0 :dtype] :double)]]
+      (try
+        (product/validate-against-node! candidate node forged algorithm body)
+        (is false "a graph annotation must not replace the retained storage contract")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :scheduled-equation-projection (:reason (ex-data e)))))))
+    (try
+      (product/graph-options (assoc node :id :unrelated) graph algorithm body)
+      (is false "the exact node must belong to the graph")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :graph-node (:missing-rule (ex-data e))))))))
+
+(deftest unknown-product-input-storage-is-not-assumed-dense
+  (let [{:keys [algorithm body graph node]} (graph-context false)]
+    (try
+      (product/graph-options node graph algorithm body)
+      (is false "unknown capacity cannot be replaced by rows*width for an indexed read")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :graph-input-extent (:missing-rule (ex-data e))))))))
+
+(deftest graph-capacity-is-not-an-index-safety-certificate
+  (let [{:keys [algorithm body graph node]} (graph-context true {:shape [1]})
+        candidate (product/schedule (:operation node)
+                                    (product/graph-options node graph algorithm body))]
+    ;; The source's row-major read may exceed this capacity for runtime rows/width > 1.
+    ;; Do not execute it: correspondence preserves that source, it does not prove it safe.
+    (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
+    (is (true? (get-in candidate [:attributes :candidate-only])))
+    (is (false? (get-in candidate [:attributes :source-storage-certified?])))))
+
+(deftest logical-representations-must-be-lowered-before-raw-product-storage
+  (doseq [storage-options [{:representation {:kind :quantized :scheme :q4-k}}
+                          {:logical-layout {:kind :strided :strides [2]}}]
+          input? [true false]]
+    (let [{:keys [algorithm body graph node]}
+          (if input? (graph-context true storage-options)
+              (graph-context true nil storage-options))]
+      (try
+        (product/graph-options node graph algorithm body)
+        (is false "logical element counts are not raw packed or strided storage capacities")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :graph-storage-representation (:missing-rule (ex-data e)))))))))
+
+(deftest output-capacity-needs-an-explicit-relation-to-the-written-segment-domain
+  (let [{:keys [algorithm body graph node]} (graph-context true nil {:shape [1]})
+        candidate (product/schedule (:operation node)
+                                    (product/graph-options node graph algorithm body))]
+    (try
+      (product/validate-against-node! candidate node graph algorithm body)
+      (is false "a retained but unrelated output capacity does not establish the row write contract")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :graph-output-storage (:missing-rule (ex-data e))))))))


### PR DESCRIPTION
## Summary
- Share exact retained equation-to-graph projection validation with fold-map.
- Derive product pointer types and extents from the reconstructed graph, then replay source refinement.
- Reject unknown input capacity, non-plain or unlowered input/output layout, forged graph facts, unrelated nodes, and incompatible output capacity.
- Explicitly keep this separate from arbitrary index safety and production admission; no new production route is enabled.

## Validation
- 28 affected product/fold-map/CPU OpenCL tests, 185 assertions passed.
- Final product namespace after added output representation coverage: 12 tests, 64 assertions passed.
- Independent read-only review found no blocker; added its output-representation regression suggestion.
- Full suite and vendor compile gates run in CI.