### PR TITLE
Preserve int/long extents in shared layout schedules

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -396,6 +396,15 @@ This is not an optimized-training result. Restore that optimization with width-p
 matrix/layout schedules or guarded specialization whose range proof covers dimensions, products
 and indexing; do not narrow retained types implicitly or relax ScheduledKernelBody validation.
 
+The first width-preserving prerequisite gives shared layout cast and transpose schedules explicit
+int/long extent parameters, with independent row/column widths and unchanged int defaults.
+Exact widened address arithmetic and checked hardware launch limits remain unchanged. Small
+OpenCL device tests exercise every width combination and poisoned tails; non-allocating checks
+cover a logical extent above int range and overflowing shape products. CUDA/HIP fixtures include
+long cast and mixed-width transpose. The mixed-DPAS Long admission gate remains closed until its
+matrix, split-K and batched stages also retain widths consistently; this prerequisite alone does
+not restore optimized Long-dimension GEMM.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/compiler/backend/gpu/layout_transform.clj
+++ b/src/raster/compiler/backend/gpu/layout_transform.clj
@@ -5,31 +5,35 @@
 
 (defn cast-body
   "Build the target-neutral body for one dense representation conversion."
-  [{:keys [id kernel-name input output source-dtype destination-dtype vector-width rounding overflow]
-    :or {vector-width 1}}]
+  [{:keys [id kernel-name input output source-dtype destination-dtype vector-width rounding overflow
+           extent-dtype]
+    :or {vector-width 1 extent-dtype :int}}]
   (schedule/cast-body
    {:id (or id [:layout-transform kernel-name])
     :input input :output output
     :source-dtype source-dtype :destination-dtype destination-dtype
-    :vector-width vector-width
+    :vector-width vector-width :extent-dtype extent-dtype
     :rounding rounding :overflow overflow}))
 
 (defn transpose-body
   "Build the target-neutral body for one dense row-major matrix transpose."
-  [{:keys [id kernel-name input output element-dtype]}]
+  [{:keys [id kernel-name input output element-dtype row-extent-dtype column-extent-dtype]
+    :or {row-extent-dtype :int column-extent-dtype :int}}]
   (schedule/transpose-body
    {:id (or id [:layout-transform kernel-name])
     :input input :output output
-    :element-dtype element-dtype}))
+    :element-dtype element-dtype
+    :row-extent-dtype row-extent-dtype :column-extent-dtype column-extent-dtype}))
 
 (defn emit-cast-kernel
   [{:keys [kernel-name input output source-dtype destination-dtype vector-width rounding overflow
-           target-dialect]
-    :or {vector-width 1 target-dialect :opencl-intel}}]
+           target-dialect extent-dtype]
+    :or {vector-width 1 target-dialect :opencl-intel extent-dtype :int}}]
   (let [kernel-body (cast-body
                      {:kernel-name kernel-name :input input :output output
                       :source-dtype source-dtype :destination-dtype destination-dtype
-                      :vector-width vector-width :rounding rounding :overflow overflow})]
+                      :vector-width vector-width :rounding rounding :overflow overflow
+                      :extent-dtype extent-dtype})]
     {:source (emitter/emit-scalar-kernel
               kernel-name kernel-body
               {:target-dialect target-dialect
@@ -37,11 +41,12 @@
      :kernel-body kernel-body}))
 
 (defn emit-transpose-kernel
-  [{:keys [kernel-name input output element-dtype target-dialect]
-    :or {target-dialect :opencl-intel}}]
+  [{:keys [kernel-name input output element-dtype target-dialect row-extent-dtype column-extent-dtype]
+    :or {target-dialect :opencl-intel row-extent-dtype :int column-extent-dtype :int}}]
   (let [kernel-body (transpose-body
                      {:kernel-name kernel-name :input input :output output
-                      :element-dtype element-dtype})]
+                      :element-dtype element-dtype
+                      :row-extent-dtype row-extent-dtype :column-extent-dtype column-extent-dtype})]
     {:source (emitter/emit-scalar-kernel
               kernel-name kernel-body
               {:target-dialect target-dialect

--- a/src/raster/compiler/passes/parallel/layout_transform_schedule.clj
+++ b/src/raster/compiler/passes/parallel/layout_transform_schedule.clj
@@ -11,6 +11,14 @@
 
 (def ^:private workgroup-size 256)
 
+(defn- extent-dtype!
+  [value]
+  (let [canonical (dtype/canon value)]
+    (when-not (contains? #{:int :long} canonical)
+      (throw (ex-info "layout extent requires a retained int or long representation"
+                      {:reason :layout-transform-index-dtype :dtype value})))
+    canonical))
+
 (defn- global-index
   [id]
   [(body/->IndexBinding :layout-group :group 0)
@@ -29,11 +37,14 @@
    `vector-width` is expressed as statically unrolled lane-owned elements, not a target vector
    builtin. This preserves the same coalesced access geometry on OpenCL, CUDA and HIP while
    leaving physical vector formation to target lowering. Narrowing behavior is an explicit part
-   of the body and can therefore participate in dispatch equivalence and certification."
-  [{:keys [id input output extent-id source-dtype destination-dtype vector-width rounding overflow]
-    :or {extent-id :layout-elements vector-width 1}}]
+   of the body and can therefore participate in dispatch equivalence and certification.
+   `extent-dtype` retains the caller's int/long representation; hardware launch limits remain
+   independently checked and are not widened by this option."
+  [{:keys [id input output extent-id extent-dtype source-dtype destination-dtype vector-width rounding overflow]
+    :or {extent-id :layout-elements extent-dtype :int vector-width 1}}]
   (let [source-dtype (dtype/canon source-dtype)
-        destination-dtype (dtype/canon destination-dtype)]
+        destination-dtype (dtype/canon destination-dtype)
+        extent-dtype (extent-dtype! extent-dtype)]
     (when-not (and rounding overflow)
       (throw (ex-info "layout conversion requires explicit rounding and overflow policies"
                       {:reason :layout-transform-numerical-policy
@@ -78,7 +89,7 @@
                      (body/->KernelParameter
                       output :output destination-dtype [extent] :global
                       (layout/row-major [extent] destination-dtype) :destination)
-                     (body/->KernelParameter extent :scalar :int [] nil nil :extent)]
+                     (body/->KernelParameter extent :scalar extent-dtype [] nil nil :extent)]
         :stable-reads [(body/stable-read input)]
         :indices (conj (global-index work-item)
                        (body/->IndexCompute
@@ -100,10 +111,15 @@
                      :source-dtype source-dtype :destination-dtype destination-dtype}}))))
 
 (defn transpose-body
-  "Schedule a dense row-major [rows, cols] -> [cols, rows] transpose."
-  [{:keys [id input output row-extent-id column-extent-id element-dtype]
-    :or {row-extent-id :layout-rows column-extent-id :layout-cols}}]
+  "Schedule a dense row-major [rows, cols] -> [cols, rows] transpose.
+   Row and column extent dtypes are independently retained int/long representations."
+  [{:keys [id input output row-extent-id column-extent-id element-dtype
+           row-extent-dtype column-extent-dtype]
+    :or {row-extent-id :layout-rows column-extent-id :layout-cols
+         row-extent-dtype :int column-extent-dtype :int}}]
   (let [element-dtype (dtype/canon element-dtype)
+        row-extent-dtype (extent-dtype! row-extent-dtype)
+        column-extent-dtype (extent-dtype! column-extent-dtype)
         linear :layout-linear
         row :layout-row
         column :layout-column
@@ -120,8 +136,8 @@
                    (body/->KernelParameter
                     output :output element-dtype [cols-id rows-id] :global
                     (layout/row-major [cols-id rows-id] element-dtype) :destination)
-                   (body/->KernelParameter rows-id :scalar :int [] nil nil :extent)
-                   (body/->KernelParameter cols-id :scalar :int [] nil nil :extent)]
+                   (body/->KernelParameter rows-id :scalar row-extent-dtype [] nil nil :extent)
+                   (body/->KernelParameter cols-id :scalar column-extent-dtype [] nil nil :extent)]
       :stable-reads [(body/stable-read input)]
       :indices (into (global-index linear)
                      [(body/->IndexCompute

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -383,6 +383,20 @@
                            (layout-transform/emit-transpose-kernel
                             {:kernel-name "layout_transpose" :input 'in :output 'out
                              :element-dtype :half :target-dialect dialect})))
+           (write-source! directory suffix "layout-cast-long"
+                          (:source
+                           (layout-transform/emit-cast-kernel
+                            {:kernel-name "layout_cast_long" :input 'in :output 'out
+                             :extent-dtype :long
+                             :source-dtype :float :destination-dtype :half
+                             :vector-width 4 :rounding :nearest-even :overflow :ieee
+                             :target-dialect dialect})))
+           (write-source! directory suffix "layout-transpose-mixed-width"
+                          (:source
+                           (layout-transform/emit-transpose-kernel
+                            {:kernel-name "layout_transpose_mixed_width" :input 'in :output 'out
+                             :row-extent-dtype :long :column-extent-dtype :int
+                             :element-dtype :half :target-dialect dialect})))
            (write-source! directory suffix "split-k-combine"
                           (:source
                            (gemm-emit/emit-split-k-combine-kernel

--- a/test/raster/compiler/backend/gpu/layout_transform_device_test.clj
+++ b/test/raster/compiler/backend/gpu/layout_transform_device_test.clj
@@ -1,0 +1,68 @@
+(ns raster.compiler.backend.gpu.layout-transform-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emitter]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.passes.parallel.layout-transform-schedule :as schedule]
+            [raster.gpu.device-probe :as probe]))
+
+(defn- execute
+  [kernel input initial-output scalars]
+  (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+        runtime #(ns-resolve ocl %)
+        parameters (:parameters kernel)
+        names (zipmap (map :id parameters) ["x" "y" "rows" "cols"])
+        compiled (artifact/make
+                  {:kernel-name "layout_width_probe" :target :opencl-c
+                   :source (emitter/emit-scalar-kernel
+                            "layout_width_probe" kernel
+                            {:target-dialect :opencl-portable :parameter-names names})
+                   :abi (body-abi/project-contracts
+                         (mapv #(abi/slot (:id %) (:kind %) (:dtype %)
+                                          :c-name (get names (:id %))) parameters)
+                         kernel)
+                   :arguments (mapv :id parameters)
+                   :launch (:launch kernel) :effects {:kind :layout-transform}})
+        x ((runtime 'buffer-of-array) input :float)]
+    (try
+      (let [y ((runtime 'buffer-of-array) initial-output :float)]
+        (try
+          ((runtime 'register-kernel!) (:kernel-name compiled) compiled)
+          (let [prepared ((runtime 'bind-kernel-call)
+                          (call/make compiled
+                                     (into [x y]
+                                           (map (fn [parameter value]
+                                                  {:type (:dtype parameter) :value value})
+                                                (drop 2 parameters) scalars))))]
+            (try
+              ((runtime 'launch-registered-bound!) prepared)
+              ((runtime 'buffer->array) y)
+              (finally ((runtime 'destroy-prepared!) prepared))))
+          (finally ((runtime 'free-buffer!) y))))
+      (finally ((runtime 'free-buffer!) x)))))
+
+(deftest layout-integer-widths-execute-with-masked-tails
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "layout transform retained integer widths")
+    (do
+      (doseq [extent-dtype [:int :long]]
+        (let [n 1025
+              input (float-array (map float (range n)))
+              kernel (schedule/cast-body
+                      {:id :cast-width :input 'x :output 'y
+                       :extent-dtype extent-dtype
+                       :source-dtype :float :destination-dtype :float
+                       :vector-width 4 :rounding :exact :overflow :exact})
+              actual (vec (execute kernel input (float-array (repeat (+ n 3) -1.0)) [n]))]
+          (is (= (vec input) (subvec actual 0 n)))
+          (is (= [-1.0 -1.0 -1.0] (subvec actual n)))))
+      (doseq [row-dtype [:int :long] column-dtype [:int :long]]
+        (let [kernel (schedule/transpose-body
+                      {:id :transpose-width :input 'x :output 'y :element-dtype :float
+                       :row-extent-dtype row-dtype :column-extent-dtype column-dtype})
+              actual (vec (execute kernel (float-array [1 2 3 4 5 6])
+                                   (float-array (repeat 8 -1.0)) [2 3]))]
+          (is (= [1.0 4.0 2.0 5.0 3.0 6.0] (subvec actual 0 6)))
+          (is (= [-1.0 -1.0] (subvec actual 6))))))))

--- a/test/raster/compiler/passes/parallel/layout_transform_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/layout_transform_schedule_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.kernel-body-opencl :as emitter]
+            [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.layout-transform-schedule :as schedule]))
@@ -42,3 +43,62 @@
            (get-in kernel [:operations 1 :coordinates])))
     (is (str/includes? source "rstr_layout_column"))
     (is (str/includes? source "rstr_layout_row"))))
+
+(deftest layout-extents-preserve-independent-integer-widths
+  (doseq [extent-dtype [:int :long]]
+    (let [kernel (layout-emitter/cast-body
+                  {:id :wide-cast :input 'x :output 'y :extent-dtype extent-dtype
+                   :source-dtype :float :destination-dtype :half :vector-width 4
+                   :rounding :nearest-even :overflow :ieee})]
+      (is (= extent-dtype (:dtype (last (:parameters kernel)))))
+      (is (= [2] (:group-count (launch/realize (:launch kernel) {:layout-elements 1025}))))
+      (doseq [dialect [:opencl-portable :cuda :hip]]
+        (is (string? (:source (layout-emitter/emit-cast-kernel
+                               {:kernel-name "wide_cast" :input 'x :output 'y
+                                :extent-dtype extent-dtype
+                                :source-dtype :float :destination-dtype :half
+                                :vector-width 4 :rounding :nearest-even :overflow :ieee
+                                :target-dialect dialect})))))))
+  (doseq [row-dtype [:int :long] column-dtype [:int :long]]
+    (let [options {:id :wide-transpose :input 'x :output 'y :element-dtype :float
+                   :row-extent-dtype row-dtype :column-extent-dtype column-dtype}
+          kernel (layout-emitter/transpose-body options)]
+      (is (= [row-dtype column-dtype] (mapv :dtype (drop 2 (:parameters kernel)))))
+      (doseq [dialect [:opencl-portable :cuda :hip]]
+        (is (string? (:source (layout-emitter/emit-transpose-kernel
+                               (assoc options :kernel-name "wide_transpose"
+                                      :target-dialect dialect)))))))))
+
+(deftest layout-extents-reject-non-index-representations
+  (doseq [invalid [:float :double :half]
+          make-kernel [(fn [] (schedule/cast-body
+                               {:input 'x :output 'y :extent-dtype invalid
+                                :source-dtype :float :destination-dtype :half
+                                :rounding :nearest-even :overflow :ieee}))
+                       (fn [] (schedule/transpose-body
+                               {:input 'x :output 'y :element-dtype :float
+                                :row-extent-dtype invalid}))
+                       (fn [] (schedule/transpose-body
+                               {:input 'x :output 'y :element-dtype :float
+                                :column-extent-dtype invalid}))]]
+    (try
+      (make-kernel)
+      (is false "non-index extent dtype must fail before emission")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :layout-transform-index-dtype (:reason (ex-data e))))))))
+
+(deftest long-extents-have-checked-non-allocating-launch-boundaries
+  (let [cast (schedule/cast-body
+              {:id :large-cast :input 'x :output 'y :extent-dtype :long
+               :source-dtype :float :destination-dtype :half :vector-width 4
+               :rounding :nearest-even :overflow :ieee})
+        transpose (schedule/transpose-body
+                   {:id :large-transpose :input 'x :output 'y :element-dtype :float
+                    :row-extent-dtype :long :column-extent-dtype :long})]
+    (is (= [2097152]
+           (:group-count (launch/realize (:launch cast) {:layout-elements 2147483648})))
+        "a logical extent above int range is retained without allocating that buffer")
+    (is (thrown? ArithmeticException
+                 (launch/realize (:launch transpose)
+                                 {:layout-rows 3037000500 :layout-cols 3037000500}))
+        "shape products cannot wrap the checked host launch arithmetic")))


### PR DESCRIPTION
Adds explicit retained extent widths to generic KernelBody layout cast and transpose schedules, including independent row/column widths. Existing int defaults, exact widened address arithmetic, and checked hardware launch limits remain unchanged. Non-index dtypes are rejected before emission.

Validation: 6 focused tests / 67 assertions passed, including real Intel Arc execution for every int/long width combination, masked tails, non-allocating launch above Integer/MAX_VALUE, and overflow rejection. CUDA/HIP compile fixtures include long cast and mixed-width transpose; the device test is automatically included in the CPU OpenCL CI gate. Independently reviewed.

This is a prerequisite, not optimized Long-dimension GEMM admission. The mixed-DPAS decline remains until matrix/split-K/batched schedules also preserve their widths. No narrowing, verifier weakening, or performance claim.