### PR TITLE
Retire unused CUDA-C source prototype from production

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -102,6 +102,12 @@ KernelBody from a compatibility emitter. Aggregate counts explicitly describe em
 including dispatch alternatives, not executed launches. The portable baseline remains unchanged;
 target-specific route evidence stays in the report and CI output. No extra compile is required.
 
+Static caller audit found the old `par-hip` elementwise source emitter referenced only by its
+historical compile-gate test, not by any production routing path. It is moved to the test-only
+`reference.elementwise-cuda` namespace with the algorithm unchanged. Historical ABI/math compile
+checks remain; mandatory CUDA/HIP CI continues to compile public equation-first KernelBody
+fixtures. This removes a misleading second production emitter, not a supported runtime target.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -5,9 +5,9 @@
   Backend differences (cast syntax, struct constructors, atomics) are
   parameterized via a config map bound to *emit-config*.
 
-  All kernel backends (par_opencl, par_vulkan, par_hip) delegate
-  expression/statement emission to this module and only implement
-  their own kernel scaffold (declarations, index computation, barriers).
+  Retained source-shaped backends (par_opencl, par_vulkan) and test-only source oracles
+  delegate expression/statement emission here. Production KernelBody emission has its own
+  typed boundary and shares semantic intrinsic descriptors, not these source scaffolds.
 
   Usage:
     (binding [*emit-config* opencl-config

--- a/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
+++ b/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
@@ -1,5 +1,8 @@
 (ns raster.compiler.backend.gpu.hip-compile-gate-test
-  "The HIP/CUDA COMPILE-GATE — the validation-ladder bottom rung (.internal/cuda_hip_plan.md §65).
+  "Historical source-oracle compile checks. Production CUDA/HIP gates compile the public
+   equation-first KernelBody fixtures in kernel-body-compile-fixtures instead.
+
+   Original HIP/CUDA COMPILE-GATE — the validation-ladder bottom rung (.internal/cuda_hip_plan.md §65).
 
    Proves raster's portable elementwise kernels (emitted by par_hip, body = the shared c-emit)
    are LEGAL CUDA-C and HIP by running them through nvcc and hipcc — pure host compilers, NO
@@ -13,7 +16,7 @@
             [clojure.java.shell :as sh]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [raster.compiler.backend.gpu.par-hip :as hip]))
+            [raster.compiler.reference.elementwise-cuda :as hip]))
 
 ;; ── compiler probes ──────────────────────────────────────────────────────────────
 (defn- on-path? [bin]

--- a/test/raster/compiler/reference/elementwise_cuda.clj
+++ b/test/raster/compiler/reference/elementwise_cuda.clj
@@ -1,5 +1,9 @@
-(ns raster.compiler.backend.gpu.par-hip
-  "HIP/CUDA kernel emission for raster.par elementwise forms — the forcing-function backend
+(ns raster.compiler.reference.elementwise-cuda
+  "TEST-ONLY historical CUDA-C elementwise emitter. Production CUDA/HIP emission uses
+   typed KernelBody and its target dialects. Keep this independent source oracle for the old
+   expression/ABI compile checks; it is not a selectable compiler backend or fallback.
+
+   Historical design: HIP/CUDA kernel emission for raster.par elementwise forms — the forcing-function backend
    that proves 'CUDA/HIP is a descriptor + emitter, not a pipeline fork' (.internal/cuda_hip_plan.md).
 
    The EXPRESSION layer is vendor-neutral: the kernel body is emitted by the shared `c-emit`


### PR DESCRIPTION
Static caller audit finds the old par-hip emitter used only by its historical source compile test, not the compiler pipeline. Moves its unchanged algorithm to a clearly marked test-only reference namespace; preserves the source/ABI assertions and optional historical nvcc/hipcc probes. Mandatory CI vendor compilers still consume public equation-first KernelBody fixtures. Focused source assertions1/45 pass; read-only review clean. No runtime target is removed.