### PR TITLE
Derive product graph capacities from shared typed region lowering

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -38,6 +38,12 @@ vertical. The north star remains the architectural specification.
   overflow; every add/multiply subtree is checked before affine normalization. The proof assumes
   active positive axis domains and checked resident capacity; deriving those access requirements
   from scalar lowering and enforcing them in graph binding remain production obligations.
+- Read-requirement follow-up shares product scalar-region lowering with scheduling and derives
+  flat minimum capacities from actual typed dense loads, without invented input shapes. The
+  graph preserves larger declared capacities and combines shared-storage requirements; existing
+  checked resident/staged binding enforces graph capacities. Gathers, broadcasts and combine
+  reads remain unsupported by this initial access proof. Production selection still requires
+  successful access admission in addition to exact source/body/graph correspondence.
 
 Exit: public product workloads use the typed route without reconstructed facts or source assembly.
 

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -8,40 +8,23 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.numeric-constant :as constant]
-            [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.index-expression :as index]
-            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
-            [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
+            [raster.compiler.passes.parallel.product-reduction-regions :as regions]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]))
 
 (defn- decline! [rule message data]
   (throw (ex-info message (assoc data :reason :product-kernel-body-declined
                                  :missing-rule rule :fallback :none))))
 
-(defn- region-binding-types
-  "Read retained TypedSOAC local tags. Explicit candidate facts may fill omissions, not override."
-  [region supplied]
-  (reduce (fn [facts id]
-            (if-let [retained (some-> (types/sym-type-tag id) dtype/dtype-for-scalar-tag)]
-              (do
-                (when (and (get supplied id) (not= retained (get supplied id)))
-                  (decline! :binding-dtype-conflict
-                            "candidate binding dtype disagrees with its retained source type"
-                            {:binding id :retained retained :supplied (get supplied id)}))
-                (assoc facts id retained))
-              facts))
-          (or supplied {}) (take-nth 2 (:bindings region))))
-
 (defn lower
   "Lower one row-segmented SegRed with retained input shapes and scalar/region binding dtypes.
    Address arithmetic must already carry the long-width facts required by lower-typed."
-  [segred {:keys [array-types array-shapes scalar-types
-                 element-binding-types combine-binding-types]}]
+  [segred {:keys [array-types array-shapes scalar-types] :as options}]
   (when-not (instance? raster.compiler.ir.segop.SegRed segred)
     (decline! :source "product body requires a retained SegRed" {:source segred}))
   (let [operator (reduction/validate! (:reduction segred))
@@ -53,10 +36,6 @@
         {row :name rows :bound} (first segments)
         {column :name width :bound} (segop/seg-space-reduced-dim (:space segred))
         components (:components operator)
-        element-binding-types (region-binding-types (reduction/element-region operator)
-                                                     element-binding-types)
-        combine-binding-types (region-binding-types (reduction/combine-region operator)
-                                                     combine-binding-types)
         types (mapv :dtype components)
         wg (:workgroup-size source-schedule)
         scratch-bytes (* wg (reduce + (map dtype/bytes-of types)))
@@ -102,13 +81,7 @@
               (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
                    scalars)
               [(body/->KernelParameter '_n_bound :scalar rows-type [] nil nil :bound)]))
-        index-types (assoc scalar-types row :int column :long)
-        lower-index (fn [expression locals]
-                      (index/lower-typed expression (set/union (set (keys index-types)) locals)
-                                         index-types :long decline!))
-        lowerer (scalar/make-lowerer
-                 {:arrays (set inputs) :array-types array-types :scalar-types scalar-types
-                  :lower-index lower-index :id-prefix "product" :decline! decline!})
+        {:keys [element combine lower-index]} (regions/lower segred options decline!)
         neutrals (mapv (fn [{:keys [neutral dtype]}]
                          (if-let [evidence (constant/value neutral)]
                            (body/literal (:value evidence) dtype)
@@ -118,18 +91,6 @@
         carries (ids "product-carry")
         lane-results (ids "product-lane-result")
         scratches (ids "product-scratch")
-        combine-region (reduction/combine-region operator)
-        combine
-        (fn [left right]
-          (let [replacements (into {} (mapcat (fn [[l r] lv rv] [[l lv] [r rv]])
-                                              (:parameters combine-region) left right))
-                region (-> combine-region
-                           (update :bindings #(util/subst-syms replacements %))
-                           (update :results #(util/subst-syms replacements %)))
-                env (into {} (concat (map vector left types) (map vector right types)))]
-            ((:lower-region lowerer) region types combine-binding-types env)))
-        element ((:lower-region lowerer) (reduction/element-region operator) types
-                 element-binding-types index-types)
         lane-update (combine carries (:results element))
         barrier #(body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
                                           (body/full-participation))
@@ -247,9 +208,9 @@
 (defn graph-options
   "Derive candidate storage/type facts from an exact retained graph projection.
 
-   Unknown input capacities are not dense-access evidence. This deliberately declines them,
-   rather than inventing rows*width for arbitrary indexed reads. Shapes describe flat physical
-   storage; this is not an index-bounds proof."
+   Unknown input capacities are not dense-access evidence. The graph may refine them from
+   actual typed loads; otherwise this declines rather than inventing rows*width. Shapes describe
+   minimum flat physical storage; this is not an independent index-bounds proof."
   [node kernel-graph algorithm scheduled-body]
   (equation-graph/validate-projection! kernel-graph algorithm scheduled-body)
   (when-not (some #(= node %) (:nodes kernel-graph))

--- a/src/raster/compiler/passes/parallel/product_reduction_regions.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_regions.clj
@@ -1,0 +1,90 @@
+(ns raster.compiler.passes.parallel.product-reduction-regions
+  "Shared typed scalar lowering for product scheduling and source-derived read requirements.
+   No physical shape is invented to lower a region; storage admission is a separate obligation."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.types :as types]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.index-expression :as index]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
+
+(defn- binding-types [region supplied decline!]
+  (reduce (fn [facts id]
+            (if-let [retained (some-> (types/sym-type-tag id) dtype/dtype-for-scalar-tag)]
+              (do
+                (when (and (get supplied id) (not= retained (get supplied id)))
+                  (decline! :binding-dtype-conflict
+                            "candidate binding dtype disagrees with its retained source type"
+                            {:binding id :retained retained :supplied (get supplied id)}))
+                (assoc facts id retained))
+              facts))
+          (or supplied {}) (take-nth 2 (:bindings region))))
+
+(defn lower
+  "Lower element once and provide a shared combine lowerer with deterministic fresh SSA IDs.
+   The caller supplies its decline mechanism and retained array/scalar/local dtype facts."
+  [segred {:keys [array-types scalar-types element-binding-types combine-binding-types]} decline!]
+  (let [operator (reduction/validate! (:reduction segred))
+        segments (segop/seg-space-segment-dims (:space segred))
+        _ (when-not (= 1 (count segments))
+            (decline! :segment-rank "product region requires one row axis" {:segments segments}))
+        {row :name rows :bound} (first segments)
+        {column :name width :bound} (segop/seg-space-reduced-dim (:space segred))
+        types (mapv :dtype (:components operator))
+        index-types (assoc scalar-types row :int column :long)
+        lower-index (fn [expression locals]
+                      (index/lower-typed expression (set/union (set (keys index-types)) locals)
+                                         index-types :long decline!))
+        lowerer (scalar/make-lowerer
+                 {:arrays (set (:inputs segred)) :array-types array-types :scalar-types scalar-types
+                  :lower-index lower-index :id-prefix "product" :decline! decline!})
+        element-region (reduction/element-region operator)
+        combine-region (reduction/combine-region operator)
+        element-types (binding-types element-region element-binding-types decline!)
+        combine-types (binding-types combine-region combine-binding-types decline!)
+        combine (fn [left right]
+                  (let [replacements (into {} (mapcat (fn [[l r] lv rv] [[l lv] [r rv]])
+                                                      (:parameters combine-region) left right))
+                        region (-> combine-region
+                                   (update :bindings #(util/subst-syms replacements %))
+                                   (update :results #(util/subst-syms replacements %)))
+                        env (into {} (concat (map vector left types) (map vector right types)))]
+                    ((:lower-region lowerer) region types combine-types env)))]
+    {:element ((:lower-region lowerer) element-region types element-types index-types)
+     :combine combine :lower-index lower-index :index-types index-types
+     :axes [[row rows] [column width]]}))
+
+(defn dense-read-requirements
+  "Derive minimum flat capacities from the actual typed element loads, or decline.
+
+   Initially every input load must implement the full row/column AxisMap. Gather, narrower
+   broadcasts, computed SSA coordinates and combine-time reads are not silently called dense.
+   This returns required capacities, not actual allocation sizes or an execution certificate.
+   The row guard and column loop must establish active domains when the body is scheduled."
+  [segred options decline!]
+  (let [{:keys [element combine index-types axes]} (lower segred options decline!)
+        layout (axis-map/of-axes axes)
+        loads (fn [operations]
+                (filter #(= "raster.compiler.ir.kernel_body.ScalarLoad" (some-> % class .getName))
+                        (tree-seq coll? seq operations)))
+        element-loads (loads (:operations element))
+        ;; The tree combine also executes when width=0, so element-domain premises do not
+        ;; justify any of its external reads. Inspect its lowered operations independently.
+        arity (count (get-in segred [:reduction :components]))
+        combine-region (combine (mapv #(symbol (str "read-left-" %)) (range arity))
+                                (mapv #(symbol (str "read-right-" %)) (range arity)))
+        _ (when (seq (loads (:operations combine-region)))
+            (decline! :combine-read "dense element bounds do not justify combine reads" {}))
+        _ (doseq [{:keys [buffer coordinates]} element-loads]
+            (when-not (and (= 1 (count coordinates))
+                           (axis-map/bounded-typed-index-matches?
+                            layout (first coordinates) index-types))
+              (decline! :dense-read-index
+                        "product input does not have a bounded typed dense index"
+                        {:input buffer :coordinates coordinates})))
+        extent (apply launch/product (map second axes))]
+    (into {} (map (fn [{:keys [buffer]}] [buffer extent])) element-loads)))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -10,9 +10,11 @@
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
-            [raster.compiler.passes.parallel.index-expression :as index-expression]))
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
+            [raster.compiler.passes.parallel.product-reduction-regions :as product-regions]))
 
 (defn- fail!
   [reason message data]
@@ -238,6 +240,37 @@
      :elements (value-elements values derived-scalars value)
      :memory-space (or (:memory-space value) :device)}))
 
+(defn- product-read-requirements
+  "Optional minimum capacities from typed product loads, never guessed from loop size alone."
+  [values operations derived-scalars]
+  (reduce
+   (fn [requirements operation]
+     (if (and (reduction/product-reduction? (:reduction operation))
+              (:element (:reduction operation))
+              (every? (fn [id]
+                        (let [value (get values id)]
+                          (and (= {:kind :plain} (:representation value))
+                               (nil? (:logical-layout value)))))
+                      (:inputs operation)))
+       (let [derived
+             (try
+               (product-regions/dense-read-requirements
+                operation
+                {:array-types (into {} (map (fn [[id v]] [id (:dtype v)])) values)
+                 :scalar-types (into {} (keep (fn [[id v]]
+                                               (when (integral-scalar-value? v)
+                                                 [id (:dtype v)]))) values)}
+                (fn [rule message data] (fail! rule message data)))
+               ;; This is an optional refinement. Unsupported source access stays unknown;
+               ;; production admission must independently require a successful access proof.
+               (catch clojure.lang.ExceptionInfo _ nil))]
+         (reduce-kv (fn [result id extent]
+                      (update result id (fnil conj [])
+                              (launch/rebind-expression extent derived-scalars)))
+                    requirements derived))
+       requirements))
+   {} operations))
+
 (defn- algorithm-boundary?
   [equation algorithm]
   (and (= algorithm (soac/validate! algorithm))
@@ -354,6 +387,17 @@
          buffer-specs (into {}
                             (map (fn [id] [id (storage-spec values derived-scalars id)]))
                             (set/union inputs outputs temporary-ids))
+         read-requirements (product-read-requirements values operations derived-scalars)
+         buffer-specs (reduce-kv
+                       (fn [specs id requirements]
+                         (let [extents (vec (distinct
+                                             (cond-> requirements
+                                               (not (unknown-shape? (get values id)))
+                                               (conj (get-in specs [id :elements])))))
+                               required (if (= 1 (count extents)) (first extents)
+                                            (apply launch/maximum extents))]
+                           (assoc-in specs [id :elements] required)))
+                       buffer-specs read-requirements)
          ;; An aliased destination can have unknown capacity while the typed result has a
          ;; precise written extent (e.g. an exclusive scan writes n+1 elements). That semantic
          ;; extent is the required capacity, not a claim about the allocation's full size.
@@ -362,7 +406,12 @@
                          (if-let [extent (and (contains? specs id)
                                               (unknown-shape? (get values id))
                                               (required-write-extent values derived-scalars result-values))]
-                           (assoc-in specs [id :elements] extent)
+                           (assoc-in specs [id :elements]
+                                     (if (contains? read-requirements id)
+                                       (let [read-extent (get-in specs [id :elements])]
+                                         (if (= read-extent extent) extent
+                                             (launch/maximum read-extent extent)))
+                                       extent))
                            specs))
                        buffer-specs result-storage-values)
          scalars (public-scalars scheduled operations buffer-specs)]

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -13,6 +13,7 @@
             [raster.compiler.ir.reduction-test :as fixtures]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.product-reduction-body :as product]
+            [raster.compiler.passes.parallel.product-reduction-regions :as regions]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
@@ -253,23 +254,73 @@
       (catch clojure.lang.ExceptionInfo e
         (is (= :graph-node (:missing-rule (ex-data e))))))))
 
-(deftest unknown-product-input-storage-is-not-assumed-dense
-  (let [{:keys [algorithm body graph node]} (graph-context false)]
-    (try
-      (product/graph-options node graph algorithm body)
-      (is false "unknown capacity cannot be replaced by rows*width for an indexed read")
-      (catch clojure.lang.ExceptionInfo e
-        (is (= :graph-input-extent (:missing-rule (ex-data e))))))))
+(deftest unknown-product-input-storage-is-refined-from-typed-loads
+  (let [{:keys [algorithm body graph node]} (graph-context false)
+        options (product/graph-options node graph algorithm body)
+        candidate (product/schedule (:operation node) options)]
+    (is (= [(launch/product 'nrows 'width)] (get-in options [:array-shapes 'values])))
+    (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
+    (is (true? (get-in candidate [:attributes :candidate-only])))))
 
 (deftest graph-capacity-is-not-an-index-safety-certificate
   (let [{:keys [algorithm body graph node]} (graph-context true {:shape [1]})
         candidate (product/schedule (:operation node)
                                     (product/graph-options node graph algorithm body))]
-    ;; The source's row-major read may exceed this capacity for runtime rows/width > 1.
-    ;; Do not execute it: correspondence preserves that source, it does not prove it safe.
+    ;; Required storage is now the maximum of the AV contract and the proven dense read.
+    ;; This still does not authorize production or bypass the runtime buffer-capacity check.
+    (is (= (launch/maximum (launch/product 'nrows 'width) 1)
+           (get-in graph [:inputs 0 :elements])))
     (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
     (is (true? (get-in candidate [:attributes :candidate-only])))
     (is (false? (get-in candidate [:attributes :source-storage-certified?])))))
+
+(deftest derived-read-capacity-is-a-checked-minimum
+  (doseq [shape [[1] [4096]]]
+    (let [{:keys [graph]} (graph-context true {:shape shape})
+          required (get-in graph [:inputs 0 :elements])]
+      (is (= (max (first shape) 12)
+             (launch/resolve-expression {'nrows 3 'width 4} required)))
+      (is (= (first shape)
+             (launch/resolve-expression {'nrows 0 'width 4} required)))
+      (is (thrown? ArithmeticException
+                   (launch/resolve-expression {'nrows Long/MAX_VALUE 'width 2} required))))))
+
+(deftest shared-product-input-keeps-every-derived-read-requirement
+  (let [{:keys [body node]} (graph-context false)
+        source (:operation node)
+        second-source (assoc-in source [:space :dims 0 :bound] 'more-rows)
+        values (assoc (:values body) 'more-rows (get-in body [:values 'nrows]))
+        derive (ns-resolve 'raster.compiler.passes.parallel.scheduled-equation-graph
+                           'product-read-requirements)
+        requirements (derive values [source second-source]
+                             {'more-rows (launch/sum 'nrows 1)})]
+    (is (= [(launch/product 'nrows 'width)
+            (launch/product (launch/sum 'nrows 1) 'width)]
+           (get requirements 'values)))
+    (is (= 16 (launch/resolve-expression {'nrows 3 'width 4}
+                                         (apply launch/maximum (get requirements 'values)))))))
+
+(deftest typed-read-requirements-do-not-assume-every-access-is-dense
+  (let [source (typed-local-address-segred)
+        decline! (fn [rule message data] (throw (ex-info message (assoc data :rule rule))))
+        derive #(regions/dense-read-requirements % options decline!)
+        change-load (fn [coordinate]
+                      (assoc-in source [:reduction :element :bindings 3]
+                                (list 'clojure.core/aget 'values coordinate)))]
+    (is (= {'values (launch/product 'nrows 'width)} (derive source)))
+    (is (= (derive source) (regions/dense-read-requirements source
+                                                          (dissoc options :array-shapes) decline!))
+        "lowering does not need a fabricated shape")
+    (doseq [coordinate ['offset 0
+                        '(clojure.core/aget indices col)]]
+      (is (thrown? clojure.lang.ExceptionInfo (derive (change-load coordinate)))))
+    (let [with-combine-read
+          (assoc-in source [:reduction :combine :results 0]
+                    '(clojure.core/aget values 0))]
+      (try (derive with-combine-read)
+           (is false "combine reads execute outside the positive element domain")
+           (catch clojure.lang.ExceptionInfo e
+             (is (= :combine-read (:rule (ex-data e)))))))))
 
 (deftest logical-representations-must-be-lowered-before-raw-product-storage
   (doseq [storage-options [{:representation {:kind :quantized :scheme :q4-k}}


### PR DESCRIPTION
Shares typed product region lowering between scheduling and read-capacity analysis. Derives required flat capacities from actual typed dense loads, without fabricated shapes; preserves larger declared capacities and combines shared-storage requirements. Gathers, broadcasts and combine-time reads conservatively decline. Production selection remains separate and is the next slice.

Validation: 18 focused tests / 107 assertions including CPU OpenCL differential execution. Adjacent emitted-graph and fold-map checks passed in a 37-test / 216-assertion run before the final additional capacity regressions. Read-only review found no blocker. Full suite and vendor gates delegated to CI. Stacked on #390.