### PR TITLE
Validate concrete KernelBody hardware index ranges before launch

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -20,6 +20,10 @@ vertical. The north star remains the architectural specification.
   production selection; those obligations remain explicit.
 - Exercise ordinary public compilation, resident execution and hidden/multiple tuple results.
 - Cover required axis/bound variants and zero-row planning; reject unsupported cases explicitly.
+- Before widening public dimension support, bind concrete launch geometry to KernelBody's int
+  hardware-index representation, including scheduler overrides and compatibility staging. Logical
+  Long dimensions must not silently overflow group/local indices; target resource limits remain
+  a separate, potentially stricter contract.
 - Select the certified body and delete the old product algorithm emitter once its coverage is
   replaced. Keep necessary target instruction lowering.
 

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -2413,3 +2413,26 @@
          operations [] schedule {} launch {} provenance {} attributes {}}}]
   (validate! (->KernelBody id parameters views stable-reads allocations indices masks fragments
                            operations schedule launch provenance attributes)))
+
+(defn validate-launch-index-ranges!
+  "Check the physical ranges of a verified body's hardware bindings at concrete launch time.
+
+   IndexBinding currently has canonical dtype int. A long logical extent does not widen the
+   hardware index representation. This cheap binding check does not rerun body verification and
+   is independent of target limits, which may impose stricter resource constraints."
+  [kernel-body geometry]
+  (let [{:keys [workgroup-size group-count]} (launch/validate-geometry! geometry)
+        workgroup-items (reduce *' 1 workgroup-size)]
+    (doseq [index (:indices kernel-body)
+            :when (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" index)]
+      (let [upper (case (:source index)
+                    :group (dec (nth group-count (:axis index)))
+                    :group-count (nth group-count (:axis index))
+                    :local (dec (nth workgroup-size (:axis index)))
+                    ;; Without a target subgroup width, the workgroup bounds both values.
+                    (:subgroup :lane) (dec workgroup-items))]
+        (when-not (scalar-range/contained-in-dtype? {:lower 0 :upper upper} :int)
+          (throw (ex-info "kernel launch exceeds its hardware index representation"
+                          {:reason :kernel-launch-index-range :index index :dtype :int
+                           :upper upper :geometry geometry}))))))
+  geometry)

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -12,6 +12,16 @@
 
 (defrecord KernelCall [artifact arguments geometry])
 
+;; Artifact-only runtime clients need not load the compiler's full body vocabulary. Cache the Var,
+;; not its root function, so a REPL reload still updates the validator used by subsequent calls.
+(def ^:private body-launch-validator
+  (delay (requiring-resolve 'raster.compiler.ir.kernel-body/validate-launch-index-ranges!)))
+
+(defn- validate-body-launch! [artifact geometry]
+  (when-let [kernel-body (get-in artifact [:attributes :kernel-body])]
+    (@body-launch-validator kernel-body geometry))
+  geometry)
+
 (defn kernel-call?
   "Recognize executable calls across Typed Clojure's child DynamicClassLoaders."
   [x]
@@ -199,6 +209,7 @@
                       {:kernel-name (:kernel-name artifact)
                        :expected (:shared-memory-bytes spec)
                        :actual (:shared-memory-bytes geometry)})))
+    (validate-body-launch! artifact geometry)
     (doseq [[slot value] (map vector abi arguments)]
       (if (= :scalar (:kind slot))
         (scalar-value! slot value)
@@ -244,8 +255,9 @@
    the caller's responsibility and KernelCall performs them for resident execution."
   [artifact arguments]
   (let [artifact (kart/validate! artifact)
-        arguments (kabi/validate-arguments! (:abi artifact) arguments)]
-    (klaunch/realize (:launch artifact) (argument-resolver artifact arguments))))
+        arguments (kabi/validate-arguments! (:abi artifact) arguments)
+        geometry (klaunch/realize (:launch artifact) (argument-resolver artifact arguments))]
+    (validate-body-launch! artifact geometry)))
 
 (defn resolve-value
   "Resolve one compiler value through a checked call's artifact/runtime argument relation. This
@@ -272,9 +284,9 @@
                    :when (= :scalar (:kind slot))]
              (scalar-value! slot value))
          resolver (or resolve-value (argument-resolver artifact arguments))
-         realized (if resolve-value
-                    (klaunch/realize (:launch artifact) resolver)
-                    (realize-launch artifact arguments))
+         ;; An override replaces the group vector; check its final geometry below, not the
+         ;; unused default grid. Staging callers of realize-launch have no such override.
+         realized (klaunch/realize (:launch artifact) resolver)
          geometry (if group-count
                     (klaunch/geometry
                      {:workgroup-size (:workgroup-size realized)

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -11,6 +11,33 @@
 (def ^:private lhs-layout (layout/dot-operand 0 acc-layout 2 :half))
 (def ^:private rhs-layout (layout/dot-operand 1 acc-layout 2 :half))
 
+(deftest concrete-launches-must-fit-the-declared-hardware-index-width
+  (doseq [[source dimension accepted rejected]
+          [[:group :group-count (inc (long Integer/MAX_VALUE)) (+ 2 (long Integer/MAX_VALUE))]
+           [:group-count :group-count (long Integer/MAX_VALUE) (inc (long Integer/MAX_VALUE))]
+           [:local :workgroup-size (inc (long Integer/MAX_VALUE)) (+ 2 (long Integer/MAX_VALUE))]
+           [:subgroup :workgroup-size (inc (long Integer/MAX_VALUE)) (+ 2 (long Integer/MAX_VALUE))]
+           [:lane :workgroup-size (inc (long Integer/MAX_VALUE)) (+ 2 (long Integer/MAX_VALUE))]]]
+    (let [index (body/->IndexBinding 'hardware-index source 0)
+          kernel (body/make {:id :index-range :indices [index]
+                             :launch (launch/spec {:workgroup-size [1] :group-count [1]})})
+          geometry #(launch/geometry (assoc {:workgroup-size [1] :group-count [1]}
+                                            dimension [%]))]
+      (is (= (geometry accepted)
+             (body/validate-launch-index-ranges! kernel (geometry accepted))))
+      (try
+        (body/validate-launch-index-ranges! kernel (geometry rejected))
+        (is false (str source " must not overflow int hardware indices"))
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :kernel-launch-index-range (:reason (ex-data e))))))))
+  (let [kernel (body/make {:id :lane-range :indices [(body/->IndexBinding 'lane :lane 0)]
+                           :launch (launch/spec {:workgroup-size [1 1 1] :group-count [1 1 1]})})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"hardware index representation"
+                         (body/validate-launch-index-ranges!
+                          kernel (launch/geometry {:workgroup-size [2147483648 2147483648 4]
+                                                   :group-count [1 1 1]})))
+        "the proof product must not overflow host arithmetic")))
+
 (defn- minimal-body []
   (body/make
    {:id :matrix

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.ocl-runtime :as ocl]
@@ -24,6 +25,32 @@
 
 (def ^:private args
   [:resident-x :resident-out {:type :float :value 2.0} {:type :int :value 513}])
+
+(deftest scheduled-call-overrides-cannot-overflow-hardware-indices
+  (let [kernel (body/make
+                {:id :range-check
+                 :parameters [(body/->KernelParameter 'n :scalar :int [] nil nil :bound)]
+                 :indices [(body/->IndexBinding 'group :group 0)]
+                 :launch (:launch artifact)})
+        scheduled-artifact (assoc-in artifact [:attributes :kernel-body] kernel)]
+    (is (kcall/kernel-call? (kcall/make scheduled-artifact args)))
+    (is (kcall/kernel-call?
+         (kcall/make scheduled-artifact args {:group-count [(inc (long Integer/MAX_VALUE))]})))
+    (try
+      (kcall/make scheduled-artifact args {:group-count [(+ 2 (long Integer/MAX_VALUE))]})
+      (is false "a scheduling override must not bypass the body's physical index width")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :kernel-launch-index-range (:reason (ex-data e))))))
+    (let [large-launch (klaunch/spec {:workgroup-size [256]
+                                      :group-count [(klaunch/product 'n 10000000)]})
+          large-artifact (-> scheduled-artifact
+                             (assoc :launch large-launch)
+                             (assoc-in [:attributes :kernel-body :launch] large-launch))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"hardware index representation"
+                           (kcall/realize-launch large-artifact args))
+          "compatibility staging checks before allocating partial storage")
+      (is (kcall/kernel-call? (kcall/make large-artifact args {:group-count [1]}))
+          "a legal explicit override is checked instead of the unused default geometry"))))
 
 (def ^:private stable-artifact
   (kart/make (assoc-in artifact [:abi 0 :aliasing] :no-write-alias)))


### PR DESCRIPTION
## Summary
- Check concrete hardware index ranges against the existing int IndexBinding representation.
- Distinguish group IDs from group counts, cover local/subgroup/lane bounds, and use unbounded proof arithmetic.
- Enforce this in resident KernelCalls and compatibility launch realization; validate final scheduler overrides rather than unused default grids.
- Keep artifact-only runtime loading lean with a lazy cached validator Var.

## Validation
- 40 focused KernelBody/KernelCall tests, 192 assertions passed.
- KernelCall plus CPU OpenCL product execution: 15 tests, 61 assertions passed before the final lazy-loading refactor; the 40-test suite was rerun after it.
- Independent read-only review in progress. Full suite and compile gates in CI.

This checks representation limits, not complete device resource limits, and does not change the product production route.