### PR TITLE
Close returned-buffer fusion and real-device graph legality gaps

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -91,6 +91,8 @@ cross-vendor performance claim is justified until comparisons run on the named d
 `:gemm-precision :f32-scalar` or `:mixed-f16-f32` is forwarded to the compiler; the resolved
 policy is recorded in the identity. Policy is not evidence that a particular matrix instruction
 executed. The explicit ReLU workload has its own identity and is checked through generated
-KernelBody candidates. Composing a contraction-return alias with an in-place map is currently
-excluded: its stable-read/output alias boundary is rejected by the binder. Retain that case as
-a compiler regression until storage normalization admits it safely; do not benchmark a bypass.
+KernelBody candidates. `:variant :relu-composed` uses an ordinary contraction-return alias
+followed by an in-place map. Exact destination-return identities are normalized before storage
+contracts, so this now executes through the pointwise inout path without bypassing the ABI
+checks. It still has two resident stages, versus one for the explicit epilogue: report that
+automatic-fusion gap rather than treating the two implementations as equally fused.

--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -96,3 +96,8 @@ followed by an in-place map. Exact destination-return identities are normalized 
 contracts, so this now executes through the pointwise inout path without bypassing the ABI
 checks. It still has two resident stages, versus one for the explicit epilogue: report that
 automatic-fusion gap rather than treating the two implementations as equally fused.
+
+The static public composition regression now fuses to one generated stage. This does not close
+the parameterized canary gap: normalized dynamic extent computation still separates its producer
+and consumer. Report static and dynamic workloads separately, and do not infer measured speedups
+from a reduced stage count.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -378,6 +378,13 @@ The public static 3×4×5 GEMM/ReLU case is one generated stage and device-check
 Dynamic composed GEMM remains two stages: its normalized extent scalar separates the equations,
 and symbolic extent equivalence plus legal scalar placement are not yet proved by this rule.
 
+Real Intel Arc checks also cover the static composed case and awkward 127×65×33 explicit
+GEMM/ReLU under both precision policies. These are numerical checks, not timing claims.
+The public equation-first RK4 and symbolic GEMM device checks exposed a runtime boundary:
+program-wide shape bookkeeping must remain available for capacity checks, but only the graph's
+declared scalar arguments enter KernelGraphCall. The binder now projects that interface without
+weakening exact call validation; both device cases execute after the fix.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -365,6 +365,12 @@ Future mechanized proofs may use the sibling Lean project. Start with small exis
 same counterexamples as executable tests. No proof assistant integration or whole-compiler
 correctness claim is implied, and this does not block workload-driven retirement.
 
+The returned-buffer follow-up separates same-type facts from exact identity facts. Known
+destination-return aliases are normalized before access analysis; producers and public return
+bindings remain intact. Scope-aware substitution and alpha-renaming of incoming free identities
+prevent local shadowing from redirecting a physical buffer. The composed GEMM/ReLU canary now
+executes safely through two generated stages. Automatic epilogue fusion remains the next gap.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -385,6 +385,15 @@ program-wide shape bookkeeping must remain available for capacity checks, but on
 declared scalar arguments enter KernelGraphCall. The binder now projects that interface without
 weakening exact call validation; both device cases execute after the fix.
 
+The next real-device model probes exposed a distinct schedule legality gap: public linear
+projection dimensions retain Long, while mixed-DPAS layout/matrix stages currently bind int
+extents. That candidate now declines explicitly as `:mixed-dpas-index-width-not-lowered`,
+leaving generated portable contraction schedules available. Tiny forward, input-gradient and
+weight-gradient executions match CPU references, and the full AD train-step compiles resident.
+This is not an optimized-training result. Restore that optimization with width-preserving
+matrix/layout schedules or guarded specialization whose range proof covers dimensions, products
+and indexing; do not narrow retained types implicitly or relax ScheduledKernelBody validation.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -390,6 +390,8 @@ projection dimensions retain Long, while mixed-DPAS layout/matrix stages current
 extents. That candidate now declines explicitly as `:mixed-dpas-index-width-not-lowered`,
 leaving generated portable contraction schedules available. Tiny forward, input-gradient and
 weight-gradient executions match CPU references, and the full AD train-step compiles resident.
+The existing train-step gate also executes a 2×3×2 AD/SGD update on an available GPU, checking
+output extent, numerical agreement with CPU AD and a nontrivial update from the saved input.
 This is not an optimized-training result. Restore that optimization with width-preserving
 matrix/layout schedules or guarded specialization whose range proof covers dimensions, products
 and indexing; do not narrow retained types implicitly or relax ScheduledKernelBody validation.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -371,6 +371,13 @@ bindings remain intact. Scope-aware substitution and alpha-renaming of incoming 
 prevent local shadowing from redirecting a physical buffer. The composed GEMM/ReLU canary now
 executes safely through two generated stages. Automatic epilogue fusion remains the next gap.
 
+Static same-destination contraction→map now uses the existing segmented-reduction result-transform
+rule. Its sole lane-owned read becomes the completed accumulator; the fused destination is write-only.
+Other destination operands, neighbor reads and externally live intermediates remain excluded.
+The public static 3×4×5 GEMM/ReLU case is one generated stage and device-checked on CPU OpenCL.
+Dynamic composed GEMM remains two stages: its normalized extent scalar separates the equations,
+and symbolic extent equivalence plus legal scalar placement are not yet proved by this rule.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -100,7 +100,10 @@
                                "reduce" 1
                                nil))]
           (cond-> {:kind :par :introduces-scope? true :liftable? false :head head}
-            (some? return-index) (assoc :return-type-arg return-index)))
+            (some? return-index) (assoc :return-type-arg return-index)
+            ;; These destination-returning primitives preserve object identity, not merely
+            ;; dtype. A reduction's init only supplies a type; it is NOT an alias promise.
+            (= 0 return-index) (assoc :return-alias-arg 0)))
 
         ;; do block — sequential, liftable (effects + result)
         (= 'do head)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1216,6 +1216,16 @@
                                    :matrix)
         matrix-view (when (and matrix-enabled? (= :float (dtype/canon dtype)))
                       (cf/dense-matrix-view facts))
+        scalar-types (into {} (keep (fn [[slot argument]]
+                                     (when (= :scalar (:kind slot))
+                                       [argument (:dtype slot)])))
+                           (map vector abi arguments))
+        ;; Matrix/layout schedules currently bind int extents. Retained long extents must
+        ;; not reach those schedules through an implicit narrowing conversion.
+        wide-dimensions (delay
+                          (filterv #(not= :int (klaunch/typed-expression-dtype % scalar-types))
+                                   (cond-> (vec (:dimensions matrix-view))
+                                     (:batched? matrix-view) (conj (:batch matrix-view)))))
         target-schedule (when (and (= :mixed-f16-f32 precision) (:ok matrix-view))
                           (gpu-gemm/mixed-dpas-schedule (:desc options) (:tile options)))]
     (cond
@@ -1244,6 +1254,11 @@
        :decline {:reason :mixed-dpas-target-capability
                  :backend (get-in options [:desc :backend])
                  :matrix (get-in options [:desc :matrix])}}
+
+      (seq @wide-dimensions)
+      {:alternatives []
+       :decline {:reason :mixed-dpas-index-width-not-lowered
+                 :dimensions @wide-dimensions :required-dtype :int}}
 
       :else
       (let [[m n k] (:dimensions matrix-view)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2452,6 +2452,23 @@
                  parameters
                  [(util/subst-syms (zipmap captures parameters) expr)])))))
 
+(defn- physical-read-uses
+  "Resolve storage reads to their latest preceding logical writer. Reads precede writes
+   within one description, so an inout map consumes its predecessor, not its own result."
+  [descriptions physical-outputs]
+  (reduce
+   (fn [{:keys [writers] :as state} description]
+     (let [scalar? (= :scalar (:kind description))
+           reads (if scalar? (util/free-syms (:expr description))
+                     (concat (:inputs description) (:scalars description)))
+           host? (and scalar? (not (supported-description? physical-outputs description)))
+           writes (into {} (map (fn [result storage] [(:destination storage) result])
+                                (:results description) (:result-storage description)))]
+       (-> state
+           (update (if host? :host-uses :operation-uses) into (keep writers reads))
+           (update :writers merge writes))))
+   {:writers {} :host-uses #{} :operation-uses #{}} descriptions))
+
 (defn- terminal-results
   [descriptions body]
   (let [physical-outputs (physical-output-symbols descriptions)
@@ -2489,9 +2506,12 @@
                       (:sym %))
                    descriptions))
         all-definitions (set/union operation-definitions scalar-definitions)
-        operation-uses (set (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
-                                    (mapcat #(util/free-syms (:expr %)) typed-scalars)))
-        host-uses (set (mapcat #(util/free-syms (:expr %)) host-scalars))
+        physical-uses (physical-read-uses descriptions physical-outputs)
+        operation-uses (into (:operation-uses physical-uses)
+                             (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
+                                     (mapcat #(util/free-syms (:expr %)) typed-scalars)))
+        host-uses (into (:host-uses physical-uses)
+                        (mapcat #(util/free-syms (:expr %)) host-scalars))
         body-uses (set (mapcat util/free-syms body))
         ;; Destination-writing source forms return the destination buffer, while TypedSOAC names
         ;; the fresh logical result produced by that write. Preserve the public return by

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1648,17 +1648,29 @@
   ;; deliberately requires one logical definition per value. Use the shared scope-aware
   ;; alpha-renamer so later references keep their lexical meaning; inventing identities only in
   ;; operation-description would disconnect host materialization from the semantic equation.
-  (let [source (util/uniquify-rebindings source)]
+  (let [source (util/uniquify-rebindings (util/free-syms source) source)]
     (if (and (seq? source) (contains? #{'let 'let*} (first source)))
       (let [[head bindings & body] source
             pairs (vec (partition 2 bindings))
             {:keys [normalized]}
             (reduce
              (fn [{:keys [compound-extents allocation-lengths scalar-aliases pure-scalar-ids
-                         local-scalar-types]
+                         local-scalar-types buffer-aliases]
                    :as state}
                   [ordinal [symbol expression]]]
-               (let [[state expression] (if (par/par-rng-fill-form? expression)
+               (let [expression (util/subst-syms buffer-aliases expression)
+                     return-index (:return-alias-arg (form/form-info expression))
+                     returned (if (symbol? expression) expression
+                                  (when (some? return-index)
+                                    (nth (rest expression) return-index nil)))
+                     ;; Only exact destination-return identity, never a same-dtype guess.
+                     ;; Keep the effectful producer binding; rewrite subsequent references
+                     ;; to its physical buffer before read/write contracts are constructed.
+                     state (if (and (symbol? returned)
+                                    (contains? (:arrays *declared-kinds*) returned))
+                             (assoc-in state [:buffer-aliases symbol] returned)
+                             state)
+                     [state expression] (if (par/par-rng-fill-form? expression)
                                           ;; rng-fill! evaluates its int count before its long seed.
                                           (normalize-fixed-scalar-inputs state expression
                                                                          [[2 :int] [3 :long]])
@@ -1776,7 +1788,7 @@
                    :else
                    (update state :normalized conj [symbol expression]))))
              {:normalized [] :compound-extents {} :allocation-lengths {}
-              :scalar-aliases {} :pure-scalar-ids {} :local-scalar-types scalar-types}
+              :scalar-aliases {} :buffer-aliases {} :pure-scalar-ids {} :local-scalar-types scalar-types}
              (map-indexed vector pairs))]
         (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
       source)))

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -632,14 +632,14 @@
       (rebuild-boundary program facts equations))))
 
 (defn- single-write-boundary?
-  [facts equation-id result destination]
+  [facts equation-id result destination allowed-access]
   (let [equation-facts (get-in facts [:equations equation-id])
         storage (get-in equation-facts [:attributes :result-storage])]
     (and (= #{:memory/write} (:effects equation-facts))
          (= {result destination} (:aliases equation-facts))
          (= 1 (count storage))
          (= destination (:destination (first storage)))
-         (= :write (:access (first storage))))))
+         (= allowed-access (:access (first storage))))))
 
 (defn- result-map-transform
   "Translate one pointwise map region into a typed post-reduction scalar region.
@@ -757,11 +757,13 @@
            :when (not (contains? (set (dialect/outputs program)) consumed-destination))
            :when (= 1 (count (filter #(= consumed-destination %)
                                      (:arrays consumer))))
-           :when (single-write-boundary? facts (:id producer) produced consumed-destination)
+           :when (single-write-boundary? facts (:id producer) produced consumed-destination :write)
            :when (single-write-boundary? facts (:id consumer) consumer-result
-                                         consumer-destination)
+                                         consumer-destination
+                                         (if (= consumed-destination consumer-destination)
+                                           :read-write :write))
            :when (empty? (set/intersection
-                          #{consumed-destination consumer-destination}
+                          (set [consumed-destination consumer-destination])
                           (set (map :value (:operands transform)))))
            :when (host-barrier-free? program producer consumer)
            :when transform]
@@ -805,6 +807,11 @@
           facts (-> (transfer-result-boundary (dialect/facts program)
                                               (:id producer) (:id consumer)
                                               :segmented-reduce-result-map)
+                    ;; The consumer's sole pointwise read of the produced destination is
+                    ;; now an accumulator use, not a read of pre-existing output storage.
+                    ;; Other reads of either destination already decline the candidate.
+                    (assoc-in [:equations (:id producer) :attributes :result-storage 0 :access]
+                              :write)
                     (update-in [:values (first (:results consumer))]
                                assoc
                                :shape (dialect/segmented-reduce-result-shape

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1436,6 +1436,8 @@
    ResidentBufferView. Distinct graph identities may share an allocation when their physical
    ranges and declared accesses are legal. `scalar-values` maps symbolic compiler values to
    explicitly typed runtime scalars, e.g. `{'n {:type :int :value 4096}}`.
+   This environment may also contain program-wide shape values used by buffer extents;
+   only declared public scalar arguments are passed into the executable graph call.
 
    The graph owns its temporary allocations and dedicated bound kernel handles. Binding validates
    the complete graph call, lowers dependencies to logical queue/event edges, then records a
@@ -1478,7 +1480,13 @@
                register! (rt-resolve device-id "register-kernel!")
                bind-call! (rt-resolve device-id "bind-kernel-call")
                record! (rt-resolve device-id "record-graph!")
-               graph-call (kgcall/make graph all-buffers scalar-values)
+               ;; Buffer extents above may use enclosing-program shape values. They are not
+               ;; executable arguments: preserve the graph call's exact public ABI boundary.
+               call-scalars (select-keys scalar-values
+                                         (keep (fn [[slot argument]]
+                                                 (when (= :scalar (:kind slot)) argument))
+                                               (map vector (:abi graph) (:arguments graph))))
+               graph-call (kgcall/make graph all-buffers call-scalars)
                execution-plan (execution/from-kernel-graph-call graph-call)]
            (doseq [node (:nodes graph)]
              (let [artifact (:operation node)]

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -217,12 +217,14 @@
 
   (testing "reduce returns its accumulator"
     (let [info (form/form-info '(raster.par/reduce out init n f))]
-      (is (= 1 (:return-type-arg info)))))
+      (is (= 1 (:return-type-arg info)))
+      (is (nil? (:return-alias-arg info)))))
 
   (testing "scan and reduce-by-key return their destination, not their keys or seed"
     (doseq [head '[raster.par/scan raster.par/scan-exclusive raster.par/reduce-by-key
                   raster.par/gather raster.par/contract]]
-      (is (= 0 (:return-type-arg (form/form-info (list head 'out 'other)))))))
+      (is (= 0 (:return-type-arg (form/form-info (list head 'out 'other)))))
+      (is (= 0 (:return-alias-arg (form/form-info (list head 'out 'other)))))))
   (testing "effects, scalar results and unknown forms have no operand-return contract"
     (doseq [head '[raster.par/atomic-add! raster.par/map-void! raster.par/map2!
                   raster.par/butterfly! raster.par/collect! raster.par/product-reduce!

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -7,6 +7,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [raster.compiler.core.util :as util]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
@@ -16,6 +17,42 @@
           y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
           total (raster.par/reduce acc 0.0 j n (+ acc (clojure.core/aget y j)))]
          total))
+
+(deftest returned-buffer-identity-is-normalized-before-access-contracts
+  (let [source '(let* [r (raster.par/contract C [[i 4]] [] (clojure.core/aget A i))
+                       alias r
+                       mapped (raster.par/map! C j 4 nil (clojure.core/aget alias j))
+                       closure (fn [C] r)
+                       data (quote r)]
+                 mapped)
+        normalized (frontend/normalize-source source {:array-types {'A :float 'C :float}})
+        bindings (into {} (map vec (partition 2 (second normalized))))]
+    (is (= 'raster.par/contract (first (get bindings 'r))) "producer effect stays")
+    (is (= 'C (get bindings 'alias)))
+    (is (= '(clojure.core/aget C j) (last (get bindings 'mapped))))
+    (is (= #{'C} (util/free-syms (get bindings 'closure))) "replacement avoids capture")
+    (is (= '(quote r) (get bindings 'data)))
+    (is (= 'mapped (last normalized)))))
+
+(deftest same-return-type-is-not-a-buffer-identity-proof
+  (let [source '(let* [r (raster.par/reduce acc A i 1 B)] r)
+        normalized (frontend/normalize-source source {:array-types {'A :float 'B :float}})]
+    (is (= 'r (last normalized)))))
+
+(deftest returned-buffer-alias-survives-an-incoming-name-being-shadowed
+  (let [source '(let* [r (raster.par/contract C [[i 4]] [] (clojure.core/aget A i))
+                       C B
+                       mapped (raster.par/map! D j 4 nil (clojure.core/aget r j))]
+                 r)
+        normalized (frontend/normalize-source source {:array-types {'A :float 'B :float
+                                                                    'C :float 'D :float}})
+        pairs (mapv vec (partition 2 (second normalized)))
+        renamed (first (second pairs))
+        consumer (second (last pairs))]
+    (is (not= 'C renamed))
+    (is (= 'B (second (second pairs))))
+    (is (= '(clojure.core/aget C j) (last consumer)))
+    (is (= 'r (last normalized)))))
 
 (deftest direct-front-end-builds-the-typed-map-reduction-program
   (let [direct (frontend/form->program source {:dtype :float :array-types {'x :float}})

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -54,6 +54,29 @@
     (is (= '(clojure.core/aget C j) (last consumer)))
     (is (= 'r (last normalized)))))
 
+(deftest physical-reads-consume-the-preceding-logical-writer
+  (let [options {:dtype :float :array-types {'A :float 'B :float 'C :float 'D :float}}
+        outputs (fn [source]
+                  (-> source (frontend/normalize-source options)
+                      (frontend/form->program options) dialect/outputs set))]
+    (is (= '#{consumed last-write}
+           (outputs '(let* [first-write (raster.par/map! C i 4 nil (aget A i))
+                            consumed (raster.par/map! D j 4 nil (aget first-write j))
+                            last-write (raster.par/map! C k 4 nil (aget B k))]
+                       last-write)))
+        "a read before overwrite consumes the first writer, not the final writer")
+    (is (= '#{last-write}
+           (outputs '(let* [first-write (raster.par/map! C i 4 nil (aget A i))
+                            last-write (raster.par/map! C j 4 nil (aget first-write j))]
+                       last-write)))
+        "inout reads are processed before registering their own write")
+    (is (= '#{first-write last-write}
+           (outputs '(let* [first-write (raster.par/map! C i 4 nil (aget A i))
+                            observed (observe first-write)
+                            last-write (raster.par/map! C j 4 nil (aget first-write j))]
+                       last-write)))
+        "an opaque host read keeps its preceding producer externally visible")))
+
 (deftest direct-front-end-builds-the-typed-map-reduction-program
   (let [direct (frontend/form->program source {:dtype :float :array-types {'x :float}})
         equations (dialect/equations direct)]

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -221,8 +221,13 @@
         [result stats] (typed-fusion/fusion-fixpoint program)]
     (is (= 3 (count (dialect/equations result))))
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
-    (is (= '[left middle right] (dialect/outputs result))
-        "the effect result remains observable and ordered between the two reads")))
+    (is (= '[left right] (dialect/outputs result))
+        "the right-hand read consumes middle's physical result, not another public output")
+    (is (= '[left middle right] (mapv #(first (nth % 2)) (dialect/equations result)))
+        "the intervening write remains ordered between the two reads")
+    (is (= #{:memory/write} (get-in (dialect/facts result) [:equations 1 :effects])))
+    (is (= [{:destination 'x :access :read-write :host-return :buffer}]
+           (get-in (dialect/facts result) [:equations 1 :attributes :result-storage])))))
 
 (deftest aliased-equations-decline-unproved-fusion
   (let [program (source-program map-map-source {'x :float})

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -343,7 +343,8 @@
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
 
 (defn- contract-result-map-program
-  [map-expression]
+  ([map-expression] (contract-result-map-program map-expression 'D))
+  ([map-expression destination]
   (frontend/form->program
    (list 'let*
          ['contract-step
@@ -352,11 +353,31 @@
             (* (clojure.core/aget A (+ (* i 16) l))
                (clojure.core/aget B (+ (* l 8) j))))
           'map-step
-          (list 'raster.par/map! 'D 't 32 nil map-expression)]
+          (list 'raster.par/map! destination 't 32 nil map-expression)]
          'map-step)
    {:dtype :float
     :array-types '{A :float B :float C :float D :float bias :float residual :float}
-    :scalar-types '{scale :float}}))
+    :scalar-types '{scale :float}})))
+
+(deftest same-destination-result-map-fuses-without-reading-old-output
+  (let [program (contract-result-map-program '(max (float 0.0) (clojure.core/aget C t)) 'C)
+        [result stats] (typed-fusion/fusion-fixpoint program)
+        facts (dialect/facts result)
+        operation (dialect/operation-parts (first (dialect/equations result)))]
+    (is (= 1 (:vertical stats)))
+    (is (= 1 (count (dialect/equations result))))
+    (is (= :write (get-in facts [:equations 0 :attributes :result-storage 0 :access])))
+    (is (= 'C (get-in facts [:equations 0 :attributes :result-storage 0 :destination])))
+    (is (empty? (get-in operation [:attributes :result-transform :operands])))
+    (is (= result (dialect/validate! result)))))
+
+(deftest same-destination-fusion-refuses-neighbor-reads
+  (doseq [expression ['(clojure.core/aget C (mod (+ t 1) 32))
+                      '(+ (clojure.core/aget C t) (clojure.core/aget C (mod (+ t 1) 32)))]]
+    (let [program (contract-result-map-program expression 'C)
+          [result stats] (typed-fusion/fusion-fixpoint program)]
+      (is (= program result))
+      (is (zero? (:vertical stats))))))
 
 (deftest segmented-reduce-result-map-becomes-a-typed-result-transform
   (let [program (contract-result-map-program

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1187,7 +1187,10 @@
       (is (= [:portable-segred] (mapv kdispatch/alternative-strategy (:alternatives dispatch))))
       (is (= :mixed-dpas-index-width-not-lowered
              (get-in dispatch [:attributes :matrix-graph-decline :reason])))
-      (is (every? #(= :long (:dtype %)) (filter #(= :scalar (:kind %)) (:abi dispatch)))))))
+      (let [scalar-slots (filter #(= :scalar (:kind %))
+                                 (:abi (first (:alternatives dispatch))))]
+        (is (= (if batched? 4 3) (count scalar-slots)))
+        (is (every? #(= :long (:dtype %)) scalar-slots))))))
 
 (deftest dynamic-f32-contraction-owns-its-dpas-graph-alternatives
   (let [source

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1163,6 +1163,32 @@
           (is (= (kernel-graph/boundary-contract (:source refinement))
                  (kernel-graph/boundary-contract (:graph refinement)))))))))
 
+(deftest long-dimensions-decline-int-only-matrix-schedules
+  (doseq [batched? [false true]]
+    (let [contract (if batched?
+                     '(raster.par/contract C [[b batch] [i m] [j n]] [[l k]]
+                        (* (aget A (+ (* (+ (* b m) i) k) l)) (aget B (+ (* l n) j))))
+                     '(raster.par/contract C [[i m] [j n]] [[l k]]
+                        (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j)))))
+          {:keys [form]} (pipeline/schedule-parallel-form
+                          (list 'let* ['step contract] 'step)
+                          {:target-device :ze:0 :dtype :float
+                           :array-types {'A :float 'B :float 'C :float}
+                           :scalar-types {'batch :long 'm :long 'n :long 'k :long}})
+          dispatch (contract-route/route-typed-contraction-dispatch
+                     (-> form :equations first :algorithm)
+                     (-> form :equations first :operations first)
+                     :dtype :float :precision :mixed-f16-f32
+                     :desc {:backend :ze :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                            :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                            :subgroup-size 16 :max-workgroup-size 1024
+                            :grf-bytes-per-lane 256 :machine-lanes 8192
+                            :shared-local-memory 131072})]
+      (is (= [:portable-segred] (mapv kdispatch/alternative-strategy (:alternatives dispatch))))
+      (is (= :mixed-dpas-index-width-not-lowered
+             (get-in dispatch [:attributes :matrix-graph-decline :reason])))
+      (is (every? #(= :long (:dtype %)) (filter #(= :scalar (:kind %)) (:abi dispatch)))))))
+
 (deftest dynamic-f32-contraction-owns-its-dpas-graph-alternatives
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -1,18 +1,17 @@
 (ns raster.dl.gpu-ad-gemm-test
   "GPU-AD validation: the matmuls an AD-transformed train step emits — the forward projection
    (linear-nb → dgemm-nt!, :nt) and its two backward gradients (linear-dx → dgemm!, :nn;
-   linear-dW → dgemm-tn!, :tn) — each lower through compile-gpu-program to a RESIDENT XMX GEMM
-   graph and match the CPU BLAS reference. This is the empirical end of the framework claim
+   linear-dW → dgemm-tn!, :tn) — each lower through compile-gpu-program to a resident typed
+   contraction executable and match the CPU BLAS reference. This is the empirical end of the framework claim
    that AD-transformed IR flows through the GPU pipeline: the backward kernels ARE ordinary
    GEMMs, so recognizing them on the resident path (incl. the :tn weight-gradient variant) is
    what makes gradient computation run on device.
 
-   The full mse∘linear-nb TRAIN STEP does NOT yet fully lower (its loss reduction + the
-   daxpy-diff-into! elementwise gradient have no resident kernel in the composed AD path);
-   compile-gpu-program returns nil for it (clean staging-fn fallback). That current boundary is
-   asserted below so progress flips it — see .internal/ad_gpu_residency.md.
+   The full mse∘linear-nb train step returning updated weights is checked for resident
+   compilation and, on a device, numerical agreement with the CPU update.
 
-   Level-Zero / Intel-XMX only (the fp16 DPAS GEMM kernel). Skips cleanly without a GPU."
+   Device checks use Level Zero. Schedule selection retains precision and index-width legality;
+   residency is not a claim that an XMX candidate was selected. Skips visibly without a GPU."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.pipeline :as pl]
             [raster.dl.array-ops :as ops]
@@ -345,7 +344,7 @@
                        (let [vg ((raster.ad.reverse/value+grad #'gpu-ad-probe-loss)
                                  W x tgt batch in-f out-f)
                              dW (clojure.core/nth vg 1)]
-                         (raster.dl.optim/sgd-step! W dW (raster.arrays/alength W) lr)
+                         (raster.dl.optim/sgd-step! W dW (raster.arrays/alength W) (float lr))
                          W)))]
     (testing "full AD train step compiles to a fully-resident program (pins residency)"
       ;; :on-non-resident :nil = probe the boundary without throwing (default is :throw now)
@@ -353,4 +352,18 @@
         (is (some? p)
             "mse∘linear train step must extract fully resident (matmuls + fused loss + SGD)")
         (when p
-          (is (seq (:steps p)) "resident descriptor carries kernel steps"))))))
+          (is (seq (:steps p)) "resident descriptor carries kernel steps"))))
+    (testing "a small AD/SGD update executes numerically, not only as a resident descriptor"
+      (if-not @gp/gpu-available?
+        (gp/gpu-skip! "gpu-ad-full-train-step-execution")
+        (let [batch 2 in-f 3 out-f 2 lr 0.01
+              weights (rnd (* in-f out-f) 31)
+              input (rnd (* batch in-f) 32)
+              target (rnd (* batch out-f) 33)
+              expected (@train (aclone weights) input target batch in-f out-f lr)
+              {:keys [out]} (run-resident train
+                                         [weights input target batch in-f out-f lr])]
+          (is (< (rel-err out expected) 1e-3)
+              "the GPU update matches the complete CPU AD and SGD composition")
+          (is (not= (vec weights) (vec expected))
+              "the fixture performs a nontrivial weight update"))))))

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -358,12 +358,16 @@
         (gp/gpu-skip! "gpu-ad-full-train-step-execution")
         (let [batch 2 in-f 3 out-f 2 lr 0.01
               weights (rnd (* in-f out-f) 31)
+              initial-weights (vec weights)
               input (rnd (* batch in-f) 32)
               target (rnd (* batch out-f) 33)
               expected (@train (aclone weights) input target batch in-f out-f lr)
               {:keys [out]} (run-resident train
                                          [weights input target batch in-f out-f lr])]
+          (is (= (* in-f out-f) (count out) (count expected)))
           (is (< (rel-err out expected) 1e-3)
               "the GPU update matches the complete CPU AD and SGD composition")
-          (is (not= (vec weights) (vec expected))
-              "the fixture performs a nontrivial weight update"))))))
+          (is (not= initial-weights (vec expected))
+              "the fixture performs a nontrivial weight update")
+          (is (not= initial-weights (vec out))
+              "the GPU cannot satisfy the check by returning unchanged weights"))))))

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -121,7 +121,9 @@
       (fn []
         (let [handle (gpu/bind-kernel-graph!
                       sess :prefix graph {'values :values 'out :out}
-                      {'n {:type :int :value 1025}} {:profile? true})
+                      {'n {:type :int :value 1025}
+                       'enclosing-count {:type :long :value 1025}
+                       '(extent values) {:type :long :value 1025}} {:profile? true})
               event (gpu/submit-kernel-graph! sess handle)
               _ (is (gpu/gpu-event? event))
               _ (is (gpu/event-complete? sess event))
@@ -136,6 +138,9 @@
               temporary (first (vals (get-in @sess [:kernel-graphs :prefix
                                                     :temporary-buffers])))]
           (is (gpu/kernel-graph-handle? handle))
+          (is (= {'n {:type :int :value 1025}}
+                 (get-in @sess [:kernel-graphs :prefix :graph-call :scalar-values]))
+              "enclosing shape bookkeeping does not widen the executable scalar ABI")
           (is (= 3 (count @registered)))
           (is (= 3 (count @bound)))
           (is (= 1 (count @recorded)))

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -135,6 +135,7 @@
    (let [entry (case variant
                  :plain #'gemm-mnk!
                  :relu #'gemm-relu!
+                 :relu-composed #'gemm-relu-composed!
                  (throw (ex-info "unknown GEMM canary variant" {:variant variant})))]
      (compiled/lower entry (into args (map long (checked-shape shape)))
                      (cond-> {:target target :dtype :float :on-non-resident :throw :constants ['A 'B]}
@@ -172,6 +173,7 @@
         workload (case variant
                    :plain (if parameterized? :gemm-mnk-resident :gemm64-resident)
                    :relu :gemm-relu-resident
+                   :relu-composed :gemm-relu-composed-resident
                    (throw (ex-info "unknown GEMM canary variant" {:variant variant})))
         identity (identity-for workload target :float dimensions
                                :host-synchronized-replay environment-tag)

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -1,5 +1,8 @@
 (ns raster.perf.production-canary-test
   (:require [clojure.test :refer [deftest is]]
+            [raster.core :refer [deftm]]
+            [raster.arrays :as arrays]
+            [raster.gpu.link :as link]
             [raster.perf.production-canary :as canary]
             [raster.runtime.microbench :as microbench]
             [raster.gpu.compiled :as compiled]
@@ -8,6 +11,33 @@
 (defn- once-only [f & _]
   (f)
   {:median-ns 100 :stationary? true})
+
+(deftm static-gemm-relu! [A :- (Array float) B :- (Array float) C :- (Array float)] :- (Array float)
+  (let [product (raster.par/contract C [[i 3] [j 4]] [[p 5]]
+                 (* (arrays/aget A (+ (* i 5) p)) (arrays/aget B (+ (* p 4) j)))
+                 :init (float 0.0))]
+    (raster.par/map! C q 12 nil (max (float 0.0) (arrays/aget product q)))))
+
+(deftest static-public-composition-fuses-through-the-generated-route
+  (let [args (canary/gemm-arguments [3 4 5])
+        prepared (compiled/lower #'static-gemm-relu! args
+                                 {:target :ocl:0 :dtype :float :constants ['A 'B]
+                                  :gemm-precision :f32-scalar :on-non-resident :throw})
+        evidence (canary/compilation-evidence prepared)]
+    (is (= 1 (:resident-step-count evidence)))
+    (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %))
+                (mapcat :alternatives (:steps evidence))))
+    (if-not @probe/opencl-available?
+      (probe/opencl-skip! "static public GEMM plus map fusion")
+      (let [live (compiled/instantiate! prepared)]
+        (try
+          (link/run! (:executable live))
+          (let [output (first (:out-tree live))
+                actual (vec (link/download (:executable live) (:node output)))
+                expected (mapv #(max (float 0.0) %)
+                               (canary/gemm-reference (first args) (second args) [3 4 5]))]
+            (is (= expected actual)))
+          (finally (compiled/close! live)))))))
 
 (deftest explicit-baseline-and-comparability
   (let [sample {:identity {:workload :example :environment-tag "fixture"}

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -78,17 +78,20 @@
           (is (seq candidates))
           (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %)) candidates)))))))
 
-(deftest composed-return-alias-retains-the-memory-safety-gate
-  ;; Known gap: the lexical type survives, but storage aliases are not yet normalized into
-  ;; a pointwise inout boundary. Do not weaken stable-read validation to make this run.
+(deftest composed-return-alias-uses-a-pointwise-inout-boundary
   (let [prepared (compiled/lower #'canary/gemm-relu-composed!
                                  (into (canary/gemm-arguments [3 4 5]) [3 4 5])
                                  {:target :ocl:0 :dtype :float :constants ['A 'B]
                                   :gemm-precision :f32-scalar :on-non-resident :throw})]
     (is (= 2 (get-in (canary/compilation-evidence prepared) [:resident-step-count])))
-    (when @probe/opencl-available?
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stable input overlaps"
-                           (compiled/instantiate! prepared))))))
+    (if-not @probe/opencl-available?
+      (probe/opencl-skip! "composed GEMM return-alias numerics")
+      (with-redefs [microbench/do-bench once-only]
+        (let [result (canary/gemm! {:shape [3 4 5] :variant :relu-composed
+                                   :gemm-precision :f32-scalar :target :ocl:0
+                                   :environment-tag "ci-correctness-only"})]
+          (is (:validated? result))
+          (is (= :gemm-relu-composed-resident (get-in result [:identity :workload]))))))))
 
 (deftest opencl-parameterized-gemm-shape-canary
   (if-not @probe/opencl-available?


### PR DESCRIPTION
Consolidated landing of reviewed #423, #424, #425 plus matrix index-width legality and complete AD/SGD numerical validation found through actual Intel Arc checks. This PR contains their exact commits and avoids repeated squash/rebase CI cycles; superseded PRs will be closed after this exact head is green and merged.

Changes: normalize exact returned-buffer identity and preceding-writer liveness; fuse proven static same-destination result maps into typed reductions; separate enclosing shape context from exact executable scalar ABI; explicitly decline int-only mixed-DPAS schedules when public dimensions retain Long (no implicit narrowing or verifier weakening); extend the existing AD residency gate to a complete GPU SGD update with an explicit float learning-rate conversion, exact output extent, CPU parity and nontrivial-update checks.

Evidence: static public GEMM/ReLU, awkward 127x65x33 explicit ReLU under both precision policies, real LevelZero RK4 and symbolic GEMM; tiny model forward/input-gradient/weight-gradient CPU parity; complete AD/SGD device test 1 test / 6 assertions. Focused route suite 57 tests / 534 assertions before strengthening executable ABI assertions (strengthened test 1 / 8 passes); graph runner + PDE suite 7 tests / 63 assertions. Full suite and vendor gates in CI. Changes independently reviewed.

Limits: dynamic composed GEMM still two stages. Long-dimension DPAS optimization remains unavailable and falls back to generated portable schedules with a recorded reason. No latency or SOTA performance claim; host memory pressure makes benchmark timing inappropriate.