### PR TITLE
Make leading-slice buffer offsets typed IR across emitters

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -415,6 +415,14 @@ fused epilogues. Public matrix dimensions and Intel block-I/O coordinates still 
 pitch, output-product and hardware-coordinate bounds must be addressed before admitting retained
 Long dimensions. This change is correctness/unification evidence, not a performance claim.
 
+Contiguous leading-slice BufferViews now carry exact long leaf products in KernelBody itself.
+The shared validator checks scalar types and preserves parent-shape/launch correspondence;
+late casts, narrow factors and non-integral extents are rejected. Scalar and matrix emission
+consume that expression without a separate matrix-only widening helper. Offset correspondence
+is not a standalone overflow proof: binding must check parent-capacity products, including every
+intermediate multiplication (a trailing zero must not conceal an overflowing prefix). Focused
+tests cover these non-allocating limits plus the existing real-device split/batched matrix routes.
+
 Static zero-reduction-axis public contractions now enter the existing typed SegMap path.
 For unresolved plain input capacities, a bounded proof over the actual lowered loads derives
 minimum storage independently of output size. Every integer arithmetic prefix must fit its

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -395,7 +395,7 @@
      :additional-indices [(kbody/->IndexBinding z :group 2)]
      :buffer-shapes {c [splits m n]}
      :buffer-views [{:id c-view :buffer c
-                     :element-offset (kbody/expression :mul z m n)
+                     :element-offset (kbody/leading-slice-offset z [m n])
                      :shape [m n]}]
      :operation-buffers {c c-view}
      :k-range [k-lower k-upper]
@@ -423,13 +423,13 @@
         b-shape (if col-batched? [batch k n] [k n])
         buffer-views
         (cond-> [{:id c-view :buffer c
-                  :element-offset (kbody/expression :mul z m n) :shape [m n]}]
+                  :element-offset (kbody/leading-slice-offset z [m n]) :shape [m n]}]
           row-batched?
           (conj {:id a-view :buffer a
-                 :element-offset (kbody/expression :mul z m k) :shape [m k]})
+                 :element-offset (kbody/leading-slice-offset z [m k]) :shape [m k]})
           col-batched?
           (conj {:id b-view :buffer b
-                 :element-offset (kbody/expression :mul z k n) :shape [k n]}))
+                 :element-offset (kbody/leading-slice-offset z [k n]) :shape [k n]}))
         operation-buffers
         (cond-> {c c-view}
           row-batched? (assoc a a-view)

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -74,13 +74,6 @@
                           {:reason :kernel-body-opencl-unimplemented
                            :expression expression}))))
 
-(defn- emit-wide-expression
-  [expression env]
-  (if (and (record-kind? "IndexExpr" expression) (= :mul (:op expression)))
-    (str/join " * " (map #(str "(long)" (emit-index-expression % env))
-                         (:arguments expression)))
-    (str "(long)" (emit-index-expression expression env))))
-
 (defn- nested-operations [operations]
   (mapcat (fn [operation]
             (cons operation
@@ -245,7 +238,7 @@
                       (when-let [offset (get buffer-offsets role)]
                         (when-not (and (number? offset) (zero? offset))
                           (str "    " pointer " += "
-                               (emit-wide-expression offset index-names) ";\n"))))
+                               (emit-index-expression offset index-names) ";\n"))))
         k-range-lines (when sliced-k?
                         (str "    " index-type " k_begin = "
                              (emit-index-expression (first k-bounds) index-names) ";\n"

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -107,6 +107,13 @@
   [argument target-dtype overflow]
   (->IndexCast argument target-dtype overflow))
 
+(defn leading-slice-offset
+  "Construct a contiguous leading-slice address, widening every factor before multiplication.
+  The owning BufferView still requires a matching parent shape and launch bound."
+  [group-index shape]
+  (apply expression :mul
+         (map #(index-cast % :long :exact) (into [group-index] shape))))
+
 (defn predicate
   "Construct an explicit target-neutral bounds predicate."
   [op & arguments]
@@ -251,6 +258,10 @@
     (= 1 divisor) true
     (integer? value) (zero? (mod value divisor))
     (value-id? value) false
+    (record-kind? "raster.compiler.ir.kernel_body.IndexCast" value)
+    (and (= :exact (:overflow value))
+         (or (integer? (:argument value)) (value-id? (:argument value)))
+         (expression-divisible? (:argument value) divisor))
     (not (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)) false
     (contains? #{:add :sub} (:op value))
     (every? #(expression-divisible? % divisor) (:arguments value))
@@ -2205,6 +2216,16 @@
                                                   "raster.compiler.ir.kernel_body.IndexExpr" offset)
                                                  (= :mul (:op offset)))
                                         (:arguments offset))
+                     _ (when-not (and (seq offset-arguments)
+                                      (every? #(and (record-kind?
+                                                    "raster.compiler.ir.kernel_body.IndexCast" %)
+                                                   (= :long (:dtype %)) (= :exact (:overflow %))
+                                                   (or (integer? (:argument %))
+                                                       (value-id? (:argument %))))
+                                              offset-arguments))
+                         (throw (ex-info "kernel buffer view must widen leaves before address arithmetic"
+                                         {:reason :kernel-body-view-index-width :view view})))
+                     offset-arguments (mapv :argument offset-arguments)
                      slice-index (first offset-arguments)
                      group-axis (get group-axes slice-index)]
                  (when-not (and (= 1 prefix-rank)
@@ -2341,6 +2362,8 @@
                      :control-uniformity all-uniform
                      :launch launch
                      :schedule schedule}]
+        (doseq [view views]
+          (expression-info! (:element-offset view) initial-values))
         (doseq [region (scalar-ssa-store-regions operations)]
           (validate-scalar-ssa-dataflow! region initial-values context))
         (validate-dataflow-operations! operations initial-values context))))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -39,7 +39,7 @@
                     (layout/row-major [2] :half) :result)
                    (body/->KernelParameter 'scale :scalar :float [] nil nil :scale)]
       :views [(body/->BufferView
-               'x-row 'x (body/expression :mul group 16) [16]
+               'x-row 'x (body/leading-slice-offset group [16]) [16]
                (layout/row-major [16] :half))]
       :stable-reads [(body/stable-read 'x) (body/stable-read 'bias)]
       :indices [(body/->IndexBinding group :group 0)
@@ -209,7 +209,7 @@
                                    'y "output_rows" 'scale "scale"}})]
     (is (str/includes? source "__global const half* restrict input_rows"))
     (is (str/includes? source
-                       "input_rows[((long)((rstr_query_row * 16)) + ((long)(rstr_lane)"))
+                       "input_rows[((long)(((long)(rstr_query_row) * (long)(16))) + ((long)(rstr_lane)"))
     (is (str/includes? source "((rstr_lane < 16)) ? input_rows"))
     (is (str/includes? source "float rstr_loop_result = rstr_clean;"))
     (is (str/includes? source "sub_group_reduce_add(rstr_loop_result)"))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -141,12 +141,19 @@
                              (layout/row-major [16 16 16] :half))
                    (assoc-in [:launch :group-count] [16]))
         view (body/->BufferView 'A-slab 'A
-                                (body/expression :mul 'group-x 16 16)
+                                (body/leading-slice-offset 'group-x [16 16])
                                 [16 16] (layout/row-major [16 16] :half))
         viewed (-> kernel
                    (assoc :views [view])
                    (assoc-in [:operations 0 :operations 1 :operations 0 :buffer] 'A-slab))]
     (is (= viewed (body/validate! viewed)))
+    (testing "address factors are exact long leaves, not late or narrowing casts"
+      (doseq [offset [(body/expression :mul 'group-x 16 16)
+                      (body/index-cast (body/expression :mul 'group-x 16 16) :long :exact)
+                      (assoc-in (:element-offset view) [:arguments 0 :overflow] :wrap)
+                      (assoc-in (:element-offset view) [:arguments 0 :dtype] :int)]]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"widen leaves"
+                              (body/validate! (assoc-in viewed [:views 0 :element-offset] offset))))))
     (testing "a view may only reference declared storage"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"undeclared storage"
                             (body/validate! (assoc viewed :views [(assoc view :buffer 'missing)])))))
@@ -159,6 +166,30 @@
     (testing "the parent extent is tied to the hardware axis launch bound"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"launch-bounded"
                             (body/validate! (assoc-in viewed [:launch :group-count 0] 15)))))))
+
+(deftest view-offsets-use-declared-scalar-types
+  (let [make-view (fn [extent-type]
+                    (body/make
+                     {:id :typed-view
+                      :parameters [(body/->KernelParameter 'A :input :float [2 'width] :global
+                                                            (layout/row-major [2 'width] :float) :input)
+                                   (body/->KernelParameter 'width :scalar extent-type [] nil nil :dimension)]
+                      :indices [(body/->IndexBinding 'row :group 0)]
+                      :views [(body/->BufferView 'slice 'A
+                                                (body/leading-slice-offset 'row ['width])
+                                                ['width] (layout/row-major ['width] :float))]
+                      :launch (launch/spec {:workgroup-size [1] :group-count [2]})}))]
+    (doseq [extent-type [:int :long]]
+      (is (body/kernel-body? (make-view extent-type))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"only exact widening"
+                          (make-view :float)))))
+
+(deftest view-capacity-products-are-checked-before-any-allocation
+  (let [resolve-capacity #(launch/resolve-expression {} (apply launch/product %))]
+    (is (= 8589934592 (resolve-capacity [2 65536 65536])))
+    (is (thrown? ArithmeticException
+                 (resolve-capacity [Integer/MAX_VALUE Integer/MAX_VALUE 3 0]))
+        "a trailing zero cannot conceal an overflowing address prefix")))
 
 (deftest scalar-regions-are-checked-against-the-ordered-kernel-abi
   (let [region (body/->ScalarRegion


### PR DESCRIPTION
## Summary
- Express leading-slice offsets as long products of exactly widened leaves in KernelBody.
- Preserve existing parent-shape, ownership, and launch-bound checks; validate offset types using the shared SSA environment.
- Reject late/wrapping/narrow casts and non-integral extents; preserve exact-cast alignment facts.
- Remove the matrix-only emitter widening helper; scalar and matrix emission consume typed offsets directly.

## Validation
- Fresh single 768 MiB REPL: 59 focused tests, 539 assertions pass, including Intel Arc direct/split/batched/epilogue matrix execution.
- Latest view/capacity regression namespace: 28 tests, 150 assertions pass.
- Independent read-only review passed. Checked capacity binding remains required; typed correspondence alone is not an overflow proof.
- Full suite and vendor compiler gates run in CI. No performance claim.