### PR TITLE
Bound typed AxisMap arithmetic before affine normalization

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -33,6 +33,11 @@ vertical. The north star remains the architectural specification.
   a separate, potentially stricter contract.
 - Select the certified body and delete the old product algorithm emitter once its coverage is
   replaced. Keep necessary target instruction lowering.
+- Typed access follow-up extends the existing AxisMap relation with a bounded conditional
+  intermediate-range proof over KernelBody indices. Exact polynomial coefficients prevent host
+  overflow; every add/multiply subtree is checked before affine normalization. The proof assumes
+  active positive axis domains and checked resident capacity; deriving those access requirements
+  from scalar lowering and enforcing them in graph binding remain production obligations.
 
 Exit: public product workloads use the typed route without reconstructed facts or source assembly.
 

--- a/src/raster/compiler/ir/axis_map.clj
+++ b/src/raster/compiler/ir/axis_map.clj
@@ -20,7 +20,8 @@
    Extents may be numbers or symbols; index expressions fold to constants when everything is
    literal and stay symbolic otherwise."
   (:refer-clojure :exclude [shape])
-  (:require [raster.compiler.core.op-descriptor :as od]))
+  (:require [raster.compiler.core.op-descriptor :as od]
+            [raster.compiler.ir.kernel-launch :as launch]))
 
 ;; ── construction ────────────────────────────────────────────────────────────────────
 (defn of-axes
@@ -151,13 +152,22 @@
 ;;
 ;; `axes` is required because `(* i k)` is ambiguous without it — axis × extent, or axis × axis.
 ;; Symbols in `axes` are atoms; every other symbol is a coefficient factor.
+(def ^:private ^:dynamic *polynomial-term-limit* nil)
+
+(defn- bounded-polynomial [p]
+  (when (and *polynomial-term-limit* (> (count p) *polynomial-term-limit*))
+    (throw (ex-info "axis-map proof budget exhausted" {:reason ::proof-budget})))
+  p)
+
 (defn- p* [a b]
   (reduce (fn [acc [sa ca]]
             (reduce (fn [acc [sb cb]]
-                      (update acc (vec (sort-by str (concat sa sb))) (fnil + 0) (* ca cb)))
+                      (bounded-polynomial
+                       (update acc (vec (sort-by str (concat sa sb))) (fnil +' 0) (*' ca cb))))
                     acc b))
           {} a))
-(defn- p+ [a b] (into {} (remove (comp zero? val)) (merge-with + a b)))
+(defn- p+ [a b]
+  (bounded-polynomial (into {} (remove (comp zero? val)) (merge-with +' a b))))
 (def ^:private p-one {[] 1})
 
 (defn affine
@@ -199,7 +209,9 @@
                                      {::one p-one} args)
                     :else {(opaque e) p-one}))
                 :else {(opaque e) p-one}))]
-    (some->> (aff e) (into {} (remove (comp empty? val))))))
+    (some->> (aff e)
+             (map (fn [[atom coefficients]] [atom (p+ coefficients {})]))
+             (into {} (remove (comp empty? second))))))
 
 (defn index=
   "Do two index expressions denote the same element for all values of `axes`? The single index
@@ -213,6 +225,88 @@
    an operand's layout if the operand's actual index provably IS that layout."
   [amap idx-expr]
   (index= idx-expr (index-expr amap) (axes amap)))
+
+(defn bounded-typed-index-matches?
+  "Conservatively prove a typed index implements this AxisMap without intermediate overflow.
+
+  CONDITIONAL proof: at the access, each axis must be in [0, extent), all extents must be
+  positive, and the checked mathematical product of extents must fit signed long and the
+  resident buffer. Callers must establish those execution/binding premises separately. This
+  function does not certify a graph, pointer, guard, or arbitrary source expression.
+
+  Accepts exact integral widenings and long add/multiply only; `leaf-dtype` supplies retained
+  types. The existing affine relation establishes layout equality. Before normalization can
+  erase arithmetic, every subtree is bounded by capacity. Bounds use the same polynomial
+  algebra with extent = 1 + nonnegative slack; nonnegative difference coefficients suffice.
+  A fixed structural/polynomial budget or an unsupported case returns false."
+  [amap expression leaf-dtype]
+  (binding [*polynomial-term-limit* 64]
+    (try
+      (let [pairs (vec (take 17 (mapcat identity (take 17 (:groups amap)))))
+            axis-extents (into {} pairs)
+            extents (mapv second pairs)
+            extent-symbols (set (filter symbol? extents))
+            decline! (fn [] (throw (ex-info "unsupported typed axis-map proof"
+                                          {:reason ::proof-decline})))
+            visited (volatile! 0)]
+        (when-not (and (<= 1 (bounded-count 17 (:groups amap)) 16)
+                       (every? seq (:groups amap))
+                       (<= 1 (count pairs) 16)
+                       (every? #(and (vector? %) (= 2 (count %)) (symbol? (first %))) pairs)
+                       (= (count pairs) (count axis-extents))
+                       (not-any? extent-symbols (keys axis-extents))
+                       (every? #(or (symbol? %)
+                                    (and (integer? %) (<= 1 % Long/MAX_VALUE))) extents))
+          (decline!))
+        ;; Bound the tree BEFORE the recursive type validator or affine normalization sees it.
+        (letfn [(check-tree! [x]
+                  (when (> (vswap! visited inc) 128) (decline!))
+                  (cond
+                    (launch/index-expr? x)
+                    (do (when-not (contains? #{:add :mul} (:op x)) (decline!))
+                        (doseq [a (:arguments x)] (check-tree! a)))
+                    (launch/index-cast? x) (check-tree! (:argument x))
+                    (symbol? x) (when-not (or (contains? axis-extents x)
+                                              (extent-symbols x)) (decline!))
+                    (integer? x) (when-not (<= 0 x Long/MAX_VALUE) (decline!))
+                    :else (decline!)))
+                (extent-poly [e]
+                  (if (symbol? e) {[] 1 [e] 1} {[] e}))
+                (nonnegative-difference? [a b]
+                  (every? (comp (complement neg?) val)
+                          (p+ a (into {} (map (fn [[k v]] [k (-' v)])) b))))]
+          (check-tree! expression)
+          (launch/validate-typed-expression! expression leaf-dtype)
+          ;; Extents omitted from the index (e.g. outermost rows) still require retained types.
+          (doseq [e extent-symbols] (launch/validate-typed-expression! e leaf-dtype))
+          (let [capacity (reduce p* p-one (map extent-poly extents))]
+            ;; The constant coefficient is capacity's minimum in the positive domain.
+            ;; If it cannot fit, no runtime binding can satisfy the proof's premise.
+            (when (> (get capacity [] 0) Long/MAX_VALUE) (decline!))
+            (letfn [(visit [x]
+                      (let [[source upper]
+                            (cond
+                              (integer? x) [x {[] x}]
+                              (symbol? x)
+                              [x (if-let [e (get axis-extents x)]
+                                   (p+ (extent-poly e) {[] -1})
+                                   (extent-poly x))]
+                              (launch/index-cast? x) (visit (:argument x))
+                              :else
+                              (do
+                                (when-not (= :long (launch/typed-expression-dtype x leaf-dtype))
+                                  (decline!))
+                                (let [args (mapv visit (:arguments x))
+                                      multiply? (= :mul (:op x))]
+                                  [(cons (if multiply? '* '+) (map first args))
+                                   (reduce (if multiply? p* p+)
+                                           (if multiply? p-one {}) (map second args))])))]
+                        (when-not (nonnegative-difference? capacity upper) (decline!))
+                        [source upper]))]
+              (let [[source upper] (visit expression)]
+                (and (nonnegative-difference? (p+ capacity {[] -1}) upper)
+                     (index-matches? amap source)))))))
+      (catch clojure.lang.ExceptionInfo _ false))))
 
 (defn transposed-2d?
   "True when `to` is `from` with its two groups swapped (the 2-D transpose case a physical

--- a/test/raster/compiler/ir/axis_map_test.clj
+++ b/test/raster/compiler/ir/axis_map_test.clj
@@ -3,7 +3,73 @@
    Covers the cases that used to be ad-hoc special cases (:nn/:nt, transposed output) plus the
    ones that were not expressible at all (merge/split, broadcast, diagonal, batch)."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.ir.axis-map :as am]))
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.kernel-body :as kb]))
+
+(deftest typed-index-proof-checks-intermediates-before-normalizing
+  (let [layout (am/of-axes '[[row rows] [col width]])
+        types {'row :int 'col :long 'rows :long 'width :long}
+        row (kb/index-cast 'row :long :exact)
+        wide #(kb/index-cast % :long :exact)
+        add #(apply kb/expression :add %&)
+        mul #(apply kb/expression :mul %&)
+        index (add (mul row 'width) 'col)
+        accepts? #(am/bounded-typed-index-matches? layout % types)]
+    (is (accepts? index))
+    (is (accepts? (add 'col (mul 'width row))))
+    (is (accepts? (add (wide 0) index)))
+    (is (not (accepts? (add index (wide 1)))) "strict final bound")
+    (is (not (accepts? (add (mul row 'rows) 'col))))
+    (is (not (accepts? (kb/index-cast index :int :exact))))
+    (is (not (accepts? (add (mul 'row 'width) 'col))) "mixed widths are not inferred")
+    (doseq [unsafe [(add index (mul (mul Long/MAX_VALUE Long/MAX_VALUE) (wide 0)))
+                    (add index (wide -1) (wide 1))
+                    (add index (mul (mul 'width 'width) (wide 0)))
+                    (add index (mul 'unknown (wide 0)))
+                    (kb/expression :mod index 'width)]]
+      (is (not (accepts? unsafe)))))
+  (let [types {'i :int 'n :int}]
+    (is (not (am/bounded-typed-index-matches?
+              (am/of-axes '[[i n]]) (kb/expression :add 'i 0) types)))
+    (is (am/bounded-typed-index-matches? (am/of-axes '[[i n]]) 'i types))))
+
+(deftest typed-index-proof-shares-axis-map-algebra
+  (let [types (zipmap '[b i j B M N] (repeat :long))
+        mul #(apply kb/expression :mul %&)
+        add #(apply kb/expression :add %&)
+        index (add (mul 'b (mul 'M 'N)) (mul 'i 'N) 'j)]
+    (is (am/bounded-typed-index-matches?
+         (am/of-groups '[[[b B]] [[i M] [j N]]]) index types))
+    (is (am/bounded-typed-index-matches?
+         (am/of-axes '[[i N] [j N]]) (add (mul 'i 'N) 'j) types))
+    (is (am/bounded-typed-index-matches?
+         (am/of-axes '[[i 4] [j 8]])
+         (add (mul 'i (kb/index-cast 8 :long :exact)) 'j) types))
+    (doseq [layout [(am/of-axes '[[i N] [i N]])
+                    (am/of-axes '[[i i]])
+                    (am/of-axes '[[i 0]])
+                    (am/of-axes '[[i -1]])
+                    (am/of-axes '[[i (+ N 1)]])]]
+      (is (not (am/bounded-typed-index-matches? layout 'i types))))
+    (is (not (am/bounded-typed-index-matches?
+              (am/of-axes '[[i N]])
+              (reduce (fn [x _] (add x (kb/index-cast 0 :long :exact))) 'i (range 130))
+              types)))
+    (is (not (am/bounded-typed-index-matches?
+              (am/of-axes '[[i missing]]) 'i types)))
+    (is (not (am/bounded-typed-index-matches?
+              (am/of-groups [[['i Long/MAX_VALUE] ['j 2]]])
+              (add (mul 'i (kb/index-cast 2 :long :exact)) 'j) types)))
+    (is (not (am/bounded-typed-index-matches?
+              {:groups (repeat [['i 'N]])} 'i types)))
+    (is (not (am/bounded-typed-index-matches?
+              {:groups [(repeat ['i 'N])]} 'i types)))))
+
+(deftest exact-affine-coefficients-and-zero-normalization
+  (is (am/index= '(+ i 0) 'i '[i]))
+  (is (am/index= (list '* 'i Long/MAX_VALUE Long/MAX_VALUE)
+                 (list '* (*' Long/MAX_VALUE Long/MAX_VALUE) 'i) '[i]))
+  (is (not (am/index= (list '* 'i Long/MAX_VALUE Long/MAX_VALUE) 'i '[i]))))
 
 (deftest plain-row-major-index
   (testing "A[i,l] over [M K] → i*K + l"


### PR DESCRIPTION
Extends the existing AxisMap algebra with a conservative typed intermediate-range proof. Preserves exact casts and retained leaf types; rejects arithmetic that only becomes safe after simplification. Exact polynomial coefficients and fixed proof budgets. This is conditional on active axis domains and checked resident capacity, not production admission by itself.\n\nFocused REPL: 30 tests, 179 assertions passed (AxisMap, contraction facts, index algebra). Product candidate tests also passed before the final robustness-only changes. Read-only review found no soundness blocker; bounded collection and impossible literal-capacity cases were added following review. Full suite and vendor gates delegated to CI. Stacked on #389.