### PR TITLE
Fuse proven same-destination result maps into typed reductions

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -96,3 +96,8 @@ followed by an in-place map. Exact destination-return identities are normalized 
 contracts, so this now executes through the pointwise inout path without bypassing the ABI
 checks. It still has two resident stages, versus one for the explicit epilogue: report that
 automatic-fusion gap rather than treating the two implementations as equally fused.
+
+The static public composition regression now fuses to one generated stage. This does not close
+the parameterized canary gap: normalized dynamic extent computation still separates its producer
+and consumer. Report static and dynamic workloads separately, and do not infer measured speedups
+from a reduced stage count.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -371,6 +371,13 @@ bindings remain intact. Scope-aware substitution and alpha-renaming of incoming 
 prevent local shadowing from redirecting a physical buffer. The composed GEMM/ReLU canary now
 executes safely through two generated stages. Automatic epilogue fusion remains the next gap.
 
+Static same-destination contraction→map now uses the existing segmented-reduction result-transform
+rule. Its sole lane-owned read becomes the completed accumulator; the fused destination is write-only.
+Other destination operands, neighbor reads and externally live intermediates remain excluded.
+The public static 3×4×5 GEMM/ReLU case is one generated stage and device-checked on CPU OpenCL.
+Dynamic composed GEMM remains two stages: its normalized extent scalar separates the equations,
+and symbolic extent equivalence plus legal scalar placement are not yet proved by this rule.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -632,14 +632,14 @@
       (rebuild-boundary program facts equations))))
 
 (defn- single-write-boundary?
-  [facts equation-id result destination]
+  [facts equation-id result destination allowed-access]
   (let [equation-facts (get-in facts [:equations equation-id])
         storage (get-in equation-facts [:attributes :result-storage])]
     (and (= #{:memory/write} (:effects equation-facts))
          (= {result destination} (:aliases equation-facts))
          (= 1 (count storage))
          (= destination (:destination (first storage)))
-         (= :write (:access (first storage))))))
+         (= allowed-access (:access (first storage))))))
 
 (defn- result-map-transform
   "Translate one pointwise map region into a typed post-reduction scalar region.
@@ -757,11 +757,13 @@
            :when (not (contains? (set (dialect/outputs program)) consumed-destination))
            :when (= 1 (count (filter #(= consumed-destination %)
                                      (:arrays consumer))))
-           :when (single-write-boundary? facts (:id producer) produced consumed-destination)
+           :when (single-write-boundary? facts (:id producer) produced consumed-destination :write)
            :when (single-write-boundary? facts (:id consumer) consumer-result
-                                         consumer-destination)
+                                         consumer-destination
+                                         (if (= consumed-destination consumer-destination)
+                                           :read-write :write))
            :when (empty? (set/intersection
-                          #{consumed-destination consumer-destination}
+                          (set [consumed-destination consumer-destination])
                           (set (map :value (:operands transform)))))
            :when (host-barrier-free? program producer consumer)
            :when transform]
@@ -805,6 +807,11 @@
           facts (-> (transfer-result-boundary (dialect/facts program)
                                               (:id producer) (:id consumer)
                                               :segmented-reduce-result-map)
+                    ;; The consumer's sole pointwise read of the produced destination is
+                    ;; now an accumulator use, not a read of pre-existing output storage.
+                    ;; Other reads of either destination already decline the candidate.
+                    (assoc-in [:equations (:id producer) :attributes :result-storage 0 :access]
+                              :write)
                     (update-in [:values (first (:results consumer))]
                                assoc
                                :shape (dialect/segmented-reduce-result-shape

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -343,7 +343,8 @@
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
 
 (defn- contract-result-map-program
-  [map-expression]
+  ([map-expression] (contract-result-map-program map-expression 'D))
+  ([map-expression destination]
   (frontend/form->program
    (list 'let*
          ['contract-step
@@ -352,11 +353,31 @@
             (* (clojure.core/aget A (+ (* i 16) l))
                (clojure.core/aget B (+ (* l 8) j))))
           'map-step
-          (list 'raster.par/map! 'D 't 32 nil map-expression)]
+          (list 'raster.par/map! destination 't 32 nil map-expression)]
          'map-step)
    {:dtype :float
     :array-types '{A :float B :float C :float D :float bias :float residual :float}
-    :scalar-types '{scale :float}}))
+    :scalar-types '{scale :float}})))
+
+(deftest same-destination-result-map-fuses-without-reading-old-output
+  (let [program (contract-result-map-program '(max (float 0.0) (clojure.core/aget C t)) 'C)
+        [result stats] (typed-fusion/fusion-fixpoint program)
+        facts (dialect/facts result)
+        operation (dialect/operation-parts (first (dialect/equations result)))]
+    (is (= 1 (:vertical stats)))
+    (is (= 1 (count (dialect/equations result))))
+    (is (= :write (get-in facts [:equations 0 :attributes :result-storage 0 :access])))
+    (is (= 'C (get-in facts [:equations 0 :attributes :result-storage 0 :destination])))
+    (is (empty? (get-in operation [:attributes :result-transform :operands])))
+    (is (= result (dialect/validate! result)))))
+
+(deftest same-destination-fusion-refuses-neighbor-reads
+  (doseq [expression ['(clojure.core/aget C (mod (+ t 1) 32))
+                      '(+ (clojure.core/aget C t) (clojure.core/aget C (mod (+ t 1) 32)))]]
+    (let [program (contract-result-map-program expression 'C)
+          [result stats] (typed-fusion/fusion-fixpoint program)]
+      (is (= program result))
+      (is (zero? (:vertical stats))))))
 
 (deftest segmented-reduce-result-map-becomes-a-typed-result-transform
   (let [program (contract-result-map-program

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -1,5 +1,8 @@
 (ns raster.perf.production-canary-test
   (:require [clojure.test :refer [deftest is]]
+            [raster.core :refer [deftm]]
+            [raster.arrays :as arrays]
+            [raster.gpu.link :as link]
             [raster.perf.production-canary :as canary]
             [raster.runtime.microbench :as microbench]
             [raster.gpu.compiled :as compiled]
@@ -8,6 +11,33 @@
 (defn- once-only [f & _]
   (f)
   {:median-ns 100 :stationary? true})
+
+(deftm static-gemm-relu! [A :- (Array float) B :- (Array float) C :- (Array float)] :- (Array float)
+  (let [product (raster.par/contract C [[i 3] [j 4]] [[p 5]]
+                 (* (arrays/aget A (+ (* i 5) p)) (arrays/aget B (+ (* p 4) j)))
+                 :init (float 0.0))]
+    (raster.par/map! C q 12 nil (max (float 0.0) (arrays/aget product q)))))
+
+(deftest static-public-composition-fuses-through-the-generated-route
+  (let [args (canary/gemm-arguments [3 4 5])
+        prepared (compiled/lower #'static-gemm-relu! args
+                                 {:target :ocl:0 :dtype :float :constants ['A 'B]
+                                  :gemm-precision :f32-scalar :on-non-resident :throw})
+        evidence (canary/compilation-evidence prepared)]
+    (is (= 1 (:resident-step-count evidence)))
+    (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %))
+                (mapcat :alternatives (:steps evidence))))
+    (if-not @probe/opencl-available?
+      (probe/opencl-skip! "static public GEMM plus map fusion")
+      (let [live (compiled/instantiate! prepared)]
+        (try
+          (link/run! (:executable live))
+          (let [output (first (:out-tree live))
+                actual (vec (link/download (:executable live) (:node output)))
+                expected (mapv #(max (float 0.0) %)
+                               (canary/gemm-reference (first args) (second args) [3 4 5]))]
+            (is (= expected actual)))
+          (finally (compiled/close! live)))))))
 
 (deftest explicit-baseline-and-comparability
   (let [sample {:identity {:workload :example :environment-tag "fixture"}


### PR DESCRIPTION
Extend the existing segmented-reduction result-transform rule to the same-destination pointwise inout case. The sole destination read becomes an accumulator use, so fused storage is write-only. Other destination operands, neighbor reads, host barriers and externally live intermediates retain the existing refusal gates.

Validation: 33 focused fusion/canary tests, 194 assertions passed on CPU OpenCL. Then small Intel Arc GPU acceptance: 3 tests, 18 assertions passed, including the static public 3x4x5 composed GEMM/ReLU and explicit epilogue precision policies. Read-only review found no blocker.

Dynamic composed GEMM remains two stages: normalized extent scalars intervene, and moving potentially throwing scalar work is not justified by purity alone. No timing speedup claimed under current memory pressure. Stacked on #423.