### PR TITLE
Preserve static graph buffer capacities in typed map kernels

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -104,6 +104,17 @@ yet the public equation-first frontend: that frontend still excludes zero-reduct
 Admitting them through retained map equations requires preserving independent input capacities;
 the generic map lowerer's output-sized input shapes must not be reused as an outer-product proof.
 
+The first generic map-capacity step preserves known positive static GraphBuffer capacities in
+each KernelBody pointer shape/layout, including larger retained input capacities. An independent
+check compares those static pointer contracts to the exact source graph node before target
+emission. The typed-map fixture carries AbstractValues a[4], b[3], C[12] through ordinary typed
+scheduling and graph construction; CPU execution uses exact buffers and rejects undersized inputs
+and outputs. Source, launch and arguments are unchanged by enlarging a retained capacity. This is
+storage-contract correspondence, not proof of arbitrary indexed access safety. Symbolic, unknown
+and zero capacities still retain the compatibility behavior; no shape-only scalar ABI is added.
+Public zero-reduction contraction admission remains a follow-up, as does access-derived capacity
+refinement where the frontend has no declared shape.
+
 CI also exposed target-registry leakage from test fixtures: matrix-capable synthetic targets can
 change another test's automatic precision route. The direct contraction ABI test now requests its
 FP32 policy explicitly. The isolation follow-up gives the hardware registry tests and the three

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -363,14 +363,18 @@
 
 (defn generate-segmap-kernel-body
   "Schedule and emit one typed SegMap through the shared scalar KernelBody dialect."
-  [segmap & {:keys [kernel-name-prefix target-dialect workgroup-size scalar-types array-types]
+  [segmap & {:keys [kernel-name-prefix target-dialect workgroup-size scalar-types array-types array-shapes
+                   graph-node kernel-graph]
              :or {kernel-name-prefix "segmap"
                   target-dialect :opencl-intel workgroup-size 256
                   scalar-types {} array-types {}}}]
   (let [scheduled
         (segmap-body/schedule segmap
                               {:workgroup-size workgroup-size
-                               :scalar-types scalar-types :array-types array-types})
+                               :scalar-types scalar-types :array-types array-types
+                               :array-shapes array-shapes})
+        _ (when (or graph-node kernel-graph)
+            (segmap-body/validate-static-graph-capacities! scheduled graph-node kernel-graph))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         ]
     (kernel-body-target/emit-artifact kernel-name scheduled target-dialect)))
@@ -439,7 +443,8 @@
    Portable targets never consume source-shaped OpenCL fallback code. OpenCL retains the verified
    compatibility emitter for scalar regions and memory effects that KernelBody cannot represent
    yet, with the structured decline attached to the artifact so the remaining debt is observable."
-  [operation & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+  [operation & {:keys [dtype kernel-name-prefix scalar-types array-types array-shapes target-dialect
+                      graph-node kernel-graph]
                 :or {kernel-name-prefix "segmap" scalar-types {} array-types {}
                      target-dialect :opencl-intel}}]
   (let [dtype (or (:dtype operation) dtype :double)
@@ -447,6 +452,8 @@
     (try
        (generate-segmap-kernel-body
         operation :dtype dtype :scalar-types scalar-types :array-types array-types
+        :array-shapes array-shapes
+        :graph-node graph-node :kernel-graph kernel-graph
         :target-dialect target-dialect :kernel-name-prefix kernel-name-prefix)
        (catch clojure.lang.ExceptionInfo exception
          (if (and (kernel-body-c-dialect/opencl? target)
@@ -785,6 +792,13 @@
         scalar-types (merge scalar-types
                             (into {} (map (juxt :id :dtype)) (:scalars graph)))
         array-types (graph-array-types graph array-types)
+        ;; Preserve independently owned static buffer capacities. Do not turn unknown or
+        ;; symbolic extents into output-sized facts or introduce new shape-only ABI scalars.
+        static-shapes (into {}
+                            (keep (fn [{:keys [id elements]}]
+                                    (when (and (integer? elements) (pos? elements))
+                                      [id [elements]])))
+                            (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
         emitted
         (kgraph/map-operations
          graph
@@ -794,6 +808,8 @@
              (generate-scheduled-segmap-kernel
               operation :dtype (:dtype operation)
               :scalar-types scalar-types :array-types array-types
+              :array-shapes static-shapes
+              :graph-node node :kernel-graph graph
               :target-dialect target-dialect
               :kernel-name-prefix "graph_segmap")
 

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -11,6 +11,7 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.segop :as segop]
@@ -106,7 +107,7 @@
 
 (defn lower
   "Apply a portable grid-stride scalar schedule to a typed one-dimensional SegMap."
-  [segmap {:keys [workgroup-size array-types scalar-types]
+  [segmap {:keys [workgroup-size array-types scalar-types array-shapes]
            :or {workgroup-size 256 array-types {} scalar-types {}}}]
   (when-not (instance? raster.compiler.ir.segop.SegMap segmap)
     (throw (ex-info "map KernelBody lowering requires SegMap"
@@ -367,16 +368,19 @@
             []
             {:association :ordered :source-order true})]
           scalar-operations)
+        ;; These are physical capacities supplied by the enclosing graph, not a proof that
+        ;; arbitrary indexed accesses are in bounds. The iteration extent remains independent.
+        pointer-shape (fn [id] (get array-shapes id ['_n_bound]))
         parameters
         (vec (concat
               (map #(body/->KernelParameter
-                     % :input (get array-types %) ['_n_bound] :global
-                     (layout/row-major ['_n_bound] (get array-types %)) :operand)
+                     % :input (get array-types %) (pointer-shape %) :global
+                     (layout/row-major (pointer-shape %) (get array-types %)) :operand)
                    read-only-inputs)
               (map #(body/->KernelParameter
                      % (if (contains? inout %) :inout :output)
-                     (get array-types %) ['_n_bound] :global
-                     (layout/row-major ['_n_bound] (get array-types %)) :result)
+                     (get array-types %) (pointer-shape %) :global
+                     (layout/row-major (pointer-shape %) (get array-types %)) :result)
                    outputs)
               (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
                    scalars)
@@ -415,6 +419,27 @@
        :attributes {:kind :portable-segmap :extent bound :no-write-alias true
                     :effect-iteration-order iteration-order}})
      :bound bound :inputs read-only-inputs :outputs outputs :scalars scalars}))
+
+(defn validate-static-graph-capacities!
+  "Check static graph-to-pointer correspondence, not arbitrary indexed access safety."
+  [candidate node kernel-graph]
+  (graph/validate! kernel-graph)
+  (when-not (and (= (:source candidate) (:operation node))
+                 (some #(= node %) (:nodes kernel-graph)))
+    (throw (ex-info "map capacity projection requires its exact graph node"
+                    {:reason :segmap-capacity-node})))
+  (let [buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs kernel-graph) (:outputs kernel-graph)
+                              (:temporaries kernel-graph)))]
+    (doseq [{:keys [id kind shape layout dtype]} (get-in candidate [:body :parameters])
+            :let [elements (:elements (get buffers id))]
+            :when (and (not= :scalar kind) (integer? elements) (pos? elements))]
+      (when-not (and (= [elements] shape)
+                     (= (raster.compiler.core.layout/row-major [elements] dtype) layout))
+        (throw (ex-info "map pointer capacity differs from its static graph buffer"
+                        {:reason :segmap-static-capacity :buffer id
+                         :expected [elements] :actual shape})))))
+  candidate)
 
 (defn schedule
   "Refine one SegMap into a complete, target-neutral ScheduledKernelBody.

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -18,6 +18,7 @@
             [raster.compiler.passes.parallel.attention-route :as attention-route]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contract-route :as contract-route]
+            [raster.compiler.passes.parallel.segmap-capacity-fixture :as capacity-fixture]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
@@ -356,6 +357,10 @@
                             (contraction-artifact dialect descriptor))
            (write-artifact! directory suffix "outer-product"
                             (outer-product-artifact dialect))
+           (write-artifact! directory suffix "map-independent-capacities"
+                            (get-in (segop-emit/generate-kernel-graph
+                                     (capacity-fixture/graph) :target-dialect dialect)
+                                    [:nodes 0 :operation]))
            (write-artifact! directory suffix "mixed-contraction"
                             (mixed-contraction-artifact dialect descriptor))
            (write-artifact! directory suffix "segmented-fold-map"

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -21,11 +21,51 @@
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
+            [raster.compiler.passes.parallel.segmap-capacity-fixture :as capacity-fixture]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segstencil-body :as segstencil-body]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
+
+(deftest typed-map-preserves-independent-static-graph-capacities
+  (doseq [a-capacity [4 8]
+          dialect [:opencl-intel :cuda :hip]]
+    (let [graph (capacity-fixture/graph a-capacity)
+          emitted (sg/generate-kernel-graph graph :target-dialect dialect)
+          artifact (get-in emitted [:nodes 0 :operation])
+          body (get-in artifact [:attributes :kernel-body])
+          shapes (into {} (map (juxt :id :shape)) (:parameters body))
+          certificate (get-in artifact [:attributes :scheduled-kernel-body])]
+      (is (= :kernel-body (kart/emission-route artifact)))
+      (is (= [a-capacity] (shapes 'a)))
+      (is (= [3] (shapes 'b)))
+      (is (= [12] (shapes 'C)))
+      (is (= [a-capacity 3] (mapv :elements (:inputs emitted))))
+      (is (= 12 (get-in body [:attributes :extent])))
+      (is (= artifact (scheduled-body/validate-artifact-projection! certificate artifact))))))
+
+(deftest map-capacity-projection-rejects-drift-without-changing-the-algorithm
+  (let [graph (capacity-fixture/graph)
+        emit #(get-in (sg/generate-kernel-graph %) [:nodes 0 :operation])
+        small (emit graph)
+        larger (emit (capacity-fixture/graph 8))
+        source #(str/replace (:source %) (:kernel-name %) "map_capacity")
+        candidate (get-in small [:attributes :scheduled-kernel-body])
+        corrupted (assoc-in candidate [:body :parameters 0 :shape] [12])]
+    (is (= (source small) (source larger)))
+    (is (= (:arguments small) (:arguments larger)))
+    (is (= (:launch small) (:launch larger)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"capacity differs"
+                         (segmap-body/validate-static-graph-capacities!
+                          corrupted (first (:nodes graph)) graph)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"capacity differs"
+                         (segmap-body/validate-static-graph-capacities!
+                          (assoc-in candidate [:body :parameters 0 :layout] nil)
+                          (first (:nodes graph)) graph)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exact graph node"
+                         (segmap-body/validate-static-graph-capacities!
+                          candidate (assoc (first (:nodes graph)) :id :foreign-node) graph)))))
 
 (deftest emitted-graph-interface-preserves-in-place-buffer-direction
   (let [operation (segop/->SegMap
@@ -38,6 +78,10 @@
                  scheduled :array-types {'output :float} :scalar-types {'n :int})]
     (is (= ['output 'n] (:arguments emitted)))
     (is (= [:inout :scalar] (mapv :kind (:abi emitted))))
+    (let [parameters (get-in emitted [:nodes 0 :operation :attributes :kernel-body :parameters])]
+      (is (= 1 (count (filter #(= :inout (:kind %)) parameters))))
+      (is (= ['_n_bound] (:shape (first parameters)))
+          "unknown graph capacities retain the compatibility shape without new scalar arguments"))
     (is (= :inout (get-in emitted [:inputs 0 :role])))))
 
 (deftest two-phase-reduction-graph-emits-its-explicit-scheduled-dataflow

--- a/test/raster/compiler/passes/parallel/outer_product_device_test.clj
+++ b/test/raster/compiler/passes/parallel/outer_product_device_test.clj
@@ -3,8 +3,30 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.passes.parallel.contract-route :as route]
+            [raster.compiler.passes.parallel.segmap-capacity-fixture :as capacity-fixture]
             [raster.gpu.core :as gpu]
             [raster.gpu.device-probe :as device-probe]))
+
+(deftest opencl-typed-map-independent-input-capacities
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "typed map independent capacities")
+    (let [graph (emit/generate-kernel-graph (capacity-fixture/graph))]
+      (gpu/with-gpu-session [session :ocl:0]
+        (gpu/alloc! session {:a [:float 4 (float-array [1 2 3 4])]
+                             :b [:float 3 (float-array [10 20 30])]
+                             :short-a [:float 3 nil] :short-b [:float 2 nil]
+                             :short-c [:float 11 nil] :c [:float 12 nil]})
+        (doseq [bindings [{'a :short-a 'b :b 'C :c}
+                          {'a :a 'b :short-b 'C :c}
+                          {'a :a 'b :b 'C :short-c}]]
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (gpu/bind-kernel-graph! session :short-map graph bindings {}))))
+        (let [handle (gpu/bind-kernel-graph! session :map graph {'a :a 'b :b 'C :c} {})]
+          (try
+            (gpu/run-kernel-graph! session handle)
+            (is (= (mapv float [10 20 30 20 40 60 30 60 90 40 80 120])
+                   (vec (gpu/download session :c))))
+            (finally (gpu/release-kernel-graph! session handle))))))))
 
 (deftest opencl-outer-product-exact-input-capacities
   (if-not @device-probe/opencl-available?

--- a/test/raster/compiler/passes/parallel/segmap_capacity_fixture.clj
+++ b/test/raster/compiler/passes/parallel/segmap_capacity_fixture.clj
@@ -1,0 +1,22 @@
+(ns raster.compiler.passes.parallel.segmap-capacity-fixture
+  "A typed flattened map with independently declared physical input capacities."
+  (:require [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]))
+
+(defn graph
+  ([] (graph 4))
+  ([a-capacity]
+   (let [options {:dtype :float :array-types {'a :float 'b :float 'C :float}
+                  :values {'a (av/tensor {:dtype :float :shape [a-capacity]})
+                           'b (av/tensor {:dtype :float :shape [3]})
+                           'C (av/tensor {:dtype :float :shape [12]})}}
+         typed (:program
+                (typed-route/attempt
+                 '(let* [r (raster.par/map! C i 12 nil
+                                          (* (aget a (quot i 3)) (aget b (rem i 3))))] r)
+                 :float (:array-types options) options))
+         algorithm (get-in typed [:equations 0 :algorithm])
+         scheduled (:form (segop-lower/segop-lower-pass typed options))]
+     (equation-graph/make algorithm scheduled))))


### PR DESCRIPTION
## Summary
- Preserve independently declared positive static GraphBuffer capacities in map KernelBody pointer shapes and layouts, instead of using the iteration count for every pointer.
- Add a narrow static graph-to-pointer correspondence check before target emission; mismatches cannot silently fall back to the legacy emitter.
- Reuse the existing array-shapes lowering option vocabulary, not another shape IR.

## Scope
This is the storage prerequisite for public zero-reduction contraction admission, which remains deferred. Symbolic, unknown and zero capacities retain compatibility behavior; no shape-only ABI scalars are introduced. This check does not prove arbitrary indexed access safety or replace complete graph/source certification.

## Validation
- 32 focused tests / 239 assertions passed, including CPU OpenCL execution from retained typed AVs a[4], b[3], C[12] through scheduling, graph construction and binding.
- Mutation test rerun after adding layout-only and foreign-node negatives: 1 test / 6 assertions passed.
- Larger retained input capacity a[8] stays intact; source, launch and arguments remain unchanged.
- CPU binder rejects undersized a, b and C independently; unknown inout capacity retains the existing ABI and pointer behavior.
- Add the same typed-map graph fixture to CUDA/HIP compile gates.
- Read-only review found no blocker. Full suites delegated to CI; one capped local REPL.