### PR TITLE
Preserve checked RNG captures through typed scalar lowering

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -163,6 +163,14 @@ until shared capture normalization and enforced scalar-domain admission preserve
 execution as well as overflow. The local `compiler/active-indices-typed-map` branch retains the
 prototype and count-check tests for that follow-up; no retirement is claimed.
 
+The next prerequisite closes the existing RNG route's scalar inputs: source-signature count and
+seed conversions become ordered host scalar equations, rather than unwrapping a captured checked
+cast. Typed scalar materialization reapplies its retained result conversion, preserving
+`long(int(seed))` even after value-equality simplification. Raw inactive host branches keep these
+checks local; missing certified leaves fail once instead of recursively rescheduling. Public
+descriptor preflight, CPU differential execution and vendor compile fixtures cover this boundary.
+This does not admit the active-ID population domain or retire its production source kernel.
+
 ## 3. General fusion and bounded specialization — price admission active; broader work queued
 
 - Validate shared scalar-region composition, coupled reductions and post-reduction transforms.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -547,17 +547,17 @@
             (swap! kernels conj k)
             k))
 
-        emit-nested-indexed!
+        emit-nested-map!
         (fn [form]
-          ;; Raw host control flow can contain a strided transfer without a surrounding
+          ;; Raw host control flow can contain an indexed/RNG map without a surrounding
           ;; ParallelProgram. Schedule that leaf at its original control-flow position: its
           ;; hoisted extent belongs beside the invocation, never outside the host branch.
           ;; A supplied typed program must already account for every scheduled operation; do
           ;; not re-analyze a missing equation at that verified boundary. Source scheduling may
           ;; still leave a body-position operation outside its binding equations.
-          (when supplied-program
-            (throw (ex-info "Strided transfer is missing its retained typed equation"
-                            {:reason :unscheduled-indexed-transfer :form form})))
+          (when (or supplied-program direct-mini-program?)
+            (throw (ex-info "Map leaf is missing its retained typed equation"
+                            {:reason :unscheduled-map-leaf :form form})))
           (let [emitted (binding [*bound-segops* nil *bound-algorithm* nil]
                           (opencl-pass form :device-id device-id :dtype dtype
                                        :min-elements min-elements :compile-spirv? compile-spirv?
@@ -921,9 +921,7 @@
                             :scalar-types top-scalar-types :array-types top-array-types)
                     k (register-kernel! kernel :ze-maps)]
                 (emit-map-invocation k device-id))
-              (throw (ex-info "GPU RNG fill source has no verified TypedSOAC map schedule"
-                              {:reason :unscheduled-rng-fill
-                               :target-dialect :kernel-body :form form :fallback :none})))
+              (emit-nested-map! form))
 
             ;; par/active-ids!
             (par/par-active-ids-form? form)
@@ -957,7 +955,7 @@
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-scatter! form))
                 (if stride
-                  (emit-nested-indexed! form)
+                  (emit-nested-map! form)
                   (let [array-types (assoc top-array-types index :int)
                         segmap (source->segmap stats (gensym "scatter_result_") form
                                               dtype device-id top-scalar-types array-types)
@@ -976,7 +974,7 @@
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-gather! form))
                 (if stride
-                  (emit-nested-indexed! form)
+                  (emit-nested-map! form)
                   (let [array-types (assoc top-array-types index :int)
                         segmap (source->segmap stats (gensym "gather_result_") form
                                               dtype device-id top-scalar-types array-types)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -967,8 +967,8 @@
                            (with-meta value (merge (meta value)
                                                   {:tag tag :raster.type/tag tag}))
                            value))
-          extent (typed-symbol (descriptor/unwrap-int-cast n) 'int)
-          base (typed-symbol (descriptor/unwrap-int-cast base-seed) 'long)
+          extent (typed-symbol n 'int)
+          base (typed-symbol base-seed 'long)
           index (with-meta (clojure.core/symbol (str "rstr_rng_index_" id))
                   {:tag 'long :raster.type/tag 'long})
           local (fn [name]
@@ -1601,6 +1601,28 @@
 
         :else nil))))
 
+(defn- normalize-fixed-scalar-inputs
+  "Expose source-signature conversions as ordinary host scalar equations, in evaluation order.
+   In particular, a captured `(int seed)` must not be erased merely because the primitive then
+   consumes a long. Known, correctly typed scalar ids need no new equation on re-entry."
+  [state expression inputs]
+  (reduce
+   (fn [[state expression] [position scalar-dtype]]
+     (let [operand (normalize-scalar-casts (nth expression position) (:local-scalar-types state))
+           operand-dtype (retained-scalar-dtype operand (:local-scalar-types state))
+           tag (dtype/scalar-tag-for-dtype scalar-dtype)]
+       (if (and (symbol? operand) (= scalar-dtype operand-dtype))
+         [state (with-meta (apply list (assoc (vec expression) position operand)) (meta expression))]
+         (let [id (with-meta (gensym "rstr_scalar_input_") {:tag tag :raster.type/tag tag})
+               conversion (if (= scalar-dtype operand-dtype)
+                            operand
+                            (list (symbol "clojure.core" (name tag)) operand))]
+           [(-> state
+                (update :normalized conj [id conversion])
+                (assoc-in [:local-scalar-types id] scalar-dtype))
+            (with-meta (apply list (assoc (vec expression) position id)) (meta expression))]))))
+   [state expression] inputs))
+
 (defn- normalize-source*
   [source scalar-types]
   ;; Direct backend entry may see source before the ordinary pipeline's SSA cleanup. Clojure
@@ -1618,7 +1640,13 @@
                          local-scalar-types]
                    :as state}
                   [ordinal [symbol expression]]]
-               (let [expression (->> expression
+               (let [[state expression] (if (par/par-rng-fill-form? expression)
+                                          ;; rng-fill! evaluates its int count before its long seed.
+                                          (normalize-fixed-scalar-inputs state expression
+                                                                         [[2 :int] [3 :long]])
+                                          [state expression])
+                     local-scalar-types (:local-scalar-types state)
+                     expression (->> expression
                                      (canonicalize-strided-indexed-operation ordinal)
                                      (canonicalize-blas-gemm ordinal))
                      ;; Host scalar identities: a binding that renames a scalar, or recomputes
@@ -1944,7 +1972,7 @@
                    (filter symbol? (take-nth 2 (second source))))
          tagged (fn [kind?]
                   (set (filter #(kind? (types/sym-type-tag %)) binders)))]
-     (binding [util/*shadowing-locals* (source-shadowing-locals source)
+     (binding [util/*shadowing-locals* (source-shadowing-locals source array-types scalar-types)
                *declared-kinds*
                {:arrays (into (set (keys array-types))
                               (tagged #(some? (dtype/dtype-for-array-tag %))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -146,7 +146,9 @@
                     (typed-store-value (symbol "clojure.core" (name scalar-tag)) (first bodies)))]
         {:equation-id equation-id
          :placement placement
-         :pairs [[result source]]
+         ;; The explicit conversion carries the JVM initializer type. Clojure rejects an
+         ;; additional primitive :tag on that binding; retain Raster's independent type facts.
+         :pairs [[(vary-meta result dissoc :tag) source]]
          :site [:binding result]
          :source source})
 

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -138,7 +138,12 @@
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results})))
             result (first results)
-            source (materialize-region region-locals (first bodies))]
+            result-dtype (:dtype (get values result))
+            ;; The shared dtype vocabulary rejects storage-only/unknown JVM scalar types.
+            scalar-tag (dtype/scalar-tag-for-dtype result-dtype)
+            source (materialize-region
+                    region-locals
+                    (typed-store-value (symbol "clojure.core" (name scalar-tag)) (first bodies)))]
         {:equation-id equation-id
          :placement placement
          :pairs [[result source]]

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -36,6 +36,10 @@
   [out :- (Array long) state :- Long n :- Long] :- (Array long)
   (raster.par/map! out i n long (unchecked-add state (long i))))
 
+(deftm public-c-family-checked-rng
+  [seeds :- (Array long) n :- Long seed :- Long] :- (Array long)
+  (raster.par/rng-fill! seeds n (int seed)))
+
 (deftm public-c-family-dot
   "Public equation-first workload compiled by nvcc/hipcc without a physical device."
   (All [T] [left :- (Array T) right :- (Array T) n :- Long] :- Double
@@ -259,6 +263,8 @@
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'public-c-family-checked-rng {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'dl-arrays/argmax-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -214,6 +214,37 @@
       (is (thrown? ArithmeticException (execute submit! n nil nil nil))))
     (is (zero? @submissions) "the retained checked conversion runs before any kernel call")))
 
+(deftest an-uncertified-direct-map-leaf-does-not-reschedule-recursively
+  (let [attempts (atom 0)]
+    (with-redefs [segop-lower/schedule-single-program (fn [& _] (swap! attempts inc) {})]
+      (is (= :unscheduled-map-leaf
+             (try (opencl-pass/opencl-pass '(raster.par/rng-fill! seeds n seed)
+                                           :dtype :long :array-types {'seeds :long}
+                                           :scalar-types {'n :int 'seed :long})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+      (is (= 1 @attempts)))))
+
+(deftest inactive-rng-leaves-do-not-evaluate-capture-checks
+  (let [emitted (opencl-pass/opencl-pass
+                 '(if enabled (raster.par/rng-fill! seeds n (int seed)) nil)
+                 :min-elements 0 :dtype :long :array-types {'seeds :long}
+                 :scalar-types {'enabled :boolean 'n :long 'seed :long})
+        host-form (walk/postwalk
+                   #(if (symbol? %) (vary-meta % dissoc :tag) %)
+                   (walk/postwalk-replace
+                    {'raster.gpu.ze-runtime/invoke-registered-kernel 'submit!} (:form emitted)))
+        execute (eval (list 'fn '[submit! enabled seeds n seed] host-form))
+        calls (atom 0)
+        submit! (fn [_ _ output _ _] (swap! calls inc) output)
+        output (long-array 3)]
+    (is (nil? (execute submit! false nil nil nil)))
+    (is (thrown? ArithmeticException
+                 (execute submit! true output 3 (inc (long Integer/MAX_VALUE)))))
+    (is (zero? @calls))
+    (is (identical? output (execute submit! true output 3 -1)))
+    (is (= 1 @calls))))
+
 (deftest inactive-host-branch-does-not-evaluate-its-checked-count
   (let [emitted (opencl-pass/opencl-pass
                  '(if enabled
@@ -250,7 +281,7 @@
                     (fn [& _] (throw (ex-info "typed program reparsed" {})))]
         (is (= [:kernel-body] (mapv #(get-in % [:attributes :emission-route])
                                    (:kernels (emit program)))))
-        (is (= :unscheduled-indexed-transfer
+        (is (= :unscheduled-map-leaf
                (try (emit (assoc program :source (list 'do source))) nil
                     (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
       (let [emitted (emit (assoc-in program [:provenance :source-dialect] :soac))]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -109,7 +109,7 @@
     (is (= ['scalar 'map] (mapv dialect/operation-kind (dialect/equations direct))))
     (is (= :analyzed-source
            (get-in routed [:stats :front-end])))
-    (is (= ['size '(clojure.core/* m n)]
+    (is (= ['size '(clojure.core/long (clojure.core/* m n))]
            (vec (take 2 (second (get-in routed [:program :source])))))
         "host allocation retains the transitive scalar binding that computes its extent")))
 
@@ -916,6 +916,20 @@
     (is (= '(int n) (second (second normalized))))
     (is (= 'int (:tag (meta extent))))
     (is (= '[scalar map] (mapv dialect/operation-kind equations)))))
+
+(deftest fixed-rng-inputs-keep-their-ordered-checked-conversions
+  (let [options {:dtype :long :array-types {'seeds :long}
+                 :scalar-types {'n :long 'seed :long}}
+        normalized (frontend/normalize-source
+                    '(let* [result (raster.par/rng-fill! seeds n (int seed))] result) options)
+        bindings (second normalized)
+        program (frontend/form->program normalized options)]
+    (is (= '(clojure.core/int n) (nth bindings 1)))
+    (is (= '(clojure.core/long (int seed)) (nth bindings 3)))
+    (is (= '[int long] (mapv #(-> % meta :raster.type/tag) [(nth bindings 0) (nth bindings 2)])))
+    (is (= '[scalar scalar map] (mapv dialect/operation-kind (dialect/equations program))))
+    (is (= normalized (frontend/normalize-source normalized options))
+        "normalization re-entry does not introduce another set of guards")))
 
 (deftest indexed-operation-counts-use-the-shared-scalar-normalizer
   (doseq [operation ['(raster.par/gather out x indices count)

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -120,8 +120,15 @@
                                     result (raster.par/map! out i n long value)] result)
                            :long {'out :long} {:scalar-types {'seed :long 'n :int}}))
         source (get-in program [:equations 0 :source])
-        execute (eval (list 'fn '[seed long] source))]
+        execute (eval (list 'fn '[seed long] source))
+        scalar-bindings (vec (take 2 (second (:source program))))
+        execute-binding (eval (list 'fn '[seed] (list 'let* scalar-bindings 'value)))]
     (is (= '(clojure.core/long (int seed)) source))
+    (is (= :long (get-in program [:values 'value :dtype])))
+    (is (nil? (:tag (meta (first scalar-bindings))))
+        "the primitive initializer, not a redundant binding hint, types the JVM local")
+    (is (instance? Long (execute-binding -1)))
+    (is (thrown? ArithmeticException (execute-binding (inc (long Integer/MAX_VALUE)))))
     (is (= (long -1) (execute -1 (fn [& _] (throw (ex-info "shadowed long" {}))))))
     (is (instance? Long (execute Integer/MAX_VALUE nil)))
     (is (thrown? ArithmeticException (execute (inc (long Integer/MAX_VALUE)) nil))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -114,6 +114,28 @@
       (is (= ['base-seed] (:captures operation)))
       (is (= 'n (get-in operation [:attributes :extent]))))))
 
+(deftest materialized-scalars-preserve-their-typed-result-conversions
+  (let [program (:program (route/attempt
+                           '(let* [^long value (long (int seed))
+                                    result (raster.par/map! out i n long value)] result)
+                           :long {'out :long} {:scalar-types {'seed :long 'n :int}}))
+        source (get-in program [:equations 0 :source])
+        execute (eval (list 'fn '[seed long] source))]
+    (is (= '(clojure.core/long (int seed)) source))
+    (is (= (long -1) (execute -1 (fn [& _] (throw (ex-info "shadowed long" {}))))))
+    (is (instance? Long (execute Integer/MAX_VALUE nil)))
+    (is (thrown? ArithmeticException (execute (inc (long Integer/MAX_VALUE)) nil))))
+  (let [program (:program (route/attempt
+                           '(let* [^float value (float seed)
+                                    result (raster.par/map! out i n float value)] result)
+                           :float {'out :float} {:scalar-types {'seed :double 'n :int}}))
+        execute (eval (list 'fn '[seed] (get-in program [:equations 0 :source])))]
+    (is (instance? Float (execute 1.00000001)))
+    (is (= (Float/floatToRawIntBits (float 1.00000001))
+           (Float/floatToRawIntBits (execute 1.00000001))))
+    (is (= (Float/floatToRawIntBits (float -0.0))
+           (Float/floatToRawIntBits (execute -0.0))))))
+
 (deftest production-route-retains-hardware-costed-placement-witnesses
   (let [poor (route/attempt expensive-fanout :float {'x :float}
                             {:abstract-machine {:ridge {:float 2.0}}})
@@ -590,7 +612,7 @@
         algorithm (:algorithm map-equation)]
     (is (= :typed-soac (:dialect program)))
     (is (= [:binding 'n] (:site scalar-equation)))
-    (is (= '(clojure.core/alength x)
+    (is (= '(clojure.core/long (clojure.core/alength x))
            (:source scalar-equation)))
     (is (= 'n (dialect/operation-extent (first (dialect/equations algorithm)))))
     (is (= :double (get-in (dialect/facts algorithm) [:values 'x :dtype])))
@@ -640,7 +662,7 @@
     (is (:typed-validated stats))
     (is (= 1 (:vertical stats)))
     (is (= ['scalar 'scalar 'map 'scalar 'scalar 'map] equation-kinds))
-    (is (= 'rows (get-in program [:equations 4 :source]))
+    (is (= '(clojure.core/long rows) (get-in program [:equations 4 :source]))
         "alength of the produced activation is value-numbered to its certified extent")
     (is (not-any? #{'raster.par/reduce} (mapcat flatten scheduled-lambdas))
         "nested source reductions are represented by typed scalar Fold terms")

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -50,6 +50,40 @@
   [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
   (raster.par/map! out i (int n) float (ra/aget x i)))
 
+(deftm ocl-session-checked-rng
+  [seeds :- (Array long) n :- Long seed :- Long] :- (Array long)
+  (raster.par/rng-fill! seeds n (int seed)))
+
+(deftest public-rng-capture-checks-precede-allocation
+  (let [descriptor (pl/compile-gpu-program #'ocl-session-checked-rng :ocl:0 :dtype :float)
+        step (first (:steps descriptor))
+        scalars (filterv #(= :scalar (:kind %)) (:argument-specs step))]
+    (is (= [:long :long :int] (mapv :dtype (:abi (:artifact step)))))
+    (is (= [-1 3] (mapv #((:value-fn %) [nil 3 -1]) scalars)))
+    (doseq [value [(inc (long Integer/MAX_VALUE)) (dec (long Integer/MIN_VALUE))]
+            position [1 2]]
+      (is (thrown? ArithmeticException
+                   ((:value-fn (first scalars)) (assoc [nil 3 0] position value)))))
+    (is (thrown? NullPointerException
+                 ((:value-fn (first scalars)) [nil nil (inc (long Integer/MAX_VALUE))]))
+        "the count conversion still precedes the seed conversion")))
+
+(deftest ocl-checked-rng-captures-match-source-values
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "checked RNG captures")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-checked-rng :ocl:0 :dtype :float)
+          s (gpu/make-session :ocl:0)]
+      (try
+        (doseq [seed [Integer/MIN_VALUE Integer/MAX_VALUE]]
+          (let [expected (long-array 17)
+                arguments [(long-array 17) 17 seed]
+                program (fixture/instantiate! s descriptor arguments)]
+            (try
+              (raster.par/rng-fill! expected 17 (int seed))
+              (is (= (vec expected) (vec (get (fixture/run! program arguments) 'seeds))))
+              (finally (fixture/close! program)))))
+        (finally (gpu/close-session! s))))))
+
 (deftm ocl-session-fused-buffer-maps
   [x :- (Array float) left :- (Array float) right :- (Array float) n :- Long] :- Object
   (let [a (raster.par/map! left i n float (+ (ra/aget x i) 1.0))


### PR DESCRIPTION
## Summary
- Preserve count-before-seed checked conversions as ordinary typed scalar equations.
- Materialize scalar results using retained dtypes instead of losing outer result conversions.
- Schedule nested RNG leaves at their original host control-flow position, with a one-attempt failure guard.
- Keep active-ID population semantics and retirement out of scope.

## Validation
- Frontend: 51 tests, 235 assertions pass.
- Focused scalar, inactive-branch, descriptor, strided-transfer, and CPU OpenCL numerical tests pass.
- Public checked-RNG fixture emits a CUDA-target artifact; mandatory vendor compiler gates run in CI.
- Full suites delegated to CI to keep the laptop feedback loop bounded.

No GPU timing or performance-parity claim.