### PR TITLE
Lower unary subtraction through shared typed scalar intrinsics

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -82,6 +82,13 @@ resetting cross-compilation fixtures fresh device, initialization and calibratio
 the original identities even on exceptions. This is a serial-JVM fixture; parallelism remains
 across CI processes. Other registration sites still need an ownership audit.
 
+The first measured elementwise gap is unary subtraction in `scale-clamp-exp`: its typed source
+reached the verified SegMap source fallback solely because the scalar lowerer required binary
+subtraction. The follow-up uses the existing negation intrinsic and shared prefix spelling for
+floating operands (preserving signed zero); integral operands retain checked subtraction and
+its explicit portable-OpenCL trap limitation. Public route, CPU OpenCL IEEE cases and vendor
+compile fixtures cover this increment. It does not retire the remaining ordered-loop fallback.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -234,7 +234,8 @@
   #{:bit-and :bit-or :bit-xor :shl :shr :ushr :rem :mod :quot :wi8-dot :dp4a})
 
 (def ^:private floating-ops
-  #{:sqrt :floor :ceil :trunc :round :sin :cos :tan :exp :log :pow :fma
+  ;; Integral negation is 0-x with an explicit overflow contract, never a bare C prefix.
+  #{:neg :sqrt :floor :ceil :trunc :round :sin :cos :tan :exp :log :pow :fma
     :asin :acos :atan :atan2 :sinh :cosh :tanh :asinh :acosh :atanh :cbrt
     :log2 :log10 :exp2 :exp10 :expm1 :log1p :hypot :deg2rad :rad2deg
     :copysign :flipsign})

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -287,6 +287,9 @@
         (= :floored-mod c) {:kind :floored-mod}
         (string? c)        {:kind :infix :op c}
         (and (map? c) (:fn c)) {:kind :fn :op (if (and glsl? (:glsl c)) (:glsl c) (:fn c))}
+        ;; A unary prefix uses the same parenthesized shape as a function: -(operand).
+        ;; Keep spelling in the descriptor, shared by the source and KernelBody emitters.
+        (and (map? c) (:prefix c)) {:kind :fn :op (:prefix c)}
         :else nil))))
 
 (defn op->c-lowering

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -320,6 +320,19 @@
                        (contains? '#{dec clojure.core/dec} (first expression)))
                   (lower (list 'clojure.core/- (second expression) 1) expected env)
 
+                  ;; Unary subtraction is the existing negation intrinsic for floating values:
+                  ;; spelling it as 0-x would lose the sign of zero. Integral negation instead
+                  ;; uses the checked/wrapping subtraction machinery, including MIN_VALUE.
+                  (and (seq? expression)
+                       (= :- (intrinsics/canonical (descriptor/semantic-op expression)))
+                       (= 1 (count (descriptor/call-args expression))))
+                  (lower (if (dtype/fp-dtype? expected)
+                           (list :neg (first (descriptor/call-args expression)))
+                           (list (descriptor/semantic-op expression)
+                                 (body/literal 0 expected)
+                                 (first (descriptor/call-args expression))))
+                         expected env)
+
                   (seq? expression)
                   (let [semantic-operation (descriptor/semantic-op expression)
                         operator (intrinsics/canonical semantic-operation)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -256,6 +256,8 @@
       (:kernels (equation-first/compile
                  #'dl-arrays/argmax-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'dl-arrays/scale-clamp-exp {:target device-id :dtype :double}))
+      (:kernels (equation-first/compile
                  #'public-c-family-map {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-scan {:target device-id :dtype :float}))

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -47,6 +47,17 @@
             (is (string? (emit/emit-scalar-kernel "unary_minus" kernel
                                                 {:target-dialect target})))))))))
 
+(deftest integer-prefix-negation-cannot-bypass-the-overflow-contract
+  (doseq [type [:byte :int :long]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (body/make
+                  {:id :invalid-integer-prefix
+                   :parameters [(body/->KernelParameter 'a :scalar type [] nil nil :parameter)]
+                   :operations [(body/->ScalarCompute (body/value 'negative type)
+                                                      (body/scalar-expression :neg type ['a]))]
+                   :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+                   :provenance {:dialect :test} :attributes {}})))))
+
 (deftest coupled-results-share-bindings-without-sharing-component-types
   (let [{:keys [operations results types] :as lowered} (mixed-region (lowerer))
         kernel

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -21,6 +21,32 @@
    [:float :int] {'candidate :float 'better :predicate}
    {'old-value :float 'old-index :int}))
 
+(deftest unary-subtraction-retains-floating-sign-and-integral-overflow
+  (doseq [type [:float :double :int :long]]
+    (let [lower (:lower-region (lowerer))
+          lowered (lower '{:bindings [] :results [(- a)]} [type] {} {'a type})
+          expression (get-in lowered [:operations 0 :expression])
+          floating? (contains? #{:float :double} type)]
+      (is (= (if floating? :neg :-) (:op expression)))
+      (is (= (if floating? 1 2) (count (:arguments expression))))
+      (is (= (when-not floating? :trap) (get-in expression [:options :overflow])))
+      (let [kernel (body/make
+                    {:id :unary-minus
+                     :parameters [(body/->KernelParameter 'a :scalar type [] nil nil :parameter)
+                                  (body/->KernelParameter 'out :output type [1] :global
+                                                         (layout/row-major [1] type) :result)]
+                     :operations (conj (:operations lowered)
+                                       (body/->ScalarStore 'out [0] (first (:results lowered)) nil))
+                     :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+                     :provenance {:dialect :test} :attributes {}})]
+        (doseq [target [:opencl-portable :cuda :hip]]
+          (if (and (not floating?) (= :opencl-portable target))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no portable trapping"
+                                 (emit/emit-scalar-kernel "unary_minus" kernel
+                                                          {:target-dialect target})))
+            (is (string? (emit/emit-scalar-kernel "unary_minus" kernel
+                                                {:target-dialect target})))))))))
+
 (deftest coupled-results-share-bindings-without-sharing-component-types
   (let [{:keys [operations results types] :as lowered} (mixed-region (lowerer))
         kernel

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -35,6 +35,35 @@
   [state :- (Array float) a :- Float n :- Long] :- (Array float)
   (raster.par/map! state i n float (* a (ra/aget state i))))
 
+(deftm ocl-session-negate!
+  [x :- (Array float) out :- (Array float) n :- Long] :- Void
+  (raster.par/map-void! i n (ra/aset out i (- (ra/aget x i)))))
+
+(deftest scale-clamp-exp-uses-the-common-scalar-body
+  (let [report (pl/compile-report #'ops/scale-clamp-exp
+                                  :target-device :ocl:0 :dtype :double)]
+    (is (= :typed-soac (get-in report [:route :source-dialect])))
+    (is (= {:kernel-body 1} (get-in report [:emission :routes])))
+    (is (empty? (get-in report [:emission :declines])))))
+
+(deftest ocl-unary-negation-preserves-ieee-signs
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "generated scalar negation")
+    (let [x (float-array [0.0 -0.0 3.5 -3.5 Float/POSITIVE_INFINITY
+                          Float/NEGATIVE_INFINITY Float/NaN])
+          out (float-array (alength x))
+          descriptor (pl/compile-gpu-program #'ocl-session-negate! :ocl:0 :dtype :float)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (let [program (fixture/instantiate! session descriptor [x out (long (alength x))])
+              result (get (fixture/run! program [x out (long (alength x))]) 'out)]
+          (is (every? #(= :kernel-body (get-in % [:artifact :attributes :emission-route]))
+                      (:steps descriptor)))
+          (is (= (mapv #(bit-xor Integer/MIN_VALUE (Float/floatToRawIntBits %)) (take 6 x))
+                 (mapv #(Float/floatToRawIntBits %) (take 6 result))))
+          (is (Float/isNaN (aget ^floats result 6))))
+        (finally (gpu/close-session! session))))))
+
 (deftm ocl-session-map2
   [x :- (Array float) y :- (Array float)
    a :- (Array float) b :- (Array float) n :- Long] :- Void


### PR DESCRIPTION
Closes the measured scale-clamp-exp compatibility fallback with generic scalar lowering, not a workload-specific kernel. Floating unary subtraction uses the existing negation intrinsic and shared descriptor prefix spelling, preserving signed zero; integer unary subtraction retains explicit overflow policy. Bare integer negation is rejected to prevent C signed-overflow UB. Tests: 9 pure scalar tests/63 assertions; public production route3 assertions; CPU OpenCL IEEE execution3 assertions. Public scale-clamp-exp is added to CUDA/HIP compile fixtures. Full suites delegated to CI. Review identified and fixed the direct integer-prefix loophole.