### PR TITLE
Validate executable scalar preconditions before allocation and launch

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -436,6 +436,19 @@ retained dtype; negative accesses, indirect coordinates and unknown domains do n
 capacities. Larger declared storage remains intact. This is not general gather bounds checking
 or symbolic shape inference. Exact-size CPU OpenCL execution is correctness evidence only.
 
+Executable scalar preconditions now use the existing checked launch/storage expression algebra,
+referencing physical ABI slot names. Binding validates scalar ranges and literal specializations;
+graph preflight checks every node before scratch allocation. Registry and tuning identities retain
+these constraints, and forced/cached selection cannot bypass them. Focused validation: 65 tests,
+374 assertions. This supplies enforcement, not proof that target requirements have been supplied.
+
+Next: derive Intel matrix restrictions from the verified schedule and share them between selection
+and artifact binding. The [Intel 2D block-I/O specification](https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroup_2d_block_io.html)
+requires at least 64-byte row widths and 64-byte base alignment; the existing tiny FP16 N/K=16
+device cases do not establish legality despite passing this driver. Validate surface maxima,
+pitch and view-slice alignment as well, widen linear output arithmetic, and keep the retained-Long
+DPAS admission gate closed until the complete contract is enforced. These target fixes remain open.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -9,7 +9,8 @@
    contraction, etc.) belong in the scheduled kernel graph and contain KernelArtifacts as nodes."
   (:require [clojure.string :as str]
             [raster.compiler.ir.kernel-abi :as kabi]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.kernel-precondition :as precondition]))
 
 (defrecord KernelArtifact
            [kernel-name   ;; emitted entry-point string
@@ -18,6 +19,7 @@
             abi           ;; ordered physical signature
             arguments     ;; compiler values in the identical order
             launch        ;; checked launch contract, not runtime handles
+            preconditions ;; ordered scalar constraints checked before allocation and launch
             temporaries   ;; explicit scheduled temporaries (vector)
             effects       ;; target effects not already implied by ABI
             provenance    ;; semantic/scheduled origin for explain/profile
@@ -36,7 +38,7 @@
   (when-not (kernel-artifact? artifact)
     (throw (ex-info "kernel artifact must be a KernelArtifact value"
                     {:artifact artifact :actual (type artifact)})))
-  (let [{:keys [kernel-name target source abi arguments launch temporaries effects provenance
+  (let [{:keys [kernel-name target source abi arguments launch preconditions temporaries effects provenance
                 attributes]} artifact]
     (when-not (and (string? kernel-name) (not (str/blank? kernel-name)))
       (throw (ex-info "kernel artifact requires a non-blank entry point"
@@ -60,6 +62,12 @@
         (throw (ex-info "kernel artifact has an invalid launch contract"
                         {:kernel-name kernel-name :launch launch}
                         e))))
+    (precondition/validate!
+     preconditions
+     (into #{} (keep (fn [slot]
+                       (when (and (= :scalar (:kind slot))
+                                  (contains? #{:int :long} (:kernel-dtype slot))) (:name slot))))
+           abi))
     (when-not (vector? temporaries)
       (throw (ex-info "kernel artifact temporaries must be an ordered vector"
                       {:kernel-name kernel-name :temporaries temporaries})))
@@ -72,10 +80,10 @@
 (defn make
   "Construct and verify a KernelArtifact.  Optional sections default to empty values, but launch
    is mandatory because an entry point without a launch contract is not executable kernel IR."
-  [{:keys [kernel-name target source abi arguments launch temporaries effects provenance attributes]
-    :or {target :opencl-c temporaries [] effects {} provenance {} attributes {}}}]
+  [{:keys [kernel-name target source abi arguments launch preconditions temporaries effects provenance attributes]
+    :or {target :opencl-c preconditions [] temporaries [] effects {} provenance {} attributes {}}}]
   (validate! (->KernelArtifact kernel-name target source abi arguments launch
-                               temporaries effects provenance attributes)))
+                               preconditions temporaries effects provenance attributes)))
 
 (defn certify-scheduled-operation
   "Bind a target artifact to the complete immutable scheduled operation it implements."

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -7,7 +7,9 @@
   (:require [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
-            [raster.compiler.ir.kernel-launch :as klaunch])
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.kernel-precondition :as precondition]
+            [raster.compiler.ir.scalar-range :as scalar-range])
   (:import [java.lang.foreign MemorySegment]))
 
 (defrecord KernelCall [artifact arguments geometry])
@@ -105,7 +107,8 @@
                  [value]))
              plan logical-values))))
 
-(defn- scalar-value!
+(defn validate-scalar-value!
+  "Validate a physical scalar against the declared ABI dtype before any conversion or arithmetic."
   [slot value]
   (when-not (and (map? value) (contains? value :value) (contains? value :type))
     (throw (ex-info "kernel scalar argument must be a typed value"
@@ -114,12 +117,13 @@
     (throw (ex-info "kernel scalar argument has the wrong kernel dtype"
                     {:slot slot :expected (:kernel-dtype slot) :actual (:type value)
                      :value value})))
-  (when (and (= :int (:kernel-dtype slot))
-             (not (and (integer? (:value value))
-                       (<= Integer/MIN_VALUE (:value value) Integer/MAX_VALUE))))
-    (throw (ex-info "kernel int scalar argument is outside its physical ABI range"
-                    {:reason :kernel-scalar-range :slot slot :value value
-                     :minimum Integer/MIN_VALUE :maximum Integer/MAX_VALUE})))
+  (when (contains? #{:int :long} (:kernel-dtype slot))
+    (let [{:keys [lower upper]} (scalar-range/for-dtype (:kernel-dtype slot))]
+      (when-not (and (integer? (:value value)) (<= lower (:value value) upper))
+        (throw (ex-info (str "kernel " (name (:kernel-dtype slot))
+                             " scalar argument is outside its physical ABI range")
+                        {:reason :kernel-scalar-range :slot slot :value value
+                         :minimum lower :maximum upper})))))
   (when (and (= :bound (:role slot))
              (or (not (integer? (:value value))) (neg? (:value value))))
     (throw (ex-info "kernel extent bound must be a non-negative integer"
@@ -177,6 +181,8 @@
                 (catch UnsupportedOperationException _ false))
       :else false)))
 
+(declare validate-preconditions!)
+
 (defn validate!
   "Validate and return a KernelCall. This is driver-independent: a backend subsequently checks
    that pointer values are its resident buffer representation and match ABI storage dtypes."
@@ -209,10 +215,11 @@
                       {:kernel-name (:kernel-name artifact)
                        :expected (:shared-memory-bytes spec)
                        :actual (:shared-memory-bytes geometry)})))
+    (validate-preconditions! artifact arguments)
     (validate-body-launch! artifact geometry)
     (doseq [[slot value] (map vector abi arguments)]
       (if (= :scalar (:kind slot))
-        (scalar-value! slot value)
+        (validate-scalar-value! slot value)
         (do
           (when (nil? value)
             (throw (ex-info "kernel pointer argument cannot be nil"
@@ -246,16 +253,36 @@
                              :value compiler-value :indexes (vec indexes) :values values})))
           (first values))))))
 
+(defn validate-preconditions!
+  "Validate scalar representations and executable constraints without requiring resident pointers.
+  Used by direct calls and graph preflight before temporary allocation."
+  [artifact arguments]
+  (let [artifact (kart/validate! artifact)
+        arguments (kabi/validate-arguments! (:abi artifact) arguments)]
+    (doseq [[slot compiler-value value] (map vector (:abi artifact) (:arguments artifact) arguments)
+            :when (= :scalar (:kind slot))]
+      (validate-scalar-value! slot value)
+      (when (and (contains? #{:int :long} (:kernel-dtype slot))
+                 (integer? compiler-value) (not= compiler-value (:value value)))
+        (throw (ex-info "kernel scalar differs from its literal specialization"
+                        {:reason :kernel-scalar-specialization :slot slot
+                         :expected compiler-value :actual (:value value)}))))
+    (let [scalars (into {} (keep (fn [[slot value]]
+                                  (when (= :scalar (:kind slot)) [(:name slot) (:value value)])))
+                        (map vector (:abi artifact) arguments))]
+      (precondition/check! (:preconditions artifact) scalars))))
+
 (defn realize-launch
   "Realize an artifact's launch from a complete ABI-ordered runtime argument vector.
 
    This deliberately does not construct a KernelCall: compatibility staging may reserve the
    artifact's result pointer itself, but it must still honor the exact symbolic launch (including
-   occupancy caps) before that allocation exists. Scalar representation and pointer checks remain
-   the caller's responsibility and KernelCall performs them for resident execution."
+   occupancy caps) before that allocation exists. Scalar representations, specializations and
+   preconditions are checked here; KernelCall checks resident pointers when they exist."
   [artifact arguments]
   (let [artifact (kart/validate! artifact)
         arguments (kabi/validate-arguments! (:abi artifact) arguments)
+        _ (validate-preconditions! artifact arguments)
         geometry (klaunch/realize (:launch artifact) (argument-resolver artifact arguments))]
     (validate-body-launch! artifact geometry)))
 
@@ -280,9 +307,7 @@
          arguments (kabi/validate-arguments! (:abi artifact) arguments)
          ;; Extent/range checks precede launch realization.  Otherwise a negative bound can first
          ;; fail as an incidental zero-sized grid—or, for a clamped schedule, realize a valid grid.
-         _ (doseq [[slot value] (map vector (:abi artifact) arguments)
-                   :when (= :scalar (:kind slot))]
-             (scalar-value! slot value))
+         _ (validate-preconditions! artifact arguments)
          resolver (or resolve-value (argument-resolver artifact arguments))
          ;; An override replaces the group vector; check its final geometry below, not the
          ;; unused default grid. Staging callers of realize-launch have no such override.
@@ -318,7 +343,7 @@
   [call registered]
   (let [artifact (:artifact (validate! call))
         registered (kart/validate! registered)
-        compiler-fields [:kernel-name :target :source :abi :arguments :launch :temporaries
+        compiler-fields [:kernel-name :target :source :abi :arguments :launch :preconditions :temporaries
                          :effects :provenance :attributes]]
     (when-not (= (select-keys artifact compiler-fields)
                  (select-keys registered compiler-fields))

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -6,7 +6,8 @@
    only in its emitted schedule. Selection is pure data evaluated after symbolic ABI scalars
    become concrete and before a backend binder sees the selected executable."
   (:require [raster.compiler.ir.kernel-executable :as kexec]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.kernel-precondition :as precondition]))
 
 (defrecord KernelDispatch
            [id
@@ -111,7 +112,7 @@
             (throw (ex-info "kernel dispatch expression case has invalid fields"
                             {:id (:id dispatch) :index index :rule rule})))
           (validate-expression! [:cases index] (:expression rule))
-          (when-not (contains? #{:< :<= := :>= :>} (:op rule))
+          (when-not (contains? precondition/comparison-ops (:op rule))
             (throw (ex-info "kernel dispatch expression case has an invalid comparison"
                             {:id (:id dispatch) :index index :op (:op rule)})))
           (when-not (finite-number? (:value rule))
@@ -183,7 +184,7 @@
       ;; denotes the same emitted module/signature; otherwise backend registration is ambiguous.
       (doseq [[kernel-name entries] (group-by first named-artifacts)]
         (let [implementations (set (map (fn [[_ artifact]]
-                                          (select-keys artifact [:target :source :abi :arguments]))
+                                          (select-keys artifact [:target :source :abi :arguments :preconditions]))
                                         entries))]
           (when-not (= 1 (count implementations))
             (throw (ex-info "kernel dispatch reuses an entry point for conflicting modules"
@@ -228,15 +229,6 @@
 (defn- runtime-number
   [value]
   (if (and (map? value) (contains? value :value)) (:value value) value))
-
-(defn- compare-value?
-  [op actual expected]
-  (case op
-    :< (< actual expected)
-    :<= (<= actual expected)
-    := (= actual expected)
-    :>= (>= actual expected)
-    :> (> actual expected)))
 
 (defn select-alternative
   "Select an executable alternative from concrete ABI-ordered values.
@@ -287,7 +279,7 @@
 
               :runtime-expression-cases
               (or (some (fn [{:keys [expression op value strategy]}]
-                          (when (compare-value?
+                          (when (precondition/compare-value?
                                  op
                                  (klaunch/resolve-expression environment expression)
                                  value)

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -52,13 +52,14 @@
         (throw (ex-info "graph symbolic scalar requires an explicitly typed runtime value"
                         {:reason :kernel-graph-call-scalar-type
                          :argument argument :slot slot :value value})))
-      (when-not (= (:dtype slot) (:type value))
+      (when-not (contains? (set [(:dtype slot) (:kernel-dtype slot)]) (:type value))
         (throw (ex-info "kernel graph scalar argument has the wrong ABI dtype"
                         {:reason :kernel-graph-call-scalar-type
                          :argument argument :slot slot :value value})))
-      ;; The graph boundary accepts the logical public dtype. Each node converts and validates
-      ;; its own physical ABI below; validate the original value before any such conversion.
-      (kcall/validate-scalar-value! (assoc slot :kernel-dtype (:dtype slot)) value))
+      ;; Direct graph callers may provide the logical dtype; the common KernelExecutable binder
+      ;; provides the slot's physical dtype. Validate the supplied declared representation before
+      ;; any node-specific conversion. Neither path accepts an unrelated type or unchecked range.
+      (kcall/validate-scalar-value! (assoc slot :kernel-dtype (:type value)) value))
     scalar-values))
 
 (defn- scalar-number

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -55,7 +55,8 @@
       (when-not (= (:kernel-dtype slot) (:type value))
         (throw (ex-info "kernel graph scalar argument has the wrong ABI dtype"
                         {:reason :kernel-graph-call-scalar-type
-                         :argument argument :slot slot :value value}))))
+                         :argument argument :slot slot :value value})))
+      (kcall/validate-scalar-value! slot value))
     scalar-values))
 
 (defn- scalar-number
@@ -76,10 +77,12 @@
   [scalar-values expression]
   (klaunch/resolve-expression #(scalar-number scalar-values %) expression))
 
+(declare preflight!)
+
 (defn temporary-specs
   "Resolve graph-owned temporary storage to core allocation specs: `{id [dtype elements nil]}`."
   [graph scalar-values]
-  (let [graph (kgraph/validate! graph)]
+  (let [graph (preflight! graph scalar-values)]
     (into {}
           (map (fn [{:keys [id dtype elements]}]
                  (let [n (resolve-integer scalar-values elements)]
@@ -114,6 +117,22 @@
     (let [value (resolve-integer scalar-values compiler-value)]
       {:type (:kernel-dtype slot)
        :value (cast-scalar (:kernel-dtype slot) value)})))
+
+(defn preflight!
+  "Check every node's scalar ABI and preconditions before graph-owned allocation.
+  Enclosing-program shape values remain available for storage sizing, not as extra call arguments."
+  [graph scalar-values]
+  (let [graph (executable/validate! graph)
+        public-values (select-keys scalar-values (map second (scalar-interface graph)))
+        _ (validate-scalar-values! graph public-values)]
+    (doseq [{:keys [operation]} (:nodes graph)]
+      (let [artifact (kart/validate! operation)
+            arguments (mapv (fn [slot compiler-value]
+                              (when (= :scalar (:kind slot))
+                                (scalar-argument public-values slot compiler-value)))
+                            (:abi artifact) (:arguments artifact))]
+        (kcall/validate-preconditions! artifact arguments)))
+    graph))
 
 (defn validate!
   "Validate and return a KernelGraphCall."

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -52,11 +52,13 @@
         (throw (ex-info "graph symbolic scalar requires an explicitly typed runtime value"
                         {:reason :kernel-graph-call-scalar-type
                          :argument argument :slot slot :value value})))
-      (when-not (= (:kernel-dtype slot) (:type value))
+      (when-not (= (:dtype slot) (:type value))
         (throw (ex-info "kernel graph scalar argument has the wrong ABI dtype"
                         {:reason :kernel-graph-call-scalar-type
                          :argument argument :slot slot :value value})))
-      (kcall/validate-scalar-value! slot value))
+      ;; The graph boundary accepts the logical public dtype. Each node converts and validates
+      ;; its own physical ABI below; validate the original value before any such conversion.
+      (kcall/validate-scalar-value! (assoc slot :kernel-dtype (:dtype slot)) value))
     scalar-values))
 
 (defn- scalar-number
@@ -92,13 +94,11 @@
                    [id [dtype n nil]])))
           (:temporaries graph))))
 
-(defn- cast-scalar
-  [dtype value]
-  (case dtype
-    :int (Math/toIntExact (long value))
-    :long (long value)
-    (throw (ex-info "derived graph scalar is only defined for integer ABI slots"
-                    {:dtype dtype :value value}))))
+(defn- physical-scalar
+  [slot value]
+  (let [typed {:type (:kernel-dtype slot) :value value}]
+    (kcall/validate-scalar-value! slot typed)
+    (executable/physical-runtime-scalar slot typed)))
 
 (defn- scalar-argument
   [scalar-values slot compiler-value]
@@ -110,13 +110,11 @@
       (if (= (:type value) (:kernel-dtype slot))
         value
         (if (every? #{:int :long} [(:type value) (:kernel-dtype slot)])
-          (executable/physical-runtime-scalar slot (:value value))
+          (physical-scalar slot (:value value))
           (throw (ex-info "graph scalar requires an unsupported physical conversion"
                           {:reason :kernel-graph-call-scalar-conversion
                            :slot slot :value value})))))
-    (let [value (resolve-integer scalar-values compiler-value)]
-      {:type (:kernel-dtype slot)
-       :value (cast-scalar (:kernel-dtype slot) value)})))
+    (physical-scalar slot (resolve-integer scalar-values compiler-value))))
 
 (defn preflight!
   "Check every node's scalar ABI and preconditions before graph-owned allocation.

--- a/src/raster/compiler/ir/kernel_precondition.clj
+++ b/src/raster/compiler/ir/kernel_precondition.clj
@@ -1,0 +1,45 @@
+(ns raster.compiler.ir.kernel-precondition
+  "Checked scalar-expression preconditions on an executable, independent of algorithm or target.
+  Expressions use the existing launch/storage algebra; this is not another numerical IR."
+  (:require [raster.compiler.ir.kernel-launch :as launch]))
+
+(def comparison-ops #{:< :<= := :!= :>= :>})
+
+(defn compare-value? [op actual expected]
+  (case op
+    :< (< actual expected)
+    :<= (<= actual expected)
+    := (= actual expected)
+    :!= (not= actual expected)
+    :>= (>= actual expected)
+    :> (> actual expected)))
+
+(defn validate!
+  "Validate ordered constraints against integral ABI slot names, not caller argument expressions.
+  This keeps a derived or privately specialized scalar tied to its actual physical value."
+  [conditions scalar-identities]
+  (when-not (vector? conditions)
+    (throw (ex-info "kernel preconditions must be an ordered vector"
+                    {:reason :kernel-preconditions :conditions conditions})))
+  (doseq [{:keys [expression op value] :as condition} conditions]
+    (when-not (and (map? condition) (= #{:expression :op :value} (set (keys condition)))
+                   (launch/expression? expression) (contains? comparison-ops op)
+                   (integer? value) (<= Long/MIN_VALUE value Long/MAX_VALUE))
+      (throw (ex-info "kernel precondition requires a checked integer comparison"
+                      {:reason :kernel-precondition-invalid :condition condition})))
+    (when-not (every? scalar-identities (launch/expression-references expression))
+      (throw (ex-info "kernel precondition references values outside the integral scalar ABI"
+                      {:reason :kernel-precondition-scope :condition condition
+                       :scalar-identities scalar-identities}))))
+  conditions)
+
+(defn check!
+  "Check in order, before allocation or launch. Arithmetic retains checked overflow semantics."
+  [conditions resolve-value]
+  (doseq [{:keys [expression op value] :as condition} conditions]
+    (let [actual (launch/resolve-expression resolve-value expression)]
+      (when-not (compare-value? op actual value)
+        (throw (ex-info "kernel scalar precondition failed"
+                        {:reason :kernel-precondition-failed
+                         :condition condition :actual actual})))))
+  true)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1032,7 +1032,7 @@
                    {:family family
                     :strategy strategy
                     :artifact (-> (select-keys artifact
-                                               [:target :source :abi :arguments :launch :effects])
+                                               [:target :source :abi :arguments :launch :preconditions :effects])
                                   (update :source str/replace kernel-name "<entry-point>"))}))
                candidates)]]
     (format "raster_typed_contraction_dispatch_%08x"

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1667,9 +1667,10 @@
   [param-syms scalar-lets expr]
   (let [clean-params (mapv strip-meta param-syms)
         clean-lets (vec (map-indexed (fn [i x] (if (even? i) (strip-meta x) x)) scalar-lets))]
-    (if (klaunch/index-algebra? expr)
-      ;; A scheduled body may project its extent as KernelBody index algebra. Evaluate it with
-      ;; the launch resolver over the same parameter/scalar-let environment instead of handing
+    (if (and (record? expr) (klaunch/expression? expr))
+      ;; A scheduled body may project its extent as launch/storage or KernelBody index algebra.
+      ;; Evaluate every structured expression through the checked launch resolver over the same
+      ;; parameter/scalar-let environment instead of handing
       ;; a compiler record to the runtime binder as if it were a number.
       (let [symbol-fn (memoize (fn [sym] (expr->arg-fn param-syms scalar-lets sym)))]
         (fn [args]

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -13,7 +13,7 @@
   (:import [java.nio.charset StandardCharsets]
            [java.security MessageDigest]))
 
-(def tuning-version 2)
+(def tuning-version 3)
 
 (defrecord DispatchTuning
            [key identity selector measurements])
@@ -59,10 +59,10 @@
                                     :dependencies (:dependencies node)
                                     :artifact (select-keys (:operation node)
                                                            [:kernel-name :target :source :abi
-                                                            :arguments :launch :temporaries])})
+                                                            :arguments :launch :preconditions :temporaries])})
                                  (:nodes executable))}
                    (select-keys executable
-                                [:kernel-name :target :source :launch :temporaries]))]
+                                [:kernel-name :target :source :launch :preconditions :temporaries]))]
     {:kind (kexec/kind executable)
      :strategy (kdispatch/alternative-strategy executable)
      :target (kexec/target executable)

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -321,7 +321,7 @@
         (is (= :scheduled-kernel-body-scalar-bindings (:reason (ex-data exception))))))
     (try
       (graph-call/make emitted {'u :resident-u 'du :resident-du}
-                       {'n {:type :int :value (inc (long Integer/MAX_VALUE))}})
+                       {'n {:type :long :value (inc (long Integer/MAX_VALUE))}})
       (is false "a proved narrowing still rejects an out-of-range runtime extent")
       (catch clojure.lang.ExceptionInfo exception
         (is (= :kernel-scalar-range (:reason (ex-data exception))))))))

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -7,6 +7,7 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.dispatch-tuning :as tuning]
             [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.resident-value :as resident-value]
             [raster.gpu.ze-runtime :as ze]))
@@ -25,6 +26,56 @@
 
 (def ^:private args
   [:resident-x :resident-out {:type :float :value 2.0} {:type :int :value 513}])
+
+(deftest scalar-preconditions-cannot-be-bypassed-by-direct-calls-or-launch-overrides
+  (let [constrained (assoc artifact :preconditions [{:expression 'n :op :>= :value 64}
+                                                   {:expression 'n :op :<= :value 1024}])
+        bad (assoc args 3 {:type :int :value 32})
+        raw (assoc (kcall/make artifact bad) :artifact constrained)]
+    (is (kcall/kernel-call? (kcall/make constrained args)))
+    (is (true? (kcall/validate-preconditions! constrained (assoc args 0 nil 1 nil)))
+        "scalar preflight does not need allocated pointers")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs from the registered artifact"
+                          (kcall/validate-registered! (kcall/make constrained args) artifact)))
+    (doseq [call [#(kcall/make constrained bad)
+                  #(kcall/make constrained bad {:group-count [1]})
+                  #(kcall/realize-launch constrained bad)
+                  #(kcall/validate! raw)]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar precondition failed" (call))))
+    (is (not= (:source-hash (tuning/executable-signature artifact))
+              (:source-hash (tuning/executable-signature constrained)))
+        "constraints participate in tuning identity")))
+
+(deftest preconditions-use-only-integral-scalar-abi-values
+  (doseq [expression ['missing 'x 'scale]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside the integral scalar ABI"
+                          (kart/validate! (assoc artifact :preconditions
+                                                 [{:expression expression :op :>= :value 1}])))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"checked integer comparison"
+                        (kart/validate! (assoc artifact :preconditions
+                                               [{:expression 'n :op :eval :value 1}])))))
+
+(deftest preconditions-preserve-checked-arithmetic-and-order
+  (let [overflow (klaunch/product Long/MAX_VALUE 2)
+        guarded (assoc artifact :preconditions [{:expression 'n :op :>= :value 64}
+                                                {:expression overflow :op :>= :value 0}])]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar precondition failed"
+                          (kcall/make guarded (assoc args 3 {:type :int :value 32}))))
+    (is (thrown? ArithmeticException (kcall/make guarded args)))))
+
+(deftest preconditions-cannot-hide-invalid-long-values-or-literal-specializations
+  (let [wide (kart/make {:kernel-name "wide_guard" :source "__kernel void wide_guard(__global float* out, long n) {}"
+                         :abi [(kabi/slot 'out :output :float) (kabi/slot 'n :scalar :long)]
+                         :arguments ['out 'n]
+                         :launch (klaunch/spec {:workgroup-size [1] :group-count [1]})
+                         :preconditions [{:expression 'n :op :>= :value 0}]})]
+    (doseq [value [1.5 (inc' Long/MAX_VALUE) (dec' Long/MIN_VALUE)]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
+                            (kcall/make wide [:out {:type :long :value value}]))))
+    (let [literal (assoc wide :arguments ['out 64] :preconditions [{:expression 64 :op :>= :value 64}])]
+      (is (kcall/kernel-call? (kcall/make literal [:out {:type :long :value 64}])))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"literal specialization"
+                            (kcall/make literal [:out {:type :long :value 32}]))))))
 
 (deftest scheduled-call-overrides-cannot-overflow-hardware-indices
   (let [kernel (body/make

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
@@ -46,6 +47,26 @@
                :threshold 256
                :at-least :subgroup-score-reuse
                :otherwise :reference}}))
+
+(deftest forced-and-cached-choices-still-enforce-binding-preconditions
+  (let [guarded (assoc subgroup :preconditions [{:expression 'width :op :>= :value 256}])
+        choice (assoc dispatch :alternatives [reference guarded])
+        arguments [:x :out {:type :long :value 32}]
+        fixed (assoc choice :selector {:kind :fixed-strategy :strategy :subgroup-score-reuse})]
+    (is (= reference (kdispatch/select-alternative choice arguments)))
+    (doseq [selected [(kdispatch/select-alternative choice arguments :subgroup-score-reuse)
+                      (kdispatch/select-alternative fixed arguments)]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar precondition failed"
+                            (kcall/make selected arguments))))))
+
+(deftest shared-entry-points-cannot-hide-different-preconditions
+  (let [a (artifact "shared_constraint_entry" :a 64)
+        b (assoc (artifact "shared_constraint_entry" :b 64)
+                 :preconditions [{:expression 'width :op :>= :value 256}])]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting modules"
+                          (kdispatch/make {:id "conflicting-constraints" :alternatives [a b]
+                                           :default-strategy :a
+                                           :selector {:kind :fixed-strategy :strategy :a}})))))
 
 (deftest logical-scalars-narrow-only-at-the-target-abi
   (let [narrowed (assoc-in reference [:abi 2 :kernel-dtype] :int)]

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -40,7 +40,7 @@
                   (update :scalars #(mapv (fn [scalar] (assoc scalar :dtype :long)) %))
                   (update :abi #(mapv (fn [slot]
                                        (if (= :scalar (:kind slot))
-                                         (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
+                                         (assoc slot :dtype :long) slot)) %))
                   (update :nodes
                           #(mapv (fn [node]
                                    (update-in node [:operation :abi]

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -49,6 +49,10 @@
                                                         (if (= :scalar (:kind slot))
                                                           (assoc slot :dtype :long) slot)) slots)))) %)))]
     (is (= graph (graph-call/preflight! graph {'n {:type :long :value 1025}})))
+    (is (= graph (graph-call/preflight! graph {'n {:type :int :value 1025}}))
+        "the common executable binder may supply the public slot's physical representation")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"wrong ABI dtype"
+                          (graph-call/preflight! graph {'n {:type :float :value 1025.0}})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/preflight! graph
                                                  {'n {:type :long :value (+' (bigint Long/MAX_VALUE) 2)}})))))

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -17,6 +17,42 @@
      (lower/scan-kernel-graph
       node operations {:array-types {'values :float 'out :float}}))))
 
+(deftest scalar-preconditions-precede-temporary-sizing
+  (let [graph (assoc-in (emitted-graph) [:nodes 0 :operation :preconditions]
+                        [{:expression '_n_bound :op :>= :value 64}])]
+    (is (= graph (graph-call/preflight! graph {'n {:type :int :value 1025}})))
+    (with-redefs [graph-call/resolve-integer
+                  (fn [& _] (throw (ex-info "temporary sizing happened first" {})))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar precondition failed"
+                            (graph-call/temporary-specs graph {'n {:type :int :value 32}}))))))
+
+(deftest later-node-preconditions-resolve-derived-physical-scalars
+  (let [graph (emitted-graph)
+        derived-slot (:name (last (get-in graph [:nodes 1 :operation :abi])))
+        guarded (assoc-in graph [:nodes 1 :operation :preconditions]
+                          [{:expression derived-slot :op :>= :value 5}])]
+    (is (= guarded (graph-call/preflight! guarded {'n {:type :int :value 1025}})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar precondition failed"
+                          (graph-call/temporary-specs guarded {'n {:type :int :value 1000}})))))
+
+(deftest public-long-scalars-are-validated-before-private-conversion
+  (let [graph (-> (emitted-graph)
+                  (update :scalars #(mapv (fn [scalar] (assoc scalar :dtype :long)) %))
+                  (update :abi #(mapv (fn [slot]
+                                       (if (= :scalar (:kind slot))
+                                         (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
+                  (update :nodes
+                          #(mapv (fn [node]
+                                   (update-in node [:operation :abi]
+                                              (fn [slots]
+                                                (mapv (fn [slot]
+                                                        (if (= :scalar (:kind slot))
+                                                          (assoc slot :dtype :long) slot)) slots)))) %)))]
+    (is (= graph (graph-call/preflight! graph {'n {:type :long :value 1025}})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
+                          (graph-call/preflight! graph
+                                                 {'n {:type :long :value (+' (bigint Long/MAX_VALUE) 2)}})))))
+
 (deftest emitted-graph-becomes-an-ordered-vector-of-kernel-calls
   (let [graph (emitted-graph)
         ids (set (map :id (concat (:inputs graph) (:outputs graph) (:temporaries graph))))

--- a/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
+++ b/test/raster/compiler/passes/parallel/full_reduction_device_test.clj
@@ -54,7 +54,7 @@
                [(:kernel-dtype slot) (:type value) (:value value)])]
     (is (= graph (executable/validate! graph)))
     (is (= #{[:int :int 1025] [:long :long 1025]} (set uses)))
-    (is (thrown? ArithmeticException
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside its physical ABI range"
                  (graph-call/make graph buffers {'n {:type :long :value (inc (long Integer/MAX_VALUE))}})))
     (is (thrown? clojure.lang.ExceptionInfo
                  (graph-call/make graph buffers {'n {:type :long :value -1}})))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -18,6 +18,15 @@
 
 (def ^:private nr-key :raster.compiler.pipeline/non-resident)
 
+(deftest structured-scalar-arguments-are-realized-with-checked-arithmetic
+  (let [compile-arg (deref #'pipeline/expr->arg-fn)
+        product (compile-arg '[rows width] '[extent (* rows width)]
+                             (klaunch/product 'extent 2))
+        rounded (compile-arg '[n] [] (klaunch/ceil-div (klaunch/product 'n 3) 16))]
+    (is (= 30 (product [3 5])))
+    (is (= 4 (rounded [17])))
+    (is (thrown? ArithmeticException (rounded [Long/MAX_VALUE])))))
+
 (defn- why [form] (get-in (pipeline/extract-gpu-program form) [nr-key :why]))
 
 (deftest effect-only-executable-results-never-alias-an-output-buffer


### PR DESCRIPTION
Adds target-neutral scalar preconditions using the existing checked launch/storage algebra and physical ABI slot names. Validates int/long ranges and literal specializations before conversion, preflights every graph node before scratch allocation, and retains constraints in registry and tuning identities. Forced or cached choices cannot bypass binding checks.

Validation: 65 focused tests, 374 assertions, all passing in one capped REPL. Independent review completed; full suites and vendor compiler gates delegated to CI.

This is enforcement infrastructure, not yet the Intel matrix legality fix. The campaign explicitly tracks minimum surface widths, pitch/coordinate bounds, base and view alignment, and wide output addressing as the next consumer. Retained-Long DPAS admission remains closed.