### PR TITLE
Keep graph shape context outside the executable scalar ABI

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -378,6 +378,13 @@ The public static 3×4×5 GEMM/ReLU case is one generated stage and device-check
 Dynamic composed GEMM remains two stages: its normalized extent scalar separates the equations,
 and symbolic extent equivalence plus legal scalar placement are not yet proved by this rule.
 
+Real Intel Arc checks also cover the static composed case and awkward 127×65×33 explicit
+GEMM/ReLU under both precision policies. These are numerical checks, not timing claims.
+The public equation-first RK4 and symbolic GEMM device checks exposed a runtime boundary:
+program-wide shape bookkeeping must remain available for capacity checks, but only the graph's
+declared scalar arguments enter KernelGraphCall. The binder now projects that interface without
+weakening exact call validation; both device cases execute after the fix.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1436,6 +1436,8 @@
    ResidentBufferView. Distinct graph identities may share an allocation when their physical
    ranges and declared accesses are legal. `scalar-values` maps symbolic compiler values to
    explicitly typed runtime scalars, e.g. `{'n {:type :int :value 4096}}`.
+   This environment may also contain program-wide shape values used by buffer extents;
+   only declared public scalar arguments are passed into the executable graph call.
 
    The graph owns its temporary allocations and dedicated bound kernel handles. Binding validates
    the complete graph call, lowers dependencies to logical queue/event edges, then records a
@@ -1478,7 +1480,13 @@
                register! (rt-resolve device-id "register-kernel!")
                bind-call! (rt-resolve device-id "bind-kernel-call")
                record! (rt-resolve device-id "record-graph!")
-               graph-call (kgcall/make graph all-buffers scalar-values)
+               ;; Buffer extents above may use enclosing-program shape values. They are not
+               ;; executable arguments: preserve the graph call's exact public ABI boundary.
+               call-scalars (select-keys scalar-values
+                                         (keep (fn [[slot argument]]
+                                                 (when (= :scalar (:kind slot)) argument))
+                                               (map vector (:abi graph) (:arguments graph))))
+               graph-call (kgcall/make graph all-buffers call-scalars)
                execution-plan (execution/from-kernel-graph-call graph-call)]
            (doseq [node (:nodes graph)]
              (let [artifact (:operation node)]

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -121,7 +121,9 @@
       (fn []
         (let [handle (gpu/bind-kernel-graph!
                       sess :prefix graph {'values :values 'out :out}
-                      {'n {:type :int :value 1025}} {:profile? true})
+                      {'n {:type :int :value 1025}
+                       'enclosing-count {:type :long :value 1025}
+                       '(extent values) {:type :long :value 1025}} {:profile? true})
               event (gpu/submit-kernel-graph! sess handle)
               _ (is (gpu/gpu-event? event))
               _ (is (gpu/event-complete? sess event))
@@ -136,6 +138,9 @@
               temporary (first (vals (get-in @sess [:kernel-graphs :prefix
                                                     :temporary-buffers])))]
           (is (gpu/kernel-graph-handle? handle))
+          (is (= {'n {:type :int :value 1025}}
+                 (get-in @sess [:kernel-graphs :prefix :graph-call :scalar-values]))
+              "enclosing shape bookkeeping does not widen the executable scalar ABI")
           (is (= 3 (count @registered)))
           (is (= 3 (count @bound)))
           (is (= 1 (count @recorded)))


### PR DESCRIPTION
Preserve enclosing shape values for resident view validation and temporary sizing, while projecting exactly the declared public scalar arguments into KernelGraphCall. Strict missing/type validation remains unchanged. Adds a driver-free regression to the existing graph runner test. Verified on Intel Arc through Level Zero: public RK4 heat equation and symbolic GEMM now execute; runner plus integration checks pass 7 tests / 63 assertions. Reviewed independently. Full suite and vendor gates run in CI. Stacked on #424.