### PR TITLE
Share reduction scalar SSA emission behind retained admission checks

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -186,6 +186,15 @@ permission to silently change accumulator widths in this floating-precision incr
 This is lowerer-level correctness coverage, not a demonstrated public-model miscompile or a
 new inference rule. Full source reachability and remaining owner-policy differences remain open.
 
+Reduction element lowering now delegates accepted loads, casts and arithmetic over typed child
+values to the shared scalar-expression SSA builder. Its admission adapter still requires retained
+nested arithmetic types, preserves literal dtypes, rejects checked integral casts/arithmetic and
+comparisons, proves load coordinates through the existing owner callback, and checks the final
+accumulator dtype. The shared builder accepts explicit owner conversion and masked-load policies;
+map/fold defaults are unchanged. This serves existing scalar reductions and portable contractions,
+without adding indirect-access admission or retiring their remaining source fallbacks. Result
+transform lowering and deterministic SSA-name hygiene remain separate consolidation work.
+
 The active-ID prototype is deliberately **not shipped**. Review found that its remainder-based
 body matches source `mod` only over positive populations, and its output conversion needs a proved
 int range. It also inherited unconditional cast erasure on seed/population captures. Passing

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -61,13 +61,16 @@
 (defn make-lowerer
   "Build a scalar-expression lowerer.
 
-   Returns `{:lower f :lower-region g}`. `f` accepts expression, expected dtype, and a map of typed
+   Returns `{:lower f :lower-region g :cast h}`. `f` accepts expression, expected dtype, and a map of typed
    local values. `g` accepts an ordered {:bindings [...] :results [...]} region, result dtypes,
    retained binding dtypes, and typed locals; it returns shared SSA operations and ordered results.
    Neither entry point stores tuple results: the schedule must commit all components together.
    `decline!` is called as `(decline! rule message data)` so each owning schedule retains an honest,
-   local coverage contract."
-  [{:keys [array-types scalar-types arrays index-scope lower-index predicate id-prefix decline!]
+   local coverage contract. `h` converts an already-lowered value to a target dtype, with source
+   context as its third argument. Owners may supply `conversion-policy` (source/target dtypes)
+   and `load-other` (storage dtype); these do not change source-language admission."
+  [{:keys [array-types scalar-types arrays index-scope lower-index predicate id-prefix decline!
+           conversion-policy load-other]
     :or {id-prefix "scalar"}}]
   (let [canon-type #(if (= :predicate %) :predicate (dtype/canon %))
         counter (atom 0)
@@ -113,9 +116,11 @@
                   lowered
                   (let [source (dtype/canon (:type lowered))
                         [rounding overflow]
-                        ;; Keep this owner's existing device-wrap policy explicit. Reduction
-                        ;; lowering must not inherit it merely by sharing conversion machinery.
-                        (or (scalar-conversion/policy source target :wrap)
+                        ;; Map/fold retain their existing device-wrap default. A stricter owner
+                        ;; supplies its conversion contract rather than inheriting that policy.
+                        (or (if conversion-policy
+                              (conversion-policy source target)
+                              (scalar-conversion/policy source target :wrap))
                             (decline! :cast-policy
                                       "scalar cast has no portable rounding and overflow policy"
                                       {:expression expression :source source :target target}))
@@ -203,7 +208,9 @@
                                          (body/->ScalarLoad
                                           (body/value id array-type) array
                                           [coordinate-expression] predicate
-                                          (when predicate (body/literal 0 array-type)) :cached))
+                                          (when predicate
+                                            (if load-other (load-other array-type)
+                                                (body/literal 0 array-type))) :cached))
                          :result id :type array-type :range range})))
 
                   (and (seq? expression) (descriptor/cast-op? (first expression))
@@ -408,6 +415,7 @@
                             "scalar expression has an unsupported value"
                             {:expression expression :type (type expression)})))]
       {:lower lower
+       :cast cast-lowered
        :lower-region
        (fn [{:keys [bindings results]} result-types binding-types env]
          ;; Region locals are evaluated once, in source order. In particular, a product's

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -23,6 +23,7 @@
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index-expression]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
 
 (defn- decline!
@@ -351,27 +352,39 @@
    result dtype retained on that expression. The lowered element must already match the certified
    accumulator dtype; this pass never invents a final narrowing conversion. A typed region owner
    may provide `declared-result-dtype` for the outer expression only; nested calls still require
-   their own retained facts."
+   their own retained facts. Admission remains here; accepted loads, conversions and arithmetic
+   over typed child values use the same SSA builder as maps and ordered fold-maps."
   [expression {:keys [index coordinate dtype arrays array-types scalars scalar-types coordinate-lower
                       load-predicate load-other declared-result-dtype]}]
   (let [dtype (dtype/canon dtype)
         operations (atom [])
-        counter (atom 0)
-        fresh (fn [prefix] (symbol (str prefix "-" (swap! counter inc))))
-        emit! (fn [operation value value-dtype]
-                (swap! operations conj operation)
-                {:value value :dtype (dtype/canon value-dtype)})]
+        environment (atom (into {} (map (fn [id] [id (dtype/canon (get scalar-types id dtype))]))
+                                scalars))
+        lowerer (scalar-expression/make-lowerer
+                 {:arrays (set arrays)
+                  :array-types (into {} (map (fn [id] [id (dtype/canon (get array-types id dtype))]))
+                                     arrays)
+                  :scalar-types @environment
+                  ;; Only this adapter's already-approved coordinates reach the SSA builder.
+                  :lower-index (fn [coordinate _] coordinate)
+                  :predicate load-predicate
+                  :load-other (fn [storage-dtype]
+                                (if load-other
+                                  (body/literal (:value load-other) storage-dtype)
+                                  (body/literal 0 storage-dtype)))
+                  :conversion-policy cast-policy :decline! decline! :id-prefix "element"})
+        append! (fn [lowered]
+                  (let [{:keys [result type]} lowered]
+                    (when (symbol? result) (swap! environment assoc result type))
+                    (swap! operations into (:operations lowered))
+                    {:value result :dtype type}))]
     (letfn [(cast! [{:keys [value dtype] :as typed} target]
               (let [source (dtype/canon dtype)
                     target (dtype/canon target)]
                 (if (= source target)
                   typed
-                  (let [[rounding overflow] (cast-policy source target)
-                        result (fresh "element-cast")]
-                    (emit! (body/->ScalarCompute
-                            (body/value result target)
-                            (body/cast-expression value target rounding overflow))
-                           result target)))))
+                  (append! ((:cast lowerer) {:operations [] :result value :type source}
+                            target nil)))))
 
             (lower [expression declared-dtype]
               (let [expression (inline-scalar-bindings expression)]
@@ -406,17 +419,8 @@
                                 "KernelBody reduction cannot prove this array load coordinate"
                                 {:expression expression :array array :coordinate source-coordinate
                                  :index index :arrays arrays}))
-                    (let [result (fresh "element-load")
-                          load-dtype (dtype/canon (get array-types array dtype))
-                          other (or load-other (body/literal 0 load-dtype))]
-                      (emit! (body/->ScalarLoad
-                              (body/value result load-dtype) array [lowered-coordinate]
-                              load-predicate
-                              (when load-predicate
-                                (if (= load-dtype (:type other)) other
-                                    (body/literal (:value other) load-dtype)))
-                              :cached)
-                             result load-dtype)))
+                    (append! ((:lower lowerer) (list 'aget array lowered-coordinate)
+                              (dtype/canon (get array-types array dtype)) @environment)))
 
                   (and (seq? expression) (descriptor/cast-op? (first expression))
                        (= 2 (count expression)))
@@ -457,12 +461,10 @@
                                 "KernelBody element expression contains an unsupported scalar operation"
                                 {:expression expression :operator operator
                                  :result-dtype result-dtype}))
-                    (let [inputs (mapv (comp :value #(cast! % result-dtype)) typed-inputs)
-                          result (fresh "element-value")]
-                      (emit! (body/->ScalarCompute
-                              (body/value result result-dtype)
-                              (body/scalar-expression operator result-dtype inputs))
-                             result result-dtype)))
+                    (append! ((:lower lowerer)
+                              (apply list (descriptor/semantic-op expression)
+                                     (map :value typed-inputs))
+                              result-dtype @environment)))
 
                   :else
                   (decline! :scalar-expression

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -132,6 +132,52 @@
              (try (segred/lower-element-operations expression options) nil
                   (catch clojure.lang.ExceptionInfo e (:missing-rule (ex-data e)))))))))
 
+(deftest reduction-admission-delegates-masked-mixed-storage-ssa
+  (let [factory scalar/make-lowerer
+        calls (atom [])
+        coordinates (atom [])
+        expression (list 'float (with-meta '(+ (aget x (+ i 1)) scale)
+                                  {:raster.type/tag 'double}))
+        options {:index 'i :coordinate 'i :dtype :float
+                 :arrays #{'x} :array-types {'x :int}
+                 :scalars #{'scale} :scalar-types {'scale :double}
+                 :coordinate-lower (fn [source]
+                                     (swap! coordinates conj source)
+                                     (body/expression :add 'i 1))
+                 :load-predicate 'active :load-other (body/literal -7 :double)}
+        result (with-redefs [scalar/make-lowerer
+                            (fn [options]
+                              (let [lowerer (factory options)]
+                                (reduce (fn [lowerer entry]
+                                          (assoc lowerer entry
+                                                 (fn [& args]
+                                                   (swap! calls conj entry)
+                                                   (apply (get lowerer entry) args))))
+                                        lowerer [:lower :cast])))]
+                 (segred/lower-element-operations expression options))
+        [load promote add narrow] (:operations result)]
+    (is (= [:lower :lower :cast] @calls))
+    (is (= ['(+ i 1)] @coordinates))
+    (is (= :int (get-in load [:result :type])))
+    (is (= 'active (:predicate load)))
+    (is (= (body/literal -7 :int) (:other load)))
+    (is (= [(body/expression :add 'i 1)] (:coordinates load)))
+    (is (= [:double :double :float]
+           (mapv #(get-in % [:result :type]) [promote add narrow])))
+    (is (= {:rounding :exact :overflow :exact} (get-in promote [:expression :options])))
+    (is (= {:rounding :nearest-even :overflow :ieee}
+           (get-in narrow [:expression :options])))))
+
+(deftest reduction-literal-conversion-is-not-contextual-literal-typing
+  (let [expression (with-meta '(+ scale 0.1) {:raster.type/tag 'float})
+        result (segred/lower-element-operations
+                expression {:dtype :float :scalars #{'scale} :scalar-types {'scale :float}})
+        [cast add] (:operations result)]
+    (is (= :cast (get-in cast [:expression :op])))
+    (is (= [(body/literal 0.1 :double)] (get-in cast [:expression :arguments])))
+    (is (= {:rounding :nearest-even :overflow :ieee} (get-in cast [:expression :options])))
+    (is (= :float (get-in add [:result :type])))))
+
 (deftest scalar-casts-use-the-shared-descriptor-vocabulary
   (doseq [[head target source overflow]
           [['byte :byte :long :wrap] ['int :int :long :wrap]


### PR DESCRIPTION
## Summary
- Reduction element admission now delegates accepted loads, conversions and arithmetic over typed child values to the map/fold scalar SSA builder.
- Keep reduction literal types, nested retained-type requirements, coordinate proofs, checked integral-cast/arithmetic rejection, exact intrinsic admission, and final accumulator checks.
- Explicit owner conversion and masked-load policies preserve the narrower reduction contract; map/fold defaults remain unchanged.
- Existing production scalar reductions and portable contractions consume this shared builder. No new indirect accesses or source-fallback retirement is claimed.

## Validation
- One replacement REPL capped at 768 MiB: 83 affected tests / 722 assertions, all green.
- Read-only pre-change emitter loaded in a separate REPL namespace: 144 combinations of storage/scalar/result dtype and masking produce exactly identical SSA.
- Added shared-builder delegation, mixed-storage masked-load, nonzero fallback, approved coordinates and intrinsic literal-conversion tests.
- Full suite, CPU OpenCL and CUDA/HIP compilation delegated to CI.

## Scope
Result-transform scalar lowering remains separate. Deterministic SSA-name collision risk is pre-existing and explicitly not solved here; there are no performance or SOTA claims.