### PR TITLE
Preserve declared Long scalar facts before GPU scheduling

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -133,6 +133,15 @@ equations. Existing source-oracle assertions remain test-only. CPU OpenCL checks
 output identity, gather overwrite and repeated-index scatter accumulation into nonzero storage;
 this is correctness evidence, not an accelerator performance measurement.
 
+Active-ID retirement uncovered a shared source/ABI type bug: `derive-param-types` narrowed every
+declared Long to int before TypedSOAC, including random seeds. The prerequisite now retains
+declared integral widths at every caller of that common derivation. This changes affected scalar
+ABIs; consumers must bind the emitted ABI, not assume an int slot for a Long parameter. Hardware
+group/local index types are unchanged; schedules requiring int parameters still need explicit
+checked narrowing. Public equation-first, resident and session paths are tested with 64-bit state
+and wrapping arithmetic. The active-ID prototype remains unshipped until its checked int count
+conversion is also retained; this prerequisite alone does not retire that kernel.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -141,8 +141,10 @@
 (defn derive-param-types
   "Declared scalar + array element types for the GPU emitter, read from a deftm's params + tags
   (the typed-dispatch system already knows these — we read them instead of letting the emitter
-  guess from parameter names). Scalar params: long/int→:int, floating scalars specialize to the
-  selected kernel dtype. Array params: the tag's element dtype, with float-family (float/double)
+  guess from parameter names). Scalar params retain their declared integral width; floating
+  scalars specialize to the selected kernel dtype. Physical narrowing belongs to a scheduled
+  ABI conversion with a range check, not source type derivation.
+  Array params: the tag's element dtype, with float-family (float/double)
   mapped to the KERNEL dtype (a single-precision kernel reads float buffers regardless of a
   parametric (All [T]) param's default).
   Returns {:scalar-types {sym kw} :array-types {sym kw}}, attached as form metadata that
@@ -151,7 +153,8 @@
   (when (and params tags)
     {:scalar-types (into {} (keep (fn [[p t]]
                                     (case (dtype/dtype-for-scalar-tag t)
-                                      (:long :int) [p :int]
+                                      :long [p :long]
+                                      :int [p :int]
                                       (:double :float) [p dtype]
                                       nil))
                                   (map vector params tags)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -32,6 +32,10 @@
             [raster.quant.kernels-k :as qk]
             [raster.runtime.hardware :as hardware]))
 
+(deftm public-c-family-long-state
+  [out :- (Array long) state :- Long n :- Long] :- (Array long)
+  (raster.par/map! out i n long (unchecked-add state (long i))))
+
 (deftm public-c-family-dot
   "Public equation-first workload compiled by nvcc/hipcc without a physical device."
   (All [T] [left :- (Array T) right :- (Array T) n :- Long] :- Double
@@ -253,6 +257,8 @@
      (concat
       (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'public-c-family-long-state {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'dl-arrays/argmax-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -38,7 +38,7 @@
                           (concat [:min-elements 0] opts)))))
 
 (deftest declared-gpu-parameter-types-preserve-the-scalar-array-partition
-  (is (= {:scalar-types {'in :int 'scale :float}
+  (is (= {:scalar-types {'in :long 'scale :float}
           :array-types {'packed :int 'metadata :byte 'values :float 'cache :half}}
          (opencl-pass/derive-param-types
           '[packed metadata values cache in scale]

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -157,7 +157,7 @@
       (is (= :kernel-body (get-in step [:artifact :provenance :dialect])))
       (is (= :kernel-body (get-in step [:artifact :attributes :emission-route])))
       (is (= '[indices src out width _n_bound] (mapv :name (:abi step))))
-      (is (= [:int :float :float :int :long] (mapv :dtype (:abi step))))
+      (is (= [:int :float :float :long :long] (mapv :dtype (:abi step))))
       (is (= 'rstr_extent_0 (last (get-in step [:artifact :arguments])))
           "the schedule names the typed scalar extent instead of embedding host code")
       (is (= 15 ((:value-fn (last (:argument-specs step)))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -280,7 +280,7 @@
         ;; mixed byte/int/float storage lowers through the verified KernelBody: the int8 store
         ;; is a stated narrowing cast, not a source spelling the SegMap generator reparses
         (is (= :kernel-body (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
-        (is (= [:byte :float :int :float :int]
+        (is (= [:byte :float :int :float :long]
                (mapv :dtype (get-in descriptor [:steps 0 :abi]))))
         (let [program (fixture/instantiate! session descriptor [x q y labels n]
                                             {'x :input 'q :input

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -11,9 +11,11 @@
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.pipeline :as pl]
+            [raster.compiler.equation-first :as equation-first]
             [raster.arrays :as ra]
             [raster.core :refer [deftm]]
             [raster.dl.array-ops :as ops]
+            [raster.dl.nn :as nn]
             [raster.gpu.core :as gpu]
             [raster.gpu.device-probe :as device-probe]
             [raster.gpu.descriptor-fixture :as fixture]))
@@ -39,6 +41,45 @@
 (deftm ocl-session-negate!
   [x :- (Array float) out :- (Array float) n :- Long] :- Void
   (raster.par/map-void! i n (ra/aset out i (- (ra/aget x i)))))
+
+(deftm ocl-session-long-state
+  [out :- (Array long) state :- Long n :- Long] :- (Array long)
+  (raster.par/map! out i n long (unchecked-add state (long i))))
+
+(deftest public-compiler-entry-points-preserve-declared-long-scalars
+  (let [emitted (equation-first/compile #'ocl-session-long-state
+                                       {:target :ocl:0 :dtype :float})
+        resident (pl/compile-gpu-program #'ocl-session-long-state :ocl:0 :dtype :float)
+        scalar-dtypes #(mapv :dtype (filter (fn [slot] (= :scalar (:kind slot))) (:abi %)))]
+    (is (= [[:long :long]] (mapv scalar-dtypes (:kernels emitted))))
+    (is (= {:kernel-body 1}
+           (get-in (pl/compile-report #'ocl-session-long-state
+                                      :target-device :ocl:0 :dtype :float)
+                   [:emission :routes])))
+    (is (= [:map] (mapv :convention (:steps resident))))))
+
+(deftest ocl-session-long-scalars-survive-session-and-resident-binding
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "declared Long scalar state")
+    (let [s (gpu/make-session :ocl:0)]
+      (try
+        (let [artifacts (gpu/compile! s :long-state #'ocl-session-long-state
+                                      {:dtype :float :min-elements 0})
+              invoke! (requiring-resolve 'raster.gpu.ocl-runtime/invoke-registered-kernel)
+              descriptor (pl/compile-gpu-program #'ocl-session-long-state :ocl:0 :dtype :float)
+              out (long-array 3)]
+          (is (= [[:long :long :long]] (mapv #(mapv :dtype (:abi %)) artifacts)))
+          (gpu/alloc! s {:state [:long 3 nil]})
+          (doseq [state [4294967297 Long/MIN_VALUE Long/MAX_VALUE]]
+            (let [expected (mapv #(unchecked-add (long state) (long %)) (range 3))]
+              (invoke! (:kernel-name (first artifacts)) [] (gpu/buffer s :state)
+                       [{:type :long :value state}] 3)
+              (is (= expected (vec (gpu/download s :state))))
+              (let [program (fixture/instantiate! s descriptor [out state 3])]
+                (try
+                  (is (= expected (vec (get (fixture/run! program [out state 3]) 'out))))
+                  (finally (fixture/close! program)))))))
+        (finally (gpu/close-session! s))))))
 
 (deftest scale-clamp-exp-uses-the-common-scalar-body
   (let [report (pl/compile-report #'ops/scale-clamp-exp
@@ -477,6 +518,23 @@
           result (execute state (float 3.0) n)]
       (is (identical? state result))
       (is (= (float (* 3.0 513.0)) (aget state 512))))))
+
+(deftest ocl-resident-contraction-binds-public-long-dimensions
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "public Long contraction dimensions")
+    (let [descriptor (pl/compile-gpu-program #'nn/linear-nb :ocl:0 :dtype :float
+                                            :gemm-precision :f32-scalar)
+          x (float-array [1 2 3 4 5 6])
+          weights (float-array [1 0 0 0 1 1])
+          arguments [x weights (long 2) (long 3) (long 2)]
+          s (gpu/make-session :ocl:0)]
+      (try
+        (let [program (fixture/instantiate! s descriptor arguments)]
+          (try
+            (is (= [1.0 5.0 4.0 11.0]
+                   (vec (get (fixture/run! program arguments) (:result-sym descriptor)))))
+            (finally (fixture/close! program))))
+        (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-contraction-roundtrip
   (if-not @device-probe/opencl-available?

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -93,7 +93,7 @@
                                                   :target-device :ze:0 :dtype :float))]
     (is (= 1 (count kernels)))
     (is (= '[[positions :input :int] [x :input :float] [out :output :float]
-             [head-dim :scalar :int] [heads :scalar :int] [theta :scalar :float]
+             [head-dim :scalar :long] [heads :scalar :long] [theta :scalar :float]
              [_n_bound :scalar :long]]
            (mapv (juxt :name :kind :dtype) (:abi (first kernels))))
         "KernelBody orders inputs, outputs, then scalars; row count is specialized out"))

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -216,11 +216,11 @@
     (is (= 2 (count quant-kernels)) "Q8_K remains an ordered two-phase reduction")
     (is (= '[[[submax :float] [x :float] [_n_bound :int]]
              [[bsums :int] [submax :float] [x :float] [xp :int]
-              [xs :float] [in :int] [_n_bound :int]]]
+              [xs :float] [in :long] [_n_bound :int]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) quant-kernels)))
-    (is (= '[[[submax :float] [x :float] [padded-in :int] [width :int] [_n_bound :int]]
+    (is (= '[[[submax :float] [x :float] [padded-in :long] [width :long] [_n_bound :int]]
              [[bsums :int] [submax :float] [x :float] [xp :int] [xs :float]
-              [padded-in :int] [width :int] [_n_bound :int]]]
+              [padded-in :long] [width :long] [_n_bound :int]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) padded-kernels))
         "the adapter changes layout indexing without changing the two-phase Q8_K representation")
     (is (every? #(re-find #"col\).*<.*width" (:source %)) padded-kernels)
@@ -239,7 +239,7 @@
         "the scheduled SegMap is preserved through OpenCL emission")
     (is (= '[[aq :byte] [bq :byte] [bsums :int] [da :float] [db :float]
              [wp :int] [xp :int] [xs :float] [y :float]
-             [in :int] [out :int] [_n_bound :long]]
+             [in :long] [out :long] [_n_bound :long]]
            (mapv (juxt :name :dtype) (:abi (first projection-kernels)))))
     (is (re-find #"rstr_dp4a" (:source (first projection-kernels)))
         "Q4_K row projection reaches the target-neutral integer-dot intrinsic")
@@ -266,10 +266,10 @@
             :backend-reused 1 :backend-relowered 0 :fallback 0}
            (:lowering i8-report)))
     (is (= '[[[bsums :int] [ds :float] [sc :byte] [wp :int] [xp :int]
-              [xs :float] [y :float] [in :int] [_n_bound :int]]]
+              [xs :float] [y :float] [in :long] [_n_bound :long]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) (:kernels q6-pipeline))))
     (is (= '[[[wp :int] [ws :float] [xp :int] [xs :float] [y :float]
-              [in :int] [out :int] [_n_bound :long]]]
+              [in :long] [out :long] [_n_bound :long]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) (:kernels i8-pipeline))))
     (is (every? #(re-find #"rstr_dp4a" (:source %))
                 (concat (:kernels q6-pipeline) (:kernels i8-pipeline)))


### PR DESCRIPTION
## Correctness boundary
The common declared-parameter derivation previously narrowed every Long to int before TypedSOAC, including 64-bit random seeds and state. Preserve the declared width; target-private narrowing remains an explicit checked ABI conversion. This fixes a disagreement between public compiler entry paths without adding a function-specific type override.

## ABI impact
Affected generated scalar slots are now Long. Callers supplying explicit typed int captures for a declared Long must follow the emitted ABI. Hardware group/local index widths and scheduling code are unchanged. The active-ID migration that exposed this bug remains unshipped until its checked count conversion is also retained.

## Focused validation
- New public entry/session/resident Long-state tests: 3 tests, 11 assertions; CPU OpenCL checks values beyond 32 bits and wrapping near both Long endpoints.
- Existing backend namespace: 24 tests, 239 assertions.
- Representative CPU OpenCL map, product reduction, scalar reduction and contraction: 6 tests, 13 assertions, including public linear-nb with Long dimensions.
- Existing checked narrowing/overflow tests: 3 tests, 20 assertions.
- Added public Long-state CUDA/HIP compile fixture. Full suite is delegated to CI.
- Read-only review found no blocker; required runtime and checked-narrowing checks pass. These are correctness checks, not accelerator performance measurements.