### PR TITLE
Identify generated candidates in production GEMM measurements

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -178,6 +178,14 @@ fan-out producer. Sole-consumer elimination still needs no cost estimate. The wi
 versioned; production typed-route tests retain both materialized consumers with an explicit reason.
 This is price admission, not a new fusion legality proof or a bounded specialization cache.
 
+An observable-result audit found a separate compatibility-boundary bug: horizontally fused stored
+maps submit through an effect-only kernel convention, but their source bindings still return
+buffers. Returning the submission's nil value lost the first host alias despite correct device
+writes. Typed materialization now emits one effect binding followed by every source buffer alias
+as a flat binding; resident extraction needs no new nested-call convention. Effect-only source
+maps remain nil. Tests check the public resident descriptor, buffer identity and CPU OpenCL values,
+alongside retained checked-count rejection. Kernel ABI, launch count and fusion legality are unchanged.
+
 Exit: representative scientific and model expressions compile with explained fusion/placement
 choices, differential correctness, and measured kernel/allocation/compile-cost changes.
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -189,7 +189,7 @@ alongside retained checked-count rejection. Kernel ABI, launch count and fusion 
 Exit: representative scientific and model expressions compile with explained fusion/placement
 choices, differential correctness, and measured kernel/allocation/compile-cost changes.
 
-## 4. Measure generated production kernels and selection — queued
+## 4. Measure generated production kernels and selection — GEMM evidence active; broader ladder queued
 
 Begin with existing production canaries, not independent handwritten builders:
 
@@ -208,6 +208,14 @@ CPU results. No SOTA claim follows from successful vendor compilation alone.
 Use the measurements to shortlist legal schedules and validate selective autotuning/cache replay.
 If comparable accelerator hardware is unavailable, complete harnesses and correctness gates but
 leave accelerator competitiveness explicitly unmeasured.
+
+The GEMM canary records candidate strategy, source/ABI signature, emission routes and entry-point
+counts from its exact Prepared value, with no second compilation. These replace the parallel
+strategy/signature arrays in the opt-in report. Candidate counts are not executed launches;
+descriptor scratch counts exclude graph-owned temporaries and do not claim peak memory. The
+register-tiled emitter now reports its actual KernelBody route through the artifact adapter,
+separate from semantic contraction provenance. Host-synchronized timing remains labeled as such;
+no device-event timing or accelerator comparison is inferred from this evidence.
 
 Exit: reproducible production measurements identify wins/regressions and explain schedule choices;
 claims are limited to tested hardware and workloads. Discuss the results before stages 5–6.

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1322,6 +1322,7 @@
      :workgroup (get-in kernel-body [:launch :workgroup-size])
      :dims dims
      :kernel-body kernel-body
+     :emission-route :kernel-body
      :epilogue-operands (mapv :name (filter #(= :input (:kind %)) epilogue-slots))
      :epilogue-scalars (mapv :name (filter #(= :scalar (:kind %)) epilogue-slots))}))
 

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1499,6 +1499,7 @@
                :abi (:abi rt)
                :dtype (:dtype rt) :out-dtype (:dtype rt) :out-elems (* M N)
                :kernel-body (:kernel-body rt)
+               :emission-route (:emission-route rt)
                :fused-epilogue (boolean epilogue)
                :epilogue-operands (:epilogue-operands rt)
                :epilogue-scalars (:epilogue-scalars rt)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -168,6 +168,8 @@
               host-bindings (or (get-in placement-facts [:attributes :host-bindings])
                                 {result host-binding})
               host-returns (set (map :host-return storage))
+              multiple-buffer-results? (and (= #{:buffer} host-returns)
+                                             (< 1 (count physical-results)))
               _ (when (and storage
                            (not (or (= #{:effect} host-returns)
                                     (= #{:buffer} host-returns))))
@@ -187,7 +189,7 @@
               effect (gensym (str "typed_soac_map_" equation-id "__"))
               source (with-meta
                        (cond
-                         (= #{:effect} host-returns)
+                         (or (= #{:effect} host-returns) multiple-buffer-results?)
                          (list 'raster.par/map-void! (:index attributes) (:extent attributes)
                                (materialize-region
                                 region-locals
@@ -209,16 +211,28 @@
                        {:raster.type/elem-type (first result-dtypes)})]
           {:equation-id equation-id
            :placement placement
-           :pairs (if storage
+           :pairs (cond
+                    multiple-buffer-results?
+                    ;; A fused submission has no single host return. Keep every source buffer
+                    ;; alias as its own flat binding; both staging and resident extraction then
+                    ;; consume the same effect call without treating nil as the primary buffer.
+                    (into [[effect source]]
+                          (keep (fn [[logical destination]]
+                                  (when-let [binding (get host-bindings logical)]
+                                    [binding destination])))
+                          (map vector results physical-results))
+
+                    storage
                     (into [[host-binding source]]
                           (keep (fn [[logical destination]]
                                   (let [binding (get host-bindings logical)]
                                     (when (and binding (not= binding host-binding))
                                       [binding destination])))
                                 (map vector results physical-results)))
+                    :else
                     (conj (mapv #(allocation-pair values % (:extent attributes)) results)
                           [effect source]))
-           :site [:binding (if storage host-binding effect)]
+           :site [:binding (if (and storage (not multiple-buffer-results?)) host-binding effect)]
            :source source}))
 
       scatter

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -204,7 +204,10 @@
     (is (= 1 (get-in emitted [:stats :direct-scheduling :horizontal])))
     (is (= 1 (get-in emitted [:stats :direct-scheduling :typed-scalar-equations])))
     (is (= 1 (count (:kernels emitted))))
-    (execute submit! 3 nil nil nil)
+    (let [left (float-array 3) right (float-array 3)
+          result (execute submit! 3 nil left right)]
+      (is (identical? left (first result)))
+      (is (identical? right (second result))))
     (is (= 1 @submissions))
     (reset! submissions 0)
     (doseq [n [(inc (long Integer/MAX_VALUE)) (dec (long Integer/MIN_VALUE))]]

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -50,6 +50,17 @@
   [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
   (raster.par/map! out i (int n) float (ra/aget x i)))
 
+(deftm ocl-session-fused-buffer-maps
+  [x :- (Array float) left :- (Array float) right :- (Array float) n :- Long] :- Object
+  (let [a (raster.par/map! left i n float (+ (ra/aget x i) 1.0))
+        b (raster.par/map! right j n float (* (ra/aget x j) 2.0))]
+    [a b]))
+
+(deftest public-fused-buffer-maps-remain-a-flat-resident-program
+  (let [descriptor (pl/compile-gpu-program #'ocl-session-fused-buffer-maps :ocl:0 :dtype :float)]
+    (is (= [:map-void] (mapv :convention (:steps descriptor))))
+    (is (= '[left right] (:result-sym descriptor)))))
+
 (deftest public-checked-count-refuses-overflow-before-allocation
   (let [descriptor (pl/compile-gpu-program #'ocl-session-checked-count :ocl:0 :dtype :float)
         bound (last (:argument-specs (first (:steps descriptor))))]
@@ -448,6 +459,43 @@
           (is (nil? (apply execute [values staged-indices nrows width]))
               "the hoisted IFn applyTo bridge also boxes void as nil")
           (is (= [3 255 411] (vec staged-indices))))
+        (finally (gpu/close-session! s))))))
+
+(deftest ocl-fused-maps-retain-each-observable-buffer-alias
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "fused map buffer identities")
+    (let [emitted (opencl-pass/opencl-pass
+                   '(let* [a (raster.par/map! left i n float (+ (aget x i) 1.0))
+                            b (raster.par/map! right j n float (* (aget x j) 2.0))]
+                           [a b])
+                   :device-id :ocl:0 :min-elements 0 :dtype :float
+                   :array-types {'x :float 'left :float 'right :float}
+                   :scalar-types {'n :long})
+          execute (eval (list 'fn '[x left right n] (:form emitted)))
+          register! (requiring-resolve 'raster.gpu.ocl-runtime/register-kernel!)
+          x (float-array [-1 0 2])
+          left (float-array 3) right (float-array 3)]
+      (is (= 1 (count (:kernels emitted))))
+      (doseq [artifact (:kernels emitted)] (register! (:kernel-name artifact) artifact))
+      (let [result (execute x left right 3)]
+        (is (identical? left (first result)))
+        (is (identical? right (second result))))
+      (is (= [0.0 1.0 3.0] (vec left)))
+      (is (= [-2.0 0.0 4.0] (vec right))))))
+
+(deftest ocl-public-fused-buffer-maps-replay-both-results
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident fused buffer maps")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-fused-buffer-maps :ocl:0 :dtype :float)
+          s (gpu/make-session :ocl:0)
+          args [(float-array [-1 0 2]) (float-array 3) (float-array 3) 3]]
+      (try
+        (let [program (fixture/instantiate! s descriptor args)]
+          (try
+            (let [result (fixture/run! program args)]
+              (is (= [0.0 1.0 3.0] (vec (get result 'left))))
+              (is (= [-2.0 0.0 4.0] (vec (get result 'right)))))
+            (finally (fixture/close! program))))
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-strided-transfers-retain-host-control-and-accumulation

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -6,7 +6,8 @@
             [raster.arrays :as arrays]
             [raster.core :refer [deftm]]
             [raster.compiler.pipeline :as pipeline]
-            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.gpu.compiled :as compiled]
             [raster.gpu.dispatch-tuning :as tuning]
             [raster.gpu.link :as link]
@@ -87,6 +88,31 @@
   (compiled/lower #'gemm64! args {:target target :dtype :float :on-non-resident :throw
                                  :constants ['A 'B]}))
 
+(defn compilation-evidence
+  "Describe alternatives from the exact prepared program, without recompiling it.
+   Entry-point counts include candidate graphs; they are not measured launch counts. Descriptor
+   scratch excludes graph-owned temporaries and is not a peak-memory measurement."
+  [prepared]
+  (let [descriptor (:descriptor prepared)]
+    {:version 1
+     :resident-step-count (count (:steps descriptor))
+     :descriptor-scratch-count (count (:allocs descriptor))
+     :steps
+     (mapv (fn [step]
+             {:convention (:convention step)
+              :alternatives
+              (mapv (fn [candidate]
+                      (let [artifacts (executable/artifacts candidate)]
+                        {:strategy (executable/strategy candidate)
+                         :signature (tuning/executable-signature candidate)
+                         :entry-point-count (count artifacts)
+                         :emission-routes (frequencies (map artifact/emission-route artifacts))}))
+                    (if-let [choice (:dispatch step)]
+                      (:alternatives choice)
+                      (when (executable/kernel-executable? (:artifact step))
+                        [(:artifact step)])))})
+           (:steps descriptor))}))
+
 (defn gemm! [{:keys [environment-tag target compiler-revision] :or {target :ocl:0}}]
   (let [identity (identity-for :gemm64-resident target :float [64 64 64]
                                :host-synchronized-replay environment-tag)
@@ -108,16 +134,13 @@
             _ (when-not (= expected actual)
                 (throw (ex-info "production GEMM canary failed independent numerical reference"
                                 {:expected-head (take 8 expected) :actual-head (take 8 actual)})))
-            alternatives (keep :dispatch (get-in prepared [:descriptor :steps]))]
+            evidence (compilation-evidence prepared)]
         {:identity (assoc identity :numerical-policy (get-in prepared [:schedule :precision]))
          :compiler-revision compiler-revision
          :compile-ns compile-ns :bind-ns bind-ns :validated? true
          :schedule (:schedule prepared)
          :execution (compiled/ir c)
-         :candidate-strategies (mapv #(mapv dispatch/alternative-strategy (:alternatives %))
-                                     alternatives)
-         :candidate-signatures (mapv #(mapv tuning/executable-signature (:alternatives %))
-                                     alternatives)
+         :compilation evidence
          :measurement (measure #(link/run! resident))})
       (finally (compiled/close! c)))))
 

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -29,10 +29,19 @@
       (is (= :sumsq-aot (get-in result [:identity :workload]))))))
 
 (deftest direct-contraction-result-is-a-public-resident-buffer
-  (let [p (canary/prepare-gemm :ocl:0 (canary/gemm-arguments))]
+  (let [p (canary/prepare-gemm :ocl:0 (canary/gemm-arguments))
+        evidence (canary/compilation-evidence p)
+        candidates (mapcat :alternatives (:steps evidence))]
     (is (= 'C (get-in p [:descriptor :result-sym])))
     (is (= ['C] (mapv :sym (:out-tree p))))
-    (is (every? #(= :executable (:convention %)) (get-in p [:descriptor :steps])))))
+    (is (every? #(= :executable (:convention %)) (get-in p [:descriptor :steps])))
+    (is (= 1 (:resident-step-count evidence)))
+    (is (= 0 (:descriptor-scratch-count evidence)))
+    (is (seq candidates))
+    (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %)) candidates))
+    (is (every? #(string? (get-in % [:signature :source-hash])) candidates))
+    (is (= evidence (canary/compilation-evidence p))
+        "evidence identifies the same already-compiled alternatives")))
 
 (deftest opencl-resident-gemm-canary-numerics
   (if-not @probe/opencl-available?


### PR DESCRIPTION
Stacked on #404. Record exact Prepared alternative strategy/signature/emission route/entry-point evidence without recompilation. Propagate the register-tiled emitter-authored KernelBody route through the artifact adapter. Distinguish candidate counts from launches and descriptor scratch from graph/peak storage; retain comparable benchmark identity across schedule changes. Replace separate strategy/signature arrays in the opt-in canary report with associated per-candidate evidence. Focused tests: 3 tests / 23 assertions, including real CPU OpenCL GEMM numerics. Read-only review clean. Timing deferred: laptop has about 1.3 GiB available and full swap; no performance or accelerator competitiveness claim. Full gates run in CI.