### PR TITLE
Enforce Intel matrix surface and input-view alignment contracts

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -447,7 +447,17 @@ and artifact binding. The [Intel 2D block-I/O specification](https://registry.kh
 requires at least 64-byte row widths and 64-byte base alignment; the existing tiny FP16 N/K=16
 device cases do not establish legality despite passing this driver. Validate surface maxima,
 pitch and view-slice alignment as well, widen linear output arithmetic, and keep the retained-Long
-DPAS admission gate closed until the complete contract is enforced. These target fixes remain open.
+DPAS admission gate closed until the complete contract is enforced.
+
+The Intel surface-contract slice derives checked bounds and pitch/fragment divisibility once for
+static admission, runtime fallback and artifact binding. A/B bases require 64-byte alignment;
+leading input views additionally require 32-half-element slice strides, while shared operands and
+scalar C stores are not over-aligned. Projection verification rejects stripped requirements.
+Intel block-I/O now admits subgroup 16 only, and C linear stores widen before multiplication.
+Focused Arc direct, split-K, batched/shared-weight and fused-SSA-epilogue execution passes with
+legal surface widths. Non-allocating tests cover maximum surfaces and rejected odd-height/K48
+batched slices. This does not admit retained Long dimensions or prove legacy ScalarRegion source
+epilogue indexing safe at large sizes; production SSA epilogues retain typed storage addressing.
 
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -13,6 +13,7 @@
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -930,12 +931,12 @@
      :refinement refinement
      :selector
      {:kind :runtime-expression-cases
-      :cases [{:expression n :op :< :value 8 :strategy :f32-scalar}
-              {:expression k :op :< :value 8 :strategy :f32-scalar}
-              {:expression (kbody/expression :mod n 8)
-               :op :> :value 0 :strategy :f32-scalar}
-              {:expression (kbody/expression :mod k (get-in tile [:matrix :k]))
-               :op :> :value 0 :strategy :f32-scalar}]
+      :cases (block-io/fallback-cases
+              (block-io/matrix-preconditions
+               m n k (cond-> []
+                       (get batching :row true) (conj (klaunch/product m k))
+                       (get batching :col true) (conj (klaunch/product k n))))
+              :f32-scalar)
       :default :xmx-batched}}))
 
 (defn requested-splits
@@ -970,7 +971,7 @@
         backend (:backend desc)]
     (when (and (contains? #{:ze :opencl} backend)
                (= :dpas family) (= [8 16 16] [m n k])
-               (contains? #{8 16} subgroup)
+               (= 16 subgroup)
                (contains? (hardware/supported-subgroup-sizes desc) (long subgroup)))
       (let [tile (or requested-tile (hardware/gemm-tile-for desc))
             workgroup-size (* (quot (:block-m tile) (:sg-m tile))
@@ -1023,12 +1024,7 @@
                                     :requested-splits factor)))
                 split-factors))
         alignment-cases
-        [{:expression n :op :< :value 8 :strategy :f32-scalar}
-         {:expression k :op :< :value 8 :strategy :f32-scalar}
-         {:expression (kbody/expression :mod n 8)
-          :op :> :value 0 :strategy :f32-scalar}
-         {:expression (kbody/expression :mod k (get-in tile [:matrix :k]))
-          :op :> :value 0 :strategy :f32-scalar}]
+        (block-io/fallback-cases (block-io/matrix-preconditions m n k) :f32-scalar)
         selector {:kind :runtime-expression-cases
                   :cases (cond-> alignment-cases
                            split? (conj {:expression split-expression :op :>= :value 2

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -192,7 +192,7 @@
         {mi :m ni :n ki :k subgroup :subgroup} instruction]
     (require! (and (= :dpas (:family instruction))
                    (= 8 mi) (= 16 ki)
-                   (contains? #{8 16} subgroup)
+                   (= 16 subgroup)
                    (= ni subgroup))
               "Intel OpenCL lowering has no builtin for this matrix instruction"
               {:instruction instruction})
@@ -328,9 +328,9 @@
                             (let [acc-expr (str "acc" m n ".s" i)]
                               (str "        { int col = n_base" n " + sg_lid;\n          if (col < N) "
                                    (if epilogue
-                                     (str "C[row*N+col] = " store-cast "("
+                                     (str "C[(long)row*(long)N+(long)col] = " store-cast "("
                                           (epilogue acc-expr "row" "col") ");\n")
-                                     (str "C[row*N+col] = " store-cast "(" acc-expr ");\n"))
+                                     (str "C[(long)row*(long)N+(long)col] = " store-cast "(" acc-expr ");\n"))
                                    "        }\n"))))
                    "      }\n    }\n")))
      "}\n")))

--- a/src/raster/compiler/backend/gpu/kernel_body_target.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_target.clj
@@ -139,6 +139,7 @@
         :source (:source emitted)
         :abi projected-abi
         :arguments (:arguments scheduled)
+        :preconditions (or (:preconditions emitted) [])
         :launch (scheduled-body/realized-launch scheduled)
         :temporaries []
         :effects (:effects scheduled)

--- a/src/raster/compiler/backend/gpu/matrix_target.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target.clj
@@ -10,6 +10,7 @@
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.kernel-body :as kernel-body]))
 
 (defn- target-parameter-names
@@ -71,8 +72,10 @@
   [body target-dialect plan]
   (let [body (kernel-body/validate! body)
         dialect (c-dialect/resolve! target-dialect)
-        pointer-alignment (when (= :cuda (:id dialect)) 32)]
-    {:parameter-alignments
+        pointer-alignment (when (= :cuda (:id dialect)) 32)
+        intel? (= :opencl-intel (:id dialect))
+        requirements (when intel? (block-io/body-requirements body))]
+    (merge {:preconditions [] :parameter-alignments
      (into {}
            (keep (fn [{:keys [id kind]}]
                    (when (and pointer-alignment (not= :scalar kind))
@@ -82,7 +85,8 @@
      {:target-dialect (:id dialect)
       :instruction (:instruction plan)
       :instruction-family (get-in plan [:instruction :family])
-      :pointer-alignment pointer-alignment}}))
+      :pointer-alignment pointer-alignment}}
+           requirements)))
 
 (defn emit-matrix-kernel
   "Emit `body` for one C-family target dialect.

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -18,6 +18,7 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.core.dtype :as dt]
             [raster.compiler.core.hardware :as hw]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as cstage]
             [raster.compiler.ir.contraction-facts :as cf]
@@ -1374,7 +1375,8 @@
    K=124) SILENTLY MISCOMPILES ~80% of outputs (device-verified) — production GEMM shapes
    (N∈{640,1024,2048}) are all N%8==0 so never hit it, but a general contraction can, and
    the gate must reject it so the caller falls back to the register-tiled kernel (which
-   handles arbitrary dims). M (the block-read HEIGHT) is unconstrained. Transposed operands
+   handles arbitrary dims). The shared surface contract also bounds M, N and K and requires
+   complete K16 fragments. Pointer alignment is enforced by the target artifact. Transposed operands
    (:tn/:nt) and a batch axis are legal extensions the golden body already has flags for —
    rejected here as :non-canonical-orientation / :not-a-contraction until wired."
   [segred dtype]
@@ -1394,6 +1396,9 @@
             {:ok false :reason :n-pitch-unaligned :N N}
             (not (pitch-ok? L))   ; A pitch = K·2 bytes must be 16-byte aligned
             {:ok false :reason :k-pitch-unaligned :L L}
+            (block-io/static-failure M N L)
+            {:ok false :reason :matrix-surface-contract
+             :condition (block-io/static-failure M N L)}
             :else
             ;; i-sym/j-sym are the FREE axes; an epilogue binds them to the store slot's row/col
             {:ok true :M M :N N :L L :i-sym i-sym :j-sym j-sym

--- a/src/raster/compiler/core/intel_block_io.clj
+++ b/src/raster/compiler/core/intel_block_io.clj
@@ -1,0 +1,62 @@
+(ns raster.compiler.core.intel-block-io
+  "Physical constraints for Intel's row-major FP16 matrix block-I/O lowering.
+
+  These are target requirements, not tensor semantics. All scalar conditions use the existing
+  checked executable expression algebra. See cl_intel_subgroup_2d_block_io §6.13.X.6."
+  (:require [clojure.walk :as walk]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-precondition :as precondition]))
+
+(defn matrix-preconditions
+  "Conditions on the two dense half surfaces A[M,K] and B[K,N]. Optional slice strides are in
+  elements and describe rebasing an input pointer between workgroups, not the scalar C stores."
+  ([m n k] (matrix-preconditions m n k []))
+  ([m n k input-slice-strides]
+   (into [{:expression m :op :>= :value 1}
+          {:expression m :op :<= :value 16777216}
+          {:expression n :op :>= :value 32}
+          {:expression n :op :<= :value 8388608}
+          {:expression k :op :>= :value 32}
+          {:expression k :op :<= :value 8388608}
+          {:expression (body/expression :mod n 8) :op := :value 0}
+          ;; The K16 instruction consumes whole fragments, beyond the pitch requirement.
+          {:expression (body/expression :mod k 16) :op := :value 0}]
+         (map (fn [stride]
+                {:expression (body/expression :mod stride 32) :op := :value 0}))
+         input-slice-strides)))
+
+(defn fallback-cases
+  "Turn the conjunction into ordered failure cases without duplicating its bounds."
+  [conditions strategy]
+  (mapv (fn [condition]
+          (-> condition
+              (update :op {:< :>= :<= :> := :!= :!= := :>= :< :> :<=})
+              (assoc :strategy strategy)))
+        conditions))
+
+(defn body-requirements
+  "Project the physical contract from a validated canonical matrix body. Matrix-plan analysis
+  separately verifies its row-major operands and leading-slice views before target emission."
+  [kernel-body]
+  (let [kernel-body (body/validate! kernel-body)
+        {:keys [m n k]} (get-in kernel-body [:attributes :dimension-parameters])
+        inputs (into #{} (comp (filter #(contains? #{:lhs :rhs} (:role %))) (map :id))
+                     (:parameters kernel-body))
+        groups (into {} (comp (filter #(= :group (:source %))) (map #(vector (:id %) 1)))
+                     (:indices kernel-body))
+        strides (for [view (:views kernel-body) :when (contains? inputs (:buffer view))]
+                  (walk/postwalk-replace groups (:element-offset view)))]
+    {:preconditions (matrix-preconditions m n k strides)
+     :parameter-alignments (zipmap inputs (repeat 64))}))
+
+(defn static-failure
+  "Return the failed condition for concrete dimensions, otherwise leave runtime checks intact."
+  [m n k]
+  (when (every? integer? [m n k])
+    (try
+      (precondition/check! (matrix-preconditions m n k) {})
+      nil
+      (catch clojure.lang.ExceptionInfo failure
+        (if (= :kernel-precondition-failed (:reason (ex-data failure)))
+          (:condition (ex-data failure))
+          (throw failure))))))

--- a/src/raster/compiler/ir/scheduled_kernel_body.clj
+++ b/src/raster/compiler/ir/scheduled_kernel_body.clj
@@ -7,6 +7,7 @@
    they must not reconstruct any of these facts from operation names or generated source."
   (:require [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-graph :as graph]
@@ -266,6 +267,9 @@
         bindings (into {} (map (juxt :parameter identity)) (:scalar-bindings scheduled))
         target-facts (get-in emitted [:attributes :target-facts])
         pointer-alignment (:pointer-alignment target-facts)
+        intel-requirements (when (and (= :opencl-intel (:target-dialect target-facts))
+                                      (= :dpas (:instruction-family target-facts)))
+                             (block-io/body-requirements (:body scheduled)))
         expected-slots
         (body-abi/project-contracts
          (mapv (fn [index {:keys [id kind dtype role]}]
@@ -273,8 +277,9 @@
                    (abi/slot id kind (or (:dtype binding) dtype)
                              :kernel-dtype (or (:kernel-dtype binding) dtype)
                              :c-name (str "p" index) :role role
-                             :alignment (when (and pointer-alignment (not= :scalar kind))
-                                          pointer-alignment))))
+                             :alignment (or (get-in intel-requirements [:parameter-alignments id])
+                                            (when (and pointer-alignment (not= :scalar kind))
+                                              pointer-alignment)))))
                (range) parameters)
          (:body scheduled))
         fields [:kind :dtype :kernel-dtype :role :aliasing :alignment]
@@ -292,6 +297,7 @@
              [:effects (:effects scheduled) (:effects emitted)]
              [:launch (realized-launch scheduled) (:launch emitted)]
              [:body (:body scheduled) (get-in emitted [:attributes :kernel-body])]
+             [:preconditions (or (:preconditions intel-requirements) []) (:preconditions emitted)]
              [:abi expected-abi actual-abi]]]
       (when-not (= expected actual)
         (fail! :scheduled-kernel-body-artifact-projection

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -17,6 +17,7 @@
    :out-elems :wg/:grid (uniform 1-3D geometry) :scalar-args [{:type :value}…] :dims, plus optional
    :fallback-reason, :scheme (quant decode) and :pre-steps (inserted layout rearranges)."
   (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.core.op-descriptor :as od]
             [raster.compiler.core.util :as util]
             [clojure.string :as str]
@@ -1260,6 +1261,11 @@
        :decline {:reason :mixed-dpas-index-width-not-lowered
                  :dimensions @wide-dimensions :required-dtype :int}}
 
+      (apply block-io/static-failure (:dimensions matrix-view))
+      {:alternatives []
+       :decline {:reason :matrix-surface-contract
+                 :condition (apply block-io/static-failure (:dimensions matrix-view))}}
+
       :else
       (let [[m n k] (:dimensions matrix-view)
             {:keys [row col]} (:bindings matrix-view)
@@ -1417,7 +1423,7 @@
     :non-aget-operand :not-a-contraction :not-2-free :body-has-unmodeled-terms
     ;; dtype / orientation / alignment
     :dtype-not-dpas :non-canonical-orientation :n-pitch-unaligned :k-pitch-unaligned
-    :non-zero-matrix-init :partial-matrix-k-fragment :matrix-family-not-lowered
+    :non-zero-matrix-init :partial-matrix-k-fragment :matrix-family-not-lowered :matrix-surface-contract
     :matrix-instruction-not-lowered
     ;; declared-operand and quant-leaf legality
     :operand-without-a-declared-map :missing-declared-contract-axes

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -8,6 +8,7 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
@@ -28,7 +29,7 @@
 (defn- lowered-dpas-instruction?
   [{:keys [family m n k subgroup]}]
   (and (= :dpas family) (= 8 m) (= 16 k)
-       (contains? #{8 16} subgroup) (= n subgroup)))
+       (= 16 subgroup) (= n subgroup)))
 
 (defn- tile-valid?
   [{:keys [block-m block-n block-k sg-m sg-n matrix num-stages]}]
@@ -371,6 +372,9 @@
       ;; bounds final fragment.  Until a zero-filled fragment load exists, refuse it loudly.
        (not (zero? (mod (long K) (long matrix-k))))
        (decline :partial-matrix-k-fragment {:K K :matrix-k matrix-k})
+
+       (block-io/static-failure M N K)
+       (decline :matrix-surface-contract {:condition (block-io/static-failure M N K)})
 
       ;; Helper strings are target source pasted above a kernel and have no KernelBody meaning.
       ;; Refuse them so callers express the computation in the typed scalar expression instead.

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -12,6 +12,7 @@
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.kernel-precondition :as precondition]
             [raster.compiler.ir.layout-stage :as layout-stage]
             [raster.compiler.ir.matrix-stage :as matrix-stage]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
@@ -173,8 +174,9 @@
     (is (= :float (:dtype result)))
     (is (= (:source contract) (-> oracle
                                   (str/replace "int k =" "long k =")
-                                  (str/replace "int pk =" "long pk =")))
-        "direct lowering preserves the oracle except for explicitly widened K arithmetic")))
+                                  (str/replace "int pk =" "long pk =")
+                                  (str/replace "C[row*N+col]" "C[(long)row*(long)N+(long)col]")))
+        "direct lowering preserves the oracle except for widened K and output arithmetic")))
 
 (deftest production-xmx-epilogue-is-part-of-the-certified-stage
   (let [tile (hardware/derive-gemm-tile {})
@@ -193,12 +195,12 @@
         scheduled (artifact/attribute contract :scheduled-kernel-body)
         stage (:source scheduled)
         runtime-arguments [:a-buffer :b-buffer :c-buffer
-                           {:type :int :value 16} {:type :int :value 16}
-                           {:type :int :value 16} :bias-buffer
+                           {:type :int :value 16} {:type :int :value 32}
+                           {:type :int :value 32} :bias-buffer
                            {:type :float :value 0.5}]
         {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
         temporary-specs (graph-call/temporary-specs graph scalar-values)
-        temporaries (into {} (map (fn [id] [id [:temporary-buffer id]]))
+        temporaries (into {} (map (fn [id] [id {:id [:temporary-buffer id] :alignment 64}]))
                           (keys temporary-specs))
         call (graph-call/make graph (merge buffers temporaries) scalar-values)]
     (is (= 1 (count alternatives)) "a result transform intentionally disables split-K")
@@ -363,8 +365,29 @@
       (let [graph (dispatch/alternative (emitted variant) strategy)
             {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
             temporary-specs (graph-call/temporary-specs graph scalar-values)
-            temporary-buffers (into {} (map (fn [id] [id [:temporary-buffer id]]))
+            temporary-buffers (into {} (map (fn [id] [id {:id [:temporary-buffer id] :alignment 64}]))
                                     (keys temporary-specs))
             call (graph-call/make graph (merge buffers temporary-buffers) scalar-values)]
         (is (graph-call/kernel-graph-call? call) (str (name variant) "/" (name strategy)))
         (is (= (count (:nodes graph)) (count (:nodes call))))))))
+
+(deftest batched-input-slices-preserve-block-io-alignment-before-allocation
+  (doseq [row-batched? [true false]]
+    (let [{:keys [graph selector]}
+          (gemm/emit-batched-matrix-alternative
+           {:id [:slice-alignment row-batched?]
+            :a 'a :b 'b :c 'c :batch 'batch :m 'm :n 'n :k 'k
+            :variant :nn :tile (hardware/derive-gemm-tile {})
+            :batching {:row row-batched? :col false}})
+          values {'batch {:type :int :value 2} 'm {:type :int :value 3}
+                  'n {:type :int :value 40} 'k {:type :int :value 48}}
+          scalar-values (into {} (map (fn [[id value]] [id (:value value)])) values)
+          fallback? (some (fn [{:keys [expression op value]}]
+                            (precondition/compare-value?
+                             op (launch/resolve-expression scalar-values expression) value))
+                          (:cases selector))]
+      (is (= row-batched? (boolean fallback?)))
+      (if row-batched?
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
+                              (graph-call/temporary-specs graph values)))
+        (is (map? (graph-call/temporary-specs graph values)))))))

--- a/test/raster/compiler/backend/gpu/matrix_target_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_target_test.clj
@@ -26,6 +26,39 @@
     :dimensions [128 128 64] :dimension-parameters ['m 'n 'k]
     :tile (mma-tile) :result-dtype :float}))
 
+(deftest intel-matrix-artifact-binds-surface-and-input-alignment-contracts
+  (let [body (schedule/matrix-body
+              {:id :intel-surface-test :row 'a :col 'b :out 'c
+               :dimensions ['m 'n 'k] :dimension-parameters ['m 'n 'k]
+               :tile (hardware/derive-gemm-tile {}) :result-dtype :float})
+        scheduled (scheduled-body/make
+                   {:source :intel-surface-test :body body :arguments ['a 'b 'c 'm 'n 'k]
+                    :effects {:kind :tensor-contraction-stage
+                              :uses [{:value 'a :access :read} {:value 'b :access :read}
+                                     {:value 'c :access :write}]}
+                    :legality {:kind :matrix-instruction-tiling}
+                    :numerics {:mode :reassociated :policy :tiled-contraction
+                               :rounding :nearest-even :accumulator-dtype :float}})
+        artifact (body-target/emit-artifact "intel_surface" scheduled :opencl-intel)
+        args (fn [m n k] [{:id :a :alignment 64} {:id :b :alignment 64} {:id :c}
+                          {:type :int :value m} {:type :int :value n} {:type :int :value k}])]
+    (is (= [64 64 nil] (mapv :alignment (take 3 (:abi artifact)))))
+    (is (seq (:preconditions artifact)))
+    (is (kernel-call/kernel-call? (kernel-call/make artifact (args 17 40 48))))
+    (doseq [dims [[17 16 32] [17 32 16] [16777217 32 32] [17 8388616 32]]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
+                            (kernel-call/make artifact (apply args dims)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"alignment contract"
+                          (kernel-call/make artifact (assoc (args 17 40 48) 0
+                                                           {:id :misaligned :alignment 32}))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs from"
+                          (scheduled-body/validate-artifact-projection!
+                           scheduled (assoc artifact :preconditions []))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs from"
+                          (scheduled-body/validate-artifact-projection!
+                           scheduled (update-in artifact [:abi 0] dissoc :alignment))))
+    (is (clojure.string/includes? (:source artifact) "C[(long)row*(long)N+(long)col]"))))
+
 (deftest target-lowering-forks-after-one-verified-body
   (let [body (mma-body)
         cuda (matrix-target/emit-matrix-kernel "matrix_target_cuda" body :cuda)]

--- a/test/raster/compiler/core/intel_block_io_test.clj
+++ b/test/raster/compiler/core/intel_block_io_test.clj
@@ -1,0 +1,26 @@
+(ns raster.compiler.core.intel-block-io-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.intel-block-io :as block-io]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.kernel-precondition :as precondition]))
+
+(deftest surface-boundaries-are-independent-of-allocation
+  (doseq [dims [[1 32 32] [16777216 8388608 8388608] [17 40 48]]]
+    (is (nil? (apply block-io/static-failure dims))))
+  (doseq [dims [[0 32 32] [16777217 32 32] [1 16 32] [1 32 16]
+                [1 8388616 32] [1 32 8388624] [1 33 32] [1 32 40]]]
+    (is (some? (apply block-io/static-failure dims))))
+  (is (nil? (block-io/static-failure 'm 'n 'k))))
+
+(deftest selector-and-binding-share-the-same-conditions
+  (let [conditions (block-io/matrix-preconditions 'm 'n 'k [(launch/product 'm 'k)])
+        cases (block-io/fallback-cases conditions :portable)]
+    (doseq [values [{'m 1 'n 32 'k 32} {'m 3 'n 40 'k 48}
+                    {'m 4 'n 40 'k 48} {'m 4 'n 16 'k 32}]]
+      (let [binding-ok? (try (precondition/check! conditions values)
+                             (catch clojure.lang.ExceptionInfo _ false))
+            fallback? (boolean
+                       (some (fn [{:keys [expression op value]}]
+                               (precondition/compare-value?
+                                op (launch/resolve-expression values expression) value)) cases))]
+        (is (= binding-ok? (not fallback?)))))))

--- a/test/raster/compiler/passes/parallel/contract_route_device_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_route_device_test.clj
@@ -385,12 +385,12 @@
             "must still reproduce the hand-tuned Arc tile")
         (is (= [256 1] (:wg r)))
         (is (= [4 2] (:grid r)))))                     ; ceil(512/128), ceil(256/128)
-    (testing "a part with HALF the GRF and subgroup 8 gets a rescaled tile AND launch geometry"
-      (let [small {:matrix {:m 8 :n 8 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+    (testing "a part with HALF the GRF and legal subgroup 16 gets a rescaled tile AND launch geometry"
+      (let [small {:matrix {:m 8 :n 16 :k 16 :subgroup 16} :grf-bytes-per-lane 128}
             r (route/route-contraction mm :dtype :half :desc small)]
         (is (= {:block-m 64 :block-n 64 :sg-m 16 :sg-n 16 :block-k 32}
                (select-keys (:tile r) [:block-m :block-n :sg-m :sg-n :block-k])))
-        (is (= [128 1] (:wg r)) "workgroup = (bm/sgm)·(bn/sgn)·subgroup = 4·4·8")
+        (is (= [256 1] (:wg r)) "workgroup = (bm/sgm)·(bn/sgn)·subgroup = 4·4·16")
         (is (= [8 4] (:grid r)) "grid follows the smaller block tile")))
     (testing "an explicit tile (e.g. an autotune result) overrides the derivation"
       (let [t (hw {} {:wg-subgroups 4})
@@ -398,7 +398,12 @@
         (is (= t (:tile r)))
         (is (not= (:block-m (hw {})) (:block-m t)) "the override must actually differ")))
     (testing "the emitted kernel source carries the derived tile, not a constant"
-      (let [small {:matrix {:m 8 :n 8 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+      (let [small {:matrix {:m 8 :n 16 :k 16 :subgroup 16} :grf-bytes-per-lane 128}
             src (:source (route/route-contraction mm :dtype :half :desc small))]
-        (is (re-find #"intel_reqd_sub_group_size\(8\)" src)
-            "subgroup size must follow the descriptor into the kernel attribute")))))
+        (is (re-find #"intel_reqd_sub_group_size\(16\)" src)
+            "a supported subgroup size follows the descriptor into the kernel attribute")))
+    (testing "hardware descriptors cannot override the target instruction restrictions"
+      (let [unsupported {:matrix {:m 8 :n 8 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+            routed (route/route-contraction mm :dtype :half :desc unsupported)]
+        (is (= :regtiled (:strategy routed)))
+        (is (not (re-find #"intel_reqd_sub_group_size" (:source routed))))))))

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -131,6 +131,7 @@
     (is (= (-> (:source oracle)
                (str/replace "int k =" "long k =")
                (str/replace "int pk =" "long pk =")
+               (str/replace "C[row*N+col]" "C[(long)row*(long)N+(long)col]")
                normalize)
            (normalize (:source routed)))
         "the schedule matches the oracle with explicitly widened K induction and lookahead")

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -172,12 +172,12 @@
     (let [scheduled (typed-dispatch :ze:0)]
       (testing "an aligned dynamic contraction selects and executes the direct matrix graph"
         (let [{:keys [strategy actual expected]}
-              (run-contraction :ze:0 scheduled 16 16 16)]
+              (run-contraction :ze:0 scheduled 16 32 32)]
           (is (= :xmx-direct strategy))
           (is (< (relative-l1 actual expected) 1.0e-3))))
       (testing "a low-output-occupancy contraction executes the graph-private split-K schedule"
         (let [{:keys [strategy actual expected]}
-              (run-contraction :ze:0 scheduled 13 16 8192)]
+              (run-contraction :ze:0 scheduled 13 32 8192)]
           (is (= :xmx-split-k strategy))
           (is (< (relative-l1 actual expected) 1.0e-3)))))))
 
@@ -187,8 +187,8 @@
     (let [device-id :ze:0
           batch 2
           m 8
-          n 16
-          k 16
+          n 32
+          k 32
           a (input-array (* batch m k) 41)
           b (input-array (* k n) 43)
           scheduled (typed-batched-dispatch device-id)
@@ -219,8 +219,8 @@
     (gpu-probe/gpu-skip! "typed matrix result transform")
     (let [device-id :ze:0
           m 8
-          n 16
-          k 16
+          n 32
+          k 32
           scale 0.5
           a (input-array (* m k) 47)
           b (input-array (* k n) 53)

--- a/test/raster/perf/matrix_width_canary.clj
+++ b/test/raster/perf/matrix_width_canary.clj
@@ -4,6 +4,7 @@
   compilation, precision conversion, transfer throughput, or external SOTA libraries."
   (:refer-clojure :exclude [run!])
   (:require [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.reference.gemm-opencl :as reference]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-dispatch :as dispatch]
@@ -37,6 +38,7 @@
                  (every? (fn [shape]
                            (and (vector? shape) (= 3 (count shape))
                                 (every? #(and (integer? %) (<= 1 % 1024)) shape)
+                                (nil? (apply block-io/static-failure shape))
                                 (zero? (mod (second shape) 16))
                                 (zero? (mod (nth shape 2) 16))
                                 (<= (apply * shape) 33554432))) shapes))
@@ -47,7 +49,7 @@
                             [:attributes :strategy] :typed-body)
         tile (get-in generated [:attributes :tile])
         baseline (artifact/make
-                  (merge (select-keys generated [:abi :arguments :launch :effects])
+                  (merge (select-keys generated [:abi :arguments :launch :effects :preconditions])
                          {:kernel-name "matrix_width_reference"
                           :source (apply reference/emit-gemm-tiled "matrix_width_reference"
                                          :c-dtype :float :prefetch (:num-stages tile)

--- a/test/raster/perf/matrix_width_canary_test.clj
+++ b/test/raster/perf/matrix_width_canary_test.clj
@@ -19,6 +19,7 @@
       (is (false? (:passed? ((:validate! case) {})))))))
 
 (deftest canary-rejects-unbounded-work-before-device-access
-  (doseq [shapes [[] [[1024 1024 1024]] [[0 16 16]] [[16 17 16]]]]
+  (doseq [shapes [[] [[1024 1024 1024]] [[0 16 16]] [[16 17 16]]
+                  [[16 16 32]] [[16 32 16]]]]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"bounded positive aligned"
                           (canary/run! :missing-device shapes)))))


### PR DESCRIPTION
Stacked on #431. Derives one checked Intel FP16 surface contract for static admission, dynamic fallback, forced graph binding and scheduled artifact projection. Enforces 64-byte minimum rows, documented surface maxima, pitch/K16 divisibility, 64-byte A/B alignment and alignment-preserving batched input slices. Shared inputs and scalar C stores are not over-aligned. Restricts this block-I/O lowering to subgroup16 and widens C linear addressing before multiplication.

Validation: 79 focused route/backend tests with 756 assertions; 24 planner/contract/device tests with 135 assertions including real Arc direct, split-K, shared-weight batching and fused SSA epilogues; final 23 tests/225 assertions cover mutation and odd-height/K48 slice rejection. Independent review completed. Full suites and cross-vendor compilation run in CI.

Retained-Long optimized admission stays closed. This does not certify large-index legacy ScalarRegion source epilogues or claim performance parity/SOTA. Specification and remaining gates are recorded in the campaign.