### PR TITLE
Complete scalar negation and ordered-fold lowering; isolate hardware tests

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -89,6 +89,13 @@ floating operands (preserving signed zero); integral operands retain checked sub
 its explicit portable-OpenCL trap limitation. Public route, CPU OpenCL IEEE cases and vendor
 compile fixtures cover this increment. It does not retire the remaining ordered-loop fallback.
 
+The next measured gap is `sum-kv-heads`: its ordered carry starts at one after loading the first
+element. The origin follow-up retains nonnegative literal starts in the existing scalar ForLoop;
+zero-origin SOAC recognition is unchanged. New nonzero coverage requires direct recursion, exact
+binding-slot updates, one loop body and no narrowing induction test. Public GQA fan-in, group-one
+signed-zero preservation and cancellation-sensitive accumulation are checked on CPU OpenCL.
+This does not authorize reassociation or arbitrary symbolic/negative loop origins.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -82,6 +82,13 @@ resetting cross-compilation fixtures fresh device, initialization and calibratio
 the original identities even on exceptions. This is a serial-JVM fixture; parallelism remains
 across CI processes. Other registration sites still need an ownership audit.
 
+The first measured elementwise gap is unary subtraction in `scale-clamp-exp`: its typed source
+reached the verified SegMap source fallback solely because the scalar lowerer required binary
+subtraction. The follow-up uses the existing negation intrinsic and shared prefix spelling for
+floating operands (preserving signed zero); integral operands retain checked subtraction and
+its explicit portable-OpenCL trap limitation. Public route, CPU OpenCL IEEE cases and vendor
+compile fixtures cover this increment. It does not retire the remaining ordered-loop fallback.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -77,7 +77,10 @@ one must not erase its independent numerical evidence. Track JVM and C/SIMD comp
 as GPU paths, using the same production corpus and retained TypedSOAC facts.
 CI also exposed target-registry leakage from test fixtures: matrix-capable synthetic targets can
 change another test's automatic precision route. The direct contraction ABI test now requests its
-FP32 policy explicitly; broader fixture isolation remains a cleanup item.
+FP32 policy explicitly. The isolation follow-up gives the hardware registry tests and the three
+resetting cross-compilation fixtures fresh device, initialization and calibration atoms, restoring
+the original identities even on exceptions. This is a serial-JVM fixture; parallelism remains
+across CI processes. Other registration sites still need an ownership audit.
 
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -234,7 +234,8 @@
   #{:bit-and :bit-or :bit-xor :shl :shr :ushr :rem :mod :quot :wi8-dot :dp4a})
 
 (def ^:private floating-ops
-  #{:sqrt :floor :ceil :trunc :round :sin :cos :tan :exp :log :pow :fma
+  ;; Integral negation is 0-x with an explicit overflow contract, never a bare C prefix.
+  #{:neg :sqrt :floor :ceil :trunc :round :sin :cos :tan :exp :log :pow :fma
     :asin :acos :atan :atan2 :sinh :cosh :tanh :asinh :acosh :atanh :cbrt
     :log2 :log10 :exp2 :exp10 :expm1 :log1p :hypot :deg2rad :rad2deg
     :copysign :flipsign})

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -287,6 +287,9 @@
         (= :floored-mod c) {:kind :floored-mod}
         (string? c)        {:kind :infix :op c}
         (and (map? c) (:fn c)) {:kind :fn :op (if (and glsl? (:glsl c)) (:glsl c) (:fn c))}
+        ;; A unary prefix uses the same parenthesized shape as a function: -(operand).
+        ;; Keep spelling in the descriptor, shared by the source and KernelBody emitters.
+        (and (map? c) (:prefix c)) {:kind :fn :op (:prefix c)}
         :else nil))))
 
 (defn op->c-lowering

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -776,6 +776,15 @@
   [loop-form]
   (match-reduce-loop* loop-form normalize-loop))
 
+(defn ordered-unit-step?
+  "A long induction step may widen explicitly, but must not erase a narrowing conversion."
+  [expression index]
+  (and (= 1 (descriptor/affine-step expression index))
+       (not-any? #(and (seq? %)
+                       (contains? '#{int clojure.core/int}
+                                  (descriptor/semantic-op %)))
+                 (tree-seq coll? seq expression))))
+
 (defn match-ordered-reduce-loop
   "Match an ordered scalar reduction and retain its literal induction origin."
   [loop-form]
@@ -784,8 +793,8 @@
           recur-args (vec (rest (:recur-form matched)))]
       (when (and (:scoped-update-expr matched)
                  (= 2 (count recur-args))
-                 (= 1 (descriptor/affine-step
-                       (nth recur-args (:index-slot normalized)) (:index-sym matched))))
+                 (ordered-unit-step? (nth recur-args (:index-slot normalized))
+                                     (:index-sym matched)))
         matched))))
 
 (defn match-binary-reduce-loop

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -490,7 +490,7 @@
         [idx (second args)])
       [nil nil])))
 
-(defn normalize-loop
+(defn- normalize-loop*
   "Normalize loop*, loop, and dotimes into a unified representation.
 	Returns {:kind :map-loop|:reduce-loop, :index-sym sym, :bound bound,
 					 :body-forms [...], :acc-sym sym, :acc-init expr} or nil.
@@ -498,7 +498,7 @@
 	dotimes: (let [n (long bound)] (loop [i 0] (when (< i n) body (recur (unchecked-inc i)))))
 	loop (1-var): (loop [i 0] (if (< i n) (do body (recur (inc i))) nil))
 	loop (2-var): (loop [acc init i 0] (if (< i n) (recur new-acc (inc i)) acc))"
-  [form]
+  [form allow-nonzero-origin?]
   (cond
     (and (seq? form)
          (= 'dotimes (first form)))
@@ -564,18 +564,57 @@
                     (= test-var sym1) [sym1 init1 sym2 init2]
                     (= test-var sym2) [sym2 init2 sym1 init1]
                     :else nil)]
-              ;; index must start at 0 to map onto a [0,bound) SOAC
-              (when (and idx-sym (int-zero? idx-init))
-                {:kind :reduce-loop
+              ;; SOAC recognition remains zero-origin. Ordered scalar loops may instead keep
+              ;; an explicit nonnegative literal origin; do not translate it into an extent.
+              (when (and idx-sym
+                         (or (int-zero? idx-init)
+                             (and allow-nonzero-origin? (integer? idx-init)
+                                  (<= 0 idx-init Long/MAX_VALUE))))
+                (cond-> {:kind :reduce-loop
                  :index-sym idx-sym
                  :acc-sym acc-sym
                  :acc-init acc-init
                  :bound bound-expr
-                 :body-form body-form}))))
+                 :body-form body-form}
+                  allow-nonzero-origin? (assoc :index-init idx-init))))))
 
         :else nil))
 
     :else nil))
+
+(defn normalize-loop
+  "Normalize only zero-origin map/reduction loops for SOAC recognition."
+  [form]
+  (normalize-loop* form false))
+
+(defn normalize-ordered-loop
+  "Normalize a scalar counted loop, retaining a nonnegative literal :index-init.
+   Unlike SOAC recognition, this boundary does not assume a [0,bound) iteration domain."
+  [form]
+  (when (and (seq? form) (= 3 (count form))
+             (vector? (second form)) (= 4 (count (second form))))
+    (let [bindings (second form)
+          ids (vec (take-nth 2 bindings))
+          normalized (normalize-loop* form true)
+          {:keys [index-sym index-init body-form]} normalized
+          test (second body-form)
+          then-branch (nth body-form 2 nil)
+          lhs (first (descriptor/call-args test))
+          ;; A long loop cannot inherit a narrowing int comparison just because a generic
+          ;; SOAC recognizer can strip cast syntax. Only the explicit widening spelling is safe.
+          lhs (if (and (seq? lhs) (= 2 (count lhs))
+                       (contains? '#{long clojure.core/long} (first lhs)))
+                (second lhs) lhs)]
+      (when (and (= :reduce-loop (:kind normalized))
+                 (every? symbol? ids) (= 2 (count (set ids)))
+                 (= 4 (count body-form))
+                 (= 2 (count (descriptor/call-args test)))
+                 (= index-sym lhs)
+                 ;; New nonzero-origin coverage is deliberately direct-recursive. Lexical
+                 ;; wrappers keep their existing zero-origin coverage, not a broader promise.
+                 (or (zero? index-init)
+                     (and (seq? then-branch) (= 'recur (first then-branch)))))
+        (assoc normalized :index-slot (.indexOf ids index-sym))))))
 
 ;; ================================================================
 ;; Stencil pattern detection — shifted array loads
@@ -690,11 +729,11 @@
 
     :else nil))
 
-(defn match-reduce-loop
+(defn- match-reduce-loop*
   "Generic matcher for reduction loops.
 	Returns a structural descriptor of the loop/update shape or nil."
-  [loop-form]
-  (when-let [normalized (normalize-loop loop-form)]
+  [loop-form normalize]
+  (when-let [normalized (normalize loop-form)]
     (when (= :reduce-loop (:kind normalized))
       (let [{:keys [acc-sym acc-init index-sym body-form]} normalized
             [_ test then-branch else-branch] body-form
@@ -718,7 +757,7 @@
             (when (and update-expr
                        ;; only (< i n) → contiguous [0,bound) iteration
                        (descriptor/less-than-op? (descriptor/semantic-op test)))
-              {:acc-sym acc-sym
+              (cond-> {:acc-sym acc-sym
                :acc-init acc-init
                :index-sym index-sym
                :bound-expr (second (test-index+bound test))
@@ -728,7 +767,26 @@
                :recur-form recur-form
                :idx-update-expr idx-update-expr
                :update-expr update-expr
-               :scoped-update-expr (scoped-recur-value then-branch update-expr)})))))))
+               :scoped-update-expr (scoped-recur-value then-branch update-expr)}
+                (contains? normalized :index-init)
+                (assoc :index-init (:index-init normalized))))))))))
+
+(defn match-reduce-loop
+  "Match a zero-origin reduction for SOAC recognition."
+  [loop-form]
+  (match-reduce-loop* loop-form normalize-loop))
+
+(defn match-ordered-reduce-loop
+  "Match an ordered scalar reduction and retain its literal induction origin."
+  [loop-form]
+  (when-let [matched (match-reduce-loop* loop-form normalize-ordered-loop)]
+    (let [normalized (normalize-ordered-loop loop-form)
+          recur-args (vec (rest (:recur-form matched)))]
+      (when (and (:scoped-update-expr matched)
+                 (= 2 (count recur-args))
+                 (= 1 (descriptor/affine-step
+                       (nth recur-args (:index-slot normalized)) (:index-sym matched))))
+        matched))))
 
 (defn match-binary-reduce-loop
   "Generic matcher for simple binary reduction loops.

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -59,7 +59,7 @@
                :else [nil nil])]
          (when (and update-expr index-update
                     (= 'recur (first then-branch))
-                    (= 1 (descriptor/affine-step (nth recur-args index-slot) index-sym)))
+                    (patterns/ordered-unit-step? (nth recur-args index-slot) index-sym))
            {:acc-sym acc-sym :acc-init acc-init :index-sym index-sym :index-init index-init
             :bound-expr bound :else-expr else-expr :update-expr update-expr
             :inclusive? true}))))))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -320,6 +320,19 @@
                        (contains? '#{dec clojure.core/dec} (first expression)))
                   (lower (list 'clojure.core/- (second expression) 1) expected env)
 
+                  ;; Unary subtraction is the existing negation intrinsic for floating values:
+                  ;; spelling it as 0-x would lose the sign of zero. Integral negation instead
+                  ;; uses the checked/wrapping subtraction machinery, including MIN_VALUE.
+                  (and (seq? expression)
+                       (= :- (intrinsics/canonical (descriptor/semantic-op expression)))
+                       (= 1 (count (descriptor/call-args expression))))
+                  (lower (if (dtype/fp-dtype? expected)
+                           (list :neg (first (descriptor/call-args expression)))
+                           (list (descriptor/semantic-op expression)
+                                 (body/literal 0 expected)
+                                 (first (descriptor/call-args expression))))
+                         expected env)
+
                   (seq? expression)
                   (let [semantic-operation (descriptor/semantic-op expression)
                         operator (intrinsics/canonical semantic-operation)

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -36,11 +36,11 @@
   "Recognize the canonical one-index/one-carry loop without authorizing reassociation."
   [expression]
   (or
-   (when-let [matched (patterns/match-reduce-loop expression)]
+   (when-let [matched (patterns/match-ordered-reduce-loop expression)]
      (assoc matched :inclusive? false
-            :update-expr (or (:scoped-update-expr matched) (:update-expr matched))))
-   (when-let [{:keys [kind index-sym acc-sym acc-init body-form bound]}
-              (patterns/normalize-loop expression)]
+            :update-expr (:scoped-update-expr matched)))
+   (when-let [{:keys [kind index-sym index-init index-slot acc-sym acc-init body-form bound]}
+              (patterns/normalize-ordered-loop expression)]
      (when (and (= :reduce-loop kind)
                 (= :le (descriptor/comparison-kind
                         (descriptor/semantic-op (second body-form)))))
@@ -57,8 +57,10 @@
                [(second recur-args) (first recur-args)]
 
                :else [nil nil])]
-         (when (and update-expr index-update)
-           {:acc-sym acc-sym :acc-init acc-init :index-sym index-sym
+         (when (and update-expr index-update
+                    (= 'recur (first then-branch))
+                    (= 1 (descriptor/affine-step (nth recur-args index-slot) index-sym)))
+           {:acc-sym acc-sym :acc-init acc-init :index-sym index-sym :index-init index-init
             :bound-expr bound :else-expr else-expr :update-expr update-expr
             :inclusive? true}))))))
 
@@ -249,7 +251,7 @@
 
                   (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
                   (if-let [{:keys [acc-sym acc-init index-sym bound-expr else-expr update-expr
-                                   inclusive?]}
+                                   inclusive? index-init]}
                            (match-ordered-loop expression)]
                     (do
                       (when (or (patterns/contains-sym? bound-expr index-sym)
@@ -288,7 +290,7 @@
                                     upper)
                             loop (body/->ForLoop
                                   (body/value loop-index :long)
-                                  (body/index-cast 0 :long :exact)
+                                  (body/index-cast index-init :long :exact)
                                   upper 1
                                   [(body/->LoopArg (body/value carry loop-type)
                                                    (:result initial))]

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -19,7 +19,8 @@
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
-            [raster.runtime.hardware :as hw]))
+            [raster.runtime.hardware :as hw]
+            [raster.hardware-fixture :as hardware-fixture]))
 
 ;; ================================================================
 ;; Test infrastructure
@@ -27,8 +28,8 @@
 
 ;; Mock hardware for codegen tests (no GPU needed)
 (use-fixtures :each
+  hardware-fixture/isolated
   (fn [f]
-    (hw/reset-hardware!)
     (hw/init!)
     (hw/register-target-device! :ze:0
                                 {:name "Test GPU"

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -256,6 +256,8 @@
       (:kernels (equation-first/compile
                  #'dl-arrays/argmax-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'dl-arrays/scale-clamp-exp {:target device-id :dtype :double}))
+      (:kernels (equation-first/compile
                  #'public-c-family-map {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-scan {:target device-id :dtype :float}))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -258,6 +258,8 @@
       (:kernels (equation-first/compile
                  #'dl-arrays/scale-clamp-exp {:target device-id :dtype :double}))
       (:kernels (equation-first/compile
+                 #'dl-arrays/sum-kv-heads {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-map {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-scan {:target device-id :dtype :float}))

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -8,12 +8,13 @@
             [raster.compiler.passes.parallel.device :as device]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]
+            [raster.hardware-fixture :as hardware-fixture]
             [clojure.string :as str]))
 
 ;; Set up target device for tests (no actual GPU required)
 (use-fixtures :each
+  hardware-fixture/isolated
   (fn [f]
-    (hw/reset-hardware!)
     (hw/init!)
     (hw/register-target-device! :ze:0
                                 {:name "Intel(R) Arc(TM) Graphics"

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.index-expression :as index]
+            [raster.compiler.passes.parallel.patterns :as patterns]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
 
 (defn- lowerer []
@@ -57,6 +58,38 @@
                                                       (body/scalar-expression :neg type ['a]))]
                    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
                    :provenance {:dialect :test} :attributes {}})))))
+
+(deftest ordered-loop-origin-is-retained-without-widening-soac-recognition
+  (doseq [origin [0 1 3 Long/MAX_VALUE]]
+    (let [form (list 'loop ['r origin 'acc (body/literal 7.0 :float)]
+                     '(if (< r n) (recur (inc r) (+ acc (float r))) acc))
+          result ((:lower-region (lowerer)) {:bindings [] :results [form]}
+                  [:float] {} {'n :long})
+          loop (last (:operations result))]
+      (is (= origin (:index-init (patterns/match-ordered-reduce-loop form))))
+      (is (= (zero? origin) (some? (patterns/match-reduce-loop form))))
+      (is (= (body/index-cast origin :long :exact) (:lower loop)))
+      (is (= :ordered (get-in loop [:attributes :association])))))
+  (doseq [origin [-1 0.5 'start 9223372036854775808N]]
+    (let [form (list 'loop ['r origin 'acc 0.0]
+                     '(if (< r n) (recur (inc r) (+ acc r)) acc))]
+      (is (nil? (patterns/match-ordered-reduce-loop form))))))
+
+(deftest ordered-loop-admission-does-not-drop-effects-or-swap-recur-slots
+  (doseq [form ['(loop [r 1 acc 0.0]
+                  (aset out 0 7.0)
+                  (if (< r n) (recur (inc r) (+ acc 1.0)) acc))
+                '(loop [r 1 acc 0]
+                   (if (< r n) (recur (+ acc 1) (inc r)) acc))
+                '(loop [r 1 acc 0.0]
+                   (if (< r n) (do (aset out 0 7.0) (recur (inc r) (+ acc 1.0))) acc))
+                '(loop [r 2147483648 acc 0.0]
+                   (if (< (int r) n) (recur (inc r) (+ acc 1.0)) acc))
+                '(loop [r 1 r 0.0] (if (< r n) (recur (inc r) r) r))]]
+    (is (nil? (patterns/match-ordered-reduce-loop form))))
+  (is (= 1 (:index-init
+            (patterns/match-ordered-reduce-loop
+             '(loop [acc 0.0 r 1] (if (< (long r) n) (recur (+ acc 1.0) (inc r)) acc)))))))
 
 (deftest coupled-results-share-bindings-without-sharing-component-types
   (let [{:keys [operations results types] :as lowered} (mixed-region (lowerer))

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -85,6 +85,8 @@
                    (if (< r n) (do (aset out 0 7.0) (recur (inc r) (+ acc 1.0))) acc))
                 '(loop [r 2147483648 acc 0.0]
                    (if (< (int r) n) (recur (inc r) (+ acc 1.0)) acc))
+                '(loop [r 2147483648 acc 0.0]
+                   (if (< r n) (recur (inc (int r)) (+ acc 1.0)) acc))
                 '(loop [r 1 r 0.0] (if (< r n) (recur (inc r) r) r))]]
     (is (nil? (patterns/match-ordered-reduce-loop form))))
   (is (= 1 (:index-init

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -47,6 +47,17 @@
             (is (string? (emit/emit-scalar-kernel "unary_minus" kernel
                                                 {:target-dialect target})))))))))
 
+(deftest integer-prefix-negation-cannot-bypass-the-overflow-contract
+  (doseq [type [:byte :int :long]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (body/make
+                  {:id :invalid-integer-prefix
+                   :parameters [(body/->KernelParameter 'a :scalar type [] nil nil :parameter)]
+                   :operations [(body/->ScalarCompute (body/value 'negative type)
+                                                      (body/scalar-expression :neg type ['a]))]
+                   :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+                   :provenance {:dialect :test} :attributes {}})))))
+
 (deftest coupled-results-share-bindings-without-sharing-component-types
   (let [{:keys [operations results types] :as lowered} (mixed-region (lowerer))
         kernel

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -21,6 +21,32 @@
    [:float :int] {'candidate :float 'better :predicate}
    {'old-value :float 'old-index :int}))
 
+(deftest unary-subtraction-retains-floating-sign-and-integral-overflow
+  (doseq [type [:float :double :int :long]]
+    (let [lower (:lower-region (lowerer))
+          lowered (lower '{:bindings [] :results [(- a)]} [type] {} {'a type})
+          expression (get-in lowered [:operations 0 :expression])
+          floating? (contains? #{:float :double} type)]
+      (is (= (if floating? :neg :-) (:op expression)))
+      (is (= (if floating? 1 2) (count (:arguments expression))))
+      (is (= (when-not floating? :trap) (get-in expression [:options :overflow])))
+      (let [kernel (body/make
+                    {:id :unary-minus
+                     :parameters [(body/->KernelParameter 'a :scalar type [] nil nil :parameter)
+                                  (body/->KernelParameter 'out :output type [1] :global
+                                                         (layout/row-major [1] type) :result)]
+                     :operations (conj (:operations lowered)
+                                       (body/->ScalarStore 'out [0] (first (:results lowered)) nil))
+                     :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+                     :provenance {:dialect :test} :attributes {}})]
+        (doseq [target [:opencl-portable :cuda :hip]]
+          (if (and (not floating?) (= :opencl-portable target))
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no portable trapping"
+                                 (emit/emit-scalar-kernel "unary_minus" kernel
+                                                          {:target-dialect target})))
+            (is (string? (emit/emit-scalar-kernel "unary_minus" kernel
+                                                {:target-dialect target})))))))))
+
 (deftest coupled-results-share-bindings-without-sharing-component-types
   (let [{:keys [operations results types] :as lowered} (mixed-region (lowerer))
         kernel

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -11,6 +11,7 @@
             [raster.dl.gsdm :as gsdm]
             [raster.gpu.core :as gpu]
             [raster.gpu.link :as link]
+            [raster.hardware-fixture :as hardware-fixture]
             [raster.numeric]
             [raster.runtime.hardware :as hardware]))
 
@@ -19,8 +20,8 @@
 ;; test JVM.  No device or driver is required to derive and emit these schedules.
 (use-fixtures
   :once
+  hardware-fixture/isolated
   (fn [f]
-    (hardware/reset-hardware!)
     (hardware/init!)
     (hardware/register-target-device!
      :ze:0

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -46,6 +46,38 @@
     (is (= {:kernel-body 1} (get-in report [:emission :routes])))
     (is (empty? (get-in report [:emission :declines])))))
 
+(deftest sum-kv-heads-keeps-an-ordered-nonzero-origin-body
+  (let [report (pl/compile-report #'ops/sum-kv-heads :target-device :ocl:0 :dtype :float)]
+    (is (= {:kernel-body 1} (get-in report [:emission :routes])))
+    (is (empty? (get-in report [:emission :declines])))))
+
+(deftest ocl-ordered-head-fan-in-preserves-initial-load-and-association
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "ordered head fan-in")
+    (let [descriptor (pl/compile-gpu-program #'ops/sum-kv-heads :ocl:0 :dtype :float)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (doseq [group [1 3 5]]
+          (let [n-kv 2 slab 3
+                input (float-array
+                       (for [head (range n-kv) r (range group) col (range slab)]
+                         (if (= group 1) -0.0
+                             (case r 0 1.0e20 1 -1.0e20 (+ 3.0 head col)))))
+                expected (float-array
+                          (for [head (range n-kv) col (range slab)]
+                            (reduce (fn [acc r]
+                                      (float (+ acc (aget input (+ (* (+ (* head group) r) slab) col)))))
+                                    (aget input (+ (* head group slab) col))
+                                    (range 1 group))))
+                arguments [input (long n-kv) (long group) (long slab)]
+                program (fixture/instantiate! session descriptor arguments)]
+            (try
+              (let [result (get (fixture/run! program arguments) (:result-sym descriptor))]
+                (is (= (mapv #(Float/floatToRawIntBits %) expected)
+                       (mapv #(Float/floatToRawIntBits %) result))))
+              (finally (fixture/close! program)))))
+        (finally (gpu/close-session! session))))))
+
 (deftest ocl-unary-negation-preserves-ieee-signs
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "generated scalar negation")

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -35,6 +35,35 @@
   [state :- (Array float) a :- Float n :- Long] :- (Array float)
   (raster.par/map! state i n float (* a (ra/aget state i))))
 
+(deftm ocl-session-negate!
+  [x :- (Array float) out :- (Array float) n :- Long] :- Void
+  (raster.par/map-void! i n (ra/aset out i (- (ra/aget x i)))))
+
+(deftest scale-clamp-exp-uses-the-common-scalar-body
+  (let [report (pl/compile-report #'ops/scale-clamp-exp
+                                  :target-device :ocl:0 :dtype :double)]
+    (is (= :typed-soac (get-in report [:route :source-dialect])))
+    (is (= {:kernel-body 1} (get-in report [:emission :routes])))
+    (is (empty? (get-in report [:emission :declines])))))
+
+(deftest ocl-unary-negation-preserves-ieee-signs
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "generated scalar negation")
+    (let [x (float-array [0.0 -0.0 3.5 -3.5 Float/POSITIVE_INFINITY
+                          Float/NEGATIVE_INFINITY Float/NaN])
+          out (float-array (alength x))
+          descriptor (pl/compile-gpu-program #'ocl-session-negate! :ocl:0 :dtype :float)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (let [program (fixture/instantiate! session descriptor [x out (long (alength x))])
+              result (get (fixture/run! program [x out (long (alength x))]) 'out)]
+          (is (every? #(= :kernel-body (get-in % [:artifact :attributes :emission-route]))
+                      (:steps descriptor)))
+          (is (= (mapv #(bit-xor Integer/MIN_VALUE (Float/floatToRawIntBits %)) (take 6 x))
+                 (mapv #(Float/floatToRawIntBits %) (take 6 result))))
+          (is (Float/isNaN (aget ^floats result 6))))
+        (finally (gpu/close-session! session))))))
+
 (deftm ocl-session-map2
   [x :- (Array float) y :- (Array float)
    a :- (Array float) b :- (Array float) n :- Long] :- Void

--- a/test/raster/hardware_fixture.clj
+++ b/test/raster/hardware_fixture.clj
@@ -1,0 +1,14 @@
+(ns raster.hardware-fixture
+  "Isolated hardware registries for serial compiler tests.
+
+   CI parallelizes across processes, not concurrent namespaces in one JVM. Like with-redefs,
+   this fixture must not overlap unrelated work in the same process. It owns all three registry
+   atoms, so initialization, synthetic targets and calibration cannot escape even on failure."
+  (:require [raster.runtime.hardware]))
+
+(defn isolated
+  [f]
+  (with-redefs-fn {#'raster.runtime.hardware/device-registry (atom {})
+                  #'raster.runtime.hardware/initialized? (atom false)
+                  #'raster.runtime.hardware/measured-registry (atom {})}
+    f))

--- a/test/raster/hardware_fixture_test.clj
+++ b/test/raster/hardware_fixture_test.clj
@@ -1,0 +1,30 @@
+(ns raster.hardware-fixture-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.hardware-fixture :as fixture]
+            [raster.runtime.hardware :as hardware]))
+
+(deftest registry-isolation-restores-identities-and-values
+  (let [registries [#'raster.runtime.hardware/device-registry
+                    #'raster.runtime.hardware/initialized?
+                    #'raster.runtime.hardware/measured-registry]
+        original-atoms (mapv deref registries)
+        original-values (mapv deref original-atoms)]
+    (doseq [fail? [false true]]
+      (let [run #(fixture/isolated
+                  (fn []
+                    (is (= [{} false {}] (mapv (comp deref deref) registries)))
+                    ;; Avoid probing hardware: this test checks fixture state, not discovery.
+                    (reset! @#'raster.runtime.hardware/initialized? true)
+                    (hardware/register-target-device! :ze:987 {:name "fixture-only"
+                                                              :capabilities {}})
+                    (hardware/set-measured! :ze:987 {:bandwidth 17})
+                    (fixture/isolated
+                     (fn [] (is (= [{} false {}] (mapv (comp deref deref) registries)))))
+                    (is (= "fixture-only" (:name (hardware/device :ze:987))))
+                    (is (= {:bandwidth 17} (hardware/measured-for :ze:987)))
+                    (if fail? (throw (ex-info "fixture failure" {})) :returned)))]
+        (if fail?
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"fixture failure" (run)))
+          (is (= :returned (run))))
+        (is (every? true? (map identical? original-atoms (map deref registries))))
+        (is (= original-values (mapv (comp deref deref) registries)))))))

--- a/test/raster/hardware_test.clj
+++ b/test/raster/hardware_test.clj
@@ -1,11 +1,12 @@
 (ns raster.hardware-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [raster.runtime.hardware :as hw]
+            [raster.hardware-fixture :as hardware-fixture]
             [raster.compiler.core.hardware :as chw]
             [raster.runtime.hardware-catalogue :as catalogue]))
 
 ;; Reset hardware state between tests
-(use-fixtures :each (fn [f] (hw/reset-hardware!) (f)))
+(use-fixtures :each hardware-fixture/isolated)
 
 ;; ================================================================
 ;; CPU detection


### PR DESCRIPTION
Consolidates the fully reviewed and green stack: #394 isolates synthetic hardware/calibration test state; #395 lowers unary subtraction through shared typed intrinsics; this slice retains nonzero literal origins in ordered scalar folds. The combined head was tested by all seven required CI jobs, including CPU OpenCL execution and CUDA/HIP compilation. Direct diff against main contains exactly these three reviewed slices. Landing the tested tip together avoids repeated squash-ancestry conflicts and unchanged full-suite reruns. Coverage: public scale-clamp-exp and sum-kv-heads now emit KernelBody; signed-zero, integer overflow, ordered accumulation, binding-slot and narrowing regressions are checked. Remaining general gather contractions and other compatibility routes are not claimed unified.