### PR TITLE
Isolate synthetic hardware and calibration in compiler tests

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -77,7 +77,10 @@ one must not erase its independent numerical evidence. Track JVM and C/SIMD comp
 as GPU paths, using the same production corpus and retained TypedSOAC facts.
 CI also exposed target-registry leakage from test fixtures: matrix-capable synthetic targets can
 change another test's automatic precision route. The direct contraction ABI test now requests its
-FP32 policy explicitly; broader fixture isolation remains a cleanup item.
+FP32 policy explicitly. The isolation follow-up gives the hardware registry tests and the three
+resetting cross-compilation fixtures fresh device, initialization and calibration atoms, restoring
+the original identities even on exceptions. This is a serial-JVM fixture; parallelism remains
+across CI processes. Other registration sites still need an ownership audit.
 
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -19,7 +19,8 @@
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
-            [raster.runtime.hardware :as hw]))
+            [raster.runtime.hardware :as hw]
+            [raster.hardware-fixture :as hardware-fixture]))
 
 ;; ================================================================
 ;; Test infrastructure
@@ -27,8 +28,8 @@
 
 ;; Mock hardware for codegen tests (no GPU needed)
 (use-fixtures :each
+  hardware-fixture/isolated
   (fn [f]
-    (hw/reset-hardware!)
     (hw/init!)
     (hw/register-target-device! :ze:0
                                 {:name "Test GPU"

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -8,12 +8,13 @@
             [raster.compiler.passes.parallel.device :as device]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]
+            [raster.hardware-fixture :as hardware-fixture]
             [clojure.string :as str]))
 
 ;; Set up target device for tests (no actual GPU required)
 (use-fixtures :each
+  hardware-fixture/isolated
   (fn [f]
-    (hw/reset-hardware!)
     (hw/init!)
     (hw/register-target-device! :ze:0
                                 {:name "Intel(R) Arc(TM) Graphics"

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -11,6 +11,7 @@
             [raster.dl.gsdm :as gsdm]
             [raster.gpu.core :as gpu]
             [raster.gpu.link :as link]
+            [raster.hardware-fixture :as hardware-fixture]
             [raster.numeric]
             [raster.runtime.hardware :as hardware]))
 
@@ -19,8 +20,8 @@
 ;; test JVM.  No device or driver is required to derive and emit these schedules.
 (use-fixtures
   :once
+  hardware-fixture/isolated
   (fn [f]
-    (hardware/reset-hardware!)
     (hardware/init!)
     (hardware/register-target-device!
      :ze:0

--- a/test/raster/hardware_fixture.clj
+++ b/test/raster/hardware_fixture.clj
@@ -1,0 +1,14 @@
+(ns raster.hardware-fixture
+  "Isolated hardware registries for serial compiler tests.
+
+   CI parallelizes across processes, not concurrent namespaces in one JVM. Like with-redefs,
+   this fixture must not overlap unrelated work in the same process. It owns all three registry
+   atoms, so initialization, synthetic targets and calibration cannot escape even on failure."
+  (:require [raster.runtime.hardware]))
+
+(defn isolated
+  [f]
+  (with-redefs-fn {#'raster.runtime.hardware/device-registry (atom {})
+                  #'raster.runtime.hardware/initialized? (atom false)
+                  #'raster.runtime.hardware/measured-registry (atom {})}
+    f))

--- a/test/raster/hardware_fixture_test.clj
+++ b/test/raster/hardware_fixture_test.clj
@@ -1,0 +1,30 @@
+(ns raster.hardware-fixture-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.hardware-fixture :as fixture]
+            [raster.runtime.hardware :as hardware]))
+
+(deftest registry-isolation-restores-identities-and-values
+  (let [registries [#'raster.runtime.hardware/device-registry
+                    #'raster.runtime.hardware/initialized?
+                    #'raster.runtime.hardware/measured-registry]
+        original-atoms (mapv deref registries)
+        original-values (mapv deref original-atoms)]
+    (doseq [fail? [false true]]
+      (let [run #(fixture/isolated
+                  (fn []
+                    (is (= [{} false {}] (mapv (comp deref deref) registries)))
+                    ;; Avoid probing hardware: this test checks fixture state, not discovery.
+                    (reset! @#'raster.runtime.hardware/initialized? true)
+                    (hardware/register-target-device! :ze:987 {:name "fixture-only"
+                                                              :capabilities {}})
+                    (hardware/set-measured! :ze:987 {:bandwidth 17})
+                    (fixture/isolated
+                     (fn [] (is (= [{} false {}] (mapv (comp deref deref) registries)))))
+                    (is (= "fixture-only" (:name (hardware/device :ze:987))))
+                    (is (= {:bandwidth 17} (hardware/measured-for :ze:987)))
+                    (if fail? (throw (ex-info "fixture failure" {})) :returned)))]
+        (if fail?
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"fixture failure" (run)))
+          (is (= :returned (run))))
+        (is (every? true? (map identical? original-atoms (map deref registries))))
+        (is (= original-values (mapv (comp deref deref) registries)))))))

--- a/test/raster/hardware_test.clj
+++ b/test/raster/hardware_test.clj
@@ -1,11 +1,12 @@
 (ns raster.hardware-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [raster.runtime.hardware :as hw]
+            [raster.hardware-fixture :as hardware-fixture]
             [raster.compiler.core.hardware :as chw]
             [raster.runtime.hardware-catalogue :as catalogue]))
 
 ;; Reset hardware state between tests
-(use-fixtures :each (fn [f] (hw/reset-hardware!) (f)))
+(use-fixtures :each hardware-fixture/isolated)
 
 ;; ================================================================
 ;; CPU detection


### PR DESCRIPTION
Give the hardware registry tests and three resetting cross-compilation fixtures fresh registry atoms with guaranteed restoration on success and failure. Removes order-dependent synthetic device and calibration leakage without changing production behavior. This fixture is explicitly serial-JVM scoped; CI remains process-parallel. Focused validation: 55 tests, 288 assertions, zero failures/errors. Four Level Zero-only numerical checks correctly report unavailable hardware locally; CPU OpenCL is available. Read-only review found no blocker. Full suites remain in CI.