### PR TITLE
Keep fan-out materialized when machine prices are invalid

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -142,6 +142,15 @@ checked narrowing. Public equation-first, resident and session paths are tested 
 and wrapping arithmetic. The active-ID prototype remains unshipped until its checked int count
 conversion is also retained; this prerequisite alone does not retire that kernel.
 
+The next prerequisite distinguishes shape-value equality from unchecked cast erasure. Source
+normalization removes integral identity/widening casts only when retained types prove them safe;
+narrowing and unknown conversions remain scalar equations. Relational extent canonicalization
+must not subsequently erase the same check. A public checked count is evaluated by the resident
+descriptor before driver contact; horizontal fusion retains the scalar equation ahead of its
+combined launch, and inactive host branches do not evaluate their local count. This does not yet
+repair convenience operations that unconditionally unwrap counts or prove every compiler pass
+preserves checked conversions.
+
 Exit: classify all remaining routes; retire duplicated paths for covered workloads with explicit
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -155,7 +155,15 @@ Exit: classify all remaining routes; retire duplicated paths for covered workloa
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.
 
-## 3. General fusion and bounded specialization — queued
+The active-ID prototype is deliberately **not shipped**. Review found that its remainder-based
+body matches source `mod` only over positive populations, and its output conversion needs a proved
+int range. It also inherited unconditional cast erasure on seed/population captures. Passing
+ordinary ABM differential tests does not establish those preconditions. Keep the production route
+until shared capture normalization and enforced scalar-domain admission preserve empty/inactive
+execution as well as overflow. The local `compiler/active-indices-typed-map` branch retains the
+prototype and count-check tests for that follow-up; no retirement is claimed.
+
+## 3. General fusion and bounded specialization — price admission active; broader work queued
 
 - Validate shared scalar-region composition, coupled reductions and post-reduction transforms.
 - Audit recompute/materialize choices on fan-out, effects, aliases and observable results.
@@ -163,6 +171,12 @@ the entire compiler unified from one successful vertical.
   and typed constant/range simplification afterward.
 - Preserve ordered arithmetic and AD/effect boundaries. Use guards and bounded specialization
   caches; do not unroll large numerical iteration spaces merely because their sizes are known.
+
+The first generic hardening rejects nonnumeric, nonpositive and nonfinite machine ridge prices,
+and overflow of their derived recompute threshold. These prices cannot authorize duplicating a
+fan-out producer. Sole-consumer elimination still needs no cost estimate. The witness policy is
+versioned; production typed-route tests retain both materialized consumers with an explicit reason.
+This is price admission, not a new fusion legality proof or a bounded specialization cache.
 
 Exit: representative scientific and model expressions compile with explained fusion/placement
 choices, differential correctness, and measured kernel/allocation/compile-cost changes.

--- a/src/raster/compiler/passes/parallel/fusion_placement.clj
+++ b/src/raster/compiler/passes/parallel/fusion_placement.clj
@@ -10,7 +10,11 @@
 
 (def policy-version
   "Stable identifier recorded with every placement witness."
-  :roofline-v1)
+  :roofline-v2)
+
+(defn- positive-finite-price?
+  [price]
+  (and (number? price) (Double/isFinite (double price)) (pos? (double price))))
 
 (defn expression-cost
   "Return registered flop-equivalent cost and its completeness for `expressions`.
@@ -61,7 +65,7 @@
         {:keys [flops complete? unknown-ops]} (expression-cost expressions)
         element-bytes (when (dtype/known? dtype) (dtype/bytes-of dtype))
         ridge (get-in abstract-machine [:ridge dtype])
-        threshold (when (and element-bytes ridge)
+        threshold (when (and element-bytes (positive-finite-price? ridge))
                     (* (long element-bytes) (double ridge)))
         base {:policy policy-version
               :consumer-count consumer-count
@@ -96,6 +100,16 @@
       (nil? ridge)
       (assoc base :decision :materialize
              :reason :unknown-roofline-ridge
+             :fuse? false)
+
+      (not (positive-finite-price? ridge))
+      (assoc base :decision :materialize
+             :reason :invalid-roofline-ridge
+             :fuse? false)
+
+      (not (positive-finite-price? threshold))
+      (assoc base :decision :materialize
+             :reason :invalid-recompute-threshold
              :fuse? false)
 
       (<= flops threshold)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -626,9 +626,37 @@
       :scalars (mapv #(-> % (assoc :value (:sym %)) (dissoc :sym)) (:scalars epilogue))
       :result-dtype (or (:dtype epilogue) :float)})))
 
-(defn- strip-index-casts
-  [expression]
-  (util/postwalk-preserving-meta strip-index-cast expression))
+(defn- retained-scalar-dtype
+  [expression scalar-types]
+  (or (get scalar-types expression)
+      (some-> (when (instance? clojure.lang.IObj expression)
+                (types/sym-type-tag expression))
+              dtype/dtype-for-scalar-tag)
+      (when (and (seq? expression)
+                 (not (contains? util/*shadowing-locals* (descriptor/semantic-op expression))))
+        (some-> (descriptor/semantic-op expression) descriptor/cast-result-tag
+                dtype/dtype-for-scalar-tag))))
+
+(defn- normalize-scalar-casts
+  "Erase only integral identity/widening casts proved by retained types. A narrowing cast
+   performs a check (or a conversion), even when its argument also names a shape dimension."
+  [expression scalar-types]
+  (util/postwalk-preserving-meta
+   (fn [form]
+     (if (and (seq? form) (descriptor/cast-op? (descriptor/semantic-op form))
+              (not (contains? util/*shadowing-locals* (descriptor/semantic-op form)))
+              (= 1 (count (descriptor/call-args form))))
+       (let [argument (first (descriptor/call-args form))
+             source (retained-scalar-dtype argument scalar-types)
+             target (some-> (descriptor/semantic-op form) descriptor/cast-result-tag
+                            dtype/dtype-for-scalar-tag)
+             integral? #{:byte :short :int :long}]
+         (if (and (integral? source) (integral? target)
+                  (<= (dtype/bytes-of source) (dtype/bytes-of target)))
+           argument
+           form))
+       form))
+   expression))
 
 (def ^:dynamic ^:private *scalar-definitions*
   "Host scalar bindings preceding the operation being described, as `{id expression}` for the
@@ -1570,7 +1598,7 @@
         :else nil))))
 
 (defn- normalize-source*
-  [source]
+  [source scalar-types]
   ;; Direct backend entry may see source before the ordinary pipeline's SSA cleanup. Clojure
   ;; permits sequential rebinding (most commonly repeated `_` effect binders), while TypedSOAC
   ;; deliberately requires one logical definition per value. Use the shared scope-aware
@@ -1582,7 +1610,8 @@
             pairs (vec (partition 2 bindings))
             {:keys [normalized]}
             (reduce
-             (fn [{:keys [compound-extents allocation-lengths scalar-aliases pure-scalar-ids]
+             (fn [{:keys [compound-extents allocation-lengths scalar-aliases pure-scalar-ids
+                         local-scalar-types]
                    :as state}
                   [ordinal [symbol expression]]]
                (let [expression (->> expression
@@ -1593,7 +1622,8 @@
                      ;; that earlier value. Extents are compared in these canonical names so
                      ;; `(* seq dff)` and `(* n1 n2)` with `n1 = seq`, `n2 = dff` are one size.
                      canonical-scalar (fn [form]
-                                        (util/subst-syms scalar-aliases (strip-index-casts form)))
+                                        (normalize-scalar-casts
+                                         (util/subst-syms scalar-aliases form) local-scalar-types))
                      ;; `(long x)` of a floating scalar is a conversion, not a renaming.
                      floating-cast? (and (seq? expression) (= 2 (count expression))
                                          (contains? '#{long int clojure.core/long clojure.core/int}
@@ -1631,6 +1661,10 @@
                                (assoc-in state [:pure-scalar-ids scalar-form] symbol))
 
                              :else state)
+                     state (if-let [scalar-dtype (or (retained-scalar-dtype symbol local-scalar-types)
+                                                    (retained-scalar-dtype expression local-scalar-types))]
+                             (assoc-in state [:local-scalar-types symbol] scalar-dtype)
+                             state)
                      scalar-aliases (:scalar-aliases state)
                      extent (parallel-extent expression)
                      ;; `(alength y)` over a local allocation is the allocation's declared
@@ -1645,12 +1679,12 @@
                      canonical-extent (some-> extent
                                               (resolve-length #{})
                                               (->> (util/subst-syms scalar-aliases))
-                                              descriptor/unwrap-int-cast)
+                                              (normalize-scalar-casts local-scalar-types))
                      state (if-let [length (allocation-length expression)]
                              (assoc-in state [:allocation-lengths symbol]
                                        (->> (resolve-length length #{})
                                             (util/subst-syms scalar-aliases)
-                                            descriptor/unwrap-int-cast))
+                                            (#(normalize-scalar-casts % local-scalar-types))))
                              (if (and (symbol? expression)
                                       (contains? allocation-lengths expression))
                                (assoc-in state [:allocation-lengths symbol]
@@ -1660,9 +1694,8 @@
                    (nil? extent)
                    (update state :normalized conj [symbol expression])
 
-                   ;; Integral casts are representation noise, not new semantic dimensions.
-                   ;; Keeping their underlying value identity also prevents one array from
-                   ;; acquiring incompatible [n] and [(long n)] shapes across operations.
+                   ;; Only proved identity/widening casts are representation noise. A narrowing
+                   ;; count remains an executable scalar equation with a distinct dimension id.
                    (dialect/extent? canonical-extent)
                    (update state :normalized conj
                            [symbol (replace-parallel-extent expression canonical-extent)])
@@ -1674,9 +1707,12 @@
                      ;; general horizontal-fusion rule (for example two same-shaped views).
                      (update state :normalized conj
                              [symbol (replace-parallel-extent expression extent-id)])
-                     (let [extent-id (with-meta
+                     (let [extent-dtype (or (retained-scalar-dtype canonical-extent local-scalar-types)
+                                            :long)
+                           extent-tag (dtype/scalar-tag-for-dtype extent-dtype)
+                           extent-id (with-meta
                                        (clojure.core/symbol (str "rstr_extent_" ordinal))
-                                       {:tag 'long :raster.type/tag 'long
+                                       {:tag extent-tag :raster.type/tag extent-tag
                                         ;; This SSA value is introduced by the frontend as the
                                         ;; canonical identity of compound launch/storage algebra.
                                         ;; Preserve that provenance without relying on its name.
@@ -1690,7 +1726,7 @@
                    :else
                    (update state :normalized conj [symbol expression]))))
              {:normalized [] :compound-extents {} :allocation-lengths {}
-              :scalar-aliases {} :pure-scalar-ids {}}
+              :scalar-aliases {} :pure-scalar-ids {} :local-scalar-types scalar-types}
              (map-indexed vector pairs))]
         (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
       source)))
@@ -1746,7 +1782,12 @@
   (loop [extent extent seen #{}]
     (let [wrapped? (and (seq? extent) (= 'value (first extent)) (= 2 (count extent)))
           inner (if wrapped? (second extent) extent)
-          normalized (descriptor/unwrap-int-cast inner)
+          ;; Consult only this expression's free values, not every program value on each
+          ;; relational shape comparison.
+          scalar-types (into {} (keep (fn [id]
+                                        (when-let [value (get values id)] [id (:dtype value)])))
+                             (util/free-syms inner))
+          normalized (normalize-scalar-casts inner scalar-types)
           array (alength-array normalized)
           proved-shape (when array (:shape (get values array)))
           proved-extent (when (= 1 (count proved-shape)) (first proved-shape))
@@ -1787,7 +1828,7 @@
               (assoc-in [:scalar-representatives (:sym description)] representative)))
 
         (:map :scatter :effect-map :stencil :reduce :scan)
-        (let [extent (descriptor/unwrap-int-cast (:extent description))
+        (let [extent (:extent description)
               array (alength-array extent)
               proved-extent (canonical-extent shape-equalities values extent)
               extent' (cond
@@ -1907,7 +1948,7 @@
                                (tagged #(contains? #{:long :int}
                                                    (some-> % dtype/dtype-for-scalar-tag
                                                            dtype/canon))))}]
-       (normalize-source* source)))))
+       (normalize-source* source scalar-types)))))
 
 (declare coverage-decline*)
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1380,6 +1380,8 @@
 (defn- parallel-extent
   [expression]
   (cond
+    (or (par/par-gather-form? expression) (par/par-scatter-form? expression)
+        (par/par-reduce-by-key-form? expression)) (nth expression 4)
     (par/par-rng-fill-form? expression) (:n (par/extract-par-rng-fill-info expression))
     (par/par-map-pure-form? expression) (nth expression 2)
     (par/par-map-form? expression) (nth expression 3)
@@ -1396,6 +1398,8 @@
 (defn- replace-parallel-extent
   [expression extent]
   (let [position (cond
+                   (or (par/par-gather-form? expression) (par/par-scatter-form? expression)
+                       (par/par-reduce-by-key-form? expression)) 4
                    (par/par-rng-fill-form? expression) 2
                    (par/par-map-pure-form? expression) 2
                    (par/par-map-form? expression) 3

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.backend.gpu.par-opencl-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.walk :as walk]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.reference.indexed-transfer-opencl :as indexed-reference]
@@ -180,6 +181,56 @@
         (when (= 'raster.par/scatter! op)
           (is (= :reducing-scatter (get-in artifact [:effects :kind])))
           (is (= :inout (:kind (first (filter #(= 'out (:name %)) (:abi artifact)))))))))))
+
+(deftest checked-extent-survives-horizontal-fusion-before-submission
+  (let [source '(let* [a (raster.par/map! left i (int n) float (+ (aget x i) 1.0))
+                       b (raster.par/map! right j (int n) float (* (aget x j) 2.0))]
+                      [a b])
+        emitted (opencl-pass/opencl-pass
+                 source :min-elements 0 :dtype :float
+                 :array-types {'x :float 'left :float 'right :float}
+                 :scalar-types {'n :long})
+        ;; Clojure's evaluator rejects an int hint on an already primitive initializer;
+        ;; Raster's bytecode emitter accepts it. Remove only that evaluator hint, retaining
+        ;; every executable cast and the compiler's own type facts.
+        host-form (walk/postwalk
+                   #(if (symbol? %) (vary-meta % dissoc :tag) %)
+                   (walk/postwalk-replace
+                    {'raster.gpu.ze-runtime/invoke-registered-map-void-kernel 'submit!}
+                    (:form emitted)))
+        execute (eval (list 'fn '[submit! n x left right] host-form))
+        submissions (atom 0)
+        submit! (fn [& _] (swap! submissions inc))]
+    (is (= 1 (get-in emitted [:stats :direct-scheduling :horizontal])))
+    (is (= 1 (get-in emitted [:stats :direct-scheduling :typed-scalar-equations])))
+    (is (= 1 (count (:kernels emitted))))
+    (execute submit! 3 nil nil nil)
+    (is (= 1 @submissions))
+    (reset! submissions 0)
+    (doseq [n [(inc (long Integer/MAX_VALUE)) (dec (long Integer/MIN_VALUE))]]
+      (is (thrown? ArithmeticException (execute submit! n nil nil nil))))
+    (is (zero? @submissions) "the retained checked conversion runs before any kernel call")))
+
+(deftest inactive-host-branch-does-not-evaluate-its-checked-count
+  (let [emitted (opencl-pass/opencl-pass
+                 '(if enabled
+                    (let* [^int count (int n)
+                           result (raster.par/map! out i count float (aget x i))]
+                          result)
+                    nil)
+                 :min-elements 0 :dtype :float
+                 :array-types {'x :float 'out :float}
+                 :scalar-types {'n :long 'enabled :boolean})
+        host-form (walk/postwalk
+                   #(if (symbol? %) (vary-meta % dissoc :tag) %)
+                   (walk/postwalk-replace
+                    {'raster.gpu.ze-runtime/invoke-registered-kernel 'submit!}
+                    (:form emitted)))
+        execute (eval (list 'fn '[submit! enabled n x out] host-form))
+        submit! (fn [& _] (throw (AssertionError. "unexpected submission")))]
+    (is (nil? (execute submit! false nil nil nil)))
+    (is (thrown? ArithmeticException
+                 (execute submit! true (inc (long Integer/MAX_VALUE)) nil nil)))))
 
 (deftest strided-transfer-retained-programs-do-not-reenter-source-lowering
   (doseq [op '[raster.par/gather raster.par/scatter!]]

--- a/test/raster/compiler/passes/parallel/fusion_placement_test.clj
+++ b/test/raster/compiler/passes/parallel/fusion_placement_test.clj
@@ -39,6 +39,28 @@
                          (assoc arguments :consumer-count 1))
                         [:decision :reason])))))
 
+(deftest invalid-machine-prices-cannot-authorize-recomputation
+  (doseq [price [0 -1 Double/NaN Double/POSITIVE_INFINITY Double/NEGATIVE_INFINITY
+                 "100" :unknown true {}]]
+    (let [arguments {:abstract-machine {:ridge {:float price}}
+                     :dtype :float :expressions '[(exp x)] :consumer-count 2}
+          witness (placement/placement-decision arguments)]
+      (is (= :roofline-v2 (:policy witness)))
+      (is (= {:decision :materialize :reason :invalid-roofline-ridge :fuse? false}
+             (select-keys witness [:decision :reason :fuse?])) (str price))
+      (is (nil? (:recompute-threshold-flops witness)))
+      (is (= {:decision :eliminate :reason :sole-consumer :fuse? true}
+             (select-keys (placement/placement-decision (assoc arguments :consumer-count 1))
+                          [:decision :reason :fuse?]))
+          "moving one computation needs no speculative hardware price"))))
+
+(deftest finite-ridge-can-still-overflow-its-derived-price
+  (let [witness (placement/placement-decision
+                 {:abstract-machine {:ridge {:double Double/MAX_VALUE}}
+                  :dtype :double :expressions '[(+ x 1)] :consumer-count 2})]
+    (is (= {:decision :materialize :reason :invalid-recompute-threshold :fuse? false}
+           (select-keys witness [:decision :reason :fuse?])))))
+
 (deftest incomplete-placement-prices-never-enable-duplicated-work
   (let [machine {:ridge {:float 100.0}}
         unknown-op (placement/placement-decision

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -917,6 +917,26 @@
     (is (= 'int (:tag (meta extent))))
     (is (= '[scalar map] (mapv dialect/operation-kind equations)))))
 
+(deftest indexed-operation-counts-use-the-shared-scalar-normalizer
+  (doseq [operation ['(raster.par/gather out x indices count)
+                     '(raster.par/scatter! out x indices count)
+                     '(raster.par/reduce-by-key out indices x count +)]
+          cast ['long 'int]]
+    (let [expression (apply list (assoc (vec operation) 4 (list cast 'n)))
+          options {:dtype :float :array-types {'x :float 'out :float 'indices :int}
+                   :scalar-types {'n :long}}
+          normalized (frontend/normalize-source (list 'let* ['result expression] 'result)
+                                                options)
+          bindings (second normalized)
+          program (frontend/form->program normalized options)
+          equations (dialect/equations program)]
+      (if (= cast 'int)
+        (do (is (= '(int n) (second bindings)))
+            (is (= 'int (:tag (meta (first bindings)))))
+            (is (= 'scalar (dialect/operation-kind (first equations)))))
+        (is (= 'n (nth (second bindings) 4))))
+      (is (some? program) (str (first operation) " / " cast)))))
+
 (deftest equal-sizes-spelled-through-host-bindings-are-one-extent
   ;; `n1 = seq`, `n2 = dff`, `(* n1 n2)` and `(* seq dff)` denote one size, and `(alength y)`
   ;; over `y = (float-array n)` is `n`. Without those identities the buffer `y` would receive

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -883,6 +883,40 @@
       (let [source (list 'let* ['r (accumulating-gemm-call '(clojure.core/aget S 0))] 'r)]
         (is (= source (frontend/normalize-source source types)))))))
 
+(deftest scalar-cast-aliases-require-a-retained-widening-proof
+  (doseq [[source-type cast eliminated?] [[:int 'long true] [:long 'long true]
+                                         [:int 'int true] [:long 'int false]
+                                         [:float 'long false] [nil 'int false]]]
+    (let [source (list 'let* ['count (list cast 'n)
+                             'result '(raster.par/map! out i count float (aget x i))]
+                       'result)
+          normalized (frontend/normalize-source
+                      source {:scalar-types (if source-type {'n source-type} {})
+                              :array-types {'x :float 'out :float}})
+          map-source (nth (second normalized) 3)]
+      (is (= (if eliminated? 'n 'count) (nth map-source 3))
+          (str source-type " → " cast)))))
+
+(deftest a-shadowed-cast-name-is-not-a-conversion-proof
+  (let [source '(let* [int convert count (int n)
+                       result (raster.par/map! out i count float (aget x i))]
+                      result)]
+    (is (= source (frontend/normalize-source
+                   source {:scalar-types {'n :int} :array-types {'x :float 'out :float}})))))
+
+(deftest narrowing-extents-remain-typed-scalar-equations
+  (let [options {:dtype :float :array-types {'x :float 'out :float}
+                 :scalar-types {'n :long}}
+        normalized (frontend/normalize-source
+                    '(let* [result (raster.par/map! out i (int n) float (aget x i))] result)
+                    options)
+        extent (first (second normalized))
+        program (frontend/form->program normalized options)
+        equations (dialect/equations program)]
+    (is (= '(int n) (second (second normalized))))
+    (is (= 'int (:tag (meta extent))))
+    (is (= '[scalar map] (mapv dialect/operation-kind equations)))))
+
 (deftest equal-sizes-spelled-through-host-bindings-are-one-extent
   ;; `n1 = seq`, `n2 = dff`, `(* n1 n2)` and `(* seq dff)` denote one size, and `(alength y)`
   ;; over `y = (float-array n)` is `n`. Without those identities the buffer `y` would receive

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -107,7 +107,8 @@
           (route/attempt
            '(let* [result (raster.par/rng-fill! seeds (int n) (long base-seed))]
                   result)
-           :long {'seeds :long})
+           :long {'seeds :long}
+           {:scalar-types {'n :int 'base-seed :long}})
           algorithm (get-in program [:equations 0 :algorithm])
           operation (dialect/operation-parts (first (dialect/equations algorithm)))]
       (is (= ['base-seed] (:captures operation)))
@@ -1706,7 +1707,8 @@
         {:keys [program stats]} (route/attempt
                                  source :float
                                  {'a :float 'out :float}
-                                 {:resident-reductions? true})
+                                 {:resident-reductions? true
+                                  :scalar-types {'n :long 'scale :double 'gain :float}})
         scheduled (:form (segop-lower/segop-lower-pass
                           program {:dtype :float :target-device :ze:0}))
         reductions (->> (:equations scheduled)

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -129,6 +129,18 @@
     (is (= 2 (count (get-in rich [:program :equations]))))
     (is (= :typed-soac (get-in rich [:stats :route])))))
 
+(deftest invalid-machine-prices-preserve-the-production-fanout
+  (doseq [[price reason] [[Double/POSITIVE_INFINITY :invalid-roofline-ridge]
+                         ["100" :invalid-roofline-ridge]
+                         [Double/MAX_VALUE :invalid-recompute-threshold]]]
+    (let [result (route/attempt expensive-fanout :float {'x :float}
+                                {:abstract-machine {:ridge {:float price}}})
+          witness (-> result :stats :placements first)]
+      (is (= :typed-soac (get-in result [:stats :route])))
+      (is (= :materialize (:decision witness)))
+      (is (= reason (:reason witness)))
+      (is (= 3 (count (get-in result [:program :equations])))))))
+
 (def ^:private inclusive-scan
   '(let* [result (raster.par/scan out acc 0.0 i n float
                                   (+ acc (clojure.core/aget x i)))]

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -46,6 +46,31 @@
   [out :- (Array long) state :- Long n :- Long] :- (Array long)
   (raster.par/map! out i n long (unchecked-add state (long i))))
 
+(deftm ocl-session-checked-count
+  [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/map! out i (int n) float (ra/aget x i)))
+
+(deftest public-checked-count-refuses-overflow-before-allocation
+  (let [descriptor (pl/compile-gpu-program #'ocl-session-checked-count :ocl:0 :dtype :float)
+        bound (last (:argument-specs (first (:steps descriptor))))]
+    (is (= :int (:type bound)))
+    (is (= 3 ((:value-fn bound) [nil nil 3])))
+    (doseq [n [(inc (long Integer/MAX_VALUE)) (dec (long Integer/MIN_VALUE))]]
+      (is (thrown? ArithmeticException ((:value-fn bound) [nil nil n]))))))
+
+(deftest ocl-public-checked-count-roundtrip
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "public checked-count map")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-checked-count :ocl:0 :dtype :float)
+          s (gpu/make-session :ocl:0)
+          arguments [(float-array [3 5 7]) (float-array 3) (long 3)]]
+      (try
+        (let [program (fixture/instantiate! s descriptor arguments)]
+          (try
+            (is (= [3.0 5.0 7.0] (vec (get (fixture/run! program arguments) 'out))))
+            (finally (fixture/close! program))))
+        (finally (gpu/close-session! s))))))
+
 (deftest public-compiler-entry-points-preserve-declared-long-scalars
   (let [emitted (equation-first/compile #'ocl-session-long-state
                                        {:target :ocl:0 :dtype :float})


### PR DESCRIPTION
Stacked on #402. Require finite positive roofline prices and derived thresholds before recomputation; invalid prices cannot throw from sole-consumer elimination or authorize unbounded duplicated work. Version placement witnesses as roofline-v2. Tests: 5 placement tests / 56 assertions; 2 production route tests / 18 assertions. Read-only review found no blocker. Full suite and vendor compilation delegated to CI. Campaign ledger explicitly records the unshipped active-ID prototype and its population/capture proof blockers; this PR does not retire that source kernel or claim a complete compiler unification.