### PR TITLE
Preserve integral dimension widths in product KernelBody

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -9,17 +9,21 @@ vertical. The north star remains the architectural specification.
 - Landed #382: shared typed multi-result scalar-region lowering.
 - Landed #383: candidate row-product KernelBody, CPU OpenCL differential execution, CUDA/HIP
   compilation. Production still uses the retained source emitter.
-- Implemented in this slice: preserve TypedSOAC local dtypes through SegRed and subsequent
+- Landed #384: preserve TypedSOAC local dtypes through SegRed and subsequent
   scalar/index lowering; compare both direct and local-address candidates on CPU OpenCL.
-- Source closure follow-up: align the retained product KernelGrid with the segment-count launch,
+- Landed #385: align the retained product KernelGrid with the segment-count launch,
   validate scratch/workgroup agreement, and replay the body refinement against the retained source.
 - Certify the exact semantic source, storage boundaries and public bindings against the graph.
-- Graph correspondence follow-up derives product pointer contracts from the exact retained
+- Landed #386: derive product pointer contracts from the exact retained
   scheduled-equation projection, shared with fold-map. Unknown capacities and unlowered storage
   representations decline. This does not prove arbitrary indexed accesses in bounds or enable
   production selection; those obligations remain explicit.
 - Exercise ordinary public compilation, resident execution and hidden/multiple tuple results.
 - Cover required axis/bound variants and zero-row planning; reject unsupported cases explicitly.
+- Long-bound follow-up preserves independent row/column int or long facts through the public
+  scalar ABI and widened induction. CPU differential execution includes Long dimensions and
+  retained local addresses; CUDA/HIP fixtures compile the same candidate. This is still not the
+  production route, and zero-row elision and source access requirements remain open.
 - Before widening public dimension support, bind concrete launch geometry to KernelBody's int
   hardware-index representation, including scheduler overrides and compatibility staging. Logical
   Long dimensions must not silently overflow group/local indices; target resource limits remain

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -74,11 +74,13 @@
               (decline! :scalar-dtype "product scalar requires retained dtype" {:scalar id})))
         _ (doseq [bound [rows width]]
             (when-not (and (or (integer? bound) (symbol? bound))
-                           (= :int (launch/typed-expression-dtype bound scalar-types))
+                           (contains? #{:int :long}
+                                      (launch/typed-expression-dtype bound scalar-types))
                            (or (symbol? bound) (not (neg? bound))))
               (decline! :bound-dtype
-                        "initial product body requires nonnegative int32 row/column bounds"
+                        "product body requires nonnegative integral row/column bounds"
                         {:bound bound})))
+        rows-type (launch/typed-expression-dtype rows scalar-types)
         _ (doseq [id inputs]
             (when-not (and (get array-types id) (seq (get array-shapes id)))
               (decline! :input-storage "product input requires retained dtype and extent"
@@ -98,7 +100,7 @@
                     components)
               (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
                    scalars)
-              [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))
+              [(body/->KernelParameter '_n_bound :scalar rows-type [] nil nil :bound)]))
         index-types (assoc scalar-types row :int column :long)
         lower-index (fn [expression locals]
                       (index/lower-typed expression (set/union (set (keys index-types)) locals)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -318,15 +318,17 @@
         swizzled-pipelined (attention-emit/emit-fp16-pipelined
                             plan swizzled-pipelined-schedule dialect descriptor)
         tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)
-        public-artifacts (equation-first-artifacts target descriptor)]
+        public-artifacts (equation-first-artifacts target descriptor)
+        product-scalar-types {'nrows :long 'width :long}]
     (into [(write-artifact! directory suffix "cooperative" cooperative)
            (write-artifact! directory suffix "candidate-product-reduction"
                             (body-target/emit-artifact
                              "candidate_product_argmax"
-                             (product-body/schedule (product-fixtures/typed-local-address-segred)
-                                                    (dissoc product-fixtures/options
-                                                            :element-binding-types
-                                                            :combine-binding-types))
+                             (product-body/schedule
+                              (product-fixtures/typed-local-address-segred product-scalar-types)
+                              (-> product-fixtures/options
+                                  (dissoc :element-binding-types :combine-binding-types)
+                                  (assoc :scalar-types product-scalar-types)))
                              dialect))
            (write-artifact! directory suffix "pipelined-attention" pipelined)
            (write-artifact! directory suffix "swizzled-pipelined-attention"

--- a/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
@@ -38,8 +38,13 @@
                                    :opencl-portable)
           local (target/emit-artifact "candidate_product_local_address"
                                      (product/schedule (fixtures/typed-local-address-segred)
-                                                       retained-options) :opencl-portable)]
-      (doseq [artifact [old new local]] (register! (:kernel-name artifact) artifact))
+                                                       retained-options) :opencl-portable)
+          long-types {'nrows :long 'width :long}
+          wide (target/emit-artifact "candidate_product_long_dimensions"
+                                    (product/schedule (fixtures/typed-local-address-segred long-types)
+                                                      (assoc retained-options :scalar-types long-types))
+                                    :opencl-portable)]
+      (doseq [artifact [old new local wide]] (register! (:kernel-name artifact) artifact))
       (doseq [[nrows width] (cons [0 1] (map #(vector 5 %) [0 1 7 32 33 65]))]
         (let [rows (vec (take nrows [(vec (repeat width (float 2)))
                     (mapv #(float (mod % 7)) (range width))
@@ -53,9 +58,11 @@
                   (mapv (fn [artifact]
                           (let [output (buffer-of-array
                                         (int-array (repeat (max 1 nrows) -77)) :int)
+                                scalar-types (into {} (map (juxt :name :kernel-dtype))
+                                                   (filter #(= :scalar (:kind %)) (:abi artifact)))
                                 bindings {'values input 'indices output
-                                          'nrows {:type :int :value (count rows)}
-                                          'width {:type :int :value width}}]
+                                          'nrows {:type (get scalar-types 'nrows) :value (count rows)}
+                                          'width {:type (get scalar-types 'width) :value width}}]
                             (try
                               (if (zero? nrows)
                                 ;; Both routes reject zero-group launches. The planner must elide
@@ -67,7 +74,7 @@
                                 (execute! (bind-call (call/make artifact
                                                                (mapv bindings (:arguments artifact))))))
                               (vec (read! output))
-                              (finally (free! output))))) [old new local])]
+                              (finally (free! output))))) [old new local wide])]
               (is (apply = (cons (if (zero? nrows) [-77] (mapv argmax rows)) results))
                   (str "rows " nrows ", width " width)))
             (finally (free! input))))))))

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -9,6 +9,7 @@
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-call :as call]
             [raster.compiler.ir.reduction-test :as fixtures]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.product-reduction-body :as product]
@@ -45,7 +46,7 @@
    :element-binding-types {'candidate :float}
    :combine-binding-types {'left-nan :int 'right-nan :int 'better :int}})
 
-(defn- typed-argmax-program [values]
+(defn- typed-argmax-program [values & [scalar-types]]
   (let [tag-bindings (fn [bindings dtypes]
                        (vec (mapcat (fn [[id init]]
                                       [(with-meta id {:raster.type/tag
@@ -61,22 +62,27 @@
         program (frontend/form->program
                  (list 'let* ['effect (apply list form)] 'effect)
                  {:dtype :float :array-types {'values :float 'indices :int}
-                  :values values :scalar-types (:scalar-types options)})]
+                  :values values :scalar-types (or scalar-types (:scalar-types options))})]
     program))
 
-(defn typed-argmax-segred []
-  (small-workgroup
-   (first (soac-lower/lower-typed-product-reduce (typed-argmax-program {}) :cpu:0 :dtype :float))))
+(defn typed-argmax-segred
+  ([] (typed-argmax-segred (:scalar-types options)))
+  ([scalar-types]
+   (small-workgroup
+    (first (soac-lower/lower-typed-product-reduce
+            (typed-argmax-program {} scalar-types) :cpu:0 :dtype :float)))))
 
-(defn typed-local-address-segred []
-  (let [segred (typed-argmax-segred)
+(defn typed-local-address-segred
+  ([] (typed-local-address-segred (:scalar-types options)))
+  ([scalar-types]
+  (let [segred (typed-argmax-segred scalar-types)
         ;; Use the semantic reduction index, not a spelling inferred from generated code.
         index (get-in segred [:reduction :index])]
     (update-in segred [:reduction :element :bindings]
                (fn [bindings]
                  (into [(with-meta 'offset {:raster.type/tag 'long}) (list 'long index)]
                        (mapcat (fn [[id init]] [id (util/subst-syms {index 'offset} init)])
-                               (partition 2 bindings)))))))
+                               (partition 2 bindings))))))))
 
 (deftest typed-product-projection-retains-local-types-without-caller-reconstruction
   (let [segred (typed-argmax-segred)
@@ -192,11 +198,12 @@
       (catch clojure.lang.ExceptionInfo e
         (is (= :source-refinement (:missing-rule (ex-data e))))))))
 
-(defn- graph-context [known-input? & [input-options output-options]]
-  (let [algorithm (typed-argmax-program
+(defn- graph-context [known-input? & [input-options output-options scalar-types]]
+  (let [scalar-types (or scalar-types (:scalar-types options))
+        algorithm (typed-argmax-program
                    (if known-input?
                      {'values (av/tensor {:dtype :float :shape ['nrows 'width]})}
-                     {}))
+                     {}) scalar-types)
         ;; Model a compiler-generated typed program as well as the analyzed-source frontend,
         ;; which already declines non-plain aget storage before this boundary.
         algorithm (if input-options
@@ -214,7 +221,7 @@
                           (route/program-envelope algorithm)
                           {:dtype :float :target-device :cpu:0
                            :array-types (:array-types options)
-                           :scalar-types (:scalar-types options)}))
+                           :scalar-types scalar-types}))
         equation (first (:equations scheduled))
         {:keys [graph body]} (equation-graph/make-for-equation scheduled equation)]
     {:algorithm (:algorithm equation) :body body :graph graph :node (first (:nodes graph))}))
@@ -280,3 +287,39 @@
       (is false "a retained but unrelated output capacity does not establish the row write contract")
       (catch clojure.lang.ExceptionInfo e
         (is (= :graph-output-storage (:missing-rule (ex-data e))))))))
+
+(deftest long-logical-dimensions-retain-their-abi-width
+  (let [{:keys [algorithm body graph node]}
+        (graph-context true nil nil {'nrows :long 'width :long})
+        derived (product/graph-options node graph algorithm body)
+        candidate (product/schedule (:operation node) derived)]
+    (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
+    (is (= #{:long} (set (map :dtype (:scalar-bindings candidate)))))
+    (doseq [dialect [:opencl-portable :cuda :hip]]
+      (let [artifact (target/emit-artifact "long_product" candidate dialect)]
+        (is (= [:long :long :long]
+               (mapv :kernel-dtype (filter #(= :scalar (:kind %)) (:abi artifact)))))))
+    (is (= :long (get-in candidate [:body :operations 0 :index :type])))
+    (is (= :int (get-in candidate [:body :parameters 1 :dtype]))
+        "dimension width does not change the winning-index component representation")
+    (let [artifact (target/emit-artifact "long_product_range" candidate :opencl-portable)
+          bindings {'values :input 'indices :output
+                    'nrows {:type :long :value (+ 2 (long Integer/MAX_VALUE))}
+                    'width {:type :long :value 1}}]
+      (try
+        (call/make artifact (mapv bindings (:arguments artifact)))
+        (is false "a long logical row count still needs representable physical group indices")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :kernel-launch-index-range (:reason (ex-data e)))))))))
+
+(deftest dimension-widths-are-independent
+  (doseq [[row-type width-type] [[:int :long] [:long :int]]]
+    (let [{:keys [algorithm body graph node]}
+          (graph-context true nil nil {'nrows row-type 'width width-type})
+          candidate (product/schedule (:operation node)
+                                      (product/graph-options node graph algorithm body))
+          artifact (target/emit-artifact "mixed_dimension_product" candidate :opencl-portable)]
+      (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
+      (is (= {'nrows row-type 'width width-type '_n_bound row-type}
+             (into {} (map (juxt :name :kernel-dtype))
+                   (filter #(= :scalar (:kind %)) (:abi artifact))))))))


### PR DESCRIPTION
Stacked on #387 until its required test check completes.

## Summary
- Preserve independently retained int/long row and column dimension types.
- Derive the private row-bound ABI type; keep the component and hardware-index representations independent.
- Exercise Long dimensions plus retained local addressing on CPU OpenCL and in CUDA/HIP compile fixtures.
- Include mixed-width graph/source replay and physical-index overflow rejection.

## Validation
- 15 focused product and CPU OpenCL tests, 87 assertions passed.
- Independent review found no blocker; added its mixed-width regression suggestion.
- Full suite/vendor compilation delegated to CI.

The product candidate is still not production-selected. Source access requirements and zero-row planning remain tracked follow-ups.