### PR TITLE
Carry exact primitive return contracts; validate generated GEMM epilogues

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -86,3 +86,11 @@ not establish accuracy on arbitrary input distributions. The scalar-dimension an
 fixed-shape workloads have distinct comparison identities. There is no automatic ladder
 runner, external adapter, tuning experiment or matched accelerator suite yet. No SOTA or
 cross-vendor performance claim is justified until comparisons run on the named devices.
+
+`:variant :relu` selects the public contraction with a typed ReLU result transform. An explicit
+`:gemm-precision :f32-scalar` or `:mixed-f16-f32` is forwarded to the compiler; the resolved
+policy is recorded in the identity. Policy is not evidence that a particular matrix instruction
+executed. The explicit ReLU workload has its own identity and is checked through generated
+KernelBody candidates. Composing a contraction-return alias with an in-place map is currently
+excluded: its stable-read/output alias boundary is rejected by the binder. Retain that case as
+a compiler regression until storage normalization admits it safely; do not benchmark a bypass.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -353,6 +353,18 @@ claims are limited to tested hardware and workloads. Discuss the results before 
 
 ## Working loop
 
+Dense workload follow-up: public parameterized GEMM and its explicit typed ReLU epilogue have
+precision-selectable correctness canaries. An ordinary contraction-return alias followed by an
+in-place map exposed two boundaries: lexical return-type propagation (now uses exact primitive
+operand-return semantics, not suffix guessing), then stable-read alias normalization (still
+rejected at binding). Closing the latter and measuring automatic fusion remains required; an
+explicit epilogue is not evidence that source composition fuses automatically.
+
+Future mechanized proofs may use the sibling Lean project. Start with small existing contracts
+(bounded integer range transfer, access/capacity refinement and alias legality), replaying the
+same counterexamples as executable tests. No proof assistant integration or whole-compiler
+correctness claim is implied, and this does not block workload-driven retirement.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -1539,8 +1539,16 @@
                                walked)))
                          args walked-args)
                     walked-args)
-        result (apply list (walk f ctx) cast-args)]
-    result))
+        result (apply list (walk f ctx) cast-args)
+        ;; Compiler forms can return an existing operand without being an ordinary
+        ;; dispatched call (e.g. contract returns its destination). Use the shared
+        ;; form contract during the lexical walk, before a following binding is
+        ;; consumed. Late result typing cannot repair an already unresolved call.
+        return-index (:return-type-arg (form/form-info result))
+        returned (when (some? return-index) (nth walked-args return-index nil))
+        return-tag (or (inf/hint-tag returned)
+                       (when (symbol? returned) (ctx-get-tag ctx returned)))]
+    (if return-tag (vary-meta result assoc :raster.type/tag return-tag) result)))
 
 ;; ================================================================
 ;; Branch: primitive cast (idempotent)

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -89,13 +89,18 @@
         (and (symbol? head)
              (some? (namespace head))
              (.startsWith ^String (namespace head) "raster.par"))
-        (let [n (name head)
-              ;; `contract` writes+returns its `out` buffer (arg 0) even though it does not
-              ;; end in `!` — it is redomap-shaped (an annotated fused map+reduce into out),
-              ;; so its return type is arg 0 like the mutating `*!` forms, not arg 1.
-              mutating? (or (.endsWith n "!") (= n "contract"))]
-          {:kind :par :introduces-scope? true :liftable? false :head head
-           :return-type-arg (if mutating? 0 1)})
+        (let [;; Semantic return contracts of compiler primitives, not a naming heuristic.
+              ;; Effect-only, scalar-returning and unknown forms must not inherit a buffer
+              ;; type merely because their name ends in !. Only the exact public namespace
+              ;; establishes these contracts; a similarly named extension is unknown.
+              return-index (when (= "raster.par" (namespace head))
+                             (case (name head)
+                               ("map!" "contract" "scan" "scan-exclusive" "scatter!"
+                                "gather" "reduce-by-key" "rng-fill!" "active-ids!" "stencil!") 0
+                               "reduce" 1
+                               nil))]
+          (cond-> {:kind :par :introduces-scope? true :liftable? false :head head}
+            (some? return-index) (assoc :return-type-arg return-index)))
 
         ;; do block — sequential, liftable (effects + result)
         (= 'do head)

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -16,6 +16,20 @@
 ;; classify-form
 ;; ================================================================
 
+(deftest operand-return-contract-is-carried-into-following-bindings
+  (doseq [init ['(raster.par/contract out [[i n]] [[j n]] 1.0)
+                '(raster.par/reduce-by-key out keys values n +)]]
+    (let [walked (wb (list 'let* ['result init] 'result)
+                     {'out 'floats 'keys 'ints 'values 'floats 'n 'long})
+          binding (first (second walked))]
+      (is (= 'floats (:raster.type/tag (meta binding))))
+      (is (= 'floats (:raster.type/tag (meta (last walked))))))))
+
+(deftest scalar-and-unknown-par-calls-do-not-inherit-array-return-tags
+  (doseq [expression ['(raster.par/atomic-add! out 0 1)
+                      '(raster.par/unknown! out 0 1)]]
+    (is (nil? (:raster.type/tag (meta (wb expression {'out 'ints})))))))
+
 (deftest classify-let-test
   (testing "let forms"
     (let [ctx (walker/make-ctx {})]

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -211,17 +211,23 @@
 ;; ================================================================
 
 (deftest par-mutating-detection-test
-  (testing "mutating par forms (ending in !) have return-type-arg 0"
+  (testing "map returns its destination"
     (let [info (form/form-info '(raster.par/map! out n f))]
       (is (= 0 (:return-type-arg info)))))
 
-  (testing "non-mutating par forms have return-type-arg 1"
+  (testing "reduce returns its accumulator"
     (let [info (form/form-info '(raster.par/reduce out init n f))]
       (is (= 1 (:return-type-arg info)))))
 
-  (testing "raster.par/scan! is mutating"
-    (let [info (form/form-info '(raster.par/scan! out n f))]
-      (is (= 0 (:return-type-arg info))))))
+  (testing "scan and reduce-by-key return their destination, not their keys or seed"
+    (doseq [head '[raster.par/scan raster.par/scan-exclusive raster.par/reduce-by-key
+                  raster.par/gather raster.par/contract]]
+      (is (= 0 (:return-type-arg (form/form-info (list head 'out 'other)))))))
+  (testing "effects, scalar results and unknown forms have no operand-return contract"
+    (doseq [head '[raster.par/atomic-add! raster.par/map-void! raster.par/map2!
+                  raster.par/butterfly! raster.par/collect! raster.par/product-reduce!
+                  raster.par/segmented-fold-map! raster.par/unknown! raster.par.extension/map!]]
+      (is (nil? (:return-type-arg (form/form-info (list head 'out 'other))))))))
 
 ;; ================================================================
 ;; scope-info — binder decomposition + rebuild round-trip

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -34,6 +34,21 @@
    These cases are not a claim of representative frontier-scale throughput."
   [[64 64 64] [1 256 256] [8 256 256] [127 65 33] [256 256 256]])
 
+(deftm gemm-relu-composed! [A :- (Array float) B :- (Array float) C :- (Array float)
+                    m :- Long n :- Long k :- Long] :- (Array float)
+  (let [product (raster.par/contract C [[i m] [j n]] [[p k]]
+                 (* (arrays/aget A (+ (* i k) p)) (arrays/aget B (+ (* p n) j)))
+                 :init (float 0.0))]
+    (raster.par/map! C q (* m n) nil (max (float 0.0) (arrays/aget product q)))))
+
+(deftm gemm-relu! [A :- (Array float) B :- (Array float) C :- (Array float)
+                    m :- Long n :- Long k :- Long] :- (Array float)
+  (raster.par/contract C [[i m] [j n]] [[p k]]
+    (* (arrays/aget A (+ (* i k) p)) (arrays/aget B (+ (* p n) j)))
+    :init (float 0.0)
+    :epilogue {:acc acc :expr (max (float 0.0) acc)
+               :operands [] :scalars [] :dtype :float}))
+
 (defn- valid-measurement? [result]
   (let [median (get-in result [:measurement :median-ns])]
     (and (true? (:validated? result)) (number? median)
@@ -115,8 +130,15 @@
    (compiled/lower #'gemm64! args {:target target :dtype :float :on-non-resident :throw
                                   :constants ['A 'B]}))
   ([target args shape]
-   (compiled/lower #'gemm-mnk! (into args (map long (checked-shape shape)))
-                   {:target target :dtype :float :on-non-resident :throw :constants ['A 'B]})))
+   (prepare-gemm target args shape {}))
+  ([target args shape {:keys [variant gemm-precision] :or {variant :plain}}]
+   (let [entry (case variant
+                 :plain #'gemm-mnk!
+                 :relu #'gemm-relu!
+                 (throw (ex-info "unknown GEMM canary variant" {:variant variant})))]
+     (compiled/lower entry (into args (map long (checked-shape shape)))
+                     (cond-> {:target target :dtype :float :on-non-resident :throw :constants ['A 'B]}
+                       gemm-precision (assoc :gemm-precision gemm-precision))))))
 
 (defn compilation-evidence
   "Describe alternatives from the exact prepared program, without recompiling it.
@@ -143,14 +165,23 @@
                         [(:artifact step)])))})
            (:steps descriptor))}))
 
-(defn gemm! [{:keys [environment-tag target compiler-revision shape] :or {target :ocl:0}}]
+(defn gemm! [{:keys [environment-tag target compiler-revision shape variant gemm-precision]
+              :or {target :ocl:0 variant :plain}}]
   (let [dimensions (checked-shape (or shape [64 64 64]))
-        identity (identity-for (if shape :gemm-mnk-resident :gemm64-resident) target :float dimensions
+        parameterized? (or shape gemm-precision (not= :plain variant))
+        workload (case variant
+                   :plain (if parameterized? :gemm-mnk-resident :gemm64-resident)
+                   :relu :gemm-relu-resident
+                   (throw (ex-info "unknown GEMM canary variant" {:variant variant})))
+        identity (identity-for workload target :float dimensions
                                :host-synchronized-replay environment-tag)
         args (gemm-arguments dimensions)
-        expected (vec (gemm-reference (first args) (second args) dimensions))
+        product (gemm-reference (first args) (second args) dimensions)
+        expected (if (= :plain variant) (vec product) (mapv #(max (float 0.0) %) product))
         started (System/nanoTime)
-        prepared (if shape (prepare-gemm target args dimensions) (prepare-gemm target args))
+        prepared (if parameterized?
+                   (prepare-gemm target args dimensions {:variant variant :gemm-precision gemm-precision})
+                   (prepare-gemm target args))
         compile-ns (- (System/nanoTime) started)
         started (System/nanoTime)
         c (compiled/instantiate! prepared)

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.perf.production-canary :as canary]
             [raster.runtime.microbench :as microbench]
+            [raster.gpu.compiled :as compiled]
             [raster.gpu.device-probe :as probe]))
 
 (defn- once-only [f & _]
@@ -59,6 +60,35 @@
                                      (float-array [1 2 3 4 5 6]) [2 2 3]))))
   (doseq [shape [[0 4 5] [-1 4 5] [3 4] [3 4 1.5] [Integer/MAX_VALUE 2 1]]]
     (is (thrown? clojure.lang.ExceptionInfo (canary/gemm-arguments shape)))))
+
+(deftest opencl-generated-gemm-epilogue-and-policy
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "public generated GEMM epilogue and precision policy")
+    (with-redefs [microbench/do-bench once-only]
+      (doseq [precision [:f32-scalar :mixed-f16-f32]]
+        (let [result (canary/gemm! {:shape [3 4 5] :variant :relu
+                                   :gemm-precision precision :target :ocl:0
+                                   :environment-tag "ci-correctness-only"})
+              evidence (:compilation result)
+              candidates (mapcat :alternatives (:steps evidence))]
+          (is (:validated? result))
+          (is (= precision (get-in result [:identity :numerical-policy])))
+          (is (= :gemm-relu-resident (get-in result [:identity :workload])))
+          (is (= 1 (:resident-step-count evidence)))
+          (is (seq candidates))
+          (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %)) candidates)))))))
+
+(deftest composed-return-alias-retains-the-memory-safety-gate
+  ;; Known gap: the lexical type survives, but storage aliases are not yet normalized into
+  ;; a pointwise inout boundary. Do not weaken stable-read validation to make this run.
+  (let [prepared (compiled/lower #'canary/gemm-relu-composed!
+                                 (into (canary/gemm-arguments [3 4 5]) [3 4 5])
+                                 {:target :ocl:0 :dtype :float :constants ['A 'B]
+                                  :gemm-precision :f32-scalar :on-non-resident :throw})]
+    (is (= 2 (get-in (canary/compilation-evidence prepared) [:resident-step-count])))
+    (when @probe/opencl-available?
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stable input overlaps"
+                           (compiled/instantiate! prepared))))))
 
 (deftest opencl-parameterized-gemm-shape-canary
   (if-not @probe/opencl-available?


### PR DESCRIPTION
## Summary
Public GEMM composition exposed missing lexical return-type propagation. Reuse explicit primitive operand-return contracts before walking consumers, replacing the old suffix heuristic that incorrectly typed reduce-by-key, atomic-add and void forms.

Add public typed ReLU epilogue and explicit precision selection to the opt-in canary. Both precision policies execute one generated KernelBody stage on CPU OpenCL. Preserve the composed alias case as a known binder rejection; do not weaken stable-read memory checks or claim automatic fusion.

## Validation
60 focused tests, 318 assertions, zero failures/errors in the existing capped REPL. Includes mixed-dtype alias typing, negative semantic-contract tests, real CPU OpenCL epilogue execution and safety rejection. Independent read-only review found no remaining blocker. Full suites and vendor gates delegated to CI.