### PR TITLE
Preserve retained floating precision before consumer promotion

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -172,6 +172,14 @@ is unchanged. Exhaustive primitive conversion pairs and owner-admission checks p
 This does not unify the full scalar lowerers, change epilogue conversion labeling, or admit new
 indirect accesses; those remaining differences must be closed separately.
 
+Retained scalar precision is a prerequisite for further sharing: a nested expression's declared
+numeric type must govern its arithmetic before a wider consumer converts its result. A direct
+map/fold lowerer regression exposed early promotion of a Float-tagged addition inside a Double
+addition. Lowering now respects retained expression metadata, including unary/variadic
+normalization and branch results; missing metadata still uses the owner's contextual type.
+This is lowerer-level correctness coverage, not a demonstrated public-model miscompile or a
+new inference rule. Full source reachability and remaining owner-policy differences remain open.
+
 The active-ID prototype is deliberately **not shipped**. Review found that its remainder-based
 body matches source `mod` only over positive populations, and its output conversion needs a proved
 int range. It also inherited unconditional cast erasure on seed/population captures. Passing

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -173,10 +173,13 @@ This does not unify the full scalar lowerers, change epilogue conversion labelin
 indirect accesses; those remaining differences must be closed separately.
 
 Retained scalar precision is a prerequisite for further sharing: a nested expression's declared
-numeric type must govern its arithmetic before a wider consumer converts its result. A direct
+floating type must govern its arithmetic before a wider consumer converts its result. A direct
 map/fold lowerer regression exposed early promotion of a Float-tagged addition inside a Double
 addition. Lowering now respects retained expression metadata, including unary/variadic
 normalization and branch results; missing metadata still uses the owner's contextual type.
+Integral contexts retain their existing behavior: the public Q4 projection has widened loop carries
+around narrower dp4a result metadata. Reconciling that boundary is a separate prerequisite, not
+permission to silently change accumulator widths in this floating-precision increment.
 This is lowerer-level correctness coverage, not a demonstrated public-model miscompile or a
 new inference rule. Full source reachability and remaining owner-policy differences remain open.
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -177,6 +177,9 @@ floating type must govern its arithmetic before a wider consumer converts its re
 map/fold lowerer regression exposed early promotion of a Float-tagged addition inside a Double
 addition. Lowering now respects retained expression metadata, including unary/variadic
 normalization and branch results; missing metadata still uses the owner's contextual type.
+The lowerer explicitly converts the completed floating result back to the owner's declared
+dtype, including narrowing before stores and loop yields; preserving inner precision must not
+violate those boundaries. Public softmax and heat-equation corpus checks exposed this obligation.
 Integral contexts retain their existing behavior: the public Q4 projection has widened loop carries
 around narrower dp4a result metadata. Reconciling that boundary is a separate prerequisite, not
 permission to silently change accumulator widths in this floating-precision increment.

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -81,12 +81,15 @@
                           range)
         known-range (fn [value type]
                       (or (get @value-ranges value) (scalar-range/for-dtype type)))
+        retained-type (fn [expression]
+                        (some-> (or (:raster.type/tag (meta expression))
+                                    (:tag (meta expression)))
+                                dtype/dtype-for-scalar-tag))
         source-type
         (fn source-type [expression expected env]
           (let [expression (inline-lets expression)]
             (or
-             (some-> (or (:raster.type/tag (meta expression)) (:tag (meta expression)))
-                     dtype/dtype-for-scalar-tag)
+             (retained-type expression)
              (cond
                (instance? raster.compiler.ir.kernel_body.Literal expression) (:type expression)
                (symbol? expression) (or (get env expression) (get scalar-types expression) expected)
@@ -129,7 +132,12 @@
 
             (lower [expression expected env]
               (let [expression (inline-lets expression)
-                    expected (canon-type expected)]
+                    ;; A consumer's conversion happens after the child's arithmetic. Promoting
+                    ;; that arithmetic early discards its retained rounding/overflow semantics.
+                    ;; Untagged regions continue to use the owner's declared contextual dtype.
+                    expected (canon-type (or (when (seq? expression)
+                                               (retained-type expression))
+                                             expected))]
                 (cond
                   (instance? raster.compiler.ir.kernel_body.Literal expression)
                   {:operations [] :result expression

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -132,12 +132,14 @@
 
             (lower [expression expected env]
               (let [expression (inline-lets expression)
-                    ;; A consumer's conversion happens after the child's arithmetic. Promoting
-                    ;; that arithmetic early discards its retained rounding/overflow semantics.
-                    ;; Untagged regions continue to use the owner's declared contextual dtype.
-                    expected (canon-type (or (when (seq? expression)
-                                               (retained-type expression))
-                                             expected))]
+                    ;; Preserve floating rounding before consumer promotion. Integral contexts
+                    ;; retain their existing owner policy: quantized loops still carry widened
+                    ;; integers around narrower intrinsic results and need separate reconciliation.
+                    expected (canon-type expected)
+                    retained (when (seq? expression) (retained-type expression))
+                    expected (if (and (dtype/fp-dtype? expected)
+                                      retained (dtype/fp-dtype? retained))
+                               retained expected)]
                 (cond
                   (instance? raster.compiler.ir.kernel_body.Literal expression)
                   {:operations [] :result expression

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -137,9 +137,15 @@
                     ;; integers around narrower intrinsic results and need separate reconciliation.
                     expected (canon-type expected)
                     retained (when (seq? expression) (retained-type expression))
-                    expected (if (and (dtype/fp-dtype? expected)
-                                      retained (dtype/fp-dtype? retained))
-                               retained expected)]
+                    operation-type (if (and (dtype/fp-dtype? expected)
+                                            retained (dtype/fp-dtype? retained))
+                                     retained expected)
+                    lowered (lower-value expression operation-type env)]
+                (if (not= operation-type expected)
+                  (cast-lowered lowered expected expression)
+                  lowered)))
+
+            (lower-value [expression expected env]
                 (cond
                   (instance? raster.compiler.ir.kernel_body.Literal expression)
                   {:operations [] :result expression
@@ -400,7 +406,7 @@
                   :else
                   (decline! :scalar-expression
                             "scalar expression has an unsupported value"
-                            {:expression expression :type (type expression)}))))]
+                            {:expression expression :type (type expression)})))]
       {:lower lower
        :lower-region
        (fn [{:keys [bindings results]} result-types binding-types env]

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -67,6 +67,18 @@
     (is (every? #(= :double (get-in % [:result :type])) (:operations result))
         "Absent retained metadata still uses the owner's contextual dtype")))
 
+(deftest floating-precision-change-does-not-retarget-integral-loop-carries
+  ;; Reduced from the public Q4 projection fixture. This freezes existing behavior, not a
+  ;; proof that widened source carries and the narrower target intrinsic are equivalent.
+  (let [update (with-meta '(raster.par/dp4a a b acc) {:raster.type/tag 'int})
+        expression (list 'loop '[j 0 acc 0]
+                         (list 'if '(< j n) (list 'recur '(inc j) update) 'acc))
+        result ((:lower (lowerer)) expression :long {'a :long 'b :long 'n :long})
+        loop (last (:operations result))]
+    (is (= :long (:type result)))
+    (is (= :long (get-in loop [:results 0 :type])))
+    (is (= :long (get-in loop [:operations 0 :result :type])))))
+
 (deftest shared-conversion-policy-keeps-narrowing-an-explicit-owner-decision
   (let [types [:byte :int :long :half :float :double]
         exact [:exact :exact]

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -25,6 +25,48 @@
    [:float :int] {'candidate :float 'better :predicate}
    {'old-value :float 'old-index :int}))
 
+(deftest nested-arithmetic-retains-precision-before-consumer-promotion
+  (doseq [tag-key [:raster.type/tag :tag]
+          expression ['(+ a b) '(inc a) '(dec a) '(- a) '(+ a b a)]]
+    (let [inner (with-meta expression {tag-key 'float})
+          result ((:lower (lowerer)) (list '+ inner 'wide) :double
+                  {'a :float 'b :float 'wide :double})
+          operations (:operations result)
+          arithmetic (remove #(= :cast (get-in % [:expression :op])) operations)
+          casts (filter #(= :cast (get-in % [:expression :op])) operations)]
+      (is (= :double (:type result)))
+      (is (every? #(= :float (get-in % [:result :type])) (butlast arithmetic))
+          (str "retained inner arithmetic: " expression))
+      (is (= :double (get-in (last arithmetic) [:result :type])))
+      (is (= 1 (count casts)))
+      (is (= [(get-in (last (butlast arithmetic)) [:result :id])]
+             (get-in (first casts) [:expression :arguments])))
+      (is (= {:rounding :exact :overflow :exact}
+             (get-in (first casts) [:expression :options])))))
+  ;; A retained region result cannot silently change its declared binding type either.
+  (let [expression (with-meta '(+ a b) {:raster.type/tag 'float})]
+    (is (= :scalar-region-dtype
+           (try ((:lower-region (lowerer)) {:bindings [] :results [expression]}
+                 [:double] {} {'a :float 'b :float})
+                nil
+                (catch clojure.lang.ExceptionInfo e (:rule (ex-data e))))))))
+
+(deftest retained-precision-composes-with-branches-and-predicates
+  (let [inner (with-meta '(if (> a b) (+ a b) (- a b))
+                {:raster.type/tag 'float :tag 'double})
+        result ((:lower (lowerer)) (list '+ inner 'wide) :double
+                {'a :float 'b :float 'wide :double})
+        [comparison branch conversion outer] (:operations result)]
+    (is (= :predicate (get-in comparison [:result :type])))
+    (is (= :float (get-in branch [:results 0 :type])))
+    (is (= :cast (get-in conversion [:expression :op])))
+    (is (= :double (get-in conversion [:result :type])))
+    (is (= :double (get-in outer [:result :type]))))
+  (let [result ((:lower (lowerer)) '(+ (+ a b) wide) :double
+                {'a :float 'b :float 'wide :double})]
+    (is (every? #(= :double (get-in % [:result :type])) (:operations result))
+        "Absent retained metadata still uses the owner's contextual dtype")))
+
 (deftest shared-conversion-policy-keeps-narrowing-an-explicit-owner-decision
   (let [types [:byte :int :long :half :float :double]
         exact [:exact :exact]

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -43,13 +43,12 @@
              (get-in (first casts) [:expression :arguments])))
       (is (= {:rounding :exact :overflow :exact}
              (get-in (first casts) [:expression :options])))))
-  ;; A retained region result cannot silently change its declared binding type either.
-  (let [expression (with-meta '(+ a b) {:raster.type/tag 'float})]
-    (is (= :scalar-region-dtype
-           (try ((:lower-region (lowerer)) {:bindings [] :results [expression]}
-                 [:double] {} {'a :float 'b :float})
-                nil
-                (catch clojure.lang.ExceptionInfo e (:rule (ex-data e))))))))
+  ;; Region consumers also receive an explicit conversion, not a mismatched store/yield.
+  (let [expression (with-meta '(+ a b) {:raster.type/tag 'float})
+        result ((:lower-region (lowerer)) {:bindings [] :results [expression]}
+                [:double] {} {'a :float 'b :float})]
+    (is (= [:float :double] (mapv #(get-in % [:result :type]) (:operations result))))
+    (is (= :cast (get-in result [:operations 1 :expression :op])))))
 
 (deftest retained-precision-composes-with-branches-and-predicates
   (let [inner (with-meta '(if (> a b) (+ a b) (- a b))
@@ -78,6 +77,19 @@
     (is (= :long (:type result)))
     (is (= :long (get-in loop [:results 0 :type])))
     (is (= :long (get-in loop [:operations 0 :result :type])))))
+
+(deftest retained-wide-arithmetic-converts-before-a-narrow-loop-yield
+  (let [update (with-meta '(+ acc x) {:raster.type/tag 'double})
+        expression (list 'loop '[j 0 acc 0.0]
+                         (list 'if '(< j n) (list 'recur '(inc j) update) 'acc))
+        result ((:lower (lowerer)) expression :float {'x :float 'n :long})
+        loop (last (:operations result))
+        operations (butlast (:operations loop))]
+    (is (= :float (:type result)))
+    (is (= [:double :double :double :float]
+           (mapv #(get-in % [:result :type]) operations)))
+    (is (= {:rounding :nearest-even :overflow :ieee}
+           (get-in (last operations) [:expression :options])))))
 
 (deftest shared-conversion-policy-keeps-narrowing-an-explicit-owner-decision
   (let [types [:byte :int :long :half :float :double]


### PR DESCRIPTION
## Summary
- Compute nested floating expressions at retained precision, then explicitly convert completed results to the declared consumer dtype. This preserves inner rounding and store/yield/carry contracts.
- Untagged and integral contexts keep their existing policy; no new type inference or reduction admission.
- Regression coverage includes widening, narrowing before loop yields, unary/variadic normalization, branches/predicates, and metadata precedence.

## CI-driven repairs
- Initial broader numeric handling exposed Long carries around Int-tagged dp4a updates in the public Q4 projection. Retain existing integral behavior, with a reduced regression; width/overflow reconciliation remains separate work.
- Corpus checks exposed softmax store and heat-RHS yield mismatches. Explicit consumer conversions now restore their expected public routes. No validators or coverage baselines were relaxed.

## Validation
- One capped REPL: 81 affected tests / 709 assertions, all passing.
- Exact softmax-1d and heat-rhs-1d! public compiler reports retain compatibility and validated TypedSOAC routes respectively.
- Public equation-first fixture path generated all 25 artifacts after the Q4 repair.
- Full suite and target gates rerun on the final head; squash only after exact-head review and all seven checks green.
- Lowerer correctness improvement, not an accelerator performance claim or completed compiler unification.