### PR TITLE
Emit certified row products through the common KernelBody graph vertical

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -443,28 +443,32 @@ now proves direct analyzed-source-to-TypedSOAC routing, typed schedule reuse and
 fallback. Subgroup/shuffle and multi-workgroup alternatives remain schedule candidates, not new
 semantic primitives.
 
-The product workgroup schedule still uses its source emitter; migrating it to KernelBody must
-preserve the simultaneous tuple update, hidden components, independent dtypes and logical ABI.
+The dense row-product workgroup schedule now uses KernelBody through the common graph emitter,
+preserving simultaneous tuple updates, hidden components, independent dtypes and logical ABI.
 The shared scalar lowerer now accepts ordered multi-result regions with explicit retained binding
 types: each local is lowered once to SSA and shared across results, without inferring its type from
-a consuming component. The candidate `product-reduction-body` now expresses lane folds, a fixed
+a consuming component. `product-reduction-body` expresses lane folds, a fixed
 workgroup tree and final stores with typed carries, independent scratch allocations and shared
 scalar/control target emission. Its mixed float/int argmax fixture is compared against both the
 retained emitter and a host oracle on CPU OpenCL (empty/short/tail rows, ties, NaNs and infinities),
 and joins the hardware-free CUDA/HIP compile gates. This is not a throughput benchmark.
 
-It is deliberately not yet a production route: it accepts one segment axis, integral int/long row/column
+The initial production subset accepts one segment axis, integral int/long row/column
 bounds, retained region-binding types and long-width address expressions. TypedSOAC local dtypes
 now survive SegRed projection and scalar SSA substitution, so computed local address bindings and
 typed integral constants use those same facts rather than a reconstructed type map. Contradictory
 candidate overrides decline. Caller-supplied storage shapes are not a source/storage
-certificate (`:source-storage-certified? false`). Exact graph/source/body storage correspondence is
-available for retained plain capacities; unknown indexed input requirements still need derivation.
+certificate (`:source-storage-certified? false`). Production admission additionally replays the exact
+graph/source/body projection, derives dense read minima from the same typed scalar lowering, and
+checks that graph capacities cover those minima. Unsupported gathers, broadcasts, combine reads
+and unlowered storage layouts decline; known capacity alone is not access evidence. Graph binding
+checks capacities before submission on session, staged and direct descriptor-step paths.
 Zero-row kernels use one physical group with a uniform guard around all computation, barriers and
 stores; zero-width rows produce the neutral tuple. This is a no-op over existing resident storage,
-not graph-node elision or support for allocating zero-byte device buffers. Next: close the remaining
-storage and public-binding obligations over the public
-TypedSOAC route, switch only certified candidates, then delete the retained source emitter.
+not graph-node elision or support for allocating zero-byte device buffers. Public argmax uses the
+common executable binder; effect-only staging copies all writes and returns nil explicitly. The
+public equation-first workload joins CUDA/HIP compilation gates. Next: finish the coverage audit
+and retire the retained source emitter, which is now only a differential/test oracle.
 The retained product `KernelGrid` now describes its actual guarded segment-count launch and tuple scratch,
 not the scalar width-reduction grid formerly used only to seed workgroup sizing. The candidate
 checks that grid against the selected tree. `validate-source!` additionally replays the body and

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -44,6 +44,13 @@ vertical. The north star remains the architectural specification.
   checked resident/staged binding enforces graph capacities. Gathers, broadcasts and combine
   reads remain unsupported by this initial access proof. Production selection still requires
   successful access admission in addition to exact source/body/graph correspondence.
+- Production follow-up admits dense row products through that combined check and the common
+  C-family graph emitter. Public resident extraction uses the existing executable convention;
+  effect-only staging has an explicit nil result policy, including multiple written outputs.
+  Direct descriptor graph binding now enforces the same capacity premise as session/LinkPlan
+  binding. Hidden/multiple outputs are checked across all three target dialects; public argmax
+  has resident and staged CPU OpenCL numerical coverage. The handwritten emitter remains only
+  as the differential/test oracle pending its final retirement and coverage transfer.
 
 Exit: public product workloads use the typed route without reconstructed facts or source assembly.
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -363,6 +363,14 @@
           (mapv :value user-scalars)
           (:value (first bound-entries)))))
 
+(defn- graph-reduction-equation? [equation]
+  (and (seq (:operations equation))
+       (every? #(and (instance? raster.compiler.ir.segop.SegRed %)
+                     (or (= :product (:phase %))
+                         (and (empty? (segop/seg-space-segment-dims (:space %)))
+                              (reduction/scalar? (:reduction %)))))
+               (:operations equation))))
+
 (defn opencl-pass
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
@@ -448,6 +456,7 @@
                       (:stride (par/extract-par-scatter-info form)))
                  (par/par-reduce-form? form)
                  (par/par-reduce-into-form? form)
+                 (par/par-product-reduce-form? form)
                  (and (croute/par-contract-form? form) (empty? (nth form 2)))
                  ;; A compound source extent normalizes to a preceding typed scalar equation. It
                  ;; cannot be projected as a closed SegMap without losing that SSA definition.
@@ -539,13 +548,18 @@
         (fn emit-scheduled-graph!
           ([scheduled] (emit-scheduled-graph! scheduled nil false))
           ([scheduled stat-key host-scalar-result?]
+           (emit-scheduled-graph! scheduled stat-key host-scalar-result? nil))
+          ([scheduled stat-key host-scalar-result? equation]
           ;; KernelDispatch is already the verified selection value above both a single artifact
           ;; and a graph.  A one-alternative dispatch therefore gives scheduled equations the same
           ;; registry/selection seam as tuned GEMM without introducing a second graph registry.
           ;; Scan is the first graph target-lowering; later graph families extend this backend
           ;; dispatcher rather than adding source/runtime conventions per operation.
           (let [emitted0 (segop-cl/generate-kernel-graph
-                          scheduled :scalar-types top-scalar-types)
+                          scheduled :scalar-types top-scalar-types
+                          :scheduled-equation-algorithm (:algorithm equation)
+                          :scheduled-equation-body
+                          (when equation (equation-graph/body-for-equation parallel-program equation)))
                 emitted (-> emitted0
                             (kgraph/map-operations
                              (fn [node]
@@ -595,8 +609,11 @@
                       (assoc (vec (:arguments emitted)) result-index (list constructor 1)))
                     (vec (:arguments emitted)))
                   invocation
-                  (list 'raster.compiler.pipeline/invoke-scheduled-executable!
-                        device-id (:id dispatch) invocation-arguments)]
+                  (apply list 'raster.compiler.pipeline/invoke-scheduled-executable!
+                         device-id (:id dispatch) invocation-arguments
+                         (when (and (seq (:operations equation))
+                                    (every? #(= :product (:phase %)) (:operations equation)))
+                           [:none]))]
               (if host-scalar-result?
                 (list 'clojure.core/aget invocation 0)
                 invocation)))))
@@ -809,15 +826,11 @@
                     {:reason :scalar-reduction-requires-typed-graph
                      :source form :target-dialect :kernel-graph :fallback :none}))
 
-            ;; Typed segmented product reduction. The portable schedule is one deterministic
-            ;; workgroup tree per segment; mixed result components remain separate ABI buffers.
+            ;; Product reduction uses the same complete graph boundary as scalar reduction.
             (par/par-product-reduce-form? form)
-            (let [segred (par->segred stats form dtype device-id
-                                      top-scalar-types top-array-types)
-                  kernel (segop-cl/generate-product-reduction-kernel
-                          segred :scalar-types top-scalar-types :array-types top-array-types)
-                  k (register-kernel! kernel :ze-reduces)]
-              (emit-map-void-invocation k device-id))
+            (throw (ex-info "product reduction requires its complete TypedSOAC graph"
+                            {:reason :product-reduction-requires-typed-graph
+                             :source form :fallback :none}))
 
             ;; Ordered segmented fold-map. The source spelling is only a host fallback; GPU
             ;; emission must consume the bound TypedSOAC SegFoldMap and its verified KernelBody.
@@ -1006,14 +1019,7 @@
                                                                           [:provenance
                                                                            :source-dialect])))
                                                           scalar-reduction?
-                                                          (and (seq (:operations equation))
-                                                               (every?
-                                                                #(and (instance?
-                                                                       raster.compiler.ir.segop.SegRed %)
-                                                                      (empty? (segop/seg-space-segment-dims (:space %)))
-                                                                      (reduction/scalar?
-                                                                       (:reduction %)))
-                                                                (:operations equation)))]
+                                                          (graph-reduction-equation? equation)]
                                                       (if (and typed-equation?
                                                                (or scalar-reduction?
                                                                    (get-in equation
@@ -1040,7 +1046,8 @@
                                                                              (:operations equation)))
                                                             :ze-reduces)
                                                           (boolean (host-scalar-result?
-                                                                    parallel-program equation))))
+                                                                    parallel-program equation))
+                                                          equation))
                                                        (binding [*bound-segops*
                                                                  (when parallel-program
                                                                    (parallel-program/operations-for-binding
@@ -1068,14 +1075,7 @@
                                                              [:provenance :source-dialect]))
                                                   (= :body (first (:site equation)))))
                                          scalar-reduction?
-                                         (and (seq (:operations equation))
-                                              (every?
-                                               #(and (instance?
-                                                      raster.compiler.ir.segop.SegRed %)
-                                                     (empty? (segop/seg-space-segment-dims (:space %)))
-                                                     (reduction/scalar?
-                                                      (:reduction %)))
-                                               (:operations equation)))]
+                                         (graph-reduction-equation? equation)]
                                      (if (and typed-equation? scalar-reduction?)
                                        (do
                                          (swap! stats update :segop-reused (fnil inc 0))
@@ -1085,7 +1085,8 @@
                                             parallel-program equation))
                                           :ze-reduces
                                           (boolean (host-scalar-result?
-                                                    parallel-program equation))))
+                                                    parallel-program equation))
+                                          equation))
                                        (binding [*bound-segops* (:operations equation)
                                                  *bound-algorithm*
                                                  (when parallel-program

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -34,6 +34,7 @@
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
+            [raster.compiler.passes.parallel.product-reduction-body :as product-body]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
             [raster.compiler.passes.parallel.segscan-body :as segscan-body]
             [raster.compiler.passes.parallel.segstencil-body :as segstencil-body]
@@ -1006,7 +1007,8 @@
 (declare generate-contraction-kernel-artifact)
 
 (defn- generate-reduction-kernel-graph
-  [graph {:keys [scalar-types array-types target-dialect target-device contraction-facts]
+  [graph {:keys [scalar-types array-types target-dialect target-device contraction-facts
+                 scheduled-equation-algorithm scheduled-equation-body]
           :or {scalar-types {} array-types {} target-dialect :opencl-intel
                contraction-facts {}}}]
   (let [array-types (graph-array-types graph array-types)
@@ -1014,7 +1016,13 @@
         (kgraph/map-operations
          graph
          (fn [{:keys [id operation] :as node}]
-           (let [outputs (vec (:outputs operation))]
+           (if (= :product (:phase operation))
+             (kernel-body-target/emit-artifact
+              (str "graph_product_" (gensym ""))
+              (product-body/schedule-for-node node graph scheduled-equation-algorithm
+                                               scheduled-equation-body)
+              target-dialect)
+             (let [outputs (vec (:outputs operation))]
              (when-not (= 1 (count outputs))
                (throw (ex-info "scalar SegRed graph node requires exactly one scheduled output"
                                {:reason :kernel-graph-reduction-output
@@ -1047,7 +1055,7 @@
                 :dtype (:dtype operation)
                 :scalar-types scalar-types :array-types array-types
                 :target-dialect target-dialect
-                :graph-node node :kernel-graph graph)))))]
+                :graph-node node :kernel-graph graph))))))]
     (finalize-emitted-graph
      emitted
      (kernel-body-c-dialect/target (kernel-body-c-dialect/resolve! target-dialect))

--- a/src/raster/compiler/backend/jvm/hoisted.clj
+++ b/src/raster/compiler/backend/jvm/hoisted.clj
@@ -69,9 +69,10 @@
       (.checkcast code target-cd))))
 
 (defn- emit-box
-  "Emit bytecode to box a primitive stack value to Object."
+  "Box a primitive result, or supply nil after a void invocation, for the IFn Object ABI."
   [code stack-type empty-cds]
   (case stack-type
+    :void (.aconst_null code)
     :double (.invokestatic code dbl-box-cd "valueOf"
                            (MethodTypeDesc/of dbl-box-cd (into-array ClassDesc [D-cd])))
     :long (.invokestatic code long-box-cd "valueOf"

--- a/src/raster/compiler/passes/parallel/product_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/product_reduction_body.clj
@@ -263,3 +263,42 @@
                     "product output must retain the exact segment extent and component dtype"
                     {:output result :rows rows :dtype dtype :buffer buffer}))))
     (validate-source! candidate source options)))
+
+(defn schedule-for-node
+  "Admit the deterministic product body through the exact source/graph and typed-access checks.
+   Graph capacities remain runtime preconditions, enforced before resident or staged submission."
+  [node kernel-graph algorithm scheduled-body]
+  (let [options (graph-options node kernel-graph algorithm scheduled-body)
+        source (:operation node)
+        candidate (schedule source options)
+        _ (validate-against-node! candidate node kernel-graph algorithm scheduled-body)
+        requirements (regions/dense-read-requirements source options decline!)
+        scalar-definitions (equation-graph/derived-scalar-expressions
+                            (:values scheduled-body)
+                            (take-while #(true? (get-in % [:attributes :host-only]))
+                                        (:equations scheduled-body)))
+        buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs kernel-graph) (:outputs kernel-graph)
+                              (:temporaries kernel-graph)))
+        covers? (fn covers? [capacity required]
+                  (or (= capacity required)
+                      (and (= "raster.compiler.ir.kernel_launch.Maximum"
+                              (some-> capacity class .getName))
+                           (some #(covers? % required) (:values capacity)))))]
+    ;; Optional graph refinement can decline while scalar lowering later succeeds. Admission
+    ;; must therefore check the resulting capacity, not assume the optional step ran. Exact
+    ;; equality or membership in a checked maximum suffices for this graph projection; do not
+    ;; invent a general symbolic inequality from guessed positivity or stripped casts.
+    (doseq [[id extent] requirements
+            :let [required (launch/rebind-expression extent scalar-definitions)
+                  capacity (:elements (get buffers id))]]
+      (when-not (covers? capacity required)
+        (decline! :graph-read-capacity "product graph does not cover its typed read requirement"
+                  {:input id :required required :capacity capacity})))
+    ;; Replaying graph construction above derives these minima from the same typed loads; it
+    ;; cannot accept a caller annotation in their place. Replaying schedule construction fixes
+    ;; the uniform row guard and positive column-loop domain that justify the access proof.
+    (-> candidate
+        (assoc-in [:legality :read-requirements] requirements)
+        (assoc-in [:attributes :candidate-only] false)
+        (assoc-in [:attributes :source-storage-certified?] true))))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -63,6 +63,11 @@
 (defn- unknown-shape? [value]
   (some #(and (seq? %) (= 'unknown-dimension (first %))) (:shape value)))
 
+(defn- unresolved-capacity? [id value elements]
+  ;; An analyzed array parameter can explicitly name its runtime allocation extent. That is
+  ;; not an independent minimum shape requirement; a proven read/write requirement replaces it.
+  (or (unknown-shape? value) (= elements (list 'extent id))))
+
 (defn- required-write-extent
   "Cover every logical write to shared physical storage; an unknown write prevents refinement."
   [values derived-scalars result-values]
@@ -258,7 +263,7 @@
                 operation
                 {:array-types (into {} (map (fn [[id v]] [id (:dtype v)])) values)
                  :scalar-types (into {} (keep (fn [[id v]]
-                                               (when (integral-scalar-value? v)
+                                               (when (empty? (:shape v))
                                                  [id (:dtype v)]))) values)}
                 (fn [rule message data] (fail! rule message data)))
                ;; This is an optional refinement. Unsupported source access stays unknown;
@@ -392,7 +397,8 @@
                        (fn [specs id requirements]
                          (let [extents (vec (distinct
                                              (cond-> requirements
-                                               (not (unknown-shape? (get values id)))
+                                               (not (unresolved-capacity?
+                                                     id (get values id) (get-in specs [id :elements])))
                                                (conj (get-in specs [id :elements])))))
                                required (if (= 1 (count extents)) (first extents)
                                             (apply launch/maximum extents))]
@@ -404,7 +410,9 @@
          buffer-specs (reduce-kv
                        (fn [specs id result-values]
                          (if-let [extent (and (contains? specs id)
-                                              (unknown-shape? (get values id))
+                                              (unresolved-capacity?
+                                               id (get values id)
+                                               (:elements (storage-spec values derived-scalars id)))
                                               (required-write-extent values derived-scalars result-values))]
                            (assoc-in specs [id :elements]
                                      (if (contains? read-requirements id)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1364,9 +1364,11 @@
 
    The indirection avoids a static pipeline -> gpu.core dependency cycle; resident extraction
    recognizes the same marker and binds its registered dispatch without staging."
-  [device-id dispatch-id arguments]
+  ([device-id dispatch-id arguments]
+   (invoke-scheduled-executable! device-id dispatch-id arguments :single))
+  ([device-id dispatch-id arguments result-policy]
   ((requiring-resolve 'raster.gpu.core/invoke-staged-executable!)
-   device-id dispatch-id arguments))
+   device-id dispatch-id arguments result-policy)))
 
 (def ^:private gpu-alloc-ops
   "Array-allocating ops that appear as devirtualized .invk (not a bare `float-array` head): a
@@ -1448,11 +1450,12 @@
       (= head 'raster.compiler.pipeline/invoke-scheduled-executable!)
       ;; Generic scheduled-executable marker. Resident extraction consumes the same dispatch and
       ;; ordered arguments as staging; the target device is carried for the staged runtime only.
-      (when (= 4 argc)
-        (let [[_ _device-id dispatch-id arguments] expr]
-          (when (vector? arguments)
+      (when (contains? #{4 5} argc)
+        (let [[_ _device-id dispatch-id arguments policy] expr
+              policy (if (= 4 argc) :single policy)]
+          (when (and (vector? arguments) (contains? #{:single :none} policy))
             {:dispatch-id dispatch-id :arguments arguments
-             :convention :executable :returns sym})))
+             :convention :executable :returns sym :result-policy policy})))
       (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
       ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
       ;; accumulator buffer (a zeros-like intermediate), written in-place via atomic +=.
@@ -1579,7 +1582,7 @@
              (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
              (if-let [s (parse-gpu-step sym expr)]
                (let [ordered-result
-                     (when (:arguments s)
+                     (when (and (:arguments s) (not= :none (:result-policy s)))
                        (let [abi (if (and (:dispatch-id s) dispatch-info-fn)
                                    ;; Graph schedules have no single kernel name. Their validated
                                    ;; common ABI owns the return value just as it owns binding.
@@ -1599,7 +1602,10 @@
                   ;; recorded into a resident graph, but must remain a clean non-resident fallback
                   ;; (rather than reaching descriptor construction and throwing there).
                    (reject! :host-scalar-reduction sym expr)
-                   (do (vswap! steps conj s) (vswap! device-buffers conj sym)
+                   (do (vswap! steps conj s)
+                       (if (= :none (:result-policy s))
+                         (vswap! aliases assoc sym nil)
+                         (vswap! device-buffers conj sym))
                   ;; A :map step's runtime VALUE is its out buffer (invoke-registered-kernel
                   ;; returns output-array), so the binding sym is a pure alias of the out
                   ;; array. Copy-propagate it like any other array alias — a later step
@@ -1996,7 +2002,7 @@
                            :phase (keyword (str "gpu-step-" i))})
 
                         (= :executable (:convention step))
-                        (let [{:keys [dispatch-id arguments]} step
+                        (let [{:keys [dispatch-id arguments result-policy]} step
                               dispatch (or (dispatch-entry dispatch-id)
                                            (throw (ex-info "resident executable dispatch is not registered"
                                                            {:dispatch-id dispatch-id})))
@@ -2010,9 +2016,11 @@
                               ;; A generic graph may be effect-only or multi-output. `:output` is
                               ;; retained solely as compatibility sugar for the one-result case;
                               ;; LinkPlan derives every write from the complete executable ABI.
-                              output (when (= 1 (count result-pairs))
+                              output (when (and (not= :none result-policy)
+                                                (= 1 (count result-pairs)))
                                        (second (first result-pairs)))]
                           {:convention :executable
+                           :result-policy (or result-policy :single)
                            :dispatch-id dispatch-id
                            :dispatch dispatch
                            :artifact executable

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1193,22 +1193,31 @@
                       {:expression expression :resolved value})))
     (long value)))
 
-(defn- validate-external-view!
-  [graph-buffer view scalar-values]
-  (let [view (bview/validate-view! view)
-        expected-dtype (dtype/canon (:dtype graph-buffer))
-        actual-dtype (dtype/canon (:dtype view))
+(defn- validate-external-capacity!
+  "The same external graph-storage precondition for session views and descriptor-step buffers."
+  [graph-buffer actual-dtype capacity scalar-values]
+  (when-not (and (integer? capacity) (not (neg? capacity)))
+    (throw (ex-info "kernel graph binding lacks a nonnegative buffer capacity"
+                    {:graph-buffer (:id graph-buffer) :capacity capacity})))
+  (let [expected-dtype (dtype/canon (:dtype graph-buffer))
+        actual-dtype (dtype/canon actual-dtype)
         expected-elements (when (some? (:elements graph-buffer))
-                            (resolve-graph-elements scalar-values (:elements graph-buffer)))
-        capacity (quot (:byte-length view) (dtype/bytes-of actual-dtype))]
+                            (resolve-graph-elements scalar-values (:elements graph-buffer)))]
     (when-not (= expected-dtype actual-dtype)
       (throw (ex-info "kernel graph buffer dtype differs from its resident view"
                       {:graph-buffer (:id graph-buffer) :expected expected-dtype
-                       :actual actual-dtype :view (:id view)})))
+                       :actual actual-dtype})))
     (when (and expected-elements (> expected-elements capacity))
       (throw (ex-info "kernel graph buffer extent exceeds its resident view"
                       {:graph-buffer (:id graph-buffer) :elements expected-elements
-                       :view-elements capacity :view (:id view)})))
+                       :view-elements capacity})))))
+
+(defn- validate-external-view!
+  [graph-buffer view scalar-values]
+  (let [view (bview/validate-view! view)]
+    (validate-external-capacity! graph-buffer (:dtype view)
+                                 (quot (:byte-length view) (dtype/bytes-of (:dtype view)))
+                                 scalar-values)
     (when-not (bview/contiguous? view)
       (throw (ex-info "kernel ABI binding currently requires a contiguous resident view"
                       {:graph-buffer (:id graph-buffer) :view (:id view)
@@ -1699,8 +1708,13 @@
    This is the ordinary compiled-function staging contract: JVM primitive arrays are copied in
    and ABI-declared writes are copied back; backend DeviceBuffers are borrowed without copying.
    Every call owns and closes its graph recording and temporary buffers. Long-lived/replayable
-   execution belongs to compile-gpu-program plus LinkPlan, which uses the same executable binder."
-  [device-id dispatch-id runtime-arguments]
+   execution belongs to compile-gpu-program plus LinkPlan, which uses the same executable binder.
+   Optional :none result policy copies every write back but returns nil for effect-only calls."
+  ([device-id dispatch-id runtime-arguments]
+   (invoke-staged-executable! device-id dispatch-id runtime-arguments :single))
+  ([device-id dispatch-id runtime-arguments result-policy]
+  (when-not (contains? #{:single :none} result-policy)
+    (throw (ex-info "unsupported staged executable result policy" {:result-policy result-policy})))
   (let [dispatch-entry (rt-resolve device-id "kernel-dispatch-registry-entry")
         dispatch (or (dispatch-entry dispatch-id)
                      (throw (ex-info "staged kernel executable dispatch is not registered"
@@ -1712,7 +1726,7 @@
         {:keys [groups arguments]} (staged-pointer-plan device-id executable typed-arguments)
         result-pairs (filterv (fn [[slot _]] (= :result (:role slot)))
                               (map vector (kexec/abi executable) typed-arguments))]
-    (when (> (count result-pairs) 1)
+    (when (and (= :single result-policy) (> (count result-pairs) 1))
       (throw (ex-info "staged kernel executable has more than one primary result"
                       {:dispatch-id dispatch-id :result-slots (mapv first result-pairs)})))
     (with-gpu-session* device-id
@@ -1731,7 +1745,7 @@
           (doseq [{:keys [key value elements resident? write?]} groups
                   :when (and write? (not resident?))]
             (download-range! session key value {:elements elements})))
-        (some-> (first result-pairs) second)))))
+        (when (= :single result-policy) (some-> (first result-pairs) second)))))))
 
 (defn kernel-graph-execution-plan
   "Return the pure backend-neutral queue/event plan for a bound KernelGraph."
@@ -1845,6 +1859,12 @@
       :kernel-graph
       (let [{:keys [buffers scalar-values]}
             (kexec/graph-bindings executable runtime-arguments)
+            extent-values (into {} (map (fn [[id buffer]]
+                                          [(list 'extent id) (:n-elements buffer)])) buffers)
+            _ (doseq [buffer-spec (concat (:inputs executable) (:outputs executable))
+                      :let [buffer (get buffers (:id buffer-spec))]]
+                (validate-external-capacity! buffer-spec (:dtype buffer) (:n-elements buffer)
+                                             (merge scalar-values extent-values)))
             temporary-buffers
             (allocate-executable-temporaries
              device-id (kgcall/temporary-specs executable scalar-values))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -6,7 +6,6 @@
             [raster.compiler.backend.gpu.gemm :as gemm-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
-            [raster.compiler.backend.gpu.kernel-body-target :as body-target]
             [raster.compiler.backend.gpu.layout-transform :as layout-transform]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
@@ -20,14 +19,13 @@
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
-            [raster.compiler.passes.parallel.product-reduction-body :as product-body]
-            [raster.compiler.passes.parallel.product-reduction-body-test :as product-fixtures]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.core :refer [deftm]]
             [raster.dl.attention :as dl-attention]
+            [raster.dl.array-ops :as dl-arrays]
             [raster.linalg.contract :as contract]
             [raster.numeric]
             [raster.par]
@@ -256,6 +254,8 @@
       (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'dl-arrays/argmax-rows! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-map {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-scan {:target device-id :dtype :float}))
@@ -318,18 +318,8 @@
         swizzled-pipelined (attention-emit/emit-fp16-pipelined
                             plan swizzled-pipelined-schedule dialect descriptor)
         tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)
-        public-artifacts (equation-first-artifacts target descriptor)
-        product-scalar-types {'nrows :long 'width :long}]
+        public-artifacts (equation-first-artifacts target descriptor)]
     (into [(write-artifact! directory suffix "cooperative" cooperative)
-           (write-artifact! directory suffix "candidate-product-reduction"
-                            (body-target/emit-artifact
-                             "candidate_product_argmax"
-                             (product-body/schedule
-                              (product-fixtures/typed-local-address-segred product-scalar-types)
-                              (-> product-fixtures/options
-                                  (dissoc :element-binding-types :combine-binding-types)
-                                  (assoc :scalar-types product-scalar-types)))
-                             dialect))
            (write-artifact! directory suffix "pipelined-attention" pipelined)
            (write-artifact! directory suffix "swizzled-pipelined-attention"
                             swizzled-pipelined)

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -290,7 +290,69 @@
           (is (= 2 (count allocations)))
           (is (identical? out (nth output-spec 2))
               "write-only ABI access does not prove full overwrite of caller storage"))
+        (is (= 1 (count (filter #(= :download (first %)) @calls))))
+        (reset! calls [])
+        (is (nil? (gpu/invoke-staged-executable!
+                   :probe "staged-graph-dispatch" [x out 3] :none)))
         (is (= 1 (count (filter #(= :download (first %)) @calls))))))))
+
+(deftest direct-descriptor-graph-binding-checks-capacities-before-driver-work
+  (let [graph (assoc-in (staged-graph) [:inputs 0 :elements] (klaunch/product 'width 2))
+        step {:convention :executable :artifact graph :phase :test
+              :argument-specs [{:kind :input :sym 'x} {:kind :output :sym 'out}
+                               {:kind :scalar :type :long :value-fn first}]}
+        driver-calls (atom [])]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name] (fn [& _] (swap! driver-calls conj function-name)))}
+      (fn []
+        (doseq [[input-capacity output-capacity input-dtype width]
+                [[5 3 :float 3] [6 2 :float 3] [6 3 :double 3]
+                 [Long/MAX_VALUE Long/MAX_VALUE :float Long/MAX_VALUE]]]
+          (let [session (atom {:device-id :probe
+                               :buffers {:x {:dtype input-dtype :n-elements input-capacity}
+                                         :out {:dtype :float :n-elements output-capacity}}})]
+            (is (thrown? Exception
+                         (gpu/bind-step! session step [width] {'x :x 'out :out})))
+            (is (empty? @driver-calls))))))))
+
+(deftest effect-only-staging-copies-every-output-without-a-primary-result
+  (let [base (staged-graph)
+        extra 'dispatch-temporary
+        graph (kexec/validate!
+               (-> base
+                   (assoc :temporaries [])
+                   (update :outputs conj (assoc (first (:temporaries base)) :role :output))
+                   (assoc :abi [(first abi) (second abi)
+                                (kabi/slot extra :output :float :role :result) (last abi)]
+                          :arguments ['x 'out extra 'width])))
+        dispatch (kdispatch/make
+                  {:id "multi-effect" :alternatives [graph] :default-strategy :two-stage
+                   :selector {:kind :fixed-strategy :strategy :two-stage}})
+        out (float-array 3)
+        intermediate (float-array 3)
+        args [(float-array [1 2 3]) out intermediate 3]
+        copies (atom [])]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" (constantly dispatch)
+           "device-buffer?" (constantly false)))
+       #'gpu/with-gpu-session* (fn [_ f] (f (atom {})))
+       #'gpu/alloc! (fn [& _])
+       #'gpu/bind-kernel-executable! (fn [& _] :handle)
+       #'gpu/run-kernel-graph! (fn [& _])
+       #'gpu/download-range! (fn [_ _ array _]
+                              (swap! copies conj array)
+                              (aset ^floats array 0 (float 7)))}
+      (fn []
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"more than one primary result"
+                             (gpu/invoke-staged-executable! :probe "multi-effect" args)))
+        (is (empty? @copies))
+        (is (nil? (gpu/invoke-staged-executable! :probe "multi-effect" args :none)))
+        (is (= [out intermediate] @copies))
+        (is (= 7.0 (aget out 0) (aget intermediate 0)))))))
 
 (deftest staged-graph-capacities-fail-before-opening-a-device-session
   (let [graph (staged-graph)
@@ -427,7 +489,8 @@
                                {:kind :scalar :type :long
                                 :value-fn (fn [args] (:width args))}]}
         session (atom {:device-id :probe
-                       :buffers {'x :resident-x 'out :resident-out}
+                       :buffers {'x {:id :resident-x :dtype :float :n-elements 256}
+                                 'out {:id :resident-out :dtype :float :n-elements 256}}
                        :prepared {} :graphs {}})
         recorded (atom [])
         destroyed (atom [])

--- a/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/product_reduction_body_test.clj
@@ -10,6 +10,7 @@
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.reduction-test :as fixtures]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.product-reduction-body :as product]
@@ -47,7 +48,7 @@
    :element-binding-types {'candidate :float}
    :combine-binding-types {'left-nan :int 'right-nan :int 'better :int}})
 
-(defn- typed-argmax-program [values & [scalar-types]]
+(defn- typed-argmax-program [values & [scalar-types materialize-value? scale?]]
   (let [tag-bindings (fn [bindings dtypes]
                        (vec (mapcat (fn [[id init]]
                                       [(with-meta id {:raster.type/tag
@@ -56,13 +57,16 @@
         ;; Supply the facts normally attached by the walker; the frontend deliberately does not
         ;; infer types from these raw test S-expressions.
         form (-> (vec (argmax-form))
+                 (cond-> materialize-value? (assoc-in [1 0] 'maxima))
+                 (cond-> scale? (update-in [6 1]
+                                          #(with-meta (list '* 'alpha %) {:raster.type/tag 'float})))
                  (update 6 tag-bindings (:element-binding-types options))
                  (update 9 tag-bindings (:combine-binding-types options))
                  (update 2 #(mapv (fn [[id neutral type]]
                                     [id (constant/literal-or-original neutral) type]) %)))
         program (frontend/form->program
                  (list 'let* ['effect (apply list form)] 'effect)
-                 {:dtype :float :array-types {'values :float 'indices :int}
+                 {:dtype :float :array-types {'values :float 'indices :int 'maxima :float}
                   :values values :scalar-types (or scalar-types (:scalar-types options))})]
     program))
 
@@ -205,12 +209,12 @@
       (catch clojure.lang.ExceptionInfo e
         (is (= :source-refinement (:missing-rule (ex-data e))))))))
 
-(defn- graph-context [known-input? & [input-options output-options scalar-types]]
+(defn- graph-context [known-input? & [input-options output-options scalar-types materialize-value? scale?]]
   (let [scalar-types (or scalar-types (:scalar-types options))
         algorithm (typed-argmax-program
                    (if known-input?
                      {'values (av/tensor {:dtype :float :shape ['nrows 'width]})}
-                     {}) scalar-types)
+                     {}) scalar-types materialize-value? scale?)
         ;; Model a compiler-generated typed program as well as the analyzed-source frontend,
         ;; which already declines non-plain aget storage before this boundary.
         algorithm (if input-options
@@ -232,6 +236,26 @@
         equation (first (:equations scheduled))
         {:keys [graph body]} (equation-graph/make-for-equation scheduled equation)]
     {:algorithm (:algorithm equation) :body body :graph graph :node (first (:nodes graph))}))
+
+(deftest production-product-emission-is-graph-bound-and-target-neutral
+  (doseq [materialize-value? [false true]
+          dialect [:opencl-portable :cuda :hip]]
+    (let [{:keys [graph algorithm body]} (graph-context false nil nil nil materialize-value?)
+          emitted (with-redefs [reference/generate-product-reduction-kernel
+                                (fn [& _] (throw (ex-info "legacy product emitter reached" {})))]
+                    (reference/generate-kernel-graph
+                     graph :target-dialect dialect
+                     :scheduled-equation-algorithm algorithm :scheduled-equation-body body))
+          artifacts (executable/artifacts emitted)
+          artifact (first artifacts)]
+      (is (= emitted (executable/validate! emitted)))
+      (is (= 1 (count artifacts)))
+      (is (= (if materialize-value? 2 1) (count (:outputs emitted))))
+      (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
+      (is (false? (get-in artifact [:attributes :candidate-only])))
+      (is (true? (get-in artifact [:attributes :source-storage-certified?])))))
+  (let [{:keys [graph]} (graph-context false)]
+    (is (thrown? clojure.lang.ExceptionInfo (reference/generate-kernel-graph graph)))))
 
 (deftest graph-storage-facts-are-derived-from-the-retained-program
   (let [{:keys [algorithm body graph node]} (graph-context true)
@@ -261,6 +285,33 @@
     (is (= [(launch/product 'nrows 'width)] (get-in options [:array-shapes 'values])))
     (is (= candidate (product/validate-against-node! candidate node graph algorithm body)))
     (is (true? (get-in candidate [:attributes :candidate-only])))))
+
+(deftest runtime-allocation-extents-are-not-independent-minimum-shapes
+  (let [{:keys [algorithm body graph node]}
+        (graph-context true {:shape ['(extent values)]} {:shape ['(extent indices)]})
+        admitted (product/schedule-for-node node graph algorithm body)]
+    (is (= (launch/product 'nrows 'width) (get-in graph [:inputs 0 :elements])))
+    (is (= 'nrows (get-in graph [:outputs 0 :elements])))
+    (is (false? (get-in admitted [:attributes :candidate-only])))))
+
+(deftest floating-captures-and-optional-refinement-cannot-bypass-read-capacity
+  (let [context #(graph-context true {:shape [1]} nil
+                                (assoc (:scalar-types options) 'alpha :float) false true)
+        {:keys [algorithm body graph node]} (context)]
+    (is (= (launch/maximum (launch/product 'nrows 'width) 1)
+           (get-in graph [:inputs 0 :elements])))
+    (is (false? (get-in (product/schedule-for-node node graph algorithm body)
+                        [:attributes :candidate-only])))
+    (with-redefs-fn
+      {(ns-resolve 'raster.compiler.passes.parallel.scheduled-equation-graph
+                    'product-read-requirements) (constantly {})}
+      (fn []
+        (let [{:keys [algorithm body graph node]} (context)]
+          (try
+            (product/schedule-for-node node graph algorithm body)
+            (is false "a known capacity cannot substitute for the omitted access requirement")
+            (catch clojure.lang.ExceptionInfo e
+              (is (= :graph-read-capacity (:missing-rule (ex-data e)))))))))))
 
 (deftest graph-capacity-is-not-an-index-safety-certificate
   (let [{:keys [algorithm body graph node]} (graph-context true {:shape [1]})

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -20,6 +20,21 @@
 
 (defn- why [form] (get-in (pipeline/extract-gpu-program form) [nr-key :why]))
 
+(deftest effect-only-executable-results-never-alias-an-output-buffer
+  (doseq [arguments ['[A C] '[A C D]]]
+    (let [call (list 'raster.compiler.pipeline/invoke-scheduled-executable!
+                     :ocl:0 "effect-dispatch" arguments :none)
+          extracted (pipeline/extract-gpu-program
+                     (list 'let* ['returned call 'again 'returned] 'again)
+                     (fn [& _] (throw (ex-info "effect result needs no kernel lookup" {})))
+                     (fn [& _] (throw (ex-info "effect result needs no primary result lookup" {}))))]
+      (is (not (contains? extracted nr-key)))
+      (is (= '[again nil] (:scalar-lets extracted)))
+      (is (= :none (get-in extracted [:steps 0 :result-policy])))))
+  (is (= :unparseable-kernel-invoke
+         (why '(let* [r (raster.compiler.pipeline/invoke-scheduled-executable!
+                         :ocl:0 "x" [A C] :unknown)] r)))))
+
 (deftest scheduled-results-use-the-dispatch-common-abi
   (let [artifact (kart/make
                   {:kernel-name "alias_fixture"

--- a/test/raster/dl/indexed_reduction_test.clj
+++ b/test/raster/dl/indexed_reduction_test.clj
@@ -1,6 +1,7 @@
 (ns raster.dl.indexed-reduction-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.dl.array-ops :as ops]))
@@ -46,7 +47,8 @@
         descriptor (get descriptors :ocl:0)
         allocs (:allocs descriptor)
         steps (:steps descriptor)
-        sources (mapv #(get-in % [:artifact :source]) steps)
+        artifacts (vec (mapcat #(executable/artifacts (:artifact %)) steps))
+        sources (mapv :source artifacts)
         lowering (resident-plan/lower
                   {:id :indexed-row-reduction
                    :target :ocl:0
@@ -59,8 +61,8 @@
       (is (= '[nrows width] (:scalar-params descriptor))))
     (testing "schedule scratch is local to the emitted product kernel"
       (is (empty? allocs))
-      (is (= :segmented-workgroup-tree
-             (get-in steps [0 :artifact :attributes :schedule :strategy]))))
+      (is (= :product-workgroup-tree
+             (get-in artifacts [0 :attributes :kernel-body :schedule :strategy]))))
     (testing "the typed product reduction is one resident scheduled step"
       (is (= {:backend :opencl
               :source-dialect :typed-soac
@@ -70,12 +72,15 @@
       (is (= 1 (get-in report [:lowering :typed-reused])))
       (is (zero? (get-in report [:lowering :backend-relowered])))
       (is (zero? (get-in report [:lowering :fallback])))
-      (is (= [:map-void] (mapv :convention steps)))
+      (is (= [:executable] (mapv :convention steps)))
       (is (= 1 (count steps)))
       (is (= ['values 'indices]
              (vec (take 2 (get-in steps [0 :artifact :arguments])))))
       (is (= [:float :int]
-             (get-in steps [0 :artifact :attributes :component-dtypes]))))
+             (get-in artifacts [0 :attributes :kernel-body :attributes :component-dtypes])))
+      (is (every? #(= :kernel-body (get-in % [:attributes :emission-route])) artifacts))
+      (is (every? #(false? (get-in % [:attributes :candidate-only])) artifacts))
+      (is (every? #(true? (get-in % [:attributes :source-storage-certified?])) artifacts)))
     (testing "OpenCL and Level Zero preserve the same typed lowering"
       (is (apply = (map (comp #(mapv :dtype %) :allocs val) descriptors)))
       (is (apply = (map (comp #(mapv :convention %) :steps val) descriptors)))
@@ -84,14 +89,13 @@
                               :steps val)
                         descriptors))))
     (testing "OpenCL C preserves mixed local products and portable NaN comparison"
-      (is (str/includes? (first sources) "__local float shared_0"))
-      (is (str/includes? (first sources) "__local int shared_1"))
-      (is (every? #(str/includes? % "shared_0[lid]") sources))
-      (is (every? #(str/includes? % "shared_0[(lid + stride)]") sources))
+      (is (= [:float :int]
+             (mapv :dtype (get-in artifacts [0 :attributes :kernel-body :allocations]))))
+      (is (str/includes? (first sources) "__local float*"))
+      (is (str/includes? (first sources) "__local int*"))
       (is (every? #(not (str/includes? % "_u005b_")) sources))
-      (is (str/includes? (first sources) "for (int col = lid"))
+      (is (str/includes? (first sources) "for (long rstr_col"))
       (is (str/includes? (first sources) "barrier(CLK_LOCAL_MEM_FENCE)"))
-      (is (every? #(not (str/includes? % "boolean(")) sources))
-      (is (every? #(str/includes? % "(float)(elem_0) == (float)(elem_0)") sources)))
+      (is (every? #(not (str/includes? % "boolean(")) sources)))
     (testing "the descriptor certifies as a composable LinkPlan before allocation"
       (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -1,5 +1,6 @@
 (ns raster.dl.row-gather-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]
@@ -191,10 +192,14 @@
       (is (= [7 400] (vec token-indices)))
       (is (= [21.0 22.0 23.0 1200.0 1201.0 1202.0] (vec rows))))
     (testing "the compiled graph retains one scheduled reduction and one independent row gather"
-      (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
+      (is (= [:executable :map-void] (mapv :convention (:steps descriptor))))
       (is (empty? (:allocs descriptor)))
-      (is (= :segmented-workgroup-tree
-             (get-in descriptor [:steps 0 :artifact :attributes :schedule :strategy]))))
+      (let [artifacts (vec (executable/artifacts (get-in descriptor [:steps 0 :artifact])))]
+        (is (= 1 (count artifacts)))
+        (is (= :product-workgroup-tree
+               (get-in artifacts [0 :attributes :kernel-body :schedule :strategy])))
+        (is (true? (get-in artifacts [0 :attributes :source-storage-certified?])))
+        (is (= :none (get-in descriptor [:steps 0 :result-policy])))))
     (testing "the ordinary multi-output descriptor certifies before allocation"
       (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))
 

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -313,6 +313,13 @@
         (let [program (fixture/instantiate! s descriptor [values indices nrows width])
               result (get (fixture/run! program [values indices nrows width]) 'indices)]
           (is (= [3 255 411] (vec result))))
+        (let [execute (pl/compile-aot #'ops/argmax-rows! :target-device :ocl:0 :dtype :float)
+              staged-indices (int-array nrows)]
+          (is (nil? (execute values staged-indices nrows width))
+              "the effect-only product returns nil, not its output buffer")
+          (is (nil? (apply execute [values staged-indices nrows width]))
+              "the hoisted IFn applyTo bridge also boxes void as nil")
+          (is (= [3 255 411] (vec staged-indices))))
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-row-gather-roundtrip


### PR DESCRIPTION
Production dense row products now use exact source/graph/access admission and the common C-family KernelBody emitter. Public resident argmax uses the executable convention; effect-only staging returns nil and supports multiple written outputs. Direct descriptor graph binding checks capacities before driver work. Fixes the hoisted JVM IFn void boxing exposed by real staging. Public equation-first argmax replaces the candidate-only vendor fixture.

Validation: final focused run47 tests283 assertions. Adjacent product/graph/fold-map41 tests264 assertions before the final alpha-capacity regression; real CPU OpenCL resident/staged/invoke/applyTo1 test4 assertions. Actual public equation-first argmax emits1 KernelBody. Review caught and closed direct-binder and captured-floating-scalar capacity gaps, with regressions. No remaining review blocker. Full suite/vendor gates delegated to CI.

Initial admission is dense rank-one segmented products; arbitrary indexed access remains an explicit decline. Handwritten source remains only as test/differential oracle pending the next retirement slice. Stacked on #391.