### PR TITLE
Share scalar conversion rules without merging owner admission policies

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -164,6 +164,14 @@ capacities and a data-dependent index-range contract. A dense AxisMap or an inde
 dtype does not prove its contents are in bounds. Keep the production operand-layout gate until
 those obligations are represented and enforced, reusing existing typed loads and graph capacities.
 
+The scalar conversion prerequisite now derives common rounding/overflow choices from dtype facets
+in one pure helper, used by map/fold expression lowering and reduction element lowering. Integral
+narrowing defaults to rejection; the existing map/fold device-wrap behavior is an explicit owner
+opt-in, not an inferred equivalence to checked Clojure casts. Reduction's source checked-cast gate
+is unchanged. Exhaustive primitive conversion pairs and owner-admission checks protect this seam.
+This does not unify the full scalar lowerers, change epilogue conversion labeling, or admit new
+indirect accesses; those remaining differences must be closed separately.
+
 The active-ID prototype is deliberately **not shipped**. Review found that its remainder-based
 body matches source `mod` only over positive populations, and its output conversion needs a proved
 int range. It also inherited unconditional cast erasure on seed/population captures. Passing

--- a/src/raster/compiler/core/scalar_conversion.clj
+++ b/src/raster/compiler/core/scalar_conversion.clj
@@ -1,0 +1,38 @@
+(ns raster.compiler.core.scalar-conversion
+  "Conversion policies derived from authoritative scalar dtypes, not source-expression inference.
+   This is a shared lowering helper, not another IR or a target/type registry."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(defn policy
+  "Return [rounding overflow], or nil when this policy cannot represent the conversion.
+
+   Integral narrowing is rejected unless the owner explicitly requests :wrap. That opt-in
+   preserves an existing device representation policy; it does not prove equivalence to a
+   checked Clojure cast. Floating-to-integral conversions remain unsupported. Identity callers
+   may elide the returned exact conversion. Unknown dtypes or policy options fail loudly."
+  ([source target] (policy source target :reject))
+  ([source target integral-narrowing]
+   (when-not (contains? #{:reject :wrap} integral-narrowing)
+     (throw (ex-info "unsupported integral narrowing policy"
+                     {:reason :unsupported-scalar-conversion-policy
+                      :integral-narrowing integral-narrowing})))
+   (let [source (dtype/canon source)
+         target (dtype/canon target)
+         fp-source? (dtype/fp-dtype? source)
+         fp-target? (dtype/fp-dtype? target)
+         widening? (<= (dtype/bytes-of source) (dtype/bytes-of target))]
+     (cond
+       (= source target) [:exact :exact]
+       (and fp-source? fp-target?)
+       (if widening? [:exact :exact] [:nearest-even :ieee])
+
+       (and (not fp-source?) (not fp-target?))
+       (cond widening? [:exact :exact]
+             (= :wrap integral-narrowing) [:exact :wrap])
+
+       (and (not fp-source?) fp-target?)
+       (if (and (= :double target) (<= (dtype/bytes-of source) 4))
+         [:exact :exact]
+         [:nearest-even (if (= :half target) :ieee :exact)])
+
+       :else nil))))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -6,6 +6,7 @@
    this pass performs no source-level type or function inference."
   (:require [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.scalar-conversion :as scalar-conversion]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
@@ -108,28 +109,13 @@
                 (if (= target (:type lowered))
                   lowered
                   (let [source (dtype/canon (:type lowered))
-                        fp-source? (dtype/fp-dtype? source)
-                        fp-target? (dtype/fp-dtype? target)
-                        widening? (<= (dtype/bytes-of source) (dtype/bytes-of target))
                         [rounding overflow]
-                        (cond
-                          (and fp-source? fp-target? widening?) [:exact :exact]
-                          (and fp-source? fp-target?) [:nearest-even :ieee]
-                          (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
-                          ;; Integral narrowing (`(int j)` on a long counter) keeps the two's
-                          ;; complement bits. The JVM source cast is range-checked and throws
-                          ;; on overflow; kernels state `:wrap` because no portable target traps
-                          ;; inside a conversion, so an out-of-range narrowing is loud on the
-                          ;; JVM and modular on the device. In-range values agree everywhere.
-                          (and (not fp-source?) (not fp-target?)) [:exact :wrap]
-                          (and (not fp-source?) fp-target? (= :double target)
-                               (<= (dtype/bytes-of source) 4)) [:exact :exact]
-                          (and (not fp-source?) fp-target?)
-                          [:nearest-even (if (= :half target) :ieee :exact)]
-                          :else
-                          (decline! :cast-policy
-                                    "scalar cast has no portable rounding and overflow policy"
-                                    {:expression expression :source source :target target}))
+                        ;; Keep this owner's existing device-wrap policy explicit. Reduction
+                        ;; lowering must not inherit it merely by sharing conversion machinery.
+                        (or (scalar-conversion/policy source target :wrap)
+                            (decline! :cast-policy
+                                      "scalar cast has no portable rounding and overflow policy"
+                                      {:expression expression :source source :target target}))
                         id (fresh "cast")]
                     (let [range (when (scalar-range/contained-in-dtype? (:range lowered) target)
                                   (:range lowered))]

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -9,6 +9,7 @@
    explicitly; scheduled graphs have no source-shaped target fallback."
   (:require [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.scalar-conversion :as scalar-conversion]
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -335,35 +336,13 @@
   [source target]
   (let [source (dtype/canon source)
         target (dtype/canon target)]
-    (cond
-      (= source target) nil
-
-      (and (dtype/fp-dtype? source) (dtype/fp-dtype? target))
-      (if (< (dtype/bytes-of source) (dtype/bytes-of target))
-        [:exact :exact]
-        [:nearest-even :ieee])
-
-      (and (dtype/integral? source) (dtype/fp-dtype? target))
-      (if (and (= :double target) (<= (dtype/bytes-of source) 4))
-        [:exact :exact]
-        [:nearest-even (if (= :half target) :ieee :exact)])
-
-      (and (dtype/fp-dtype? source) (dtype/integral? target))
-      (decline! :checked-scalar-cast
-                "KernelBody reduction cannot preserve a checked floating-to-integral cast"
-                {:source-dtype source :target-dtype target})
-
-      (and (dtype/integral? source) (dtype/integral? target))
-      (if (< (dtype/bytes-of source) (dtype/bytes-of target))
-        [:exact :exact]
-        (decline! :checked-scalar-cast
-                  "KernelBody reduction cannot preserve a checked narrowing integral cast"
-                  {:source-dtype source :target-dtype target}))
-
-      :else
-      (decline! :scalar-cast
-                "KernelBody reduction has no explicit numerical cast policy"
-                {:source-dtype source :target-dtype target}))))
+    (when-not (= source target)
+      (or (scalar-conversion/policy source target)
+          (decline! :checked-scalar-cast
+                    (if (dtype/fp-dtype? source)
+                      "KernelBody reduction cannot preserve a checked floating-to-integral cast"
+                      "KernelBody reduction cannot preserve a checked narrowing integral cast")
+                    {:source-dtype source :target-dtype target})))))
 
 (defn lower-element-operations
   "Lower a scalar reduction element into typed SSA. coordinate-lower may translate a verified

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -2,10 +2,13 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
             [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.scalar-conversion :as conversion]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.index-expression :as index]
             [raster.compiler.passes.parallel.patterns :as patterns]
+            [raster.compiler.passes.parallel.segred-body :as segred]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
 
 (defn- lowerer []
@@ -21,6 +24,47 @@
      :results [(if better candidate old-value) (if better i old-index)]}
    [:float :int] {'candidate :float 'better :predicate}
    {'old-value :float 'old-index :int}))
+
+(deftest shared-conversion-policy-keeps-narrowing-an-explicit-owner-decision
+  (let [types [:byte :int :long :half :float :double]
+        exact [:exact :exact]
+        rounded [:nearest-even :exact]
+        ieee [:nearest-even :ieee]
+        wrap [:exact :wrap]
+        ;; Independent complete matrix: rows are source types, columns target types.
+        expected [[exact exact exact ieee rounded exact]
+                  [wrap exact exact ieee rounded exact]
+                  [wrap wrap exact ieee rounded rounded]
+                  [nil nil nil exact exact exact]
+                  [nil nil nil ieee exact exact]
+                  [nil nil nil ieee ieee exact]]]
+    (is (= (set types) (set (keys dtype/dtype-info))))
+    (doseq [[row source] (map-indexed vector types)
+            [column target] (map-indexed vector types)]
+      (let [policy (get-in expected [row column])]
+        (is (= policy (conversion/policy source target :wrap)) (str source " → " target))
+        (is (= (when-not (= wrap policy) policy) (conversion/policy source target))
+            (str "checked owner: " source " → " target))))
+    (is (= exact (conversion/policy :i32 :f64)))
+    (is (= ieee (conversion/policy :f64 :f16)))
+    (is (thrown? clojure.lang.ExceptionInfo (conversion/policy :missing :float)))
+    (is (thrown? clojure.lang.ExceptionInfo (conversion/policy :int :float :unchecked)))))
+
+(deftest reduction-element-conversions-retain-their-stricter-admission
+  (let [expression (with-meta '(+ (aget x i) scale) {:raster.type/tag 'double})
+        options {:index 'i :coordinate 'i :dtype :double
+                 :arrays #{'x} :array-types {'x :float}
+                 :scalars #{'scale} :scalar-types {'scale :int}}
+        result (segred/lower-element-operations expression options)
+        casts (filter #(= :cast (get-in % [:expression :op])) (:operations result))]
+    (is (= [:double :double] (mapv #(get-in % [:result :type]) casts)))
+    (is (every? #(= {:rounding :exact :overflow :exact}
+                   (get-in % [:expression :options])) casts))
+    ;; The source-level checked-cast gate remains independent from implicit promotion policy.
+    (doseq [expression ['(int scale) '(long scale) '(float (int scale))]]
+      (is (= :checked-scalar-cast
+             (try (segred/lower-element-operations expression options) nil
+                  (catch clojure.lang.ExceptionInfo e (:missing-rule (ex-data e)))))))))
 
 (deftest scalar-casts-use-the-shared-descriptor-vocabulary
   (doseq [[head target source overflow]


### PR DESCRIPTION
## Summary
- Derive scalar rounding/overflow policy once from the existing dtype facets.
- Map/fold lowering explicitly keeps its existing device-wrap narrowing policy; reduction lowering defaults to rejection and retains its source checked-cast gate.
- Remove duplicated conversion rules without introducing an IR, type inference or target registry.
- Record remaining epilogue labeling, full scalar-lowering and indirect-access proof work in the campaign.

## Validation
- Scalar region suite: 14 tests, 204 assertions pass, including a complete primitive conversion matrix and explicit owner-admission checks.
- Existing contraction suite: 15 tests, 118 assertions pass, including cross-target emission and mixed storage.
- Full unit/CPU OpenCL suites and CUDA/HIP compiler gates run in CI.

No new program admission or numerical/performance claim.