### PR TITLE
Enforce Intel matrix partition fragment contracts

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -475,6 +475,18 @@ rejection. Focused validation: 83 tests, 1084 assertions. The public Long-DPAS a
 closed. Existing int-sized layout/combine slots still impose capacity limits; complete their wide
 lowering and selector admission before promising a fallback for every oversized specialization.
 
+The following width slice preserves graph-derived physical extents in cast, transpose and generic
+split-combine bodies. The segment-count ABI follows its own shape expression, independently of
+wide coordinate uses; mixed Int-output/Long-reduction cases remain valid. Allocation-free checks
+cover multi-billion-element layout and combine plans. Focused validation: 53 tests, 909 assertions,
+plus three Arc matrix tests with eight assertions. Public Long-DPAS admission remains closed.
+
+Intel split-K artifacts additionally require positive, K16-aligned chunks, derived from canonical
+scheduled partition bounds. Literal terminal K bounds are tied to the physical K parameter;
+unknown sliced forms fail closed. This protects direct artifact binding, not only graph-generated
+chunks. Focused validation: 32 tests, 745 assertions including Arc execution. It does not prove that
+an arbitrary caller supplied enough partitions to cover K, nor add CUDA partition constraints.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -279,6 +279,7 @@
         (layout-emitter/cast-body
          {:id stage-id :input in :output out
           :source-dtype :float :destination-dtype :half :vector-width vector-width
+          :extent-dtype (klaunch/typed-expression-dtype elements scalar-types)
           :rounding :nearest-even :overflow :ieee})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
@@ -310,7 +311,9 @@
         kernel-name (c-emit/c-symbol kernel-name)
         kernel-body
         (layout-emitter/transpose-body
-         {:id stage-id :input in :output out :element-dtype :half})]
+         {:id stage-id :input in :output out :element-dtype :half
+          :row-extent-dtype (klaunch/typed-expression-dtype rows scalar-types)
+          :column-extent-dtype (klaunch/typed-expression-dtype cols scalar-types)})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name
       :source stage
@@ -575,7 +578,8 @@
             :scalar-types scalar-types :target-dialect target-dialect))))
 
 (defn- split-k-combine-plan
-  [stage-id]
+  ([stage-id] (split-k-combine-plan stage-id {'mn :int 'splits :int}))
+  ([stage-id scalar-types]
   (let [form '(raster.par/contract C [[i mn]] [[s splits]]
                                    (clojure.core/aget
                                     partials (clojure.core/+ (clojure.core/* s mn) i)))
@@ -585,11 +589,11 @@
         planned (contraction-schedule/plan-portable-body
                  facts operation {}
                  {:array-types {'partials :float 'C :float}
-                  :scalar-types {'mn :int 'splits :int}})
+                  :scalar-types scalar-types})
         _ (when-not (:ok planned)
             (throw (ex-info "split-K combination did not admit the portable contraction schedule"
                             {:reason :raster/bug :plan planned})))]
-    {:operation operation :body (:body planned) :plan planned}))
+    {:operation operation :body (:body planned) :plan planned})))
 
 (defn emit-split-k-combine-kernel
   "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
@@ -606,7 +610,10 @@
 
 (defn- combine-artifact
   [kernel-name operation partials c mn splits target-dialect scalar-types]
-  (let [{body :body} (split-k-combine-plan (:id operation))]
+  (let [{body :body} (split-k-combine-plan
+                    (:id operation)
+                    {'mn (klaunch/typed-expression-dtype mn scalar-types)
+                     'splits (klaunch/typed-expression-dtype splits scalar-types)})]
     (emit-scheduled-body-artifact
      {:kernel-name kernel-name :source operation :body body
       :arguments [partials c mn splits mn]

--- a/src/raster/compiler/core/intel_block_io.clj
+++ b/src/raster/compiler/core/intel_block_io.clj
@@ -7,6 +7,29 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-precondition :as precondition]))
 
+(defn- partition-preconditions
+  "Accept the canonical full-K or uniform grid-Z partition. Fragment alignment must hold at
+  every partition boundary, not merely at the full surface width. Matrix-plan analysis also
+  verifies that these declared bounds are the actual loop bounds."
+  [kernel-body k]
+  (let [[lower upper] (get-in kernel-body [:attributes :iteration-range :k])]
+    (if (= [0 k] [lower upper])
+      []
+      (let [[group chunk] (:arguments lower)
+            limit (second (:arguments upper))
+            group-binding (some #(when (= group (:id %)) %) (:indices kernel-body))
+            chunk-parameter (some #(when (= chunk (:id %)) %) (:parameters kernel-body))]
+        (when-not (and (= lower (body/expression :mul group chunk))
+                       (= :group (:source group-binding)) (= 2 (:axis group-binding))
+                       (= :scalar (:kind chunk-parameter))
+                       (or (= limit k) (integer? limit))
+                       (= upper (body/expression :min (body/expression :add lower chunk) limit)))
+          (throw (ex-info "Intel matrix K partition requires a canonical uniform grid-Z range"
+                          {:reason :matrix-partition-contract :lower lower :upper upper})))
+        (cond-> [{:expression chunk :op :> :value 0}
+                 {:expression (body/expression :mod chunk 16) :op := :value 0}]
+          (integer? limit) (conj {:expression k :op := :value limit}))))))
+
 (defn matrix-preconditions
   "Conditions on the two dense half surfaces A[M,K] and B[K,N]. Optional slice strides are in
   elements and describe rebasing an input pointer between workgroups, not the scalar C stores."
@@ -46,7 +69,8 @@
                      (:indices kernel-body))
         strides (for [view (:views kernel-body) :when (contains? inputs (:buffer view))]
                   (walk/postwalk-replace groups (:element-offset view)))]
-    {:preconditions (matrix-preconditions m n k strides)
+    {:preconditions (into (matrix-preconditions m n k strides)
+                          (partition-preconditions kernel-body k))
      :parameter-alignments (zipmap inputs (repeat 64))}))
 
 (defn static-failure

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -169,12 +169,17 @@
                         (apply body/expression (:op expression)
                                (map widen-index (:arguments expression)))
                         :else expression))
-        lower-index (fn [expression scope]
-                      (widen-index (lower-index expression scope)))
         segment-count-source (if map-only?
                                (reduce (fn [a d] (list '* a (:bound d)))
                                        (:bound (first segment-dims)) (rest segment-dims))
                                (segop/seg-space-num-segments-expr space))
+        segment-count-dtype
+        (launch/typed-expression-dtype
+         (index-expression/to-launch-expression
+          (lower-index segment-count-source index-scope) decline!)
+         (into {} (map (fn [id] [id (dtype/canon (scalar-dtype id))])) scalars))
+        lower-index (fn [expression scope]
+                      (widen-index (lower-index expression scope)))
         segment-count (lower-index segment-count-source index-scope)
         launch-segment-count (index-expression/to-launch-expression segment-count decline!)
         reduced-bound (when reduced-dim (lower-index (:bound reduced-dim) index-scope))
@@ -255,7 +260,8 @@
                    scalars)
               transform-operand-parameters
               transform-scalar-parameters
-              [(body/->KernelParameter '_nseg :scalar :int [] nil nil :bound)]))]
+              [(body/->KernelParameter '_nseg :scalar segment-count-dtype
+                                       [] nil nil :bound)]))]
     (let [parameter-map (into {} (map (juxt :id clojure.core/identity)) parameters)
           lowered-transform
           (when result-region

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -415,7 +415,7 @@
         (doseq [node (:nodes graph)
                 binding (get-in node [:operation :attributes :scheduled-kernel-body :scalar-bindings])]
           (is (= (launch/typed-expression-dtype (:value binding) by-argument) (:dtype binding)))
-          (is (= (if (= :long (:dtype binding)) :checked-range :identity)
+          (is (= (if (= (:kernel-dtype binding) (:dtype binding)) :identity :checked-range)
                  (:conversion binding))))
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                               (graph-call/temporary-specs graph
@@ -435,7 +435,7 @@
         bindings (mapcat #(get-in % [:operation :attributes :scheduled-kernel-body :scalar-bindings])
                          (:nodes graph))]
     (is (every? #(= :long (:dtype %)) bindings))
-    (is (every? #(= :checked-range (:conversion %)) bindings))
+    (is (= #{:identity :checked-range} (set (map :conversion bindings))))
     (is (map? (graph-call/temporary-specs graph values)))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
@@ -295,6 +296,34 @@
         (is (re-find #"int batch" (:source batched)))
         (is (every? #(re-find (re-pattern (str % " \\+= ")) (:source batched))
                     ["A" "B" "C"]))))))
+
+(deftest direct-split-matrix-requires-whole-positive-k-fragments
+  (let [emitted (gemm/emit-scheduled-split-k-kernel
+                 {:kernel-name "partition_contract" :a 'a :b 'b :c 'partials
+                  :m 'm :n 'n :k 'k :kc 'chunk :splits 'partitions
+                  :tile (hardware/derive-gemm-tile {})})
+        conditions (:preconditions emitted)
+        values {'m 8 'n 32 'k 64 'partitions 2}]
+    (doseq [chunk [16 32 64]]
+      (is (precondition/check! conditions (assoc values 'chunk chunk))))
+    (doseq [chunk [-16 0 1 17 31]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
+                            (precondition/check! conditions (assoc values 'chunk chunk)))))))
+
+(deftest partition-contract-binds-literal-limits-and-rejects-unknown-ranges
+  (let [emitted (gemm/emit-scheduled-split-k-kernel
+                 {:kernel-name "literal_partition" :a 'a :b 'b :c 'partials
+                  :m 8 :n 32 :k 64 :kc 'chunk :splits 'partitions
+                  :tile (hardware/derive-gemm-tile {})})
+        kernel (:kernel-body emitted)
+        {:keys [m n k]} (get-in kernel [:attributes :dimension-parameters])
+        values {m 8 n 32 k 64 'chunk 32 'partitions 2}]
+    (is (precondition/check! (:preconditions emitted) values))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
+                          (precondition/check! (:preconditions emitted) (assoc values k 32))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"canonical uniform grid-Z"
+                          (block-io/body-requirements
+                           (assoc-in kernel [:attributes :iteration-range :k] [1 64]))))))
 
 (deftest layout-variants-are-graph-topology-not-runtime-conventions
   (doseq [[variant expected-node-count transpose-phase]

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -394,7 +394,7 @@
 
 (deftest matrix-stages-derive-logical-widths-from-their-graph
   (doseq [variant [:nn :nt :tn :tt]
-          widths [[:long :long :long] [:long :int :long]]]
+          widths [[:long :long :long] [:long :int :long] [:int :int :long]]]
     (let [interface (executable/common-view (dispatch/default-alternative (emitted variant)))
           by-argument (zipmap [:m :n :k] widths)
           interface (update interface :abi
@@ -439,3 +439,25 @@
     (is (map? (graph-call/temporary-specs graph values)))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))
+
+(deftest long-layout-and-combine-extents-do-not-narrow-shape-products
+  (let [interface (update (executable/common-view (dispatch/default-alternative (emitted :nn)))
+                          :abi #(mapv (fn [slot] (if (= :scalar (:kind slot))
+                                                 (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
+        {:keys [alternatives]}
+        (gemm/emit-matrix-alternatives
+         {:id :wide-products :a 'a :b 'b :c 'c :m :m :n :n :k :k :variant :nn
+          :tile (hardware/derive-gemm-tile {}) :fill-workgroups 32 :split-factors [2]
+          :external-interface interface})
+        direct (first alternatives)
+        split (some #(when (= :xmx-split-k-2 (executable/strategy %)) %) alternatives)
+        values (fn [m n k] (zipmap [:m :n :k] (mapv #(hash-map :type :long :value %) [m n k])))
+        input-specs (graph-call/temporary-specs direct (values 65536 32 65536))
+        output-specs (graph-call/temporary-specs split (values 65536 65536 64))
+        combine (:operation (last (:nodes split)))]
+    (is (some #{4294967296} (map second (vals input-specs))))
+    (is (some #{8589934592} (map second (vals output-specs))))
+    (is (every? #(= :long (:kernel-dtype %)) (filter #(= :scalar (:kind %)) (:abi combine))))
+    (is (re-find #"long mn" (:source combine)))
+    (is (every? #(= :identity (:conversion %))
+                (get-in combine [:attributes :scheduled-kernel-body :scalar-bindings])))))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -99,13 +99,16 @@
     (is (= :float (get parameters 'x)))
     (is (= :float (get parameters 'scale)))
     (is (= :double (get parameters 'y)))
+    (is (= :long (get parameters '_nseg)))
     (is (= :long (get-in loop [:index :type])))
     (is (some #(and (= :cast (get-in % [:expression :op]))
                     (= :double (get-in % [:expression :result-type])))
               (:operations loop)))
     (doseq [target [:opencl-intel :cuda :hip]]
-      (is (string? (:source (emit/generate-contraction-kernel-artifact
-                            kernel :target-dialect target)))))))
+      (let [emitted (emit/generate-contraction-kernel-artifact
+                     kernel :target-dialect target)]
+        (is (string? (:source emitted)))
+        (is (= :long (:kernel-dtype (last (:abi emitted)))))))))
 
 (deftest mixed-storage-cannot-select-a-uniform-pointer-leaf
   (let [form '(raster.par/contract C [[i 4] [j 8]] [[l 16]]


### PR DESCRIPTION
Derive positive and K16-divisible chunk preconditions from the canonical scheduled grid-Z K range. Literal terminal limits are tied to physical K; unknown sliced forms fail closed. Existing artifact projection and binding preserve/enforce the target contract, so direct callers no longer bypass the alignment guaranteed by graph construction.

Validation: 32 focused tests, 745 assertions including Intel Arc direct/split/batched/epilogue execution; independent review. Regression coverage includes zero/negative/misaligned chunks, literal mismatch and malformed ranges.

Scope is chunk legality, not proving arbitrary caller partition-count coverage or introducing CUDA partition conditions. The public Long matrix gate remains closed.