### PR TITLE
Schedule raw effect maps through TypedSOAC before reported compatibility

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -182,6 +182,10 @@ need their own typed closure. The independent source-emitter tests remain unchan
 An explicit logical-SoA guard precedes plain-array scheduling: the typed frontend can otherwise
 accept the container as one float pointer rather than decline. Bare, conditional and let-bound probes
 retain the existing per-field dtypes, names and grouped logical binding through the source adapter.
+Unscheduled effects within partially scheduled source programs also retain that reported adapter:
+introducing leaf-local lets after emission breaks flat resident extraction, and alpha-renaming
+only the host form would disconnect its artifact argument plan. Semantic-stage composition tests
+exercise this boundary. Complete host-region normalization must precede emission before retiring it.
 
 ## 3. General fusion and bounded specialization — price admission active; broader work queued
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -179,6 +179,9 @@ Unscheduled raw bodies retain the existing adapter with an explicit `:compatibil
 emission route and `:effect-compatibility` count, including through nested host control. This is
 not full effect-emitter retirement: logical SoA expansion and other unsupported effect bodies still
 need their own typed closure. The independent source-emitter tests remain unchanged.
+An explicit logical-SoA guard precedes plain-array scheduling: the typed frontend can otherwise
+accept the container as one float pointer rather than decline. Bare and nested regression probes
+retain the existing per-field dtypes, names and grouped logical binding through the source adapter.
 
 ## 3. General fusion and bounded specialization — price admission active; broader work queued
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -113,7 +113,7 @@ The next caller audit distinguishes a remaining source edge from demonstrated ru
 | Boundary | Retained owner / consumer | Current evidence |
 |---|---|---|
 | General contractions | `generate-segmented-reduce-kernel` → `contract_route` | Nested gather selects the source fallback after `:operand-layout` decline. |
-| Unscheduled effects | `generate-par-map-void-kernel` → `opencl_pass` | Raw/unbound effect fallback still present. |
+| Unscheduled effects | Typed mini-program first; `generate-par-map-void-kernel` on decline | Raw/nested plain-array effects schedule once; unsupported bodies retain a reported compatibility route. |
 | Strided transfers | Typed mini-program → KernelBody | Bare and host-wrapped leaves share typed scheduling; source generators moved to test-only oracles. |
 | Active IDs | `generate-par-active-ids-kernel` → `opencl_pass` | ABM firms uses seeded agent indices, not arbitrary visibility compaction. |
 | Compound local | `generate-compound-local-kernel` → `opencl_pass` | Compatibility markers remain; structured typed programs bypass detection. |
@@ -170,6 +170,15 @@ cast. Typed scalar materialization reapplies its retained result conversion, pre
 checks local; missing certified leaves fail once instead of recursively rescheduling. Public
 descriptor preflight, CPU differential execution and vendor compile fixtures cover this boundary.
 This does not admit the active-ID population domain or retire its production source kernel.
+
+Raw effect-map follow-up uses the same one-attempt typed mini-program boundary as RNG and strided
+transfers. Conditional leaves keep checked extents beside their invocation. Plain mixed-storage
+maps and pre-store lexical snapshots have CPU OpenCL differential checks; tiny host-only bodies
+still use the existing scalar fallback. A supplied typed program cannot re-enter source lowering.
+Unscheduled raw bodies retain the existing adapter with an explicit `:compatibility-effect-opencl`
+emission route and `:effect-compatibility` count, including through nested host control. This is
+not full effect-emitter retirement: logical SoA expansion and other unsupported effect bodies still
+need their own typed closure. The independent source-emitter tests remain unchanged.
 
 ## 3. General fusion and bounded specialization — price admission active; broader work queued
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -180,7 +180,7 @@ emission route and `:effect-compatibility` count, including through nested host 
 not full effect-emitter retirement: logical SoA expansion and other unsupported effect bodies still
 need their own typed closure. The independent source-emitter tests remain unchanged.
 An explicit logical-SoA guard precedes plain-array scheduling: the typed frontend can otherwise
-accept the container as one float pointer rather than decline. Bare and nested regression probes
+accept the container as one float pointer rather than decline. Bare, conditional and let-bound probes
 retain the existing per-field dtypes, names and grouped logical binding through the source adapter.
 
 ## 3. General fusion and bounded specialization — price admission active; broader work queued

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -378,9 +378,9 @@
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
    Uses full SegOp conversion for par/map! and par/reduce.
-   Certified effect-only map-void forms consume their scheduled TypedSOAC SegMap; unsupported
-   bodies and the remaining active-id and key-reduction forms retain
-   explicit compatibility generators.
+   Effect-only map-void forms consume their scheduled TypedSOAC SegMap, including raw nested
+   leaves. Effect bodies without a typed schedule retain a reported compatibility route;
+   the remaining active-id and key-reduction forms also retain compatibility generators.
 
    Returns {:form new-form :stats {:ze-maps N :ze-reduces N :fallback N}
             :kernels [{:kernel-name :source ...} ...]}
@@ -453,6 +453,7 @@
         direct-mini-program?
         (and (nil? supplied-program)
              (or (par/par-rng-fill-form? form)
+                 (par/par-map-void-form? form)
                  (and (par/par-gather-form? form)
                       (:stride (par/extract-par-gather-info form)))
                  (and (par/par-scatter-form? form)
@@ -549,7 +550,7 @@
 
         emit-nested-map!
         (fn [form]
-          ;; Raw host control flow can contain an indexed/RNG map without a surrounding
+          ;; Raw host control flow can contain an indexed, RNG or effect map without a surrounding
           ;; ParallelProgram. Schedule that leaf at its original control-flow position: its
           ;; hoisted extent belongs beside the invocation, never outside the host branch.
           ;; A supplied typed program must already account for every scheduled operation; do
@@ -885,22 +886,27 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-map-void! form))
-                (let [scheduled (take-bound-segop
+                (if-let [scheduled (take-bound-segop
                                  stats :segmap
                                  #(and (instance? raster.compiler.ir.segop.SegMap %)
-                                       (= :typed-soac (:algorithm-dialect %))))
-                      kernel (if scheduled
-                               (segop-cl/generate-scheduled-segmap-kernel
+                                       (= :typed-soac (:algorithm-dialect %))))]
+                  (let [kernel (segop-cl/generate-scheduled-segmap-kernel
                                 scheduled
                                 :dtype (:dtype scheduled)
                                 :scalar-types top-scalar-types
                                 :array-types top-array-types)
-                               (legacy/generate-par-map-void-kernel
-                                form :dtype dtype :device-id device-id
-                                :array-types top-array-types
-                                :scalar-types top-scalar-types))
                       k (register-kernel! kernel :ze-maps)]
-                  (emit-map-void-invocation k device-id))))
+                    (emit-map-void-invocation k device-id))
+                  (if (and direct-mini-program? (not supplied-program))
+                    (let [kernel (legacy/generate-par-map-void-kernel
+                                  form :dtype dtype :device-id device-id
+                                  :array-types top-array-types :scalar-types top-scalar-types)
+                          kernel (assoc-in kernel [:attributes :emission-route]
+                                           :compatibility-effect-opencl)
+                          k (register-kernel! kernel :ze-maps)]
+                      (swap! stats update :effect-compatibility (fnil inc 0))
+                      (emit-map-void-invocation k device-id))
+                    (emit-nested-map! form)))))
 
             ;; par/scan-exclusive
             (par/par-scan-exclusive-form? form)

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -42,6 +42,10 @@
   (and (par/par-map-void-form? form)
        (seq (soa-lower/collect-soa-env (:body (par/extract-par-map-void-info form))))))
 
+(defn- contains-unlowered-soa-effect?
+  [source]
+  (boolean (some unlowered-soa-effect? (tree-seq coll? seq source))))
+
 (defn- host-scalar-result?
   [program equation]
   (let [value (get-in program [:values (first (:results equation))])
@@ -486,7 +490,8 @@
             :scalar-types (merge scalar-types retained-scalar-types)
             :array-types (merge array-types retained-array-types)})
 
-          (and (nil? supplied-program) (form/binding-form? form))
+          (and (nil? supplied-program) (form/binding-form? form)
+               (not (contains-unlowered-soa-effect? form)))
           (segop-lower-pass/schedule-source-program
            form {:target-device device-id :dtype dtype
                  :scalar-types scalar-types :array-types array-types})

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -910,8 +910,12 @@
                                 :array-types top-array-types)
                       k (register-kernel! kernel :ze-maps)]
                     (emit-map-void-invocation k device-id))
+                  ;; A partially scheduled source program still needs a flat resident marker.
+                  ;; Re-scheduling just this binding would introduce private scalar lets after
+                  ;; graph/ABI formation. Keep that explicit compatibility boundary until the
+                  ;; whole host region can be normalized before emission.
                   (if (and (not supplied-program)
-                           (or direct-mini-program? (unlowered-soa-effect? form)))
+                           (or direct-mini-program? parallel-program (unlowered-soa-effect? form)))
                     (let [kernel (legacy/generate-par-map-void-kernel
                                   form :dtype dtype :device-id device-id
                                   :array-types top-array-types :scalar-types top-scalar-types)

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -27,6 +27,7 @@
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.typed-soac-resident :as resident]
+            [raster.compiler.passes.scalar.soa-lower :as soa-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -34,6 +35,12 @@
             [raster.compiler.backend.gpu.par-opencl :as legacy]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]))
+
+(defn- unlowered-soa-effect?
+  "A logical SoA must retain its grouped pointer ABI until shared scalar replacement expands it."
+  [form]
+  (and (par/par-map-void-form? form)
+       (seq (soa-lower/collect-soa-env (:body (par/extract-par-map-void-info form))))))
 
 (defn- host-scalar-result?
   [program equation]
@@ -453,7 +460,8 @@
         direct-mini-program?
         (and (nil? supplied-program)
              (or (par/par-rng-fill-form? form)
-                 (par/par-map-void-form? form)
+                 ;; Plain-array scheduling cannot interpret a logical SoA as one tensor pointer.
+                 (and (par/par-map-void-form? form) (not (unlowered-soa-effect? form)))
                  (and (par/par-gather-form? form)
                       (:stride (par/extract-par-gather-info form)))
                  (and (par/par-scatter-form? form)
@@ -897,7 +905,8 @@
                                 :array-types top-array-types)
                       k (register-kernel! kernel :ze-maps)]
                     (emit-map-void-invocation k device-id))
-                  (if (and direct-mini-program? (not supplied-program))
+                  (if (and (not supplied-program)
+                           (or direct-mini-program? (unlowered-soa-effect? form)))
                     (let [kernel (legacy/generate-par-map-void-kernel
                                   form :dtype dtype :device-id device-id
                                   :array-types top-array-types :scalar-types top-scalar-types)

--- a/test/raster/abm/firms/gpu_test.clj
+++ b/test/raster/abm/firms/gpu_test.clj
@@ -512,11 +512,15 @@
                                       (if (== 1 (aget alive i))
                                         (aset output i (float 1.0))
                                         (aset output i (float 0.0))))
-          result (opencl-pass/opencl-pass form :dtype :float :compile-spirv? false)]
+          result (opencl-pass/opencl-pass form :dtype :float :compile-spirv? false
+                                          :array-types {'alive :int 'output :float}
+                                          :scalar-types {'n :int})]
       (is (seq (:kernels result))
           "Should generate at least one kernel")
       (when (seq (:kernels result))
         (let [src (:source (first (:kernels result)))]
           (is (string? src) "Kernel source should be a string")
           (is (.contains ^String src "__kernel") "Should contain __kernel")
-          (is (.contains ^String src "if") "Should contain if statement"))))))
+          (is (= :kernel-body (get-in result [:kernels 0 :attributes :emission-route])))
+          (is (.contains ^String src "?")
+              "the typed value conditional lowers to a scalar selection"))))))

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -3,6 +3,7 @@
             [clojure.walk :as walk]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.core.types :as types]
             [raster.compiler.reference.indexed-transfer-opencl :as indexed-reference]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -405,6 +406,28 @@
         (is (= 1 (get-in emitted [:stats :effect-compatibility])))
         (is (= [:compatibility-effect-opencl]
                (mapv kart/emission-route (:kernels emitted))))))))
+
+(deftest unexpanded-soa-effects-retain-their-logical-abi-group
+  (with-redefs [types/soa-registry
+                (atom {'Particle {:fields [{:name "x" :element-tag 'float :array-tag 'floats}
+                                           {:name "id" :element-tag 'int :array-tag 'ints}]}})
+                types/soa-reverse-registry (atom {'ParticleSoA 'Particle})
+                segop-lower/schedule-single-program
+                (fn [& _] (throw (ex-info "unexpanded SoA entered plain-array scheduling" {})))]
+    (doseq [wrap [identity #(list 'if 'enabled % nil)]]
+      (let [emitted (opencl-pass/opencl-pass
+                     (wrap '(raster.par/map-void! i n
+                              (aset out i (.x (aget ^ParticleSoA particles i)))))
+                     :dtype :float :min-elements 0 :array-types {'out :float}
+                     :scalar-types {'n :int 'enabled :boolean})
+            kernel (first (:kernels emitted))
+            fields (filterv #(= 'particles (:binding %)) (:abi kernel))]
+        (is (= 1 (get-in emitted [:stats :effect-compatibility])))
+        (is (= :compatibility-effect-opencl (kart/emission-route kernel)))
+        (is (= '[particles_x particles_id] (mapv :name fields)))
+        (is (= [:float :int] (mapv :dtype fields)))
+        (is (= ["x" "id"] (mapv :field fields)))
+        (is (= '[out particles] (kabi/pointer-binding-names (:abi kernel))))))))
 
 (deftest opencl-pass-fallback-test
   (testing "Small arrays fall back to scalar expansion"

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -413,8 +413,11 @@
                                            {:name "id" :element-tag 'int :array-tag 'ints}]}})
                 types/soa-reverse-registry (atom {'ParticleSoA 'Particle})
                 segop-lower/schedule-single-program
-                (fn [& _] (throw (ex-info "unexpanded SoA entered plain-array scheduling" {})))]
-    (doseq [wrap [identity #(list 'if 'enabled % nil)]]
+                (fn [& _] (throw (ex-info "unexpanded SoA entered plain-array scheduling" {})))
+                segop-lower/schedule-source-program
+                (fn [& _] (throw (ex-info "unexpanded SoA entered source scheduling" {})))]
+    (doseq [wrap [identity #(list 'if 'enabled % nil)
+                 #(list 'let* ['effect %] 'effect)]]
       (let [emitted (opencl-pass/opencl-pass
                      (wrap '(raster.par/map-void! i n
                               (aset out i (.x (aget ^ParticleSoA particles i)))))

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -351,13 +351,60 @@
             result (opencl-pass/opencl-pass
                     form :device-id device :dtype :float
                     :array-types {'state :int 'x :float 'y :float}
-                    :scalar-types {'limit :int 'scale :float})
-            marker (:form result)
+                    :scalar-types {'limit :int 'scale :float 'n :int})
+            marker (some #(when (and (seq? %) (= expected-head (first %))) %)
+                         (tree-seq coll? seq (:form result)))
             abi (:abi (first (:kernels result)))]
         (is (= expected-head (first marker)))
         (is (= (kabi/pointer-binding-names abi) (nth marker 2)))
         (is (= '[limit scale] (nth marker 3)))
         (is (= 'n (nth marker 4)))))))
+
+(deftest nested-effect-maps-use-typed-scheduling-at-their-host-position
+  (with-redefs [par-opencl/generate-par-map-void-kernel
+                (fn [& _] (throw (ex-info "legacy effect emitter reached" {})))]
+    (let [emitted (opencl-pass/opencl-pass
+                   '(if enabled (raster.par/map-void! i (int n) (aset out i (aget x i))) nil)
+                   :dtype :float :min-elements 0
+                   :array-types {'out :float 'x :float}
+                   :scalar-types {'n :long 'enabled :boolean})
+          host (walk/postwalk
+                 #(if (symbol? %) (vary-meta % dissoc :tag) %)
+                 (walk/postwalk-replace
+                  {'raster.gpu.ze-runtime/invoke-registered-map-void-kernel 'submit!}
+                  (:form emitted)))
+          execute (eval (list 'fn '[submit! enabled n x out] host))
+          calls (atom 0)
+          submit! (fn [& _] (swap! calls inc) nil)]
+      (is (= [:kernel-body] (mapv kart/emission-route (:kernels emitted))))
+      (is (nil? (execute submit! false nil nil nil)))
+      (is (thrown? ArithmeticException
+                   (execute submit! true (inc (long Integer/MAX_VALUE)) nil nil)))
+      (is (zero? @calls))
+      (is (nil? (execute submit! true 3 (float-array 3) (float-array 3))))
+      (is (= 1 @calls)))))
+
+(deftest literal-small-effect-maps-preserve-the-host-fallback
+  (with-redefs [par-opencl/generate-par-map-void-kernel
+                (fn [& _] (throw (ex-info "unexpected GPU source emission" {})))]
+    (let [emitted (opencl-pass/opencl-pass '(raster.par/map-void! i 2 (println i))
+                                         :dtype :float :min-elements 4096)]
+      (is (empty? (:kernels emitted)))
+      (is (= 1 (get-in emitted [:stats :fallback])))
+      (is (= "0\n1\n" (with-out-str (is (nil? (eval (:form emitted))))))))))
+
+(deftest declined-raw-effect-scheduling-is-reported-once
+  (let [attempts (atom 0)]
+    (with-redefs [segop-lower/schedule-single-program (fn [& _] (swap! attempts inc) {})]
+      (let [emitted (opencl-pass/opencl-pass
+                     '(if enabled (raster.par/map-void! i n (aset out i (aget x i))) nil)
+                     :dtype :float :min-elements 0
+                     :array-types {'out :float 'x :float}
+                     :scalar-types {'n :int 'enabled :boolean})]
+        (is (= 1 @attempts))
+        (is (= 1 (get-in emitted [:stats :effect-compatibility])))
+        (is (= [:compatibility-effect-opencl]
+               (mapv kart/emission-route (:kernels emitted))))))))
 
 (deftest opencl-pass-fallback-test
   (testing "Small arrays fall back to scalar expansion"

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -8,6 +8,7 @@
   buffers (uninitialized device memory — Intel's driver zeroes allocations,
   POCL's malloc does not)."
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.pipeline :as pl]
@@ -282,6 +283,52 @@
       (register! (:kernel-name kernel) kernel)
       (invoke! (:kernel-name kernel) [out q] [{:type :int :value 7}] n)
       (is (every? true? (map-indexed (fn [i v] (= v (+ 7 (aget q i)))) out))))))
+
+(deftest ocl-nested-effect-map-mixed-storage-roundtrip
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "nested typed effect map")
+    (let [emitted (opencl-pass/opencl-pass
+                   '(if enabled
+                      (raster.par/map-void! i (int n)
+                        (aset out i (+ (int (aget q i)) limit))) nil)
+                   :device-id :ocl:0 :min-elements 0 :dtype :float
+                   :array-types {'out :int 'q :byte}
+                   :scalar-types {'enabled :boolean 'n :long 'limit :int})
+          register! (resolve 'raster.gpu.ocl-runtime/register-kernel!)
+          execute (eval (list 'fn '[enabled n q out limit]
+                              (walk/postwalk #(if (symbol? %) (vary-meta % dissoc :tag) %)
+                                             (:form emitted))))
+          q (byte-array [-128 -3 0 127])
+          out (int-array [99 99 99 99])]
+      (is (= [:kernel-body] (mapv #(get-in % [:attributes :emission-route]) (:kernels emitted))))
+      (doseq [kernel (:kernels emitted)] (register! (:kernel-name kernel) kernel))
+      (is (nil? (execute false nil nil nil nil)))
+      (is (nil? (execute true 4 q out 7)))
+      (is (= [-121 4 7 134] (vec out))))))
+
+(deftest ocl-raw-effect-map-retains-pre-store-snapshots
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "typed effect lexical snapshots")
+    (let [emitted (opencl-pass/opencl-pass
+                   '(raster.par/map-void! i n
+                      (let* [^float next-state (+ (aget state i) (aget grad i))]
+                        (aset state i (float next-state))
+                        (aset param i (float (- (aget param i) next-state)))))
+                   :device-id :ocl:0 :min-elements 0 :dtype :float
+                   :array-types {'state :float 'grad :float 'param :float}
+                   :scalar-types {'n :int})
+          register! (resolve 'raster.gpu.ocl-runtime/register-kernel!)
+          execute (eval (list 'fn '[state grad param n]
+                              (walk/postwalk #(if (symbol? %) (vary-meta % dissoc :tag) %)
+                                             (:form emitted))))
+          state (float-array [1 2 3])
+          grad (float-array [4 5 6])
+          param (float-array [20 30 40])]
+      (is (= [:kernel-body] (mapv #(get-in % [:attributes :emission-route]) (:kernels emitted))))
+      (doseq [kernel (:kernels emitted)] (register! (:kernel-name kernel) kernel))
+      (is (nil? (execute state grad param 3)))
+      (is (= [5.0 7.0 9.0] (vec state)))
+      (is (= [15.0 23.0 31.0] (vec param))))))
 
 (deftest ocl-resident-session-roundtrip
   (if-not @device-probe/opencl-available?


### PR DESCRIPTION
Prerequisite #407 is merged.

## Summary
- Bare and nested plain-array effect maps get one ordinary typed scheduling attempt and emit KernelBody when admitted.
- Host branches retain local checked counts, nil returns and pre-store lexical snapshots.
- Unsupported raw bodies retain the existing adapter with an explicit compatibility-effect-opencl route and counter. Supplied typed programs cannot re-enter source lowering.
- Logical SoA containers explicitly bypass plain-array admission in bare, conditional and let-bound raw forms, preserving grouped per-field ABI bindings.
- Full effect-emitter retirement and supplied-program SoA closure remain deferred.

## Validation
- Focused backend suite and CPU OpenCL execution cover ABI order, mixed byte/int storage, inactive branches, checked counts and pre-store lexical snapshots.
- Tiny host-only effects preserve scalar fallback; simulated admission decline is reported once.
- SoA probes preserve separate float/int fields and one logical binding, intercepting both source and single-leaf scheduling.
- Read-only review clean. Full suites and mandatory CUDA/HIP compiler gates must pass on the final head before merge.

No accelerator performance claim.