### PR TITLE
Lower static outer-product contractions through shared KernelBody

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -96,7 +96,7 @@ The zero-reduction contraction router now attempts the shared portable contracti
 lowerer, using a semantic SegMap projected directly from verified facts. The map branch emits
 scalar operations and one store without a synthetic reduction, and obtains each input extent from
 its own proven AxisMap (not the output count). Initial admission is deliberately limited to
-positive static free-axis extents, no options/result transforms or destination reads, and one
+positive static free-axis extents whose product fits the int launch ABI, no options/result transforms or destination reads, and one
 index expression per input array. Unsupported maps retain an explicit compatibility decline.
 Focused CPU OpenCL execution uses exact input lengths and a partial final workgroup; the same
 routed body is included in CUDA/HIP compile fixtures. This is a contraction-router migration, not

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -92,6 +92,18 @@ compiler performance evidence. The legacy orientation gate remains shared with o
 now; live staged quantized contractions still require the epilogue-splice helper. This retirement
 does not remove their source emission or the general gathered-contraction fallback.
 
+The zero-reduction contraction router now attempts the shared portable contraction KernelBody
+lowerer, using a semantic SegMap projected directly from verified facts. The map branch emits
+scalar operations and one store without a synthetic reduction, and obtains each input extent from
+its own proven AxisMap (not the output count). Initial admission is deliberately limited to
+positive static free-axis extents, no options/result transforms or destination reads, and one
+index expression per input array. Unsupported maps retain an explicit compatibility decline.
+Focused CPU OpenCL execution uses exact input lengths and a partial final workgroup; the same
+routed body is included in CUDA/HIP compile fixtures. This is a contraction-router migration, not
+yet the public equation-first frontend: that frontend still excludes zero-reduction contractions.
+Admitting them through retained map equations requires preserving independent input capacities;
+the generic map lowerer's output-sized input shapes must not be reused as an outer-product proof.
+
 CI also exposed target-registry leakage from test fixtures: matrix-capable synthetic targets can
 change another test's automatic precision route. The direct contraction ABI test now requests its
 FP32 policy explicitly. The isolation follow-up gives the hardware registry tests and the three

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -75,6 +75,25 @@
                     nil
                     dtype)))
 
+(defn contraction-facts->segmap
+  "Project a zero-reduction contraction's verified facts into its semantic map space.
+   No surface form is reconstructed. Physical layouts remain in the accompanying facts."
+  [facts]
+  (when-not (and (contraction-facts/facts? facts)
+                 (seq (:free-axes facts)) (empty? (:contract-axes facts)))
+    (throw (ex-info "map projection requires verified zero-reduction contraction facts"
+                    {:reason :contraction-map-facts})))
+  (let [{:keys [out free-axes body dtype]} facts
+        arrays (set (map :sym (:operands facts)))
+        bound-symbols (reduce set/union #{} (map (comp util/free-syms second) free-axes))
+        scalars (set/difference (set/union bound-symbols (util/free-syms body))
+                                arrays #{out} (set (map first free-axes)))]
+    (segop/->SegMap 0
+                    (segop/make-seg-space-nd
+                     (mapv (fn [[index bound]] {:name index :bound bound}) free-axes))
+                    (segop/->SegLevel :thread :virtual)
+                    body nil arrays #{out} scalars nil dtype out nil)))
+
 (defn contract-form->segmap
   "Parse a 0-CONTRACT `(raster.par/contract out [[i mi] …] [] body)` form → a SegMap (a pure
    N-D map = outer product / broadcast / elementwise). The free axes ARE the map/output space

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -499,16 +499,33 @@
            :scalar-args [] :dims [1]})
 
         (zero? n-contract)
-        (let [sm (cl/contract-form->segmap
-                  (compatibility-form! contract-form :segmap) :dtype dtype)
+        (let [sm (cl/contraction-facts->segmap contract-facts)
+              portable (contraction-schedule/plan-portable-body
+                        contract-facts sm desc
+                        {:array-types (or array-types {}) :scalar-types (or scalar-types {})})
+              emitted (when (:ok portable)
+                        (sco/generate-contraction-kernel-body (:body portable)))
               {:keys [kernel-name source array-params scalar-params abi]}
-              (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
-          {:strategy :segmap
-           :kernel-name kernel-name :source source :array-params array-params :abi abi
-           :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
-           :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
-                              {:type :int :value nseg})
-           :out-elems nseg :dims [nseg]})
+              (or emitted
+                  (sco/generate-segmap-nd-kernel
+                   (cl/contract-form->segmap
+                    (compatibility-form! (or contract-form (cf/surface-form contract-facts)) :segmap)
+                    :dtype dtype)
+                   out-sym :dtype dtype))
+              workgroup-size (or (:workgroup-size portable) 256)
+              scalar-dtypes (into {} (map (juxt :name :dtype)) abi)]
+          (cond->
+           {:strategy :segmap
+            :emission-route (if emitted :kernel-body :verified-segmap-opencl)
+            :kernel-body (:body portable)
+            :kernel-name kernel-name :source source :array-params array-params :abi abi
+            :dtype dtype :out-dtype dtype :wg [workgroup-size] :grid [(ceil-div nseg workgroup-size)]
+            :scalar-args (conj (mapv (fn [p] {:type (get scalar-dtypes p :int) :value p}) scalar-params)
+                               {:type :int :value nseg})
+            :out-elems nseg :dims [nseg]}
+            (not emitted) (assoc :fallback-reason (:reason portable)
+                                 :declines [{:leaf :portable-kernel-body
+                                             :reason (:reason portable) :data (:detail portable)}])))
 
       ;; 2 free + 1 contract → the tensorize fast path (DPAS if legal, else regtiled).
       ;; A `{::declines …}` result means BOTH tensorize leaves refused for a documented reason —

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -66,6 +66,13 @@
                       "initial zero-reduction schedule requires positive static axis extents"
                       {:dimensions segment-dims}))
         _ (when (and map-only?
+                     (> (reduce *' 1 (map :bound segment-dims)) Integer/MAX_VALUE))
+            ;; The artifact's trailing count is int. A source fallback has the same ABI and
+            ;; cannot repair this domain, so fail instead of wrapping or declining to it.
+            (throw (ex-info "zero-reduction output count exceeds its int launch ABI"
+                            {:reason :contraction-map-count-overflow
+                             :dimensions segment-dims :limit Integer/MAX_VALUE})))
+        _ (when (and map-only?
                      (or (seq (:opts contract-facts)) (:epilogue contract-facts)
                          (some #(= (:out contract-facts) (:sym %)) (:operands contract-facts))))
             (decline! :map-options

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -50,8 +50,27 @@
     (throw (ex-info "portable contraction lowering requires verified facts"
                     {:reason :raster/bug :facts contract-facts})))
   (let [space (:space segred)
-        segment-dims (segop/seg-space-segment-dims space)
-        reduced-dim (segop/seg-space-reduced-dim space)
+        map-only? (empty? (:contract-axes contract-facts))
+        segment-dims (if map-only? (segop/seg-space-dims space)
+                        (segop/seg-space-segment-dims space))
+        reduced-dim (when-not map-only? (segop/seg-space-reduced-dim space))
+        _ (when (and map-only?
+                     (some #(> (count (set (map :idx %))) 1)
+                           (vals (group-by :sym (:operands contract-facts)))))
+            (decline! :map-multiple-accesses
+                      "initial map capacity proof requires one index expression per input"
+                      {:operands (:operands contract-facts)}))
+        _ (when (and map-only?
+                     (not (every? #(and (integer? (:bound %)) (pos? (:bound %))) segment-dims)))
+            (decline! :map-domain
+                      "initial zero-reduction schedule requires positive static axis extents"
+                      {:dimensions segment-dims}))
+        _ (when (and map-only?
+                     (or (seq (:opts contract-facts)) (:epilogue contract-facts)
+                         (some #(= (:out contract-facts) (:sym %)) (:operands contract-facts))))
+            (decline! :map-options
+                      "initial zero-reduction schedule requires an unadorned, non-aliasing map"
+                      {:options (:opts contract-facts)}))
         _ (when (empty? segment-dims)
             (decline! :no-segments
                       "portable contraction body requires at least one free axis"
@@ -122,7 +141,8 @@
                       {:operands (vec missing)
                        :indices (mapv (juxt :sym :idx) (:operands contract-facts))}))
         reduced-index (:name reduced-dim)
-        axis-symbols (set (concat (map :name segment-dims) [reduced-index]))
+        axis-symbols (set (cond-> (mapv :name segment-dims)
+                           reduced-index (conj reduced-index)))
         index-scope (into axis-symbols
                           (filter #(contains? #{:int :long} (dtype/canon (scalar-dtype %))) scalars))
         ;; Physical coordinates are wide. Preserve the scalar ABI's retained widths and insert
@@ -144,10 +164,13 @@
                         :else expression))
         lower-index (fn [expression scope]
                       (widen-index (lower-index expression scope)))
-        segment-count-source (segop/seg-space-num-segments-expr space)
+        segment-count-source (if map-only?
+                               (reduce (fn [a d] (list '* a (:bound d)))
+                                       (:bound (first segment-dims)) (rest segment-dims))
+                               (segop/seg-space-num-segments-expr space))
         segment-count (lower-index segment-count-source index-scope)
         launch-segment-count (index-expression/to-launch-expression segment-count decline!)
-        reduced-bound (lower-index (:bound reduced-dim) index-scope)
+        reduced-bound (when reduced-dim (lower-index (:bound reduced-dim) index-scope))
         segment-index 'segment-index
         group-index 'segment-group
         local-index 'segment-lane
@@ -164,7 +187,9 @@
              (body/->IndexCompute
               name (body/expression :mod quotient (lower-index bound index-scope)))))
          (range) segment-dims)
-        {:keys [operator identity element]} (segred-body/scalar-plan segred)
+        {:keys [operator identity element]} (if map-only?
+                                             {:identity 0.0 :element (:body contract-facts)}
+                                             (segred-body/scalar-plan segred))
         _ (when-not (number? identity)
             (decline! :literal-identity
                       "portable contraction requires a typed numeric reduction identity"
@@ -191,7 +216,7 @@
                   :load-other (body/literal identity dtype)})
         accumulator 'segment-accumulator
         next-accumulator 'next-segment-accumulator
-        reduction-result 'segment-result
+        reduction-result (if map-only? result 'segment-result)
         physical-extent
         (fn [array]
           (lower-index (axis-map/n-elements (get operand-maps array)) index-scope))
@@ -260,7 +285,9 @@
          :operations
          (vec
           (concat
-           [(body/->ForLoop
+           (if map-only?
+             operations
+             [(body/->ForLoop
              (body/value reduced-index (if wide-indices? :long :int))
              (widen-builtin 0) reduced-bound 1
              [(body/->LoopArg (body/value accumulator dtype)
@@ -272,10 +299,10 @@
                      (body/scalar-expression operator dtype [accumulator result]))
                     (body/->Yield [next-accumulator])]))
              [(body/value reduction-result dtype)]
-             {})]
+             {})])
            (:operations lowered-transform)
            [(body/->ScalarStore output [segment-index] stored-result active-mask)]))
-         :schedule {:strategy :sequential-segments
+         :schedule {:strategy (if map-only? :independent-segments :sequential-segments)
                     :workgroup-size workgroup-size
                     :reduction-operator operator}
          :launch (launch/spec
@@ -288,8 +315,8 @@
                       :segment-count segment-count
                       :launch-segment-count launch-segment-count
                       :reduced-bound reduced-bound
-                      :axis-symbols (vec (concat (map :name segment-dims)
-                                                 [reduced-index]))
+                      :axis-symbols (cond-> (mapv :name segment-dims)
+                                      reduced-index (conj reduced-index))
                       :result-transform result-transform}})
        :arrays arrays
        :scalars scalars

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -17,6 +17,7 @@
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.attention-route :as attention-route]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
+            [raster.compiler.passes.parallel.contract-route :as contract-route]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
@@ -137,6 +138,16 @@
     (segop-emit/generate-contraction-kernel-body
      (:body planned) :target-dialect dialect
      :kernel-name-prefix "portable_contraction")))
+
+(defn- outer-product-artifact
+  [dialect]
+  (let [routed (contract-route/route-contraction
+                '(raster.par/contract C [[i 17] [j 19]] [] (* (aget a i) (aget b j)))
+                :dtype :float)]
+    (when-not (= :kernel-body (:emission-route routed))
+      (throw (ex-info "outer-product fixture did not select KernelBody" routed)))
+    (segop-emit/generate-contraction-kernel-body
+     (:kernel-body routed) :target-dialect dialect :kernel-name-prefix "outer_product")))
 
 (defn- mixed-contraction-artifact
   [dialect descriptor]
@@ -343,6 +354,8 @@
                             (reduction-artifact dialect))
            (write-artifact! directory suffix "portable-contraction"
                             (contraction-artifact dialect descriptor))
+           (write-artifact! directory suffix "outer-product"
+                            (outer-product-artifact dialect))
            (write-artifact! directory suffix "mixed-contraction"
                             (mixed-contraction-artifact dialect descriptor))
            (write-artifact! directory suffix "segmented-fold-map"

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -158,4 +158,6 @@
              '(raster.par/contract out-buffer [[row-index 4]] []
                                    (aget input-buffer row-index))
              :dtype :double)]
-      (is (= ["input_buffer" "out" "_nseg"] (mapv :c-name (:abi d)))))))
+      ;; The KernelBody route preserves the declared output's mangled name instead of the
+      ;; historical source emitter's fixed "out" placeholder; source and ABI still agree.
+      (is (= ["input_buffer" "out_buffer" "_nseg"] (mapv :c-name (:abi d)))))))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -41,6 +41,16 @@
       (is (string? (:source (emit/generate-contraction-kernel-body
                             kernel :target-dialect dialect)))))))
 
+(deftest outer-product-rejects-unrepresentable-launch-count
+  (let [failure (try
+                  (route/route-contraction
+                   '(raster.par/contract C [[i 65536] [j 65536]] []
+                                         (* (aget a i) (aget b j))) :dtype :float)
+                  nil
+                  (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+    (is (= :contraction-map-count-overflow (:reason failure)))
+    (is (= Integer/MAX_VALUE (:limit failure)))))
+
 (deftest outer-product-retains-explicit-migration-declines
   (doseq [[form reason]
           [['(raster.par/contract C [[i m] [j n]] [] (* (aget a i) (aget b j))) :map-domain]

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -20,6 +20,38 @@
         segred (lower/contract-form->segred matvec :dtype :float :facts verified)]
     (schedule/plan-portable-body verified segred nil)))
 
+(deftest outer-product-uses-facts-and-exact-operand-extents
+  (let [verified (facts/from-components
+                  {:out 'C :free-axes '[[i 4] [j 3]] :contract-axes []
+                   :body '(* (aget a i) (aget b j)) :dtype :double})
+        routed (with-redefs [facts/surface-form (fn [& _] (throw (ex-info "reconstructed source" {})))
+                            lower/contract-form->segmap (fn [& _] (throw (ex-info "reparsed source" {})))
+                            emit/generate-segmap-nd-kernel (fn [& _] (throw (ex-info "source fallback" {})))]
+                 (route/route-contraction nil :facts verified :dtype :double))
+        kernel (:kernel-body routed)
+        parameters (into {} (map (juxt :id identity)) (:parameters kernel))]
+    (is (= :kernel-body (artifact/emission-route (:artifact routed))))
+    (is (= :segmap (:strategy routed)))
+    (is (= '[4] (:shape (parameters 'a))))
+    (is (= '[3] (:shape (parameters 'b))))
+    (is (= :independent-segments (get-in kernel [:schedule :strategy])))
+    (is (not-any? #(instance? raster.compiler.ir.kernel_body.ForLoop %)
+                  (:operations kernel)))
+    (doseq [dialect [:opencl-intel :cuda :hip]]
+      (is (string? (:source (emit/generate-contraction-kernel-body
+                            kernel :target-dialect dialect)))))))
+
+(deftest outer-product-retains-explicit-migration-declines
+  (doseq [[form reason]
+          [['(raster.par/contract C [[i m] [j n]] [] (* (aget a i) (aget b j))) :map-domain]
+           ['(raster.par/contract C [[i 4] [j 3]] [] (* (aget a i) (aget b j)) :init 1.0) :map-options]
+           ['(raster.par/contract C [[i 4] [j 3]] [] (* (aget a (aget ids i)) (aget b j))) :operand-layout]
+           ['(raster.par/contract C [[i 2] [j 5]] [] (+ (aget A i) (aget A j))) :map-multiple-accesses]]]
+    (let [routed (route/route-contraction form :dtype :double)]
+      (is (= :segmap (:strategy routed)))
+      (is (= :verified-segmap-opencl (artifact/emission-route (:artifact routed))))
+      (is (= reason (:fallback-reason routed))))))
+
 (defn- portable-result-transform-form []
   (let [epilogue {:acc 'acc
                   :expr '(raster.numeric/*

--- a/test/raster/compiler/passes/parallel/outer_product_device_test.clj
+++ b/test/raster/compiler/passes/parallel/outer_product_device_test.clj
@@ -1,0 +1,34 @@
+(ns raster.compiler.passes.parallel.outer-product-device-test
+  "Execute the routed zero-reduction KernelBody with exact, differently sized input buffers."
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.passes.parallel.contract-route :as route]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]))
+
+(deftest opencl-outer-product-exact-input-capacities
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "routed outer product")
+    (doseq [[m n] [[4 3] [17 19]]]
+      (let [form (list 'raster.par/contract 'C [['i m] ['j n]] []
+                       '(* (aget a i) (aget b j)))
+            routed (route/route-contraction form :dtype :float)
+            artifact (emit/generate-contraction-kernel-artifact (:kernel-body routed))
+            a (doto (float-array (map #(- (float %) 2.0) (range m)))
+                (aset-float 0 -0.0))
+            b (float-array (map #(* 0.5 (float %)) (range n)))]
+        (is (= :kernel-body (:emission-route routed)))
+        (gpu/with-gpu-session [session :ocl:0]
+          (gpu/alloc! session {:a [:float m a] :b [:float n b] :c [:float (* m n) nil]})
+          (let [handle (gpu/bind-kernel-executable!
+                        session :outer-product artifact
+                        [:a :b :c {:type :int :value (* m n)}])]
+            (try
+              (gpu/run-kernel-graph! session handle)
+              ;; An artificial fold from +0 would erase negative zero. This is a map, not
+              ;; a length-one reduction, so compare the actual FP32 product bits.
+              (is (= (mapv #(Float/floatToRawIntBits (float %))
+                           (for [x a y b] (float (* x y))))
+                     (mapv #(Float/floatToRawIntBits (float %))
+                           (gpu/download session :c))))
+              (finally (gpu/release-kernel-graph! session handle)))))))))


### PR DESCRIPTION
## Summary
- Project zero-reduction contraction facts directly into a semantic map and reuse the contraction KernelBody lowerer, with no synthetic fold or reconstructed surface form on the accepted route.
- Derive each input capacity from its own AxisMap, not the output size.
- Initially admit positive static free-axis extents, no options/epilogues/destination reads, and one distinct index expression per input. Keep explicit source-fallback declines for unsupported cases.
- Include the routed body in CUDA/HIP compile fixtures.

## Boundary
This is a backend contraction-router migration, not yet public equation-first frontend admission. The frontend still excludes zero-reduction contractions. Its generic map input-capacity assumptions need a separate fix before that admission. No new performance claim.

## Validation
- 28 focused tests / 213 assertions green in one capped REPL, including CPU OpenCL execution with exact 4/3 and 17/19 input sizes and partial final workgroups.
- CPU execution rerun after strengthening comparison to FP32 bits, including negative zero: 1 test / 4 assertions green.
- Facts-only route tests forbid surface reconstruction and handwritten fallback; explicit decline tests cover symbolic domains, options, indirect loads and differing accesses to the same input.
- Review identified the repeated-input capacity hazard; admission now declines it. Follow-up review found no blocker.
- Full suites and hardware-free vendor compilers delegated to CI.

## Launch-count hardening
A subsequent boundary probe found that a 65536 x 65536 map could advertise an int count of 4294967296. The admitted KernelBody map route now rejects static output products above Integer/MAX_VALUE without falling back to the same narrow ABI. The affected body suite reran green: 18 tests / 141 assertions, including the new count regression.
