### PR TITLE
Expose actual compiler emission routes and retire unused CUDA-C prototype

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -4,11 +4,11 @@ Authorized scope: complete the four stages below in order. Each production migra
 its numerical, ABI, ownership and resource contracts; isolated emitter coverage is not a completed
 vertical. The north star remains the architectural specification.
 
-## 1. Close product reduction production lowering — active
+## 1. Close product reduction production lowering — landed for the dense row subset
 
 - Landed #382: shared typed multi-result scalar-region lowering.
 - Landed #383: candidate row-product KernelBody, CPU OpenCL differential execution, CUDA/HIP
-  compilation. Production still uses the retained source emitter.
+  compilation. At that stage production still used the retained source emitter.
 - Landed #384: preserve TypedSOAC local dtypes through SegRed and subsequent
   scalar/index lowering; compare both direct and local-address candidates on CPU OpenCL.
 - Landed #385: align the retained product KernelGrid with the segment-count launch,
@@ -58,7 +58,7 @@ vertical. The north star remains the architectural specification.
 
 Exit: public product workloads use the typed route without reconstructed facts or source assembly.
 
-## 2. Retire the remaining compatibility paths — queued
+## 2. Retire the remaining compatibility paths — active
 
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:
@@ -95,6 +95,12 @@ zero-origin SOAC recognition is unchanged. New nonzero coverage requires direct 
 binding-slot updates, one loop body and no narrowing induction test. Public GQA fan-in, group-one
 signed-zero preservation and cancellation-sensitive accumulation are checked on CPU OpenCL.
 This does not authorize reassociation or arbitrary symbolic/negative loop origins.
+
+Coverage reporting now retains the normalized emission routes and decline details from each
+existing corpus compilation. TypedSOAC frontend coverage alone cannot distinguish generated
+KernelBody from a compatibility emitter. Aggregate counts explicitly describe emitted artifacts,
+including dispatch alternatives, not executed launches. The portable baseline remains unchanged;
+target-specific route evidence stays in the report and CI output. No extra compile is required.
 
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -68,7 +68,7 @@ before treating a definition as live or dead:
 | 1 | General contraction fallback in `contract_route` / `segop_opencl` | General/scientific contractions, exact decline inventory |
 | 2 | Unscheduled effect maps in `opencl_pass` / `par_opencl` | Resident mutation, aliasing, nil/buffer returns |
 | 3 | Strided scatter/gather source emission | Block transfers, collision and view contracts |
-| 4 | Active-ID compaction | ABM firms, stable output order and count/capacity |
+| 4 | Seeded active-ID generation | ABM firms, stable order and count/capacity; not general predicate compaction |
 | 5 | Compound-local algorithm emission | Structured loop dependencies, storage and barriers |
 | 6 | Staged/quantized contractions | Decode/lift algebra, typed accumulators and overflow |
 
@@ -107,6 +107,24 @@ historical compile-gate test, not by any production routing path. It is moved to
 `reference.elementwise-cuda` namespace with the algorithm unchanged. Historical ABI/math compile
 checks remain; mandatory CUDA/HIP CI continues to compile public equation-first KernelBody
 fixtures. This removes a misleading second production emitter, not a supported runtime target.
+
+The next caller audit distinguishes a remaining source edge from demonstrated runtime reachability:
+
+| Boundary | Retained owner / consumer | Current evidence |
+|---|---|---|
+| General contractions | `generate-segmented-reduce-kernel` → `contract_route` | Nested gather selects the source fallback after `:operand-layout` decline. |
+| Unscheduled effects | `generate-par-map-void-kernel` → `opencl_pass` | Raw/unbound effect fallback still present. |
+| Strided transfers | `par_opencl` stride emitters → `opencl_pass` | Bare gather/scatter probes already take typed mini-programs; remaining source edges need retirement proof. |
+| Active IDs | `generate-par-active-ids-kernel` → `opencl_pass` | ABM firms uses seeded agent indices, not arbitrary visibility compaction. |
+| Compound local | `generate-compound-local-kernel` → `opencl_pass` | Compatibility markers remain; structured typed programs bypass detection. |
+| Staged/quantized contractions | `generate-staged-contraction-kernel` → `contract_route` | Device-tested staged/lift/quantized source assembly remains. |
+| JVM SIMD / scalar | `pipeline` → `par_simd` or source expansion | Bound SegOps coexist with traversal of the retained source projection. |
+| CPU C/SIMD | `cpu/aot` → `cpu/csimd` | Bound SegOps preferred; compatibility reconstruction and distinct vector emission remain. |
+
+Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
+handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
+provenance as the emission route. The follow-up propagates the actual emitter's route through
+the adapter; semantic provenance remains separate. No schedule or precision changes.
 
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -102,6 +102,12 @@ KernelBody from a compatibility emitter. Aggregate counts explicitly describe em
 including dispatch alternatives, not executed launches. The portable baseline remains unchanged;
 target-specific route evidence stays in the report and CI output. No extra compile is required.
 
+Static caller audit found the old `par-hip` elementwise source emitter referenced only by its
+historical compile-gate test, not by any production routing path. It is moved to the test-only
+`reference.elementwise-cuda` namespace with the algorithm unchanged. Historical ABI/math compile
+checks remain; mandatory CUDA/HIP CI continues to compile public equation-first KernelBody
+fixtures. This removes a misleading second production emitter, not a supported runtime target.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -5,9 +5,9 @@
   Backend differences (cast syntax, struct constructors, atomics) are
   parameterized via a config map bound to *emit-config*.
 
-  All kernel backends (par_opencl, par_vulkan, par_hip) delegate
-  expression/statement emission to this module and only implement
-  their own kernel scaffold (declarations, index computation, barriers).
+  Retained source-shaped backends (par_opencl, par_vulkan) and test-only source oracles
+  delegate expression/statement emission here. Production KernelBody emission has its own
+  typed boundary and shares semantic intrinsic descriptors, not these source scaffolds.
 
   Usage:
     (binding [*emit-config* opencl-config

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1004,6 +1004,7 @@
      :epilogue-scalars epilogue-scalars
      :output output
      :kernel-body kernel-body
+     :emission-route :kernel-body
      :launch (:launch kernel-body)}))
 
 (defn generate-contraction-kernel-artifact

--- a/src/raster/compiler/coverage.clj
+++ b/src/raster/compiler/coverage.clj
@@ -83,6 +83,9 @@
                        :route (get-in report [:route :source-dialect])
                        :typed-validated (boolean (get-in report [:route :typed-validated]))
                        :declines (decline-facts (get-in report [:route :declines]))
+                       ;; TypedSOAC frontend coverage does not imply KernelBody emission.
+                       ;; Retain the existing normalized emitter evidence from this SAME compile.
+                       :emission (:emission report)
                        :emission-declines (count (get-in report [:emission :declines])))
           (seq orders) (assoc :effect-orders orders)))
       (catch Throwable t
@@ -97,6 +100,10 @@
       :dtype (:dtype opts :float)
       :summary (merge {:total (count rows)}
                       (frequencies (map :route rows)))
+      ;; Counts artifacts, including dispatch alternatives, not runtime launches or latency.
+      :emission-summary
+      {:artifact-routes (reduce #(merge-with + %1 (get-in %2 [:emission :routes] {})) {} rows)
+       :programs-with-declines (count (filter #(seq (get-in % [:emission :declines])) rows))}
       :vars (vec (sort-by (comp str :var) rows))})))
 
 (def route-rank
@@ -139,6 +146,13 @@
   (with-open [reader (java.io.PushbackReader. (io/reader path))]
     (edn/read reader)))
 
+(defn baseline-facts
+  "The existing device-independent ratchet excludes target-specific emission diagnostics."
+  [report]
+  (-> report
+      (dissoc :emission-summary)
+      (update :vars #(mapv (fn [row] (dissoc row :emission :emission-declines)) %))))
+
 (defn write-baseline!
   "Write `report` as the committed baseline. Emission facts are excluded: they depend on the
    device's tuned leaves, while route and error facts are device-independent."
@@ -146,9 +160,7 @@
   (io/make-parents path)
   (with-open [writer (io/writer path)]
     (binding [*print-length* nil *print-level* nil]
-      (pp/pprint (update report :vars
-                         (fn [rows] (mapv #(dissoc % :emission-declines) rows)))
-                 writer)))
+      (pp/pprint (baseline-facts report) writer)))
   path)
 
 (defn -main
@@ -157,6 +169,7 @@
   [& [command]]
   (let [report (corpus-report {:target-device :ocl:0 :dtype :float})]
     (println "coverage summary:" (pr-str (:summary report)))
+    (println "emitted artifacts (not executed launches):" (pr-str (:emission-summary report)))
     (if (= "update" command)
       (println "baseline written:" (write-baseline! default-baseline-path report))
       (let [violations (ratchet-violations (read-baseline default-baseline-path) report)]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -109,7 +109,7 @@
             :dtype dtype
             :out-dtype out-dtype}
            (select-keys descriptor [:fallback-reason :declines :tile :tensorized :packed
-                                    :fused-epilogue :dims :stages :kernel-body]))}))
+                                    :fused-epilogue :dims :stages :kernel-body :emission-route]))}))
 
 (defn kernel-signature-params
   "The parameter list of the single __kernel in `src`, split at top-level commas. Used to check a
@@ -567,6 +567,7 @@
                 workgroup-size (or (:workgroup-size portable) 256)]
             (cond->
              {:strategy (if (:ok portable) :portable-segred :naive-segred)
+              :emission-route (if emitted (:emission-route emitted) :verified-segmented-opencl)
               :declines declines
               :kernel-name kernel-name :source source :array-params array-params :abi abi
               :epilogue-operands epilogue-operands

--- a/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
+++ b/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
@@ -1,5 +1,8 @@
 (ns raster.compiler.backend.gpu.hip-compile-gate-test
-  "The HIP/CUDA COMPILE-GATE — the validation-ladder bottom rung (.internal/cuda_hip_plan.md §65).
+  "Historical source-oracle compile checks. Production CUDA/HIP gates compile the public
+   equation-first KernelBody fixtures in kernel-body-compile-fixtures instead.
+
+   Original HIP/CUDA COMPILE-GATE — the validation-ladder bottom rung (.internal/cuda_hip_plan.md §65).
 
    Proves raster's portable elementwise kernels (emitted by par_hip, body = the shared c-emit)
    are LEGAL CUDA-C and HIP by running them through nvcc and hipcc — pure host compilers, NO
@@ -13,7 +16,7 @@
             [clojure.java.shell :as sh]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [raster.compiler.backend.gpu.par-hip :as hip]))
+            [raster.compiler.reference.elementwise-cuda :as hip]))
 
 ;; ── compiler probes ──────────────────────────────────────────────────────────────
 (defn- on-path? [bin]

--- a/test/raster/compiler/coverage_corpus_test.clj
+++ b/test/raster/compiler/coverage_corpus_test.clj
@@ -8,6 +8,7 @@
    `scripts/update-coverage-baseline.sh` after an intended change."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.coverage :as coverage]
+            [raster.compiler.pipeline :as pipeline]
             [raster.gpu.device-probe :as device-probe]))
 
 (deftest corpus-does-not-leave-the-typed-route
@@ -17,6 +18,7 @@
           report (coverage/corpus-report {:target-device :ocl:0 :dtype :float})
           violations (coverage/ratchet-violations baseline report)]
       (println "  [coverage] summary:" (pr-str (:summary report)))
+      (println "  [coverage] emitted artifacts:" (pr-str (:emission-summary report)))
       (testing "every var that took the typed route still does, and no var started failing"
         (is (empty? violations)
             (with-out-str
@@ -24,3 +26,37 @@
                 (println "  coverage regression:" (pr-str v))))))
       (testing "the corpus compiled for a real device"
         (is (pos? (:total (:summary report))))))))
+
+(deftest frontend-coverage-retains-independent-emission-evidence
+  (let [calls (atom 0)
+        compiled {:backend :opencl
+                  :soac-fused-stats {:route :typed-soac :typed-validated true}
+                  :kernels [{:target :opencl-c
+                             :attributes {:emission-route :verified-segmap-opencl
+                                          :kernel-body-decline {:reason :unsupported-loop
+                                                                :missing-rule :ordered-loop}}}]}]
+    (with-redefs [pipeline/show-pipeline (fn [& _] (swap! calls inc) compiled)]
+      (let [row (coverage/report-var #'coverage/report-var {:target-device :ocl:0})]
+        (is (= 1 @calls) "emission diagnostics must not trigger another compilation")
+        (is (= :typed-soac (:route row)))
+        (is (= {:verified-segmap-opencl 1} (get-in row [:emission :routes])))
+        (is (= :unsupported-loop (get-in row [:emission :declines 0 :reason])))
+        (is (= 1 (:emission-declines row)))))))
+
+(deftest emitted-artifact-summary-does-not-change-the-portable-ratchet
+  (let [rows [{:var 'a :route :typed-soac :typed-validated true :declines []
+               :emission-declines 0 :emission {:routes {:kernel-body 2} :declines []}}
+              {:var 'b :route :typed-soac :typed-validated true :declines []
+               :emission-declines 1 :emission {:routes {:verified-segmap-opencl 1}
+                                             :declines [{:reason :unsupported-loop}]}}
+              {:var 'c :route :error :error :unsupported}]]
+    (with-redefs [coverage/corpus-vars (fn [_] rows)
+                  coverage/report-var (fn [row _] row)]
+      (let [report (coverage/corpus-report [] {:target-device :ocl:0})
+            baseline (coverage/baseline-facts report)]
+        (is (= {:artifact-routes {:kernel-body 2 :verified-segmap-opencl 1}
+                :programs-with-declines 1} (:emission-summary report)))
+        (is (= {:total 3 :typed-soac 2 :error 1} (:summary report)))
+        (is (not (contains? baseline :emission-summary)))
+        (is (every? #(not-any? (set (keys %)) [:emission :emission-declines]) (:vars baseline)))
+        (is (empty? (coverage/ratchet-violations baseline report)))))))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -238,6 +238,8 @@
     (is (= (:launch (:kernel-body routed))
            (:launch (:artifact routed)))
         "routing preserves the schedule's actual 1-D launch contract")
+    (is (= :kernel-body (artifact/emission-route (:artifact routed)))
+        "the descriptor must preserve the emitter route independently of semantic provenance")
     (is (empty? (:declines routed)))))
 
 (deftest eligible-affine-contractions-never-reenter-the-source-template
@@ -275,6 +277,7 @@
                 (* (aget A (aget indices i)) (aget x l)))
         routed (route/route-contraction form :dtype :float :desc {})]
     (is (= :naive-segred (:strategy routed)))
+    (is (= :verified-segmented-opencl (artifact/emission-route (:artifact routed))))
     (is (= :operand-layout (:fallback-reason routed)))
     (is (= :portable-kernel-body (-> routed :declines last :leaf)))
     (is (nil? (:kernel-body routed)))))

--- a/test/raster/compiler/reference/elementwise_cuda.clj
+++ b/test/raster/compiler/reference/elementwise_cuda.clj
@@ -1,5 +1,9 @@
-(ns raster.compiler.backend.gpu.par-hip
-  "HIP/CUDA kernel emission for raster.par elementwise forms — the forcing-function backend
+(ns raster.compiler.reference.elementwise-cuda
+  "TEST-ONLY historical CUDA-C elementwise emitter. Production CUDA/HIP emission uses
+   typed KernelBody and its target dialects. Keep this independent source oracle for the old
+   expression/ABI compile checks; it is not a selectable compiler backend or fallback.
+
+   Historical design: HIP/CUDA kernel emission for raster.par elementwise forms — the forcing-function backend
    that proves 'CUDA/HIP is a descriptor + emitter, not a pipeline fork' (.internal/cuda_hip_plan.md).
 
    The EXPRESSION layer is vendor-neutral: the kernel body is emitted by the shared `c-emit`


### PR DESCRIPTION
The public matmul audit exposed a reporting hole: generated portable KernelBody contracts appeared under semantic segcontract provenance. Propagate the emitter-authored route through descriptor closure, retaining semantic provenance separately. Source gather fallback remains explicitly classified. No schedule, ABI, arithmetic or precision changes. 15 focused tests/118 assertions pass; actual public matmul compile reports KernelBody. Documents remaining caller inventory without mistaking source edges for dynamic reachability.