### PR TITLE
Admit guarded all-Long unbatched typed matrix contractions

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -487,6 +487,17 @@ unknown sliced forms fail closed. This protects direct artifact binding, not onl
 chunks. Focused validation: 32 tests, 745 assertions including Arc execution. It does not prove that
 an arbitrary caller supplied enough partitions to cover K, nor add CUDA partition constraints.
 
+The first guarded Long admission is unbatched dense contraction with all three dimension
+expressions retained as Long. Layout and combine extents stay wide; matrix coordinates are
+checked specializations, and surface selectors retain the portable fallback. Batched and mixed
+widths remain declined pending their separate admission proofs. All four graph orientations
+execute on Arc through direct and explicit split schedules; ordinary public Long contraction
+executes direct and dynamic split schedules. Selector fallback and forced-alternative rejection
+are both tested. The affected route suite passed 85 tests / 1272 assertions before adding the
+extra mixed-width rejection cases; forward/input-gradient/weight-gradient and a complete tiny
+AD/SGD update also passed (two tests, 12 assertions). These are correctness results, not measured
+projection throughput or a claim that every oversized workload has an executable fallback.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1221,8 +1221,9 @@
                                      (when (= :scalar (:kind slot))
                                        [argument (:dtype slot)])))
                            (map vector abi arguments))
-        ;; Matrix/layout schedules currently bind int extents. Retained long extents must
-        ;; not reach those schedules through an implicit narrowing conversion.
+        ;; All-Long unbatched shapes retain wide layout/combine extents; matrix coordinates
+        ;; use explicit checked specialization. Mixed-width products and batch admission
+        ;; remain separate gates, never implicit narrowing conversions.
         wide-dimensions (delay
                           (filterv #(not= :int (klaunch/typed-expression-dtype % scalar-types))
                                    (cond-> (vec (:dimensions matrix-view))
@@ -1256,7 +1257,10 @@
                  :backend (get-in options [:desc :backend])
                  :matrix (get-in options [:desc :matrix])}}
 
-      (seq @wide-dimensions)
+      (and (seq @wide-dimensions)
+           (or (:batched? matrix-view)
+               (not-every? #(= :long (klaunch/typed-expression-dtype % scalar-types))
+                           (:dimensions matrix-view))))
       {:alternatives []
        :decline {:reason :mixed-dpas-index-width-not-lowered
                  :dimensions @wide-dimensions :required-dtype :int}}

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -26,19 +26,20 @@
      step))
 
 (defn- typed-dispatch
-  [device-id]
+  ([device-id] (typed-dispatch device-id :int))
+  ([device-id scalar-dtype]
   (let [{:keys [form]}
         (pipeline/schedule-parallel-form
          source {:target-device device-id
                  :dtype :float
                  :array-types {'A :float 'B :float 'C :float}
-                 :scalar-types {'m :int 'n :int 'k :int}})
+                 :scalar-types {'m scalar-dtype 'n scalar-dtype 'k scalar-dtype}})
         equation (first (:equations form))]
     (contract-route/route-typed-contraction-dispatch
      (:algorithm equation) (first (:operations equation))
      :dtype :float
      :desc (hardware/descriptor-for device-id)
-     :precision :mixed-f16-f32)))
+     :precision :mixed-f16-f32))))
 
 (defn- typed-batched-dispatch
   [device-id]
@@ -214,6 +215,16 @@
               (run-contraction :ze:0 scheduled 13 32 8192)]
           (is (= :xmx-split-k strategy))
           (is (< (relative-l1 actual expected) 1.0e-3)))))))
+
+(deftest public-long-contraction-executes-guarded-matrix-schedules
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "public Long typed contraction")
+    (let [scheduled (typed-dispatch :ze:0 :long)]
+      (doseq [[m n k expected-strategy] [[16 32 32 :xmx-direct] [13 32 8192 :xmx-split-k]]
+              :let [{:keys [strategy actual expected]}
+                    (run-contraction :ze:0 scheduled m n k :long)]]
+        (is (= expected-strategy strategy))
+        (is (< (relative-l1 actual expected) 1.0e-3))))))
 
 (deftest batched-typed-contraction-executes-with-shared-weights
   (if-not @gpu-probe/gpu-available?

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -146,8 +146,15 @@
 (defn- run-contraction
   ([device-id scheduled m n k] (run-contraction device-id scheduled m n k :int))
   ([device-id scheduled m n k scalar-dtype]
+   (run-contraction device-id scheduled m n k scalar-dtype :nn))
+  ([device-id scheduled m n k scalar-dtype variant]
   (let [a (input-array (* m k) 17)
         b (input-array (* k n) 29)
+        transpose (fn [^floats values rows columns]
+                    (float-array (for [column (range columns) row (range rows)]
+                                   (aget values (+ (* row columns) column)))))
+        stored-a (if (contains? #{:tn :tt} variant) (transpose a m k) a)
+        stored-b (if (contains? #{:nt :tt} variant) (transpose b k n) b)
         runtime-arguments
         [:a :b :c
          {:type scalar-dtype :value m}
@@ -157,8 +164,8 @@
                    (dispatch/select-alternative scheduled runtime-arguments)
                    scheduled)]
     (gpu/with-gpu-session [session device-id]
-      (gpu/alloc! session {:a [:float (* m k) a]
-                           :b [:float (* k n) b]
+      (gpu/alloc! session {:a [:float (* m k) stored-a]
+                           :b [:float (* k n) stored-b]
                            :c [:float (* m n) nil]})
       (let [handle (gpu/bind-kernel-executable!
                     session [:typed-contraction m n k] selected runtime-arguments)]
@@ -178,17 +185,18 @@
                              (dispatch/default-alternative (typed-dispatch device-id))) :abi
                             #(mapv (fn [slot] (if (= :scalar (:kind slot))
                                                (assoc slot :dtype :long :kernel-dtype :long)
-                                               slot)) %))
-          {:keys [alternatives]}
-          (gemm/emit-matrix-alternatives
-           {:id :long-device-matrix :a 'A :b 'B :c 'C :m 'm :n 'n :k 'k
-            :variant :nn :tile (hardware/derive-gemm-tile {})
-            :fill-workgroups 32 :split-factors [2] :external-interface interface})]
+                                               slot)) %))]
       ;; This exercises the graph constructor and common binder; it deliberately does not
       ;; bypass the still-closed Long admission gate in the public typed contraction route.
-      (doseq [strategy [:xmx-direct :xmx-split-k-2]
+      (doseq [variant [:nn :nt :tn :tt]
+              :let [{:keys [alternatives]}
+                    (gemm/emit-matrix-alternatives
+                     {:id [:long-device-matrix variant] :a 'A :b 'B :c 'C :m 'm :n 'n :k 'k
+                      :variant variant :tile (hardware/derive-gemm-tile {})
+                      :fill-workgroups 32 :split-factors [2] :external-interface interface})]
+              strategy [:xmx-direct :xmx-split-k-2]
               :let [graph (some #(when (= strategy (executable/strategy %)) %) alternatives)
-                    {:keys [actual expected]} (run-contraction device-id graph 8 32 64 :long)]]
+                    {:keys [actual expected]} (run-contraction device-id graph 8 32 64 :long variant)]]
         (is (some? graph))
         (is (< (relative-l1 actual expected) 1.0e-3))))))
 

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -3,6 +3,7 @@
    backend-neutral KernelExecutable binder.  This is the device guard that permits the old
    Level Zero GEMM-specific binding surface to disappear without losing its numerical oracle."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-dispatch :as dispatch]
             [raster.compiler.ir.kernel-executable :as executable]
@@ -143,15 +144,18 @@
       (/ difference (max scale 1.0e-30)))))
 
 (defn- run-contraction
-  [device-id scheduled m n k]
+  ([device-id scheduled m n k] (run-contraction device-id scheduled m n k :int))
+  ([device-id scheduled m n k scalar-dtype]
   (let [a (input-array (* m k) 17)
         b (input-array (* k n) 29)
         runtime-arguments
         [:a :b :c
-         {:type :int :value m}
-         {:type :int :value n}
-         {:type :int :value k}]
-        selected (dispatch/select-alternative scheduled runtime-arguments)]
+         {:type scalar-dtype :value m}
+         {:type scalar-dtype :value n}
+         {:type scalar-dtype :value k}]
+        selected (if (dispatch/kernel-dispatch? scheduled)
+                   (dispatch/select-alternative scheduled runtime-arguments)
+                   scheduled)]
     (gpu/with-gpu-session [session device-id]
       (gpu/alloc! session {:a [:float (* m k) a]
                            :b [:float (* k n) b]
@@ -164,7 +168,29 @@
            :actual (gpu/download session :c)
            :expected (reference a b m n k)}
           (finally
-            (gpu/release-kernel-graph! session handle)))))))
+            (gpu/release-kernel-graph! session handle))))))))
+
+(deftest long-graph-interface-executes-layout-matrix-and-combine
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "Long matrix graph interface")
+    (let [device-id :ze:0
+          interface (update (executable/common-view
+                             (dispatch/default-alternative (typed-dispatch device-id))) :abi
+                            #(mapv (fn [slot] (if (= :scalar (:kind slot))
+                                               (assoc slot :dtype :long :kernel-dtype :long)
+                                               slot)) %))
+          {:keys [alternatives]}
+          (gemm/emit-matrix-alternatives
+           {:id :long-device-matrix :a 'A :b 'B :c 'C :m 'm :n 'n :k 'k
+            :variant :nn :tile (hardware/derive-gemm-tile {})
+            :fill-workgroups 32 :split-factors [2] :external-interface interface})]
+      ;; This exercises the graph constructor and common binder; it deliberately does not
+      ;; bypass the still-closed Long admission gate in the public typed contraction route.
+      (doseq [strategy [:xmx-direct :xmx-split-k-2]
+              :let [graph (some #(when (= strategy (executable/strategy %)) %) alternatives)
+                    {:keys [actual expected]} (run-contraction device-id graph 8 32 64 :long)]]
+        (is (some? graph))
+        (is (< (relative-l1 actual expected) 1.0e-3))))))
 
 (deftest ordinary-typed-contraction-executes-the-matrix-schedule
   (if-not @gpu-probe/gpu-available?

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -57,7 +57,7 @@
      :precision :mixed-f16-f32)))
 
 (defn- typed-epilogue-dispatch
-  [device-id]
+  [device-id scalar-dtype]
   (let [transform {:acc 'acc
                    :expr '(raster.numeric/*
                            (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
@@ -77,7 +77,7 @@
          {:target-device device-id
           :dtype :float
           :array-types {'A :float 'B :float 'C :float 'bias :float}
-          :scalar-types {'m :int 'n :int 'k :int 'scale :float}})
+          :scalar-types {'m scalar-dtype 'n scalar-dtype 'k scalar-dtype 'scale :float}})
         equation (first (:equations form))]
     (contract-route/route-typed-contraction-dispatch
      (:algorithm equation) (first (:operations equation))
@@ -262,7 +262,8 @@
 (deftest typed-result-transform-executes-inside-the-matrix-store
   (if-not @gpu-probe/gpu-available?
     (gpu-probe/gpu-skip! "typed matrix result transform")
-    (let [device-id :ze:0
+    (doseq [scalar-dtype [:int :long]]
+     (let [device-id :ze:0
           m 8
           n 32
           k 32
@@ -277,13 +278,13 @@
                     (float (* scale
                               (+ (double (aget base index))
                                  (double (aget bias (mod index n))))))))
-          scheduled (typed-epilogue-dispatch device-id)
+          scheduled (typed-epilogue-dispatch device-id scalar-dtype)
           runtime-arguments
           [:a :b :c :bias
            {:type :float :value scale}
-           {:type :int :value m}
-           {:type :int :value n}
-           {:type :int :value k}]
+           {:type scalar-dtype :value m}
+           {:type scalar-dtype :value n}
+           {:type scalar-dtype :value k}]
           selected (dispatch/select-alternative scheduled runtime-arguments)]
       (is (= :xmx-direct (executable/strategy selected)))
       (gpu/with-gpu-session [session device-id]
@@ -297,4 +298,4 @@
             (gpu/run-kernel-graph! session handle)
             (is (< (relative-l1 (gpu/download session :c) expected) 1.0e-3))
             (finally
-              (gpu/release-kernel-graph! session handle))))))))
+              (gpu/release-kernel-graph! session handle)))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -8,6 +8,7 @@
             [raster.compiler.ir.kernel-artifact :as kernel-artifact]
             [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
@@ -1163,9 +1164,11 @@
           (is (= (kernel-graph/boundary-contract (:source refinement))
                  (kernel-graph/boundary-contract (:graph refinement)))))))))
 
-(deftest long-dimensions-decline-int-only-matrix-schedules
-  (doseq [batched? [false true]]
-    (let [contract (if batched?
+(deftest long-dimensions-admit-only-guarded-unbatched-matrix-schedules
+  (doseq [batched? [false true]
+          widths [{'m :long 'n :long 'k :long} {'m :int 'n :int 'k :long}]]
+    (let [declined? (or batched? (some #{:int} (vals widths)))
+          contract (if batched?
                      '(raster.par/contract C [[b batch] [i m] [j n]] [[l k]]
                         (* (aget A (+ (* (+ (* b m) i) k) l)) (aget B (+ (* l n) j))))
                      '(raster.par/contract C [[i m] [j n]] [[l k]]
@@ -1174,7 +1177,7 @@
                           (list 'let* ['step contract] 'step)
                           {:target-device :ze:0 :dtype :float
                            :array-types {'A :float 'B :float 'C :float}
-                           :scalar-types {'batch :long 'm :long 'n :long 'k :long}})
+                           :scalar-types (assoc widths 'batch :long)})
           dispatch (contract-route/route-typed-contraction-dispatch
                      (-> form :equations first :algorithm)
                      (-> form :equations first :operations first)
@@ -1184,13 +1187,33 @@
                             :subgroup-size 16 :max-workgroup-size 1024
                             :grf-bytes-per-lane 256 :machine-lanes 8192
                             :shared-local-memory 131072})]
-      (is (= [:portable-segred] (mapv kdispatch/alternative-strategy (:alternatives dispatch))))
-      (is (= :mixed-dpas-index-width-not-lowered
-             (get-in dispatch [:attributes :matrix-graph-decline :reason])))
+      (if declined?
+        (do
+          (is (= [:portable-segred] (mapv kdispatch/alternative-strategy (:alternatives dispatch))))
+          (is (= :mixed-dpas-index-width-not-lowered
+                 (get-in dispatch [:attributes :matrix-graph-decline :reason]))))
+        (let [{:keys [abi arguments]} (executable/common-view (kdispatch/default-alternative dispatch))]
+          (is (= #{:portable-segred :xmx-direct :xmx-split-k}
+                 (set (map kdispatch/alternative-strategy (:alternatives dispatch)))))
+          (doseq [[dimensions expected] [[{'m 16 'n 32 'k 32} :xmx-direct]
+                                         [{'m 16 'n 16 'k 32} :portable-segred]
+                                         [{'m 2147483648 'n 32 'k 32} :portable-segred]]
+                  :let [values (mapv (fn [slot argument]
+                                       (if (= :scalar (:kind slot))
+                                         {:type :long :value (get dimensions argument)} argument))
+                                     abi arguments)]]
+            (is (= expected (kdispatch/alternative-strategy
+                             (kdispatch/select-alternative dispatch values)))))
+          (doseq [dimensions [{'m 16 'n 16 'k 32} {'m 2147483648 'n 32 'k 32}]]
+            (is (thrown? clojure.lang.ExceptionInfo
+                         (kernel-graph-call/temporary-specs
+                          (kdispatch/alternative dispatch :xmx-direct)
+                          (into {} (map (fn [[id value]] [id {:type :long :value value}]))
+                                dimensions)))))))
       (let [scalar-slots (filter #(= :scalar (:kind %))
                                  (:abi (first (:alternatives dispatch))))]
         (is (= (if batched? 4 3) (count scalar-slots)))
-        (is (every? #(= :long (:dtype %)) scalar-slots))))))
+        (is (= (set (vals widths)) (set (map :dtype scalar-slots))))))))
 
 (deftest dynamic-f32-contraction-owns-its-dpas-graph-alternatives
   (let [source


### PR DESCRIPTION
Restore matrix alternatives only for unbatched dense contractions whose three dimension expressions are Long. Mixed-width and batched Long cases remain declined. Wide layout/combine bodies, checked matrix-coordinate specialization, shared surface fallback and graph preflight remain authoritative.

Device validation: all four graph orientations through direct and explicit split schedules; public Long typed contraction through direct and dynamic split. Allocation-free tests check unsupported surface fallback, oversized dimension fallback, forced-alternative rejection and retained mixed-width decline.

Focused route/backend/device suite: 85 tests / 1272 assertions before the additional negative cases. Existing AD forward/input-gradient/weight-gradient and complete tiny SGD update: 2 tests / 12 assertions. Independent review found no blocker; requested negative cases were added.

This is correctness/admission evidence, not a throughput or SOTA claim. Full suites and vendor compilation run in CI.