### PR TITLE
Report emitted kernel routes alongside typed frontend coverage

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -4,11 +4,11 @@ Authorized scope: complete the four stages below in order. Each production migra
 its numerical, ABI, ownership and resource contracts; isolated emitter coverage is not a completed
 vertical. The north star remains the architectural specification.
 
-## 1. Close product reduction production lowering — active
+## 1. Close product reduction production lowering — landed for the dense row subset
 
 - Landed #382: shared typed multi-result scalar-region lowering.
 - Landed #383: candidate row-product KernelBody, CPU OpenCL differential execution, CUDA/HIP
-  compilation. Production still uses the retained source emitter.
+  compilation. At that stage production still used the retained source emitter.
 - Landed #384: preserve TypedSOAC local dtypes through SegRed and subsequent
   scalar/index lowering; compare both direct and local-address candidates on CPU OpenCL.
 - Landed #385: align the retained product KernelGrid with the segment-count launch,
@@ -58,7 +58,7 @@ vertical. The north star remains the architectural specification.
 
 Exit: public product workloads use the typed route without reconstructed facts or source assembly.
 
-## 2. Retire the remaining compatibility paths — queued
+## 2. Retire the remaining compatibility paths — active
 
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:
@@ -95,6 +95,12 @@ zero-origin SOAC recognition is unchanged. New nonzero coverage requires direct 
 binding-slot updates, one loop body and no narrowing induction test. Public GQA fan-in, group-one
 signed-zero preservation and cancellation-sensitive accumulation are checked on CPU OpenCL.
 This does not authorize reassociation or arbitrary symbolic/negative loop origins.
+
+Coverage reporting now retains the normalized emission routes and decline details from each
+existing corpus compilation. TypedSOAC frontend coverage alone cannot distinguish generated
+KernelBody from a compatibility emitter. Aggregate counts explicitly describe emitted artifacts,
+including dispatch alternatives, not executed launches. The portable baseline remains unchanged;
+target-specific route evidence stays in the report and CI output. No extra compile is required.
 
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring

--- a/src/raster/compiler/coverage.clj
+++ b/src/raster/compiler/coverage.clj
@@ -83,6 +83,9 @@
                        :route (get-in report [:route :source-dialect])
                        :typed-validated (boolean (get-in report [:route :typed-validated]))
                        :declines (decline-facts (get-in report [:route :declines]))
+                       ;; TypedSOAC frontend coverage does not imply KernelBody emission.
+                       ;; Retain the existing normalized emitter evidence from this SAME compile.
+                       :emission (:emission report)
                        :emission-declines (count (get-in report [:emission :declines])))
           (seq orders) (assoc :effect-orders orders)))
       (catch Throwable t
@@ -97,6 +100,10 @@
       :dtype (:dtype opts :float)
       :summary (merge {:total (count rows)}
                       (frequencies (map :route rows)))
+      ;; Counts artifacts, including dispatch alternatives, not runtime launches or latency.
+      :emission-summary
+      {:artifact-routes (reduce #(merge-with + %1 (get-in %2 [:emission :routes] {})) {} rows)
+       :programs-with-declines (count (filter #(seq (get-in % [:emission :declines])) rows))}
       :vars (vec (sort-by (comp str :var) rows))})))
 
 (def route-rank
@@ -139,6 +146,13 @@
   (with-open [reader (java.io.PushbackReader. (io/reader path))]
     (edn/read reader)))
 
+(defn baseline-facts
+  "The existing device-independent ratchet excludes target-specific emission diagnostics."
+  [report]
+  (-> report
+      (dissoc :emission-summary)
+      (update :vars #(mapv (fn [row] (dissoc row :emission :emission-declines)) %))))
+
 (defn write-baseline!
   "Write `report` as the committed baseline. Emission facts are excluded: they depend on the
    device's tuned leaves, while route and error facts are device-independent."
@@ -146,9 +160,7 @@
   (io/make-parents path)
   (with-open [writer (io/writer path)]
     (binding [*print-length* nil *print-level* nil]
-      (pp/pprint (update report :vars
-                         (fn [rows] (mapv #(dissoc % :emission-declines) rows)))
-                 writer)))
+      (pp/pprint (baseline-facts report) writer)))
   path)
 
 (defn -main
@@ -157,6 +169,7 @@
   [& [command]]
   (let [report (corpus-report {:target-device :ocl:0 :dtype :float})]
     (println "coverage summary:" (pr-str (:summary report)))
+    (println "emitted artifacts (not executed launches):" (pr-str (:emission-summary report)))
     (if (= "update" command)
       (println "baseline written:" (write-baseline! default-baseline-path report))
       (let [violations (ratchet-violations (read-baseline default-baseline-path) report)]

--- a/test/raster/compiler/coverage_corpus_test.clj
+++ b/test/raster/compiler/coverage_corpus_test.clj
@@ -8,6 +8,7 @@
    `scripts/update-coverage-baseline.sh` after an intended change."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.coverage :as coverage]
+            [raster.compiler.pipeline :as pipeline]
             [raster.gpu.device-probe :as device-probe]))
 
 (deftest corpus-does-not-leave-the-typed-route
@@ -17,6 +18,7 @@
           report (coverage/corpus-report {:target-device :ocl:0 :dtype :float})
           violations (coverage/ratchet-violations baseline report)]
       (println "  [coverage] summary:" (pr-str (:summary report)))
+      (println "  [coverage] emitted artifacts:" (pr-str (:emission-summary report)))
       (testing "every var that took the typed route still does, and no var started failing"
         (is (empty? violations)
             (with-out-str
@@ -24,3 +26,37 @@
                 (println "  coverage regression:" (pr-str v))))))
       (testing "the corpus compiled for a real device"
         (is (pos? (:total (:summary report))))))))
+
+(deftest frontend-coverage-retains-independent-emission-evidence
+  (let [calls (atom 0)
+        compiled {:backend :opencl
+                  :soac-fused-stats {:route :typed-soac :typed-validated true}
+                  :kernels [{:target :opencl-c
+                             :attributes {:emission-route :verified-segmap-opencl
+                                          :kernel-body-decline {:reason :unsupported-loop
+                                                                :missing-rule :ordered-loop}}}]}]
+    (with-redefs [pipeline/show-pipeline (fn [& _] (swap! calls inc) compiled)]
+      (let [row (coverage/report-var #'coverage/report-var {:target-device :ocl:0})]
+        (is (= 1 @calls) "emission diagnostics must not trigger another compilation")
+        (is (= :typed-soac (:route row)))
+        (is (= {:verified-segmap-opencl 1} (get-in row [:emission :routes])))
+        (is (= :unsupported-loop (get-in row [:emission :declines 0 :reason])))
+        (is (= 1 (:emission-declines row)))))))
+
+(deftest emitted-artifact-summary-does-not-change-the-portable-ratchet
+  (let [rows [{:var 'a :route :typed-soac :typed-validated true :declines []
+               :emission-declines 0 :emission {:routes {:kernel-body 2} :declines []}}
+              {:var 'b :route :typed-soac :typed-validated true :declines []
+               :emission-declines 1 :emission {:routes {:verified-segmap-opencl 1}
+                                             :declines [{:reason :unsupported-loop}]}}
+              {:var 'c :route :error :error :unsupported}]]
+    (with-redefs [coverage/corpus-vars (fn [_] rows)
+                  coverage/report-var (fn [row _] row)]
+      (let [report (coverage/corpus-report [] {:target-device :ocl:0})
+            baseline (coverage/baseline-facts report)]
+        (is (= {:artifact-routes {:kernel-body 2 :verified-segmap-opencl 1}
+                :programs-with-declines 1} (:emission-summary report)))
+        (is (= {:total 3 :typed-soac 2 :error 1} (:summary report)))
+        (is (not (contains? baseline :emission-summary)))
+        (is (every? #(not-any? (set (keys %)) [:emission :emission-declines]) (:vars baseline)))
+        (is (empty? (coverage/ratchet-violations baseline report)))))))


### PR DESCRIPTION
Retains normalized emission routes and decline details from the existing corpus compile. TypedSOAC frontend coverage no longer hides compatibility emission in diagnostic reports. Summary counts are explicitly emitted artifacts, including dispatch alternatives, not runtime launches or performance measurements. Device-specific emission facts stay out of the portable baseline/ratchet. Adds no compilation pass or benchmark to the hot loop. Pure tests2/10 pass; read-only review clean. Full CI remains required.