### PR TITLE
Preserve typed extents through matrix layout and split-combine stages

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -279,6 +279,7 @@
         (layout-emitter/cast-body
          {:id stage-id :input in :output out
           :source-dtype :float :destination-dtype :half :vector-width vector-width
+          :extent-dtype (klaunch/typed-expression-dtype elements scalar-types)
           :rounding :nearest-even :overflow :ieee})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
@@ -310,7 +311,9 @@
         kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/transpose-body
-         {:id stage-id :input in :output out :element-dtype :half})]
+         {:id stage-id :input in :output out :element-dtype :half
+          :row-extent-dtype (klaunch/typed-expression-dtype rows scalar-types)
+          :column-extent-dtype (klaunch/typed-expression-dtype cols scalar-types)})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
       :source stage
@@ -575,7 +578,8 @@
             :scalar-types scalar-types :target-dialect target-dialect))))
 
 (defn- split-k-combine-plan
-  [stage-id]
+  ([stage-id] (split-k-combine-plan stage-id {'mn :int 'splits :int}))
+  ([stage-id scalar-types]
   (let [form '(raster.par/contract C [[i mn]] [[s splits]]
                                    (clojure.core/aget
                                     partials (clojure.core/+ (clojure.core/* s mn) i)))
@@ -585,11 +589,11 @@
         planned (contraction-schedule/plan-portable-body
                  facts operation {}
                  {:array-types {'partials :float 'C :float}
-                  :scalar-types {'mn :int 'splits :int}})
+                  :scalar-types scalar-types})
         _ (when-not (:ok planned)
             (throw (ex-info "split-K combination did not admit the portable contraction schedule"
                             {:reason :raster/bug :plan planned})))]
-    {:operation operation :body (:body planned) :plan planned}))
+    {:operation operation :body (:body planned) :plan planned})))
 
 (defn emit-split-k-combine-kernel
   "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
@@ -606,7 +610,10 @@
 
 (defn- combine-artifact
   [kernel-name operation partials c mn splits target-dialect scalar-types]
-  (let [{body :body} (split-k-combine-plan (:id operation))]
+  (let [{body :body} (split-k-combine-plan
+                    (:id operation)
+                    {'mn (klaunch/typed-expression-dtype mn scalar-types)
+                     'splits (klaunch/typed-expression-dtype splits scalar-types)})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name :source operation :body body
       :arguments [partials c mn splits mn]

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -169,12 +169,17 @@
                         (apply body/expression (:op expression)
                                (map widen-index (:arguments expression)))
                         :else expression))
-        lower-index (fn [expression scope]
-                      (widen-index (lower-index expression scope)))
         segment-count-source (if map-only?
                                (reduce (fn [a d] (list '* a (:bound d)))
                                        (:bound (first segment-dims)) (rest segment-dims))
                                (segop/seg-space-num-segments-expr space))
+        segment-count-dtype
+        (launch/typed-expression-dtype
+         (index-expression/to-launch-expression
+          (lower-index segment-count-source index-scope) decline!)
+         (into {} (map (fn [id] [id (dtype/canon (scalar-dtype id))])) scalars))
+        lower-index (fn [expression scope]
+                      (widen-index (lower-index expression scope)))
         segment-count (lower-index segment-count-source index-scope)
         launch-segment-count (index-expression/to-launch-expression segment-count decline!)
         reduced-bound (when reduced-dim (lower-index (:bound reduced-dim) index-scope))
@@ -255,7 +260,8 @@
                    scalars)
               transform-operand-parameters
               transform-scalar-parameters
-              [(body/->KernelParameter '_nseg :scalar :int [] nil nil :bound)]))]
+              [(body/->KernelParameter '_nseg :scalar segment-count-dtype
+                                       [] nil nil :bound)]))]
     (let [parameter-map (into {} (map (juxt :id clojure.core/identity)) parameters)
           lowered-transform
           (when result-region

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -415,7 +415,7 @@
         (doseq [node (:nodes graph)
                 binding (get-in node [:operation :attributes :scheduled-kernel-body :scalar-bindings])]
           (is (= (launch/typed-expression-dtype (:value binding) by-argument) (:dtype binding)))
-          (is (= (if (= :long (:dtype binding)) :checked-range :identity)
+          (is (= (if (= (:kernel-dtype binding) (:dtype binding)) :identity :checked-range)
                  (:conversion binding))))
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                               (graph-call/temporary-specs graph
@@ -435,7 +435,7 @@
         bindings (mapcat #(get-in % [:operation :attributes :scheduled-kernel-body :scalar-bindings])
                          (:nodes graph))]
     (is (every? #(= :long (:dtype %)) bindings))
-    (is (every? #(= :checked-range (:conversion %)) bindings))
+    (is (= #{:identity :checked-range} (set (map :conversion bindings))))
     (is (map? (graph-call/temporary-specs graph values)))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -394,7 +394,7 @@
 
 (deftest matrix-stages-derive-logical-widths-from-their-graph
   (doseq [variant [:nn :nt :tn :tt]
-          widths [[:long :long :long] [:long :int :long]]]
+          widths [[:long :long :long] [:long :int :long] [:int :int :long]]]
     (let [interface (executable/common-view (dispatch/default-alternative (emitted variant)))
           by-argument (zipmap [:m :n :k] widths)
           interface (update interface :abi
@@ -439,3 +439,25 @@
     (is (map? (graph-call/temporary-specs graph values)))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))
+
+(deftest long-layout-and-combine-extents-do-not-narrow-shape-products
+  (let [interface (update (executable/common-view (dispatch/default-alternative (emitted :nn)))
+                          :abi #(mapv (fn [slot] (if (= :scalar (:kind slot))
+                                                 (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
+        {:keys [alternatives]}
+        (gemm/emit-matrix-alternatives
+         {:id :wide-products :a 'a :b 'b :c 'c :m :m :n :n :k :k :variant :nn
+          :tile (hardware/derive-gemm-tile {}) :fill-workgroups 32 :split-factors [2]
+          :external-interface interface})
+        direct (first alternatives)
+        split (some #(when (= :xmx-split-k-2 (executable/strategy %)) %) alternatives)
+        values (fn [m n k] (zipmap [:m :n :k] (mapv #(hash-map :type :long :value %) [m n k])))
+        input-specs (graph-call/temporary-specs direct (values 65536 32 65536))
+        output-specs (graph-call/temporary-specs split (values 65536 65536 64))
+        combine (:operation (last (:nodes split)))]
+    (is (some #{4294967296} (map second (vals input-specs))))
+    (is (some #{8589934592} (map second (vals output-specs))))
+    (is (every? #(= :long (:kernel-dtype %)) (filter #(= :scalar (:kind %)) (:abi combine))))
+    (is (re-find #"long mn" (:source combine)))
+    (is (every? #(= :identity (:conversion %))
+                (get-in combine [:attributes :scheduled-kernel-body :scalar-bindings])))))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -99,13 +99,16 @@
     (is (= :float (get parameters 'x)))
     (is (= :float (get parameters 'scale)))
     (is (= :double (get parameters 'y)))
+    (is (= :long (get parameters '_nseg)))
     (is (= :long (get-in loop [:index :type])))
     (is (some #(and (= :cast (get-in % [:expression :op]))
                     (= :double (get-in % [:expression :result-type])))
               (:operations loop)))
     (doseq [target [:opencl-intel :cuda :hip]]
-      (is (string? (:source (emit/generate-contraction-kernel-artifact
-                            kernel :target-dialect target)))))))
+      (let [emitted (emit/generate-contraction-kernel-artifact
+                     kernel :target-dialect target)]
+        (is (string? (:source emitted)))
+        (is (= :long (:kernel-dtype (last (:abi emitted)))))))))
 
 (deftest mixed-storage-cannot-select-a-uniform-pointer-leaf
   (let [form '(raster.par/contract C [[i 4] [j 8]] [[l 16]]


### PR DESCRIPTION
Retain authoritative graph widths when constructing layout casts, transposes, and generic split-K combination bodies. Segment-count ABI width follows its own shape expression, independently of coordinate widening. No post-hoc ABI rewriting and no opening of the public Long matrix admission gate.

Validation: 53 focused tests / 909 assertions; 3 Intel Arc device tests / 8 assertions; independent review. Mixed-width NN/NT/TN/TT graphs and allocation-free products above 2^31 are covered. Full suites and vendor compilation run in CI.

Remaining separate work: direct split-K artifacts need an explicit chunk-size contract; quiet-device performance measurements remain necessary.