### PR TITLE
Bound automatic specialization and admit each class once

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -186,6 +186,13 @@ as a flat binding; resident extraction needs no new nested-call convention. Effe
 maps remain nil. Tests check the public resident descriptor, buffer identity and CPU OpenCL values,
 alongside retained checked-count rejection. Kernel ABI, launch count and fusion legality are unchanged.
 
+Automatic Object-array element-class specialization now has a separate, explicit admission bound
+(default 32 attempts per generic function, configurable down to zero), with generic dispatch at
+capacity. One atomic claim owns each pending compilation, and clearing the cache revokes its old
+completion token. Failed/pending entries consume the budget too. This bounds this existing host
+specialization cache, not the number of functions, manually generated JVM classes, GPU shape
+variants or global compilation memory. It is not yet the shared cluster/resource admission policy.
+
 Exit: representative scientific and model expressions compile with explained fusion/placement
 choices, differential correctness, and measured kernel/allocation/compile-cost changes.
 

--- a/src/raster/compiler/core/dispatch.clj
+++ b/src/raster/compiler/core/dispatch.clj
@@ -243,6 +243,39 @@
   "When true (default), deftm dispatch auto-specializes methods with Object[]."
   true)
 
+(def ^:dynamic *auto-specialization-limit*
+  "Maximum automatic element-class specializations retained per generic function (default 32).
+   Pending and failed attempts count toward the limit. At capacity dispatch uses its existing
+   generic method; zero disables new attempts. This does not bound manually compiled methods,
+   the number of generic functions, or total JVM classloader memory."
+  32)
+
+(defn- claim-specialization!
+  [cache-atom elem-class]
+  (let [limit *auto-specialization-limit*]
+    (when-not (and (integer? limit) (<= 0 limit))
+      (throw (ex-info "automatic specialization limit must be a nonnegative integer"
+                      {:reason :auto-specialization-limit :limit limit})))
+    (loop []
+      (let [entries @cache-atom
+            claim (Object.)]
+        (cond
+          (contains? entries elem-class) nil
+          (<= limit (count entries)) nil
+          (compare-and-set! cache-atom entries
+                            (assoc entries elem-class {:fn nil :pending? true :claim claim})) claim
+          :else (recur))))))
+
+(defn- complete-specialization!
+  [cache-atom elem-class claim compiled]
+  (swap! cache-atom
+         (fn [entries]
+           ;; Clearing/redefining a function revokes its old claims. An old compiler task must
+           ;; not repopulate the cleared cache or overwrite a newly admitted specialization.
+           (if (identical? claim (get-in entries [elem-class :claim]))
+             (assoc entries elem-class {:fn compiled :pending? false})
+             entries))))
+
 (defn- get-specialization-cache [fn-key]
   (or (get @specialization-cache fn-key)
       (do (swap! specialization-cache
@@ -286,12 +319,8 @@
       (and cached (:fn cached)) (:fn cached)
       (and cached (:pending? cached)) nil
       :else
-      (let [prev (get (swap! cache-atom
-                             (fn [m]
-                               (if (contains? m elem-class) m
-                                   (assoc m elem-class {:fn nil :pending? true}))))
-                      elem-class)]
-        (when (and (:pending? prev) (nil? (:fn prev)))
+      (let [claim (claim-specialization! cache-atom elem-class)]
+        (when claim
           (let [elem-sym (symbol (.getName ^Class elem-class))
                 var-ns (the-ns (:ns (meta dispatch-var)))
                 var-name (:name (meta dispatch-var))
@@ -305,9 +334,9 @@
                       (let [spec-sym (specialize! dispatch-var {:element-type elem-short :ns-obj var-ns})
                             spec-var (ns-resolve var-ns spec-sym)
                             spec-fn (when spec-var (deref spec-var))]
-                        (swap! cache-atom assoc elem-class {:fn spec-fn :pending? false})))))
+                        (complete-specialization! cache-atom elem-class claim spec-fn)))))
                 (catch Exception e
-                  (swap! cache-atom assoc elem-class {:fn nil :pending? false})
+                  (complete-specialization! cache-atom elem-class claim nil)
                   (binding [*out* *err*]
                     (println (str "Auto-specialization failed for " var-name
                                   " [" elem-sym "]: " (.getMessage e)))))))))

--- a/test/raster/compiler/core/auto_specialization_test.clj
+++ b/test/raster/compiler/core/auto_specialization_test.clj
@@ -1,0 +1,88 @@
+(ns raster.compiler.core.auto-specialization-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.dispatch :as dispatch]
+            [raster.compiler.core.specialize :as specialize])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn subject [x] x)
+(defn compiled-subject [x] [:compiled x])
+
+(deftest admission-limit-preserves-the-generic-dispatch-result
+  (let [entry (dispatch/make-method-entry ['objects] (fn [xs] [:generic (vec xs)]))
+        cache (atom {})]
+    (binding [dispatch/*auto-specialization-limit* 0]
+      (with-redefs-fn {#'dispatch/get-specialization-cache (fn [_] cache)
+                      #'clojure.core/future-call (fn [_] (throw (ex-info "unexpected compile" {})))}
+        (fn []
+          (is (= [:generic ["value"]]
+                 (#'dispatch/dispatch-arity "subject" [entry]
+                  (object-array ["value"]) nil nil nil nil 1 (atom {1 [entry]}) #'subject)))
+          (is (empty? @cache)))))))
+
+(deftest automatic-specialization-admission-is-bounded-and-single-flight
+  (let [cache (atom {}) tasks (atom []) calls (atom 0)]
+    (binding [dispatch/*auto-specialization-limit* 2]
+      (with-redefs [clojure.core/future-call (fn [task] (swap! tasks conj task) nil)
+                    specialize/specialize-fn! (fn [& _]
+                                               (swap! calls inc)
+                                               'compiled-subject)]
+        (doseq [cls [String String Long Long Double]]
+          (is (nil? (#'dispatch/try-auto-specialize! #'subject cls cache))))
+        (is (= 2 (count @tasks)))
+        (is (= #{String Long} (set (keys @cache))))
+        (run! (fn [task] (task)) @tasks)
+        (is (= 2 @calls))
+        (is (= [:compiled :value]
+               ((#'dispatch/try-auto-specialize! #'subject String cache) :value)))
+        (is (nil? (#'dispatch/try-auto-specialize! #'subject Double cache)))
+        (is (= 2 (count @tasks)))))))
+
+(deftest rejected-and-failed-attempts-cannot-grow-the-cache
+  (let [cache (atom {}) tasks (atom [])]
+    (binding [dispatch/*auto-specialization-limit* 0]
+      (is (nil? (#'dispatch/claim-specialization! cache String)))
+      (is (empty? @cache)))
+    (binding [dispatch/*auto-specialization-limit* 1
+              *err* (java.io.StringWriter.)]
+      (with-redefs [clojure.core/future-call (fn [task] (swap! tasks conj task) nil)
+                    specialize/specialize-fn! (fn [& _] (throw (ex-info "fixture failure" {})))]
+        (#'dispatch/try-auto-specialize! #'subject String cache)
+        ((first @tasks))
+        (is (= {:fn nil :pending? false} (get @cache String)))
+        (#'dispatch/try-auto-specialize! #'subject String cache)
+        (#'dispatch/try-auto-specialize! #'subject Long cache)
+        (is (= 1 (count @tasks)))
+        (is (= 1 (count @cache)))))
+    (doseq [limit [-1 1.5 nil "2"]]
+      (binding [dispatch/*auto-specialization-limit* limit]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"nonnegative integer"
+                             (#'dispatch/claim-specialization! (atom {}) String)))))))
+
+(deftest clearing-a-cache-revokes-an-old-completion
+  (let [cache (atom {})
+        old (#'dispatch/claim-specialization! cache String)]
+    (reset! cache {})
+    (let [current (#'dispatch/claim-specialization! cache String)]
+      (#'dispatch/complete-specialization! cache String old :stale)
+      (is (identical? current (get-in @cache [String :claim])))
+      (#'dispatch/complete-specialization! cache String current :current)
+      (is (= {:fn :current :pending? false} (get @cache String))))
+    (reset! cache {})
+    (#'dispatch/complete-specialization! cache String old :stale)
+    (is (empty? @cache))))
+
+(deftest concurrent-admission-has-exactly-one-owner
+  ;; Only admission is raced; no compiler, namespace mutation or device work occurs here.
+  (let [cache (atom {}) start (CountDownLatch. 1)
+        workers (mapv (fn [_]
+                        (future
+                          (when (.await start 2 TimeUnit/SECONDS)
+                            (#'dispatch/claim-specialization! cache String))))
+                      (range 4))]
+    (try
+      (.countDown start)
+      (let [claims (mapv #(deref % 2000 ::timeout) workers)]
+        (is (not-any? #{::timeout} claims))
+        (is (= 1 (count (remove nil? claims))))
+        (is (= 1 (count @cache))))
+      (finally (run! future-cancel workers)))))


### PR DESCRIPTION
Stacked on #405. Add a configurable automatic Object-array element-class specialization limit (default 32 attempts per function); pending/failed entries consume capacity, and capacity exhaustion keeps generic dispatch. CAS admission fixes duplicate compilation under concurrent misses; owner tokens prevent old completions repopulating a cleared cache. This is not a GPU variant limit, global memory budget, or cancellation of compiler namespace side effects. Five new lightweight tests / 28 assertions and ten existing dispatch tests / 55 assertions pass in the existing 768 MiB REPL. New tests mock actual compilation and race admission only. Read-only review found no blocker. Full tests and vendor gates in CI.