### PR TITLE
Guard empty product domains uniformly across workgroups

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -453,20 +453,23 @@ scalar/control target emission. Its mixed float/int argmax fixture is compared a
 retained emitter and a host oracle on CPU OpenCL (empty/short/tail rows, ties, NaNs and infinities),
 and joins the hardware-free CUDA/HIP compile gates. This is not a throughput benchmark.
 
-It is deliberately not yet a production route: it accepts one segment axis, int32 row/column
+It is deliberately not yet a production route: it accepts one segment axis, integral int/long row/column
 bounds, retained region-binding types and long-width address expressions. TypedSOAC local dtypes
 now survive SegRed projection and scalar SSA substitution, so computed local address bindings and
 typed integral constants use those same facts rather than a reconstructed type map. Contradictory
 candidate overrides decline. Caller-supplied storage shapes are not a source/storage
-certificate (`:source-storage-certified? false`); exact graph/source/body storage closure must be
-added before selection. Zero-row calls retain the existing zero-group rejection and need planner
-elision; zero-width rows produce the neutral tuple. Next: close those obligations over the public
+certificate (`:source-storage-certified? false`). Exact graph/source/body storage correspondence is
+available for retained plain capacities; unknown indexed input requirements still need derivation.
+Zero-row kernels use one physical group with a uniform guard around all computation, barriers and
+stores; zero-width rows produce the neutral tuple. This is a no-op over existing resident storage,
+not graph-node elision or support for allocating zero-byte device buffers. Next: close the remaining
+storage and public-binding obligations over the public
 TypedSOAC route, switch only certified candidates, then delete the retained source emitter.
-The retained product `KernelGrid` now describes its actual segment-count launch and tuple scratch,
+The retained product `KernelGrid` now describes its actual guarded segment-count launch and tuple scratch,
 not the scalar width-reduction grid formerly used only to seed workgroup sizing. The candidate
 checks that grid against the selected tree. `validate-source!` additionally replays the body and
-ABI refinement against an independently supplied SegRed; neither check substitutes for the pending
-graph/storage proof.
+ABI refinement against an independently supplied SegRed. Graph reconstruction and source replay
+preserve storage contracts; they do not certify arbitrary source indices as in bounds.
 
 TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
 axes, one innermost reduction axis, typed accumulator products, dense element operands and stable

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -20,10 +20,13 @@ vertical. The north star remains the architectural specification.
   production selection; those obligations remain explicit.
 - Exercise ordinary public compilation, resident execution and hidden/multiple tuple results.
 - Cover required axis/bound variants and zero-row planning; reject unsupported cases explicitly.
+- Empty-domain kernel follow-up uses one physical group and a workgroup-uniform guard enclosing
+  every reduction operation, barrier and store. CPU differential tests execute this path and verify
+  untouched outputs. This does not implement zero-byte device allocation or graph-node elision.
 - Long-bound follow-up preserves independent row/column int or long facts through the public
   scalar ABI and widened induction. CPU differential execution includes Long dimensions and
   retained local addresses; CUDA/HIP fixtures compile the same candidate. This is still not the
-  production route, and zero-row elision and source access requirements remain open.
+  production route; source access requirements remain open, as does eventual zero-row elision.
 - Before widening public dimension support, bind concrete launch geometry to KernelBody's int
   hardware-index representation, including scheduler overrides and compatibility staging. Logical
   Long dimensions must not silently overflow group/local indices; target resource limits remain

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -443,11 +443,12 @@
             (throw (ex-info "product reduction workgroup size must be a positive power of two"
                             {:reason :product-reduction-workgroup :block-size block-size})))
         num-segments (segop/seg-space-num-segments-expr space)
-        launch-segments (let [bounds (mapv :bound segment-dims)]
-                          (case (count bounds)
-                            0 1
-                            1 (klaunch/runtime-value (first bounds))
-                            (apply klaunch/product bounds)))
+        launch-segments (klaunch/maximum
+                         1 (let [bounds (mapv :bound segment-dims)]
+                             (case (count bounds)
+                               0 1
+                               1 (klaunch/runtime-value (first bounds))
+                               (apply klaunch/product bounds))))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         input-params (vec (sort-by name (:inputs segred)))
         output-params (vec (keep :result components))

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -60,7 +60,8 @@
         types (mapv :dtype components)
         wg (:workgroup-size source-schedule)
         scratch-bytes (* wg (reduce + (map dtype/bytes-of types)))
-        expected-grid {:num-blocks rows :block-size wg :shared-mem-bytes scratch-bytes}
+        expected-grid {:num-blocks (list 'max 1 rows) :block-size wg
+                       :shared-mem-bytes scratch-bytes}
         _ (when-not (= expected-grid (select-keys (:grid segred) (keys expected-grid)))
             (decline! :source-grid
                       "product source grid must agree with its segment launch and tuple scratch"
@@ -170,7 +171,14 @@
           :indices [(body/->IndexBinding row :group 0)
                     (body/->IndexBinding 'product-lane :local 0)]
           :operations
-          (vec (concat
+          [(body/->ScalarCompute
+            (body/value :product-active :predicate)
+            (body/scalar-expression :lt :predicate
+                                    [(body/cast-expression row :long :exact :exact)
+                                     (body/cast-expression '_n_bound :long :exact :exact)]))
+           (body/->IfRegion
+            :product-active
+            (conj (vec (concat
                 [(body/->ForLoop
                   (body/value column :long) (body/index-cast 'product-lane :long :exact)
                   (lower-index width #{}) wg
@@ -191,9 +199,11 @@
                             [(body/->ScalarLoad (body/value value dtype) scratch [0] nil nil :cached)
                              (body/->ScalarStore result [row] value nil)]))
                         components scratches (ids "product-final"))) (body/->Yield []))
-                  [(body/->Yield [])] [])]))
+                  [(body/->Yield [])] [])])) (body/->Yield []))
+            [(body/->Yield [])] [])]
           :schedule {:strategy :product-workgroup-tree :workgroup-size wg}
-          :launch (launch/spec {:workgroup-size [wg] :group-count [(launch/runtime-value '_n_bound)]
+          :launch (launch/spec {:workgroup-size [wg]
+                                :group-count [(launch/maximum 1 (launch/runtime-value '_n_bound))]
                                 :shared-memory-bytes scratch-bytes})
           :provenance {:dialect :kernel-body :source-dialect :segred :segop-id (:id segred)}
           :attributes {:kind :product-reduction :component-dtypes types}})]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -935,9 +935,10 @@
         planned-grid (phase-grid :reduce device-id bound dtype)
         product-grid-info (when product? (product-grid device-id planned-grid reduction))
         grid-1 (cond-> (or (:grid product-grid-info) planned-grid)
-                 ;; Product schedules own one workgroup per segment. The scalar reduction's
-                 ;; capped width-based grid is only a workgroup-size seed, not their launch.
-                 product? (assoc :num-blocks (segop/seg-space-num-segments-expr space)))
+                 ;; Product schedules own one workgroup per segment, or one uniformly guarded
+                 ;; group for an empty domain. The scalar grid only seeds workgroup sizing.
+                 product? (assoc :num-blocks
+                                 (list 'max 1 (segop/seg-space-num-segments-expr space))))
         product-schedule
         (when product?
           (let [workgroup-size (:block-size grid-1)

--- a/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_device_test.clj
@@ -64,15 +64,11 @@
                                           'nrows {:type (get scalar-types 'nrows) :value (count rows)}
                                           'width {:type (get scalar-types 'width) :value width}}]
                             (try
-                              (if (zero? nrows)
-                                ;; Both routes reject zero-group launches. The planner must elide
-                                ;; a zero-row operation rather than submit an invalid device call.
-                                (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                                     #"group-count dimension must be a positive integer"
-                                                     (call/make artifact
-                                                                (mapv bindings (:arguments artifact)))))
-                                (execute! (bind-call (call/make artifact
-                                                               (mapv bindings (:arguments artifact))))))
+                              (let [kernel-call (call/make artifact
+                                                          (mapv bindings (:arguments artifact)))]
+                                (when (zero? nrows)
+                                  (is (= [1] (get-in kernel-call [:geometry :group-count]))))
+                                (execute! (bind-call kernel-call)))
                               (vec (read! output))
                               (finally (free! output))))) [old new local wide])]
               (is (apply = (cons (if (zero? nrows) [-77] (mapv argmax rows)) results))

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -132,9 +132,11 @@
   (let [scheduled (product/schedule (argmax-segred) options)
         kernel (:body scheduled)
         kind #(.getSimpleName (class %))
-        loop-op (first (:operations kernel))
+        reduction-operations (get-in kernel [:operations 1 :then-operations])
+        loop-op (first reduction-operations)
         tree-branches (filter #(and (= "IfRegion" (kind %))
-                                    (not= :product-writer (:condition %))) (:operations kernel))]
+                                    (not= :product-writer (:condition %))) reduction-operations)]
+    (is (= :product-active (get-in kernel [:operations 1 :condition])))
     (is (= [:float :int] (mapv (comp :type :binding) (:iter-args loop-op))))
     (is (= [:float :int] (mapv :dtype (:allocations kernel))))
     (is (= ['indices] (mapv :id (filter #(= :output (:kind %)) (:parameters kernel))))
@@ -144,7 +146,7 @@
       (is (= ["ScalarStore" "ScalarStore" "Yield"]
              (mapv kind (take-last 3 (:then-operations branch)))))
       (is (not-any? #(= "WorkgroupBarrier" (kind %)) (:then-operations branch))))
-    (is (= 6 (count (filter #(= "WorkgroupBarrier" (kind %)) (:operations kernel)))))
+    (is (= 6 (count (filter #(= "WorkgroupBarrier" (kind %)) reduction-operations))))
     (is (false? (get-in scheduled [:attributes :source-storage-certified?])))))
 
 (deftest invalid-neutral-or-unretained-address-width-is-rejected
@@ -162,7 +164,7 @@
 
 (deftest source-product-grid-is-the-actual-segment-schedule
   (doseq [source [(argmax-segred) (typed-argmax-segred)]]
-    (is (= 'nrows (get-in source [:grid :num-blocks])))
+    (is (= '(max 1 nrows) (get-in source [:grid :num-blocks])))
     (doseq [[field bad] [[:num-blocks 'width] [:block-size 64] [:shared-mem-bytes 128]]]
       (try
         (product/schedule (assoc-in source [:grid field] bad) options)
@@ -176,10 +178,14 @@
         candidate (product/schedule source options)]
     (is (= candidate (product/validate-source! candidate source options)))
     (doseq [forged [(assoc-in candidate [:numerics :policy] :different-tree)
-                    (assoc-in candidate [:body :operations 0 :upper]
+                    (assoc-in candidate [:body :operations 1 :then-operations 0 :upper]
                               (body/index-cast 0 :long :exact))
-                    (assoc-in candidate [:body :operations 0 :iter-args 1 :initial]
-                              (body/literal 0 :int))]]
+                    (assoc-in candidate [:body :operations 1 :then-operations 0 :iter-args 1 :initial]
+                              (body/literal 0 :int))
+                    (assoc-in candidate [:body :operations 0 :expression :arguments 1]
+                              (body/literal 0 :long))
+                    (assoc-in candidate [:body :launch :group-count]
+                              [(launch/runtime-value '_n_bound)])]]
       (try
         (product/validate-source! forged source options)
         (is false "a well-typed but different computation must not retain the source witness")
@@ -299,7 +305,7 @@
       (let [artifact (target/emit-artifact "long_product" candidate dialect)]
         (is (= [:long :long :long]
                (mapv :kernel-dtype (filter #(= :scalar (:kind %)) (:abi artifact)))))))
-    (is (= :long (get-in candidate [:body :operations 0 :index :type])))
+    (is (= :long (get-in candidate [:body :operations 1 :then-operations 0 :index :type])))
     (is (= :int (get-in candidate [:body :parameters 1 :dtype]))
         "dimension width does not change the winning-index component representation")
     (let [artifact (target/emit-artifact "long_product_range" candidate :opencl-portable)


### PR DESCRIPTION
Stacked on #388.

## Summary
- Represent empty product domains with max(1, rows) physical groups and a uniform guard enclosing all reduction loads, work, barriers, and stores.
- Align the retained source grid, source-reference launch, and KernelBody launch.
- Replay rejects changed guards or launch relationships.
- Actually execute zero-row CPU OpenCL kernels and verify all independently poisoned outputs stay untouched.

## Validation
- Product/source/CPU device: 23 tests, 145 assertions passed.
- Typed frontend: 46 tests, 202 assertions passed.
- Read-only review found no blocker.
- Full suite and vendor compile gates run in CI.

This is a no-op over existing resident buffers, not zero-byte device allocation or graph-node launch elision. Product production migration remains tracked separately.