### PR TITLE
Normalize exact returned-buffer identities before access analysis

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -91,6 +91,8 @@ cross-vendor performance claim is justified until comparisons run on the named d
 `:gemm-precision :f32-scalar` or `:mixed-f16-f32` is forwarded to the compiler; the resolved
 policy is recorded in the identity. Policy is not evidence that a particular matrix instruction
 executed. The explicit ReLU workload has its own identity and is checked through generated
-KernelBody candidates. Composing a contraction-return alias with an in-place map is currently
-excluded: its stable-read/output alias boundary is rejected by the binder. Retain that case as
-a compiler regression until storage normalization admits it safely; do not benchmark a bypass.
+KernelBody candidates. `:variant :relu-composed` uses an ordinary contraction-return alias
+followed by an in-place map. Exact destination-return identities are normalized before storage
+contracts, so this now executes through the pointwise inout path without bypassing the ABI
+checks. It still has two resident stages, versus one for the explicit epilogue: report that
+automatic-fusion gap rather than treating the two implementations as equally fused.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -365,6 +365,12 @@ Future mechanized proofs may use the sibling Lean project. Start with small exis
 same counterexamples as executable tests. No proof assistant integration or whole-compiler
 correctness claim is implied, and this does not block workload-driven retirement.
 
+The returned-buffer follow-up separates same-type facts from exact identity facts. Known
+destination-return aliases are normalized before access analysis; producers and public return
+bindings remain intact. Scope-aware substitution and alpha-renaming of incoming free identities
+prevent local shadowing from redirecting a physical buffer. The composed GEMM/ReLU canary now
+executes safely through two generated stages. Automatic epilogue fusion remains the next gap.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -100,7 +100,10 @@
                                "reduce" 1
                                nil))]
           (cond-> {:kind :par :introduces-scope? true :liftable? false :head head}
-            (some? return-index) (assoc :return-type-arg return-index)))
+            (some? return-index) (assoc :return-type-arg return-index)
+            ;; These destination-returning primitives preserve object identity, not merely
+            ;; dtype. A reduction's init only supplies a type; it is NOT an alias promise.
+            (= 0 return-index) (assoc :return-alias-arg 0)))
 
         ;; do block — sequential, liftable (effects + result)
         (= 'do head)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2452,6 +2452,23 @@
                  parameters
                  [(util/subst-syms (zipmap captures parameters) expr)])))))
 
+(defn- physical-read-uses
+  "Resolve storage reads to their latest preceding logical writer. Reads precede writes
+   within one description, so an inout map consumes its predecessor, not its own result."
+  [descriptions physical-outputs]
+  (reduce
+   (fn [{:keys [writers] :as state} description]
+     (let [scalar? (= :scalar (:kind description))
+           reads (if scalar? (util/free-syms (:expr description))
+                     (concat (:inputs description) (:scalars description)))
+           host? (and scalar? (not (supported-description? physical-outputs description)))
+           writes (into {} (map (fn [result storage] [(:destination storage) result])
+                                (:results description) (:result-storage description)))]
+       (-> state
+           (update (if host? :host-uses :operation-uses) into (keep writers reads))
+           (update :writers merge writes))))
+   {:writers {} :host-uses #{} :operation-uses #{}} descriptions))
+
 (defn- terminal-results
   [descriptions body]
   (let [physical-outputs (physical-output-symbols descriptions)
@@ -2489,9 +2506,12 @@
                       (:sym %))
                    descriptions))
         all-definitions (set/union operation-definitions scalar-definitions)
-        operation-uses (set (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
-                                    (mapcat #(util/free-syms (:expr %)) typed-scalars)))
-        host-uses (set (mapcat #(util/free-syms (:expr %)) host-scalars))
+        physical-uses (physical-read-uses descriptions physical-outputs)
+        operation-uses (into (:operation-uses physical-uses)
+                             (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
+                                     (mapcat #(util/free-syms (:expr %)) typed-scalars)))
+        host-uses (into (:host-uses physical-uses)
+                        (mapcat #(util/free-syms (:expr %)) host-scalars))
         body-uses (set (mapcat util/free-syms body))
         ;; Destination-writing source forms return the destination buffer, while TypedSOAC names
         ;; the fresh logical result produced by that write. Preserve the public return by

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1648,17 +1648,29 @@
   ;; deliberately requires one logical definition per value. Use the shared scope-aware
   ;; alpha-renamer so later references keep their lexical meaning; inventing identities only in
   ;; operation-description would disconnect host materialization from the semantic equation.
-  (let [source (util/uniquify-rebindings source)]
+  (let [source (util/uniquify-rebindings (util/free-syms source) source)]
     (if (and (seq? source) (contains? #{'let 'let*} (first source)))
       (let [[head bindings & body] source
             pairs (vec (partition 2 bindings))
             {:keys [normalized]}
             (reduce
              (fn [{:keys [compound-extents allocation-lengths scalar-aliases pure-scalar-ids
-                         local-scalar-types]
+                         local-scalar-types buffer-aliases]
                    :as state}
                   [ordinal [symbol expression]]]
-               (let [[state expression] (if (par/par-rng-fill-form? expression)
+               (let [expression (util/subst-syms buffer-aliases expression)
+                     return-index (:return-alias-arg (form/form-info expression))
+                     returned (if (symbol? expression) expression
+                                  (when (some? return-index)
+                                    (nth (rest expression) return-index nil)))
+                     ;; Only exact destination-return identity, never a same-dtype guess.
+                     ;; Keep the effectful producer binding; rewrite subsequent references
+                     ;; to its physical buffer before read/write contracts are constructed.
+                     state (if (and (symbol? returned)
+                                    (contains? (:arrays *declared-kinds*) returned))
+                             (assoc-in state [:buffer-aliases symbol] returned)
+                             state)
+                     [state expression] (if (par/par-rng-fill-form? expression)
                                           ;; rng-fill! evaluates its int count before its long seed.
                                           (normalize-fixed-scalar-inputs state expression
                                                                          [[2 :int] [3 :long]])
@@ -1776,7 +1788,7 @@
                    :else
                    (update state :normalized conj [symbol expression]))))
              {:normalized [] :compound-extents {} :allocation-lengths {}
-              :scalar-aliases {} :pure-scalar-ids {} :local-scalar-types scalar-types}
+              :scalar-aliases {} :buffer-aliases {} :pure-scalar-ids {} :local-scalar-types scalar-types}
              (map-indexed vector pairs))]
         (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
       source)))

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -217,12 +217,14 @@
 
   (testing "reduce returns its accumulator"
     (let [info (form/form-info '(raster.par/reduce out init n f))]
-      (is (= 1 (:return-type-arg info)))))
+      (is (= 1 (:return-type-arg info)))
+      (is (nil? (:return-alias-arg info)))))
 
   (testing "scan and reduce-by-key return their destination, not their keys or seed"
     (doseq [head '[raster.par/scan raster.par/scan-exclusive raster.par/reduce-by-key
                   raster.par/gather raster.par/contract]]
-      (is (= 0 (:return-type-arg (form/form-info (list head 'out 'other)))))))
+      (is (= 0 (:return-type-arg (form/form-info (list head 'out 'other)))))
+      (is (= 0 (:return-alias-arg (form/form-info (list head 'out 'other)))))))
   (testing "effects, scalar results and unknown forms have no operand-return contract"
     (doseq [head '[raster.par/atomic-add! raster.par/map-void! raster.par/map2!
                   raster.par/butterfly! raster.par/collect! raster.par/product-reduce!

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -7,6 +7,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [raster.compiler.core.util :as util]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
@@ -16,6 +17,42 @@
           y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
           total (raster.par/reduce acc 0.0 j n (+ acc (clojure.core/aget y j)))]
          total))
+
+(deftest returned-buffer-identity-is-normalized-before-access-contracts
+  (let [source '(let* [r (raster.par/contract C [[i 4]] [] (clojure.core/aget A i))
+                       alias r
+                       mapped (raster.par/map! C j 4 nil (clojure.core/aget alias j))
+                       closure (fn [C] r)
+                       data (quote r)]
+                 mapped)
+        normalized (frontend/normalize-source source {:array-types {'A :float 'C :float}})
+        bindings (into {} (map vec (partition 2 (second normalized))))]
+    (is (= 'raster.par/contract (first (get bindings 'r))) "producer effect stays")
+    (is (= 'C (get bindings 'alias)))
+    (is (= '(clojure.core/aget C j) (last (get bindings 'mapped))))
+    (is (= #{'C} (util/free-syms (get bindings 'closure))) "replacement avoids capture")
+    (is (= '(quote r) (get bindings 'data)))
+    (is (= 'mapped (last normalized)))))
+
+(deftest same-return-type-is-not-a-buffer-identity-proof
+  (let [source '(let* [r (raster.par/reduce acc A i 1 B)] r)
+        normalized (frontend/normalize-source source {:array-types {'A :float 'B :float}})]
+    (is (= 'r (last normalized)))))
+
+(deftest returned-buffer-alias-survives-an-incoming-name-being-shadowed
+  (let [source '(let* [r (raster.par/contract C [[i 4]] [] (clojure.core/aget A i))
+                       C B
+                       mapped (raster.par/map! D j 4 nil (clojure.core/aget r j))]
+                 r)
+        normalized (frontend/normalize-source source {:array-types {'A :float 'B :float
+                                                                    'C :float 'D :float}})
+        pairs (mapv vec (partition 2 (second normalized)))
+        renamed (first (second pairs))
+        consumer (second (last pairs))]
+    (is (not= 'C renamed))
+    (is (= 'B (second (second pairs))))
+    (is (= '(clojure.core/aget C j) (last consumer)))
+    (is (= 'r (last normalized)))))
 
 (deftest direct-front-end-builds-the-typed-map-reduction-program
   (let [direct (frontend/form->program source {:dtype :float :array-types {'x :float}})

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -54,6 +54,29 @@
     (is (= '(clojure.core/aget C j) (last consumer)))
     (is (= 'r (last normalized)))))
 
+(deftest physical-reads-consume-the-preceding-logical-writer
+  (let [options {:dtype :float :array-types {'A :float 'B :float 'C :float 'D :float}}
+        outputs (fn [source]
+                  (-> source (frontend/normalize-source options)
+                      (frontend/form->program options) dialect/outputs set))]
+    (is (= '#{consumed last-write}
+           (outputs '(let* [first-write (raster.par/map! C i 4 nil (aget A i))
+                            consumed (raster.par/map! D j 4 nil (aget first-write j))
+                            last-write (raster.par/map! C k 4 nil (aget B k))]
+                       last-write)))
+        "a read before overwrite consumes the first writer, not the final writer")
+    (is (= '#{last-write}
+           (outputs '(let* [first-write (raster.par/map! C i 4 nil (aget A i))
+                            last-write (raster.par/map! C j 4 nil (aget first-write j))]
+                       last-write)))
+        "inout reads are processed before registering their own write")
+    (is (= '#{first-write last-write}
+           (outputs '(let* [first-write (raster.par/map! C i 4 nil (aget A i))
+                            observed (observe first-write)
+                            last-write (raster.par/map! C j 4 nil (aget first-write j))]
+                       last-write)))
+        "an opaque host read keeps its preceding producer externally visible")))
+
 (deftest direct-front-end-builds-the-typed-map-reduction-program
   (let [direct (frontend/form->program source {:dtype :float :array-types {'x :float}})
         equations (dialect/equations direct)]

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -221,8 +221,13 @@
         [result stats] (typed-fusion/fusion-fixpoint program)]
     (is (= 3 (count (dialect/equations result))))
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
-    (is (= '[left middle right] (dialect/outputs result))
-        "the effect result remains observable and ordered between the two reads")))
+    (is (= '[left right] (dialect/outputs result))
+        "the right-hand read consumes middle's physical result, not another public output")
+    (is (= '[left middle right] (mapv #(first (nth % 2)) (dialect/equations result)))
+        "the intervening write remains ordered between the two reads")
+    (is (= #{:memory/write} (get-in (dialect/facts result) [:equations 1 :effects])))
+    (is (= [{:destination 'x :access :read-write :host-return :buffer}]
+           (get-in (dialect/facts result) [:equations 1 :attributes :result-storage])))))
 
 (deftest aliased-equations-decline-unproved-fusion
   (let [program (source-program map-map-source {'x :float})

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -135,6 +135,7 @@
    (let [entry (case variant
                  :plain #'gemm-mnk!
                  :relu #'gemm-relu!
+                 :relu-composed #'gemm-relu-composed!
                  (throw (ex-info "unknown GEMM canary variant" {:variant variant})))]
      (compiled/lower entry (into args (map long (checked-shape shape)))
                      (cond-> {:target target :dtype :float :on-non-resident :throw :constants ['A 'B]}
@@ -172,6 +173,7 @@
         workload (case variant
                    :plain (if parameterized? :gemm-mnk-resident :gemm64-resident)
                    :relu :gemm-relu-resident
+                   :relu-composed :gemm-relu-composed-resident
                    (throw (ex-info "unknown GEMM canary variant" {:variant variant})))
         identity (identity-for workload target :float dimensions
                                :host-synchronized-replay environment-tag)

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -78,17 +78,20 @@
           (is (seq candidates))
           (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %)) candidates)))))))
 
-(deftest composed-return-alias-retains-the-memory-safety-gate
-  ;; Known gap: the lexical type survives, but storage aliases are not yet normalized into
-  ;; a pointwise inout boundary. Do not weaken stable-read validation to make this run.
+(deftest composed-return-alias-uses-a-pointwise-inout-boundary
   (let [prepared (compiled/lower #'canary/gemm-relu-composed!
                                  (into (canary/gemm-arguments [3 4 5]) [3 4 5])
                                  {:target :ocl:0 :dtype :float :constants ['A 'B]
                                   :gemm-precision :f32-scalar :on-non-resident :throw})]
     (is (= 2 (get-in (canary/compilation-evidence prepared) [:resident-step-count])))
-    (when @probe/opencl-available?
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stable input overlaps"
-                           (compiled/instantiate! prepared))))))
+    (if-not @probe/opencl-available?
+      (probe/opencl-skip! "composed GEMM return-alias numerics")
+      (with-redefs [microbench/do-bench once-only]
+        (let [result (canary/gemm! {:shape [3 4 5] :variant :relu-composed
+                                   :gemm-precision :f32-scalar :target :ocl:0
+                                   :environment-tag "ci-correctness-only"})]
+          (is (:validated? result))
+          (is (= :gemm-relu-composed-resident (get-in result [:identity :workload]))))))))
 
 (deftest opencl-parameterized-gemm-shape-canary
   (if-not @probe/opencl-available?


### PR DESCRIPTION
Separate buffer identity from return-type propagation. Normalize verified destination-return aliases before constructing access contracts, retaining producer effects and public return identities. Seed scope-aware alpha-renaming with incoming free symbols to prevent local shadowing from redirecting buffers.

The ordinary GEMM-return-alias plus in-place ReLU now executes safely through two KernelBody stages; no memory-validation bypass. Automatic epilogue fusion remains follow-up.

Validation: 84 focused tests, 427 assertions, zero failures/errors. Includes lexical capture/shadowing, quoted data, same-type-not-identity, typed fusion regressions and CPU OpenCL numerical execution. Read-only re-review found no remaining blocker. Stacked on #422.