### PR TITLE
Derive static map capacities from typed loads; admit public outer products

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -349,6 +349,13 @@ claims are limited to tested hardware and workloads. Discuss the results before 
 
 ## Working loop
 
+Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
+For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
+minimum storage independently of output size. Every integer arithmetic prefix must fit its
+retained dtype; negative accesses, indirect coordinates and unknown domains do not establish
+capacities. Larger declared storage remains intact. This is not general gather bounds checking
+or symbolic shape inference. Exact-size CPU OpenCL execution is correctness evidence only.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -5,7 +5,9 @@
    literals and exact widening casts. Unknown values retain their full declared range, so the
    analysis can certify `:no-overflow` only when a canonical scalar operation is representable
    for every runtime value admitted by the typed contract."
-  (:require [raster.compiler.core.dtype :as dtype]))
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.kernel-launch :as launch]))
+
 
 (def ^:private integral-bounds
   {:byte [Byte/MIN_VALUE Byte/MAX_VALUE]
@@ -87,3 +89,53 @@
       (when (and (= divisor-value (:upper divisor)) (pos? divisor-value))
         {:lower (quot (:lower numerator) divisor-value)
          :upper (quot (:upper numerator) divisor-value)}))))
+
+(defn typed-index-range
+  "Conditional interval proof for a bounded typed index tree.
+   Leaf domains must hold at the access. Every intermediate must fit its declared integer
+   width; exact widening, add/subtract/multiply and nonnegative div/rem by a positive constant
+   are supported. Unknowns or a tree exceeding 128 nodes return nil, never an assumed bound."
+  [expression leaf-types leaf-ranges]
+  (try
+    (let [remaining (volatile! 128)
+          check! (fn check! [x]
+                   (when (neg? (vswap! remaining dec))
+                     (throw (ex-info "index proof budget" {})))
+                   (cond
+                     (launch/index-expr? x) (doseq [a (:arguments x)] (check! a))
+                     (launch/index-cast? x) (check! (:argument x))
+                     (or (integer? x) (symbol? x)) nil
+                     :else (throw (ex-info "unsupported index proof leaf" {}))))]
+      (check! expression)
+      (launch/typed-expression-dtype expression leaf-types)
+      (letfn [(visit [x]
+                (let [type (launch/typed-expression-dtype x leaf-types)
+                      result
+                      (cond
+                        (integer? x) (literal x type)
+                        (symbol? x) (get leaf-ranges x)
+                        (launch/index-cast? x) (visit (:argument x))
+                        (launch/index-expr? x)
+                        (let [args (mapv visit (:arguments x))
+                              [a b] args]
+                          (when (every? some? args)
+                            (case (:op x)
+                              (:add :mul)
+                              (reduce (fn [a b]
+                                        (let [r (arithmetic (if (= :add (:op x)) :+ :*) [a b])]
+                                          (when (contained-in-dtype? r type) r)))
+                                      args)
+                              :sub (when (= 2 (count args)) (arithmetic :- args))
+                              (:floor-div :mod)
+                              (when (and (= 2 (count args)) (<= 0 (:lower a))
+                                         (= (:lower b) (:upper b)) (pos? (:lower b)))
+                                (if (= :floor-div (:op x))
+                                  (quotient args)
+                                  {:lower 0 :upper (min (:upper a) (dec (:lower b)))}))
+                              nil)))
+                        :else nil)]
+                  (when (and result (<= (:lower result) (:upper result))
+                             (contained-in-dtype? result type))
+                    result)))]
+        (visit expression)))
+    (catch clojure.lang.ExceptionInfo _ nil)))

--- a/src/raster/compiler/passes/parallel/map_read_requirements.clj
+++ b/src/raster/compiler/passes/parallel/map_read_requirements.clj
@@ -1,0 +1,38 @@
+(ns raster.compiler.passes.parallel.map-read-requirements
+  "Minimum flat storage derived from actual typed map loads, not from output size."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.scalar-range :as ranges]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.segmap-body :as map-body]))
+
+(defn static-read-requirements
+  "Optional all-load proof for a plain, positive static, one-dimensional result map.
+   The map schedule establishes 0<=index<bound at each :map-active load. Indirect/local-SSA
+   coordinates, effects and unknown domains decline. Returned counts are minimum capacities."
+  [operation options]
+  (when (and (instance? raster.compiler.ir.segop.SegMap operation)
+             (:out-sym operation)
+             (= 1 (count (get-in operation [:space :dims])))
+             (empty? (set/intersection (set (:inputs operation)) (set (:outputs operation))))
+             (not (seq (get-in operation [:scalar-region :effects]))))
+    (let [{index :name bound :bound} (first (get-in operation [:space :dims]))]
+      (when (and (integer? bound) (<= 1 bound Integer/MAX_VALUE))
+        (try
+          (let [lowered (map-body/lower operation options)
+                loads (filter #(= "raster.compiler.ir.kernel_body.ScalarLoad"
+                                  (some-> % class .getName))
+                              (tree-seq coll? seq (get-in lowered [:kernel-body :operations])))
+                requirements
+                (mapv (fn [{:keys [buffer coordinates predicate]}]
+                        (when (and (= :map-active predicate) (= 1 (count coordinates)))
+                          (when-let [range (ranges/typed-index-range
+                                           (first coordinates)
+                                           (assoc (:scalar-types options) index :long)
+                                           {index {:lower 0 :upper (dec bound)}})]
+                            (when (<= 0 (:lower range))
+                              [buffer (inc' (:upper range))]))))
+                      loads)]
+            (when (and (seq loads) (every? some? requirements))
+              (reduce (fn [result [id extent]] (update result id (fnil max 0) extent))
+                      {} requirements)))
+          (catch clojure.lang.ExceptionInfo _ nil))))))

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -14,7 +14,8 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.passes.parallel.index-expression :as index-expression]
-            [raster.compiler.passes.parallel.product-reduction-regions :as product-regions]))
+            [raster.compiler.passes.parallel.product-reduction-regions :as product-regions]
+            [raster.compiler.passes.parallel.map-read-requirements :as map-reads]))
 
 (defn- fail!
   [reason message data]
@@ -392,7 +393,28 @@
          buffer-specs (into {}
                             (map (fn [id] [id (storage-spec values derived-scalars id)]))
                             (set/union inputs outputs temporary-ids))
-         read-requirements (product-read-requirements values operations derived-scalars)
+         read-requirements
+         (reduce
+          (fn [requirements operation]
+            (if (and (some (fn [id]
+                             (unresolved-capacity? id (get values id)
+                                                   (get-in buffer-specs [id :elements])))
+                           (:inputs operation))
+                     (every? (fn [id]
+                          (let [value (get values id)]
+                            (and (= {:kind :plain} (:representation value))
+                                 (nil? (:logical-layout value)))))
+                        (:inputs operation)))
+              (merge-with into requirements
+                          (into {} (map (fn [[id extent]] [id [extent]]))
+                                (map-reads/static-read-requirements
+                                 operation
+                                 {:array-types (into {} (map (fn [[id v]] [id (:dtype v)])) values)
+                                  :scalar-types (into {} (keep (fn [[id v]]
+                                                                (when (empty? (:shape v))
+                                                                  [id (:dtype v)]))) values)})))
+              requirements))
+          (product-read-requirements values operations derived-scalars) operations)
          buffer-specs (reduce-kv
                        (fn [specs id requirements]
                          (let [extents (vec (distinct

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1276,6 +1276,24 @@
       ;; The direct slice is scalar segmented-reduction algebra plus an optional closed typed
       ;; result transform. Staged quantization carries additional schedule/load contracts and must
       ;; not be admitted by dropping those facts.
+      (if (empty? contract-axes)
+        ;; A static zero-reduction contraction is a map, not a fold from a fabricated zero.
+        ;; Coordinate decomposition is the existing axis-flattening operation. Required input
+        ;; capacities are derived later from actual typed loads, independently of output size.
+        (when (and (seq free-axes) (empty? opts) (not= symbol out)
+                   (contains? #{:float :double} contraction-dtype)
+                   (every? #(and (integer? (second %)) (pos? (second %))) free-axes)
+                   (<= (reduce *' 1 (map second free-axes)) Integer/MAX_VALUE)
+                   (not-any? #(= out (:sym %)) (:operands facts)))
+          (let [[index extent body] (contraction-facts/flatten-contract-axes
+                                    free-axes (:body facts))
+                io (extract-io body index [out])]
+            (merge {:kind :map :id id :sym symbol :results [symbol]
+                    :index index :extent extent :locals [] :casts [nil] :bodies [body]
+                    :result-storage [{:destination out :access :write :host-return :buffer}]
+                    :host-binding symbol :elem-type contraction-dtype
+                    :source-operation :raster.par/contract}
+                   io)))
       (when (and (seq contract-axes)
                  (or (seq free-axes)
                      ;; The first rank-zero tensor reduction uses the ordinary pointwise
@@ -1327,7 +1345,7 @@
            ;; transform that reads the destination (an accumulating GEMM) makes it read-write.
            :result-storage [{:destination out
                              :access (if (contains? epilogue-arrays out) :read-write :write)
-                             :host-return :buffer}]})))
+                             :host-return :buffer}]}))))
 
     (or (par/par-scan-form? expression)
         (par/par-scan-exclusive-form? expression))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -361,6 +361,10 @@
                             (get-in (segop-emit/generate-kernel-graph
                                      (capacity-fixture/graph) :target-dialect dialect)
                                     [:nodes 0 :operation]))
+           (write-artifact! directory suffix "public-outer-product"
+                            (get-in (segop-emit/generate-kernel-graph
+                                     (capacity-fixture/inferred-graph) :target-dialect dialect)
+                                    [:nodes 0 :operation]))
            (write-artifact! directory suffix "mixed-contraction"
                             (mixed-contraction-artifact dialect descriptor))
            (write-artifact! directory suffix "segmented-fold-map"

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -21,12 +21,35 @@
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
+            [raster.compiler.passes.parallel.map-read-requirements :as map-reads]
             [raster.compiler.passes.parallel.segmap-capacity-fixture :as capacity-fixture]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segstencil-body :as segstencil-body]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
+
+(deftest map-access-proof-declines-negative-and-indirect-coordinates
+  (doseq [expression ['(aget a (- i 1))
+                      '(aget a (int (aget b j)))]]
+    (let [graph (capacity-fixture/inferred-graph expression)
+          operation (get-in graph [:nodes 0 :operation])]
+      (is (nil? (map-reads/static-read-requirements
+                 operation {:dtype :float :array-types {'a :float 'b :float 'C :float}}))))))
+
+(deftest public-outer-product-derives-unknown-input-capacities
+  (doseq [[expression expected]
+          [['(* (aget a i) (aget b j)) {'a 4 'b 3}]
+           ['(+ (aget a i) (aget a j)) {'a 4}]
+           ['(let* [k (+ i j)] (aget a k)) {'a 6}]]]
+    (let [graph (capacity-fixture/inferred-graph expression)
+          emitted (sg/generate-kernel-graph graph)
+          artifact (get-in emitted [:nodes 0 :operation])]
+      (is (= expected (into {} (map (juxt :id :elements)) (:inputs graph))))
+      (is (= :kernel-body (kart/emission-route artifact)))
+      (is (= (into {} (map (fn [[id n]] [id [n]])) expected)
+             (into {} (comp (filter #(= :input (:kind %))) (map (juxt :id :shape)))
+                   (get-in artifact [:attributes :kernel-body :parameters])))))))
 
 (deftest typed-map-preserves-independent-static-graph-capacities
   (doseq [a-capacity [4 8]

--- a/test/raster/compiler/ir/scalar_range_test.clj
+++ b/test/raster/compiler/ir/scalar_range_test.clj
@@ -1,0 +1,30 @@
+(ns raster.compiler.ir.scalar-range-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.scalar-range :as ranges]))
+
+(deftest typed-index-ranges-cover-every-small-domain-value
+  (doseq [width [1 2 7 12] divisor [1 2 3 5]
+          op [:floor-div :mod]]
+    (let [expression (body/expression op 'i (body/index-cast divisor :long :exact))
+          proof (ranges/typed-index-range expression {'i :long}
+                                          {'i {:lower 0 :upper (dec width)}})
+          values (map #((if (= op :mod) rem quot) % divisor) (range width))]
+      (is (some? proof))
+      (is (every? #(<= (:lower proof) % (:upper proof)) values)))))
+
+(deftest typed-index-proof-declines-unsafe-or-unknown-intermediates
+  (let [prove #(ranges/typed-index-range % {'i :int} {'i {:lower 0 :upper 3}})]
+    (is (nil? (prove (body/expression :add 'i Integer/MAX_VALUE))))
+    (is (nil? (prove (body/expression :sub
+                                    (body/expression :add 'i Integer/MAX_VALUE)
+                                    Integer/MAX_VALUE))))
+    (is (nil? (prove (body/expression :floor-div 'i 0))))
+    (is (nil? (prove (body/expression :mod 'i -1))))
+    (is (nil? (prove 'unknown)))
+    (is (nil? (prove (body/index-cast 'i :long :wrap))))
+    (is (nil? (prove (body/expression :add Integer/MAX_VALUE 1 -1))))
+    (is (nil? (prove (body/expression :mul Integer/MAX_VALUE 2 0))))
+    (is (nil? (ranges/typed-index-range (body/index-cast 'j :int :exact)
+                                        {'j :long} {'j {:lower 0 :upper 3}})))
+    (is (nil? (prove (reduce (fn [x _] (body/expression :add x 0)) 'i (range 130)))))))

--- a/test/raster/compiler/passes/parallel/outer_product_device_test.clj
+++ b/test/raster/compiler/passes/parallel/outer_product_device_test.clj
@@ -10,7 +10,7 @@
 (deftest opencl-typed-map-independent-input-capacities
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "typed map independent capacities")
-    (let [graph (emit/generate-kernel-graph (capacity-fixture/graph))]
+    (let [graph (emit/generate-kernel-graph (capacity-fixture/inferred-graph))]
       (gpu/with-gpu-session [session :ocl:0]
         (gpu/alloc! session {:a [:float 4 (float-array [1 2 3 4])]
                              :b [:float 3 (float-array [10 20 30])]

--- a/test/raster/compiler/passes/parallel/segmap_capacity_fixture.clj
+++ b/test/raster/compiler/passes/parallel/segmap_capacity_fixture.clj
@@ -20,3 +20,14 @@
          algorithm (get-in typed [:equations 0 :algorithm])
          scheduled (:form (segop-lower/segop-lower-pass typed options))]
      (equation-graph/make algorithm scheduled))))
+
+(defn inferred-graph
+  "No input shapes are supplied: graph requirements must follow the typed access expressions."
+  ([] (inferred-graph '(* (aget a i) (aget b j))))
+  ([expression]
+   (let [options {:dtype :float :array-types {'a :float 'b :float 'C :float}}
+         source (list 'let* ['r (list 'raster.par/contract 'C '[[i 4] [j 3]] [] expression)] 'r)
+         typed (:program (typed-route/attempt source :float (:array-types options) options))
+         algorithm (get-in typed [:equations 0 :algorithm])
+         scheduled (:form (segop-lower/segop-lower-pass typed options))]
+     (equation-graph/make algorithm scheduled))))


### PR DESCRIPTION
## Summary
- Route positive static zero-reduction-axis public contractions through existing typed SegMap.
- Derive unresolved plain input capacities from actual lowered loads, with bounded typed integer range proofs and intermediate overflow checks.
- Preserve larger declared capacities; decline negative, indirect and unknown access proofs.
- Add exact-size CPU OpenCL execution and shared vendor compile fixtures.

## Validation
Focused capped REPL: 87 tests, 561 assertions, zero failures/errors. Includes frontend regressions, negative proof cases, ABI capacity checks and CPU OpenCL execution. Full suite and CUDA/HIP compile gates delegated to CI. CPU results do not establish accelerator performance.