### PR TITLE
Derive matrix stage scalar certificates from graph types

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -466,6 +466,15 @@ The existing typed SSA storage-address emitter serves matrix epilogues on both I
 Fresh capped-REPL validation: 68 tests, 688 assertions including Arc matrix execution. This removes
 a duplicate lowering path; it is not a new tensor IR or a performance claim.
 
+Mixed-precision graph emission now derives each node's logical scalar widths from the original
+GraphScalar environment through the existing checked expression algebra. Matrix, cast, transpose,
+split-combine and batched stages state identity or checked Long-to-int bindings before target
+projection; emitted ABIs are not rewritten afterward. Mixed-width/all-Long graph tests cover all
+four orientations, direct/split execution plans, shared-weight batches and pre-allocation overflow
+rejection. Focused validation: 83 tests, 1084 assertions. The public Long-DPAS admission gate remains
+closed. Existing int-sized layout/combine slots still impose capacity limits; complete their wide
+lowering and selector admission before promising a fallback for every oversized specialization.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -141,7 +141,7 @@
 
 (defn- emit-scheduled-body-artifact
   [{:keys [kernel-name source body arguments effects legality numerics phase target-dialect
-           parameter-names provenance attributes]
+           parameter-names provenance attributes scalar-types]
     :or {target-dialect :opencl-intel effects {:kind :tensor-contraction-stage}
          provenance {} attributes {}}}]
   (let [uses (scheduled-body/derive-uses body arguments)
@@ -150,6 +150,7 @@
          {:source source
           :body body
           :arguments arguments
+          :scalar-bindings (scheduled-body/derive-scalar-bindings body arguments scalar-types)
           :effects (assoc effects :uses uses)
           :legality legality
           :numerics numerics
@@ -258,7 +259,7 @@
     :policy {:permutation [1 0]}}))
 
 (defn- convert-artifact
-  [kernel-name stage phase target-dialect]
+  [kernel-name stage phase target-dialect scalar-types]
   (let [{stage-id :id in :input out :output input-shape :input-shape policy :policy}
         (layout-stage/validate! stage)
         elements (first input-shape)
@@ -283,6 +284,7 @@
      {:kernel-name kernel-name
       :source stage
       :body kernel-body :arguments [in out elements]
+      :scalar-types scalar-types
       :effects {:kind :layout-transform-stage}
       :legality {:kind :dense-affine-cast :vector-width vector-width}
       :numerics {:mode :bounded-error :policy :f32-to-f16-storage
@@ -296,7 +298,7 @@
       :parameter-names {in "input" out "output" :layout-elements "n"}})))
 
 (defn- transpose-artifact
-  [kernel-name stage phase target-dialect]
+  [kernel-name stage phase target-dialect scalar-types]
   (let [{stage-id :id in :input out :output
          [rows cols] :input-shape} (layout-stage/validate! stage)
         _ (when-not (and (= :half (:input-dtype stage)) (= :half (:output-dtype stage))
@@ -313,6 +315,7 @@
      {:kernel-name kernel-name
       :source stage
       :body kernel-body :arguments [in out rows cols]
+      :scalar-types scalar-types
       :effects {:kind :layout-transform-stage}
       :legality {:kind :bijective-affine-permutation :permutation [1 0]}
       :numerics {:mode :exact :policy :bit-preserving-permutation}
@@ -459,7 +462,7 @@
   (emit-scheduled-matrix-kernel (batched-matrix-spec spec)))
 
 (defn- emit-scheduled-matrix-artifact
-  [{:keys [kernel-name target-dialect parameter-names argument-values source-operation phase]
+  [{:keys [kernel-name target-dialect parameter-names argument-values source-operation phase scalar-types]
     :or {target-dialect :opencl-intel argument-values {}}
     :as spec}]
   (let [kernel-name (c-emit/c-symbol kernel-name)
@@ -480,6 +483,7 @@
                                        :phase phase})))
           :body kernel-body
           :arguments arguments
+          :scalar-bindings (scheduled-body/derive-scalar-bindings kernel-body arguments scalar-types)
           :effects {:kind :tensor-contraction-stage :uses uses}
           :legality {:kind :matrix-instruction-tiling
                      :scheduled-body (:id kernel-body)}
@@ -521,7 +525,7 @@
       :schedule {:kind :matrix-instruction-tiling :tile tile}})))
 
 (defn- gemm-artifact
-  [stage kernel-name phase target-dialect]
+  [stage kernel-name phase target-dialect scalar-types]
   (let [{stage-id :id a :lhs b :rhs c :result
          [m n k] :dimensions reduction :reduction epilogue :epilogue
          batching :batching schedule :schedule} (matrix-stage/validate! stage)
@@ -553,7 +557,7 @@
                    :source-operation stage
                    :provenance {:operation-id stage-id :phase phase}}]
     (emit-scheduled-matrix-artifact
-     (cond
+     (assoc (cond
        batching
        (assoc (batched-matrix-spec
                (assoc emit-args
@@ -567,7 +571,8 @@
               :phase phase :source-operation stage
               :argument-values {:k-chunk kc :splits splits})
 
-       :else emit-args))))
+       :else emit-args)
+            :scalar-types scalar-types :target-dialect target-dialect))))
 
 (defn- split-k-combine-plan
   [stage-id]
@@ -600,11 +605,12 @@
      {:kernel-name kernel-name :source source :kernel-body kernel-body :workgroup-size 256})))
 
 (defn- combine-artifact
-  [kernel-name operation partials c mn splits target-dialect]
+  [kernel-name operation partials c mn splits target-dialect scalar-types]
   (let [{body :body} (split-k-combine-plan (:id operation))]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name :source operation :body body
       :arguments [partials c mn splits mn]
+      :scalar-types scalar-types
       :effects {:kind :tensor-contraction-stage}
       :legality {:kind :portable-contraction :purpose :split-k-combine}
       :numerics {:mode :reassociated :policy :sequential-segment-fold
@@ -688,24 +694,24 @@
     {:partials (first partials) :output (first outputs) :mn mn :splits splits}))
 
 (defn- emit-stage-artifact
-  [target-dialect prefix {:keys [operation] :as node}]
+  [target-dialect prefix scalar-types {:keys [operation] :as node}]
   (let [phase (last (:id node))]
     (cond
       (layout-stage/layout-stage? operation)
       (case (:operation operation)
         :cast (convert-artifact (str prefix "_" (name phase)) operation
-                                phase target-dialect)
+                                phase target-dialect scalar-types)
         :transpose (transpose-artifact (str prefix "_" (name phase)) operation
-                                       phase target-dialect))
+                                       phase target-dialect scalar-types))
 
       (matrix-stage/matrix-stage? operation)
       (gemm-artifact operation (str prefix "_" (name phase))
-                     :matrix-contract target-dialect)
+                     :matrix-contract target-dialect scalar-types)
 
       (instance? raster.compiler.ir.segop.SegRed operation)
       (let [{:keys [partials output mn splits]} (split-combine-values operation)]
         (combine-artifact (str prefix "_" (name phase)) operation
-                          partials output mn splits target-dialect))
+                          partials output mn splits target-dialect scalar-types))
 
       :else
       (throw (ex-info "GEMM stage has no ScheduledKernelBody lowering"
@@ -721,6 +727,7 @@
   [stage-graph {:keys [target-dialect prefix refinement]
                 :or {target-dialect :opencl-intel prefix "scheduled_gemm"}}]
   (let [stage-graph (kgraph/validate! stage-graph)
+        scalar-types (into {} (map (juxt :id :dtype)) (:scalars stage-graph))
         _ (when (and refinement
                      (not= stage-graph (graph-refinement/scheduled-graph refinement)))
             (throw (ex-info "GEMM emission refinement does not retain the exact scheduled graph"
@@ -729,7 +736,7 @@
         (kgraph/map-operations
          stage-graph
          (fn [node]
-           (let [artifact (emit-stage-artifact target-dialect prefix node)
+           (let [artifact (emit-stage-artifact target-dialect prefix scalar-types node)
                  scheduled (kart/attribute artifact :scheduled-kernel-body)]
              (scheduled-body/validate-against-node! scheduled node stage-graph)
              (scheduled-body/validate-artifact-projection! scheduled artifact)

--- a/src/raster/compiler/ir/scheduled_kernel_body.clj
+++ b/src/raster/compiler/ir/scheduled_kernel_body.clj
@@ -80,18 +80,28 @@
      [] (map vector (:parameters kernel-body) arguments))))
 
 (defn derive-scalar-bindings
-  "Derive ordered identity scalar bindings. Schedules needing a representation conversion must
-   construct and certify that conversion explicitly rather than relying on an ABI rewrite."
-  [kernel-body arguments]
+  "Derive ordered scalar bindings before target projection. With a typed graph environment,
+   logical expression widths come from that environment and any Long→int specialization is
+   explicitly checked-range. Without one, retain the body's declared identity bindings."
+  ([kernel-body arguments] (derive-scalar-bindings kernel-body arguments nil))
+  ([kernel-body arguments scalar-types]
   (let [kernel-body (body/validate! kernel-body)]
     (mapv (fn [[parameter argument]]
-            {:parameter (:id parameter)
-             :value argument
-             :dtype (:dtype parameter)
-             :kernel-dtype (:dtype parameter)
-             :conversion :identity})
+            (let [physical (:dtype parameter)
+                  logical (if (nil? scalar-types) physical
+                            (if (contains? #{:int :long} physical)
+                              (launch/typed-expression-dtype argument scalar-types)
+                              (get scalar-types argument)))
+                  conversion (cond (= logical physical) :identity
+                                   (= [:long :int] [logical physical]) :checked-range
+                                   :else (fail! :scheduled-kernel-body-scalar-bindings
+                                                "graph scalar has no supported representation conversion"
+                                                {:parameter parameter :argument argument
+                                                 :logical logical :physical physical}))]
+              {:parameter (:id parameter) :value argument :dtype logical
+               :kernel-dtype physical :conversion conversion}))
           (filter (fn [[parameter _]] (= :scalar (:kind parameter)))
-                  (map vector (:parameters kernel-body) arguments)))))
+                  (map vector (:parameters kernel-body) arguments))))))
 
 (defn- validate-scalar-bindings!
   [kernel-body arguments scalar-bindings]

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -391,3 +391,51 @@
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
                               (graph-call/temporary-specs graph values)))
         (is (map? (graph-call/temporary-specs graph values)))))))
+
+(deftest matrix-stages-derive-logical-widths-from-their-graph
+  (doseq [variant [:nn :nt :tn :tt]
+          widths [[:long :long :long] [:long :int :long]]]
+    (let [interface (executable/common-view (dispatch/default-alternative (emitted variant)))
+          by-argument (zipmap [:m :n :k] widths)
+          interface (update interface :abi
+                            (fn [slots]
+                              (mapv (fn [slot argument]
+                                      (if-let [dtype (get by-argument argument)]
+                                        (assoc slot :dtype dtype :kernel-dtype dtype) slot))
+                                    slots (:arguments interface))))
+          {:keys [alternatives]}
+          (gemm/emit-matrix-alternatives
+           {:id [:graph-widths variant widths] :a 'a :b 'b :c 'c :m :m :n :n :k :k
+            :variant variant :tile (hardware/derive-gemm-tile {}) :fill-workgroups 32
+            :external-interface interface})
+          values (zipmap [:m :n :k] (mapv (fn [dtype value] {:type dtype :value value})
+                                         widths [3 32 1024]))]
+      (doseq [graph alternatives]
+        (is (map? (graph-call/temporary-specs graph values)))
+        (doseq [node (:nodes graph)
+                binding (get-in node [:operation :attributes :scheduled-kernel-body :scalar-bindings])]
+          (is (= (launch/typed-expression-dtype (:value binding) by-argument) (:dtype binding)))
+          (is (= (if (= :long (:dtype binding)) :checked-range :identity)
+                 (:conversion binding))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
+                              (graph-call/temporary-specs graph
+                                                         (assoc-in values [:m :value] 2147483648))))))))
+
+(deftest batched-matrix-stages-retain-the-public-long-environment
+  (let [spec {:id :long-batch :a 'a :b 'b :c 'c :batch 'batch :m 'm :n 'n :k 'k
+              :variant :nn :tile (hardware/derive-gemm-tile {})
+              :batching {:row true :col false}}
+        base (:graph (gemm/emit-batched-matrix-alternative spec))
+        interface (update (executable/common-view base) :abi
+                          #(mapv (fn [slot] (if (= :scalar (:kind slot))
+                                             (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
+        graph (:graph (gemm/emit-batched-matrix-alternative
+                       (assoc spec :external-interface interface)))
+        values (zipmap '[batch m n k] (mapv #(hash-map :type :long :value %) [2 8 32 32]))
+        bindings (mapcat #(get-in % [:operation :attributes :scheduled-kernel-body :scalar-bindings])
+                         (:nodes graph))]
+    (is (every? #(= :long (:dtype %)) bindings))
+    (is (every? #(= :checked-range (:conversion %)) bindings))
+    (is (map? (graph-call/temporary-specs graph values)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
+                          (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))


### PR DESCRIPTION
Stacked on #433. Uses the existing GraphScalar environment and checked expression algebra to derive logical scalar widths for matrix, cast, transpose, split-combine and batched stages. Identity or checked Long-to-int conversion is stated before target projection and validated against the original graph node; no posthoc ABI rewriting or new type registry.

Validation: 83 affected tests/1084 assertions, plus real Arc matrix device tests. Covers mixed Int/Long and all-Long graph boundaries, four matrix orientations, direct/split plans, shared-weight batches, and pre-allocation range rejection. Independently reviewed.

Public mixed-dpas-index-width-not-lowered remains in place. This prerequisite does not enable optimized Long projection, widen every layout/combine slot, or promise automatic fallback for all oversized inputs. Those admission/width gates remain next in the campaign.