### PR TITLE
Require typed SSA matrix stores; retire source-expression lowering

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -456,8 +456,15 @@ scalar C stores are not over-aligned. Projection verification rejects stripped r
 Intel block-I/O now admits subgroup 16 only, and C linear stores widen before multiplication.
 Focused Arc direct, split-K, batched/shared-weight and fused-SSA-epilogue execution passes with
 legal surface widths. Non-allocating tests cover maximum surfaces and rejected odd-height/K48
-batched slices. This does not admit retained Long dimensions or prove legacy ScalarRegion source
-epilogue indexing safe at large sizes; production SSA epilogues retain typed storage addressing.
+batched slices. This does not admit retained Long dimensions.
+
+Executable matrix stores now require ScalarSSARegion. The semantic ScalarRegion descriptor remains
+an input to scheduling, but cannot bypass typed lowering into KernelBody. The old source-expression
+store emitter, tag reconstruction and op-map-derived call whitelist are removed. Ordered epilogue
+ABI checks remain shared; an explicit rejection test prevents reintroducing unlowered store regions.
+The existing typed SSA storage-address emitter serves matrix epilogues on both Intel and CUDA.
+Fresh capped-REPL validation: 68 tests, 688 assertions including Arc matrix execution. This removes
+a duplicate lowering path; it is not a new tensor IR or a performance claim.
 
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -361,7 +361,7 @@
   front doors. Caller identities remain the KernelBody ABI identities; OpenCL parameter spelling
   is solely a target concern. Optional views, hardware indices, and K bounds are explicit schedule
   values used by the split-K and batched wrappers below. An optional epilogue becomes a typed
-  ScalarRegion on every store and is lowered as part of the body."
+  ScalarSSARegion on every store and is lowered as part of the body."
   [{:keys [kernel-name id a b c m n k dimension-parameters tile result-dtype provenance
            target-dialect
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -4,17 +4,13 @@
   Matrix fragments retain their Intel OpenCL leaf. The general scalar/control path is shared by
   OpenCL, CUDA and HIP through thin target dialect descriptors; geometry is recovered from explicit
   index/operation IR, never from the source algorithm or a second schedule registry."
-  (:require [clojure.set :as set]
-            [clojure.string :as str]
-            [clojure.walk :as walk]
+  (:require [clojure.string :as str]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
-            [raster.compiler.core.op-descriptor :as descriptor]
-            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-body :as body]))
 
 (defn- record-kind? [simple-name value]
@@ -81,85 +77,10 @@
                     (nested-operations nested))))
           operations))
 
-(def ^:private scalar-builtins
-  (into #{"float" "double" "half" "int" "long" "short" "char"
-          "uint" "ulong" "ushort" "uchar" "if"}
-        (comp (filter string?) (filter #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" %)))
-        (vals ce/op-map)))
-
-(defn- validate-emitted-scalar-calls!
-  [region emitted]
-  (let [calls (into #{} (map second) (re-seq #"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(" emitted))
-        ;; rstr_dp4a is accompanied by a helper in general kernels, but matrix store regions do not
-        ;; inject helper source. Keep the scalar-region target vocabulary self-contained.
-        unsupported (set/difference calls (disj scalar-builtins "rstr_dp4a"))]
-    (when (seq unsupported)
-      (throw (ex-info "OpenCL scalar region contains calls without a typed target lowering"
-                      {:reason :scalar-region-opencl-call-unsupported
-                       :calls (vec (sort unsupported)) :region region})))
-    emitted))
-
-(defn- scalar-tag [dtype]
-  (symbol (name dtype)))
-
-(defn- array-tag [dtype]
-  (symbol (str (name dtype) "s")))
-
-(defn- lower-scalar-region
-  [kernel-body region parameter-names]
-  (let [parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))
-        operand-ids (set (map :sym (:operands region)))
-        scalar-ids (remove operand-ids (rest (:parameters region)))
-        free-syms (subvec (vec (get-in kernel-body [:attributes :axis-symbols])) 0 2)
-        [i-sym j-sym] free-syms
-        ctype (dtype/ctype :opencl (:result-dtype region))
-        array-syms (set (map (comp #(symbol (name %)) :sym) (:operands region)))
-        int-vars (into #{} (map #(symbol (name %))) free-syms)
-        indices (into {} (map (juxt :sym (comp axis-map/index-expr :map)))
-                      (:operands region))
-        expression (descriptor/rewrite-aget-indices (:expression region) indices)
-        accumulator (first (:parameters region))
-        accumulator-token (str "__acc_" (name (gensym "")))
-        typed-parameters
-        (into {}
-              (for [id (rest (:parameters region))
-                    :let [parameter (get parameters id)]]
-                [id (with-meta (symbol (get parameter-names id))
-                      {:raster.type/tag (if (= :scalar (:kind parameter))
-                                          (scalar-tag (:dtype parameter))
-                                          (array-tag (:dtype parameter)))})]))
-        replacements (assoc typed-parameters accumulator
-                            (with-meta (symbol accumulator-token)
-                              {:raster.type/tag (scalar-tag (:result-dtype region))}))
-        emitted (validate-emitted-scalar-calls!
-                 region
-                 (binding [ce/*emit-config* ce/opencl-config
-                           ce/*scalar-type* ctype
-                           ce/*int-vars* (into ce/*int-vars* int-vars)]
-                   (ce/emit-expr
-                    (walk/postwalk-replace replacements expression)
-                    (gensym "z__") array-syms)))
-        params (apply str
-                      (concat
-                       (for [{:keys [sym dtype] :or {dtype :float}} (:operands region)]
-                         (str ", __global const " (dtype/ctype :opencl dtype)
-                              "* restrict " (get parameter-names sym)))
-                       (for [id scalar-ids
-                             :let [parameter (get parameters id)]]
-                         (str ", " (dtype/ctype :opencl (:dtype parameter))
-                              " " (get parameter-names id)))))]
-    {:epilogue (fn [accumulator-expression row col]
-                 (-> emitted
-                     (str/replace accumulator-token (str "(" accumulator-expression ")"))
-                     (str/replace (re-pattern (str "\\b" (ce/c-symbol i-sym) "\\b")) row)
-                     (str/replace (re-pattern (str "\\b" (ce/c-symbol j-sym) "\\b")) col)))
-     :epilogue-params params
-     :region region}))
-
 (declare lower-scalar-ssa-region)
 
 (defn lower-store-region
-  "Lower the one verified ScalarRegion shared by all matrix stores to OpenCL scalar syntax.
+  "Lower the one verified ScalarSSARegion shared by all matrix stores to OpenCL scalar syntax.
 
   Returns nil for identity stores. This is a target lowering of typed KernelBody data: callers
   never supply source callbacks, parameter declaration strings, or helper source."
@@ -177,9 +98,7 @@
       (throw (ex-info "all matrix tile stores must carry the same scalar region"
                       {:reason :raster/bug :regions (vec regions)})))
     (when-let [region (first regions)]
-      (if (record-kind? "ScalarSSARegion" region)
-        (lower-scalar-ssa-region kernel-body region parameter-names)
-        (lower-scalar-region kernel-body region parameter-names))))))
+      (lower-scalar-ssa-region kernel-body region parameter-names)))))
 
 (defn- require!
   [condition message data]
@@ -349,7 +268,7 @@
 (defn emit-matrix-kernel
   "Lower a verified f16 DPAS KernelBody directly to OpenCL C.
 
-  ScalarRegion stores are lowered as part of this boundary. The optional target map contains only
+  ScalarSSARegion stores are lowered as part of this boundary. The optional target map contains only
   target naming policy; it cannot inject source or replace the store expression."
   ([kernel-name kernel-body]
    (emit-matrix-kernel kernel-name kernel-body {}))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -491,21 +491,6 @@
                             {:scalar id :parameter parameter})))))
       region)))
 
-(defn- validate-scalar-region!
-  [region storage epilogue-abi]
-  (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarRegion" region)
-    (throw (ex-info "tile-store value region must be a ScalarRegion" {:region region})))
-  (when-not (and (some? (:expression region))
-                 (dtype/known? (:result-dtype region)))
-    (throw (ex-info "tile-store scalar region is incomplete or has ambiguous parameters"
-                    {:region region})))
-  (validate-scalar-region-boundary! region storage epilogue-abi #{:epilogue} #{:epilogue})
-  (let [legal (scalar-region-legal? region)]
-    (when-not (:ok legal)
-      (throw (ex-info "tile-store scalar region is not store-local"
-                      (assoc legal :region region)))))
-  region)
-
 (defn- validate-scalar-ssa-region!
   [region storage masks scope epilogue-abi]
   (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion" region)
@@ -668,9 +653,7 @@
                            :buffer p :coordinates (:coordinates operation)})))
         (mask (:mask operation))
         (when-let [region (:value-region operation)]
-          (if (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion" region)
-            (validate-scalar-ssa-region! region storage masks scope epilogue-abi)
-            (validate-scalar-region! region storage epilogue-abi))))
+          (validate-scalar-ssa-region! region storage masks scope epilogue-abi)))
 
       (record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" operation)
       (do

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -192,11 +192,13 @@
         "a trailing zero cannot conceal an overflowing address prefix")))
 
 (deftest scalar-regions-are-checked-against-the-ordered-kernel-abi
-  (let [region (body/->ScalarRegion
+  (let [semantic-region (body/->ScalarRegion
                 ['value 'bias 'scale]
                 '(raster.numeric/* (raster.numeric/+ value (aget bias group-x)) scale)
                 [{:sym 'bias :map (axis-map/of-axes [['group-x 16]]) :dtype :half}]
                 :float)
+        region (body/->ScalarSSARegion (:parameters semantic-region) (:operands semantic-region)
+                                      ['i 'j] :float [] 'value :float)
         kernel (-> (minimal-body)
                    (update :parameters into
                            [(body/->KernelParameter
@@ -205,6 +207,11 @@
                             (body/->KernelParameter 'scale :scalar :float [] nil nil :epilogue)])
                    (assoc-in [:operations 0 :operations 2 :value-region] region))]
     (is (= kernel (body/validate! kernel)))
+    (testing "semantic source regions must be lowered before entering executable KernelBody"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be typed scalar SSA"
+                            (body/validate! (assoc-in kernel
+                                                     [:operations 0 :operations 2 :value-region]
+                                                     semantic-region)))))
     (testing "operand identities occupy the ordered prefix after the accumulator"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered prefix"
                             (body/validate!


### PR DESCRIPTION
Stacked on #432. Executable KernelBody TileStore regions now require ScalarSSARegion. Semantic ScalarRegion remains upstream and is lowered by the existing scheduling pass. Removes the obsolete source-expression emitter, tag reconstruction, and op-map-derived call whitelist; both matrix targets retain the shared typed scalar-storage lowering.

Validation: fresh single 768MiB REPL, 68 tests/688 assertions passing, including Arc direct, split-K, batched/shared-weight and fused epilogue execution. Ordered ABI validation is preserved; a negative test rejects unlowered semantic store regions. Independent review found no blockers. Full suite and target compile gates run in CI.

This is retirement of a duplicate executable lowering path, not a new tensor IR or a performance claim.