### PR TITLE
Add shape-aware public resident GEMM canaries

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -68,8 +68,21 @@ not a regression-test pass.
 
 ## Current evidence boundary
 
-The existing production canary measures one generated resident GEMM shape and the public
-CPU sum-of-squares path. It has no matched external accelerator suite yet. The next code
-slice is a shape ladder using the same public preparation and evidence extraction, followed
-by baseline adapters. No SOTA or cross-vendor performance claim is justified until those
-comparisons have run on the named devices.
+The production canary retains the original fixed GEMM and accepts an optional `:shape [m n k]`
+for the public scalar-dimension `gemm-mnk!` entry point. `gemm-shapes` lists small suggested
+cases. Run one case per options file, output file and explicit baseline, using the existing
+canary CLI. For example, the options below select an awkward-tail case (replace revision,
+environment and device with the actual run identity):
+
+```clojure
+{:case :gemm :shape [127 65 33] :target :ocl:0
+ :compiler-revision "<exact revision>" :environment-tag "<stable machine/driver tag>"
+ :output "bench/results/gemm-127-65-33.edn"}
+```
+
+Without a baseline the CLI reports `:unbaselined` and exits 2, rather than blessing its own
+measurement. The fixture uses small dyadic inputs and exact reference comparison; it does
+not establish accuracy on arbitrary input distributions. The scalar-dimension and original
+fixed-shape workloads have distinct comparison identities. There is no automatic ladder
+runner, external adapter, tuning experiment or matched accelerator suite yet. No SOTA or
+cross-vendor performance claim is justified until comparisons run on the named devices.

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -23,6 +23,17 @@
     (* (arrays/aget A (+ (* i 64) k)) (arrays/aget B (+ (* k 64) j)))
     :init (float 0.0)))
 
+(deftm gemm-mnk! [A :- (Array float) B :- (Array float) C :- (Array float)
+                   m :- Long n :- Long k :- Long] :- (Array float)
+  (raster.par/contract C [[i m] [j n]] [[p k]]
+    (* (arrays/aget A (+ (* i k) p)) (arrays/aget B (+ (* p n) j)))
+    :init (float 0.0)))
+
+(def gemm-shapes
+  "Small opt-in shape ladder, including decode, multi-row projection and awkward tails.
+   These cases are not a claim of representative frontier-scale throughput."
+  [[64 64 64] [1 256 256] [8 256 256] [127 65 33] [256 256 256]])
+
 (defn- valid-measurement? [result]
   (let [median (get-in result [:measurement :median-ns])]
     (and (true? (:validated? result)) (number? median)
@@ -72,21 +83,40 @@
      :compiler-revision compiler-revision :compile-ns compile-ns :validated? true
      :measurement (measure thunk)}))
 
-(defn gemm-arguments []
-  [(float-array (map #(float (/ (- (mod % 13) 6) 8.0)) (range 4096)))
-   (float-array (map #(float (/ (- (mod % 11) 5) 8.0)) (range 4096)))
-   (float-array 4096)])
+(defn- checked-shape [shape]
+  (when-not (and (vector? shape) (= 3 (count shape))
+                 (every? #(and (integer? %) (<= 1 % Integer/MAX_VALUE)) shape)
+                 (every? #(<= % Integer/MAX_VALUE)
+                         (let [[m n k] shape] [(*' m n) (*' m k) (*' k n)])))
+    (throw (ex-info "GEMM canary requires positive [m n k] with int-sized buffers" {:shape shape})))
+  shape)
 
-(defn gemm-reference [^floats a ^floats b]
-  (float-array
-   (for [i (range 64) j (range 64)]
-     (float (reduce + 0.0
-                    (for [k (range 64)]
-                      (* (double (aget a (+ (* i 64) k))) (double (aget b (+ (* k 64) j))))))))))
+(defn gemm-arguments
+  ([] (gemm-arguments [64 64 64]))
+  ([shape]
+   (let [[m n k] (checked-shape shape)]
+     [(float-array (map #(float (/ (- (mod % 13) 6) 8.0)) (range (* m k))))
+      (float-array (map #(float (/ (- (mod % 11) 5) 8.0)) (range (* k n))))
+      (float-array (* m n))])))
 
-(defn prepare-gemm [target args]
-  (compiled/lower #'gemm64! args {:target target :dtype :float :on-non-resident :throw
-                                 :constants ['A 'B]}))
+(defn gemm-reference
+  ([a b] (gemm-reference a b [64 64 64]))
+  ([^floats a ^floats b shape]
+   (let [[m n k] (checked-shape shape)]
+     (float-array
+      (for [i (range m) j (range n)]
+        (float (reduce + 0.0
+                       (for [p (range k)]
+                         (* (double (aget a (+ (* i k) p)))
+                            (double (aget b (+ (* p n) j))))))))))))
+
+(defn prepare-gemm
+  ([target args]
+   (compiled/lower #'gemm64! args {:target target :dtype :float :on-non-resident :throw
+                                  :constants ['A 'B]}))
+  ([target args shape]
+   (compiled/lower #'gemm-mnk! (into args (map long (checked-shape shape)))
+                   {:target target :dtype :float :on-non-resident :throw :constants ['A 'B]})))
 
 (defn compilation-evidence
   "Describe alternatives from the exact prepared program, without recompiling it.
@@ -113,13 +143,14 @@
                         [(:artifact step)])))})
            (:steps descriptor))}))
 
-(defn gemm! [{:keys [environment-tag target compiler-revision] :or {target :ocl:0}}]
-  (let [identity (identity-for :gemm64-resident target :float [64 64 64]
+(defn gemm! [{:keys [environment-tag target compiler-revision shape] :or {target :ocl:0}}]
+  (let [dimensions (checked-shape (or shape [64 64 64]))
+        identity (identity-for (if shape :gemm-mnk-resident :gemm64-resident) target :float dimensions
                                :host-synchronized-replay environment-tag)
-        args (gemm-arguments)
-        expected (vec (gemm-reference (first args) (second args)))
+        args (gemm-arguments dimensions)
+        expected (vec (gemm-reference (first args) (second args) dimensions))
         started (System/nanoTime)
-        prepared (prepare-gemm target args)
+        prepared (if shape (prepare-gemm target args dimensions) (prepare-gemm target args))
         compile-ns (- (System/nanoTime) started)
         started (System/nanoTime)
         c (compiled/instantiate! prepared)

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -51,3 +51,23 @@
         (is (:validated? result))
         (is (= :host-synchronized-replay (get-in result [:identity :timing-source])))
         (is (seq (:execution result)))))))
+
+(deftest gemm-shape-inputs-and-rejection
+  (is (= [15 20 12] (mapv alength (canary/gemm-arguments [3 4 5]))))
+  (is (= [22.0 28.0 49.0 64.0]
+         (vec (canary/gemm-reference (float-array [1 2 3 4 5 6])
+                                     (float-array [1 2 3 4 5 6]) [2 2 3]))))
+  (doseq [shape [[0 4 5] [-1 4 5] [3 4] [3 4 1.5] [Integer/MAX_VALUE 2 1]]]
+    (is (thrown? clojure.lang.ExceptionInfo (canary/gemm-arguments shape)))))
+
+(deftest opencl-parameterized-gemm-shape-canary
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "parameterized production GEMM shape numerics")
+    (with-redefs [microbench/do-bench once-only]
+      (doseq [shape [[1 7 5] [3 4 5]]]
+        (let [result (canary/gemm! {:shape shape :target :ocl:0
+                                   :environment-tag "ci-correctness-only"})]
+          (is (:validated? result))
+          (is (= shape (get-in result [:identity :shape])))
+          (is (= :gemm-mnk-resident (get-in result [:identity :workload])))
+          (is (seq (:execution result))))))))


### PR DESCRIPTION
## Summary
- Add public scalar-dimension GEMM through the existing compiler and resident ABI.
- Opt-in :shape selects rectangular, batch-one and awkward-tail canaries; retain original fixed-shape entrypoint and comparison identity.
- Validate buffer extents before allocation and compare with independent rectangular host reference.
- Preserve exact prepared-program evidence and host-synchronized timing labels.

## Validation
Single capped REPL: 6 tests, 40 assertions, zero failures/errors, including CPU OpenCL batch-one and rectangular execution. Read-only review found no blocker. No accelerator performance measured; dyadic smoke inputs are not a general numerical accuracy suite. Stacked on #420.