### PR TITLE
Use shared primitive cast descriptors in scalar KernelBody lowering

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -155,6 +155,15 @@ Exit: classify all remaining routes; retire duplicated paths for covered workloa
 production coverage and no silent legacy re-entry. Report any remaining gaps rather than declaring
 the entire compiler unified from one successful vertical.
 
+Scalar-emission audit removes the map/fold lowerer's private copy of primitive cast spellings in
+favor of the shared operation descriptor and dtype vocabulary. This does not change narrowing or
+rounding policies. Before sharing that lowerer with contraction elements, reconcile its explicit
+device-wrap narrowing policy with reduction lowering's checked-cast rejection; do not widen
+reduction admission accidentally. Indirect contraction loads also need independent storage
+capacities and a data-dependent index-range contract. A dense AxisMap or an index array's integral
+dtype does not prove its contents are in bounds. Keep the production operand-layout gate until
+those obligations are represented and enforced, reusing existing typed loads and graph capacities.
+
 The active-ID prototype is deliberately **not shipped**. Review found that its remainder-based
 body matches source `mod` only over positive populations, and its output conversion needs a proved
 int range. It also inherited unconditional cast erasure on seed/population captures. Passing

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -12,13 +12,6 @@
             [raster.compiler.ir.scalar-range :as scalar-range]
             [raster.compiler.passes.parallel.patterns :as patterns]))
 
-(def ^:private cast-heads
-  {'byte :byte, 'clojure.core/byte :byte
-   'int :int, 'clojure.core/int :int
-   'long :long, 'clojure.core/long :long
-   'float :float, 'clojure.core/float :float
-   'double :double, 'clojure.core/double :double})
-
 (defn- contains-indexed-load?
   [expression]
   (boolean (some descriptor/aget-call? (tree-seq coll? seq expression))))
@@ -99,8 +92,8 @@
                (number? expression) expected
                (descriptor/aget-call? expression)
                (or (get array-types (descriptor/aget-array-sym expression)) expected)
-               (and (seq? expression) (contains? cast-heads (first expression)))
-               (get cast-heads (first expression))
+               (and (seq? expression) (descriptor/cast-op? (first expression)))
+               (dtype/dtype-for-scalar-tag (descriptor/cast-result-tag (first expression)))
                (and (seq? expression)
                     (= :cmp (:kind (intrinsics/descriptor
                                     (intrinsics/canonical
@@ -211,9 +204,10 @@
                                           (when predicate (body/literal 0 array-type)) :cached))
                          :result id :type array-type :range range})))
 
-                  (and (seq? expression) (contains? cast-heads (first expression))
+                  (and (seq? expression) (descriptor/cast-op? (first expression))
                        (= 2 (count expression)))
-                  (let [target (dtype/canon (get cast-heads (first expression)))
+                  (let [target (dtype/dtype-for-scalar-tag
+                                (descriptor/cast-result-tag (first expression)))
                         source-expected (dtype/canon (source-type (second expression) target env))
                         lowered (lower (second expression) source-expected env)]
                     (cast-lowered lowered target expression))

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -22,6 +22,23 @@
    [:float :int] {'candidate :float 'better :predicate}
    {'old-value :float 'old-index :int}))
 
+(deftest scalar-casts-use-the-shared-descriptor-vocabulary
+  (doseq [[head target source overflow]
+          [['byte :byte :long :wrap] ['int :int :long :wrap]
+           ['long :long :int :exact] ['float :float :double :ieee]
+           ['double :double :float :exact]]
+          qualified? [false true]]
+    (let [head (if qualified? (symbol "clojure.core" (name head)) head)
+          result ((:lower (lowerer)) (list head 'value) target {'value source})
+          expression (:expression (last (:operations result)))]
+      (is (= target (:type result)))
+      (is (= :cast (:op expression)))
+      (is (= overflow (get-in expression [:options :overflow])))))
+  (let [result ((:lower (lowerer)) '(double (int value)) :double {'value :long})]
+    (is (= [:int :double] (mapv #(get-in % [:result :type]) (:operations result))))
+    (is (= [:wrap :exact] (mapv #(get-in % [:expression :options :overflow])
+                              (:operations result))))))
+
 (deftest unary-subtraction-retains-floating-sign-and-integral-overflow
   (doseq [type [:float :double :int :long]]
     (let [lower (:lower-region (lowerer))


### PR DESCRIPTION
## Summary
- Remove the duplicate primitive cast spelling/type map from scalar KernelBody lowering.
- Use the existing shared operation descriptor and dtype vocabulary at both recognition sites.
- Preserve all current conversion policies; record the separate narrowing-policy and indirect-index proof obligations before contraction-lowerer unification.

## Validation
- Scalar region suite: 12 tests, 122 assertions pass.
- New coverage checks all ten qualified/unqualified spellings and nested conversion order/policy.
- Read-only review confirms the vocabularies are identical. Full suites in CI.

No admission or performance changes.