### PR TITLE
Preserve every buffer return through horizontal fusion

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -178,6 +178,14 @@ fan-out producer. Sole-consumer elimination still needs no cost estimate. The wi
 versioned; production typed-route tests retain both materialized consumers with an explicit reason.
 This is price admission, not a new fusion legality proof or a bounded specialization cache.
 
+An observable-result audit found a separate compatibility-boundary bug: horizontally fused stored
+maps submit through an effect-only kernel convention, but their source bindings still return
+buffers. Returning the submission's nil value lost the first host alias despite correct device
+writes. Typed materialization now emits one effect binding followed by every source buffer alias
+as a flat binding; resident extraction needs no new nested-call convention. Effect-only source
+maps remain nil. Tests check the public resident descriptor, buffer identity and CPU OpenCL values,
+alongside retained checked-count rejection. Kernel ABI, launch count and fusion legality are unchanged.
+
 Exit: representative scientific and model expressions compile with explained fusion/placement
 choices, differential correctness, and measured kernel/allocation/compile-cost changes.
 

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -168,6 +168,8 @@
               host-bindings (or (get-in placement-facts [:attributes :host-bindings])
                                 {result host-binding})
               host-returns (set (map :host-return storage))
+              multiple-buffer-results? (and (= #{:buffer} host-returns)
+                                             (< 1 (count physical-results)))
               _ (when (and storage
                            (not (or (= #{:effect} host-returns)
                                     (= #{:buffer} host-returns))))
@@ -187,7 +189,7 @@
               effect (gensym (str "typed_soac_map_" equation-id "__"))
               source (with-meta
                        (cond
-                         (= #{:effect} host-returns)
+                         (or (= #{:effect} host-returns) multiple-buffer-results?)
                          (list 'raster.par/map-void! (:index attributes) (:extent attributes)
                                (materialize-region
                                 region-locals
@@ -209,16 +211,28 @@
                        {:raster.type/elem-type (first result-dtypes)})]
           {:equation-id equation-id
            :placement placement
-           :pairs (if storage
+           :pairs (cond
+                    multiple-buffer-results?
+                    ;; A fused submission has no single host return. Keep every source buffer
+                    ;; alias as its own flat binding; both staging and resident extraction then
+                    ;; consume the same effect call without treating nil as the primary buffer.
+                    (into [[effect source]]
+                          (keep (fn [[logical destination]]
+                                  (when-let [binding (get host-bindings logical)]
+                                    [binding destination])))
+                          (map vector results physical-results))
+
+                    storage
                     (into [[host-binding source]]
                           (keep (fn [[logical destination]]
                                   (let [binding (get host-bindings logical)]
                                     (when (and binding (not= binding host-binding))
                                       [binding destination])))
                                 (map vector results physical-results)))
+                    :else
                     (conj (mapv #(allocation-pair values % (:extent attributes)) results)
                           [effect source]))
-           :site [:binding (if storage host-binding effect)]
+           :site [:binding (if (and storage (not multiple-buffer-results?)) host-binding effect)]
            :source source}))
 
       scatter

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -204,7 +204,10 @@
     (is (= 1 (get-in emitted [:stats :direct-scheduling :horizontal])))
     (is (= 1 (get-in emitted [:stats :direct-scheduling :typed-scalar-equations])))
     (is (= 1 (count (:kernels emitted))))
-    (execute submit! 3 nil nil nil)
+    (let [left (float-array 3) right (float-array 3)
+          result (execute submit! 3 nil left right)]
+      (is (identical? left (first result)))
+      (is (identical? right (second result))))
     (is (= 1 @submissions))
     (reset! submissions 0)
     (doseq [n [(inc (long Integer/MAX_VALUE)) (dec (long Integer/MIN_VALUE))]]

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -50,6 +50,17 @@
   [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
   (raster.par/map! out i (int n) float (ra/aget x i)))
 
+(deftm ocl-session-fused-buffer-maps
+  [x :- (Array float) left :- (Array float) right :- (Array float) n :- Long] :- Object
+  (let [a (raster.par/map! left i n float (+ (ra/aget x i) 1.0))
+        b (raster.par/map! right j n float (* (ra/aget x j) 2.0))]
+    [a b]))
+
+(deftest public-fused-buffer-maps-remain-a-flat-resident-program
+  (let [descriptor (pl/compile-gpu-program #'ocl-session-fused-buffer-maps :ocl:0 :dtype :float)]
+    (is (= [:map-void] (mapv :convention (:steps descriptor))))
+    (is (= '[left right] (:result-sym descriptor)))))
+
 (deftest public-checked-count-refuses-overflow-before-allocation
   (let [descriptor (pl/compile-gpu-program #'ocl-session-checked-count :ocl:0 :dtype :float)
         bound (last (:argument-specs (first (:steps descriptor))))]
@@ -448,6 +459,43 @@
           (is (nil? (apply execute [values staged-indices nrows width]))
               "the hoisted IFn applyTo bridge also boxes void as nil")
           (is (= [3 255 411] (vec staged-indices))))
+        (finally (gpu/close-session! s))))))
+
+(deftest ocl-fused-maps-retain-each-observable-buffer-alias
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "fused map buffer identities")
+    (let [emitted (opencl-pass/opencl-pass
+                   '(let* [a (raster.par/map! left i n float (+ (aget x i) 1.0))
+                            b (raster.par/map! right j n float (* (aget x j) 2.0))]
+                           [a b])
+                   :device-id :ocl:0 :min-elements 0 :dtype :float
+                   :array-types {'x :float 'left :float 'right :float}
+                   :scalar-types {'n :long})
+          execute (eval (list 'fn '[x left right n] (:form emitted)))
+          register! (requiring-resolve 'raster.gpu.ocl-runtime/register-kernel!)
+          x (float-array [-1 0 2])
+          left (float-array 3) right (float-array 3)]
+      (is (= 1 (count (:kernels emitted))))
+      (doseq [artifact (:kernels emitted)] (register! (:kernel-name artifact) artifact))
+      (let [result (execute x left right 3)]
+        (is (identical? left (first result)))
+        (is (identical? right (second result))))
+      (is (= [0.0 1.0 3.0] (vec left)))
+      (is (= [-2.0 0.0 4.0] (vec right))))))
+
+(deftest ocl-public-fused-buffer-maps-replay-both-results
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident fused buffer maps")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-fused-buffer-maps :ocl:0 :dtype :float)
+          s (gpu/make-session :ocl:0)
+          args [(float-array [-1 0 2]) (float-array 3) (float-array 3) 3]]
+      (try
+        (let [program (fixture/instantiate! s descriptor args)]
+          (try
+            (let [result (fixture/run! program args)]
+              (is (= [0.0 1.0 3.0] (vec (get result 'left))))
+              (is (= [-2.0 0.0 4.0] (vec (get result 'right)))))
+            (finally (fixture/close! program))))
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-strided-transfers-retain-host-control-and-accumulation


### PR DESCRIPTION
Typed materialization emits one flat effect submission and explicit aliases for every stored buffer result. Previously the first alias could become nil while device writes were numerically correct. No new kernel ABI, nested-call convention, or fusion rule. Tests cover checked count preflight and identities, staged CPU OpenCL values and identities, public resident descriptor shape, resident CPU OpenCL replay of both outputs, and unchanged JVM effect nil returns. Focused new/changed tests: 5 tests / 21 assertions; adjacent offset/tuple and resident shared-region tests also pass. Reviewed after moving the fix from the compatibility emitter into the shared typed materializer. Full suites and hardware-free vendor gates in CI.