### PR TITLE
Reuse graph physical scalar ranges in batched matrix admission

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -498,6 +498,13 @@ extra mixed-width rejection cases; forward/input-gradient/weight-gradient and a 
 AD/SGD update also passed (two tests, 12 assertions). These are correctness results, not measured
 projection throughput or a claim that every oversized workload has an executable fallback.
 
+Graph admission can now reuse direct public/node scalar ABI ranges from the existing scalar-range
+facts. The batched matrix selector consumes these guards, including its private Int grid-Z count,
+before surface arithmetic. This helper deliberately does not evaluate computed arguments or
+replace artifact preconditions and allocation preflight. Oversized Long batches select fallback;
+forced graph binding still rejects them. Focused validation: 32 tests / 741 assertions, followed
+by a six-assertion graph-only API check. Public batch admission remains a separate follow-up.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -20,6 +20,7 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.layout-stage :as layout-stage]
@@ -946,10 +947,11 @@
      :selector
      {:kind :runtime-expression-cases
       :cases (block-io/fallback-cases
-              (block-io/matrix-preconditions
-               m n k (cond-> []
-                       (get batching :row true) (conj (klaunch/product m k))
-                       (get batching :col true) (conj (klaunch/product k n))))
+              (into (graph-call/direct-scalar-range-preconditions graph)
+                    (block-io/matrix-preconditions
+                     m n k (cond-> []
+                             (get batching :row true) (conj (klaunch/product m k))
+                             (get batching :col true) (conj (klaunch/product k n)))))
               :f32-scalar)
       :default :xmx-batched}}))
 

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -40,7 +40,7 @@
   This is deliberately partial: computed node arguments, allocation products and artifact
   preconditions still require ordinary binding preflight. No expression is evaluated here."
   [graph]
-  (let [graph (executable/validate! graph)
+  (let [graph (executable/validate! (kgraph/validate! graph))
         public (scalar-interface graph)
         public-ids (set (map second public))
         bindings (concat public

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -8,7 +8,8 @@
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as kgraph]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.scalar-range :as scalar-range]))
 
 (defrecord ScheduledKernelCall [id call dependencies])
 (defrecord KernelGraphCall [graph buffers scalar-values nodes])
@@ -33,6 +34,28 @@
   [graph]
   (filterv (fn [[slot _]] (= :scalar (:kind slot)))
            (mapv vector (:abi graph) (:arguments graph))))
+
+(defn direct-scalar-range-preconditions
+  "Project physical integer ranges for direct public scalar bindings into selector conditions.
+  This is deliberately partial: computed node arguments, allocation products and artifact
+  preconditions still require ordinary binding preflight. No expression is evaluated here."
+  [graph]
+  (let [graph (executable/validate! graph)
+        public (scalar-interface graph)
+        public-ids (set (map second public))
+        bindings (concat public
+                         (mapcat (fn [{:keys [operation]}]
+                                   (map vector (:abi operation) (:arguments operation)))
+                                 (:nodes graph)))]
+    (vec
+     (distinct
+      (mapcat (fn [[slot argument]]
+                (when (and (= :scalar (:kind slot)) (contains? public-ids argument))
+                  (when-let [{:keys [lower upper]} (scalar-range/for-dtype (:kernel-dtype slot))]
+                    [{:expression argument :op :>=
+                      :value (if (= :bound (:role slot)) (max 0 lower) lower)}
+                     {:expression argument :op :<= :value upper}])))
+              bindings)))))
 
 (defn- validate-scalar-values!
   [graph scalar-values]

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -458,14 +458,23 @@
         interface (update (executable/common-view base) :abi
                           #(mapv (fn [slot] (if (= :scalar (:kind slot))
                                              (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
-        graph (:graph (gemm/emit-batched-matrix-alternative
-                       (assoc spec :external-interface interface)))
+        {graph :graph selector :selector}
+        (gemm/emit-batched-matrix-alternative (assoc spec :external-interface interface))
         values (zipmap '[batch m n k] (mapv #(hash-map :type :long :value %) [2 8 32 32]))
         bindings (mapcat #(get-in % [:operation :attributes :scheduled-kernel-body :scalar-bindings])
                          (:nodes graph))]
     (is (every? #(= :long (:dtype %)) bindings))
     (is (= #{:identity :checked-range} (set (map :conversion bindings))))
     (is (map? (graph-call/temporary-specs graph values)))
+    (doseq [[batch fallback?] [[2 false] [2147483648 true]]]
+      (let [scalars (assoc (into {} (map (fn [[id value]] [id (:value value)])) values)
+                           'batch batch)]
+        (is (= fallback?
+               (boolean
+                (some (fn [{:keys [expression op value]}]
+                        (precondition/compare-value?
+                         op (launch/resolve-expression scalars expression) value))
+                      (:cases selector)))))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))
 

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
+            [raster.compiler.ir.kernel-precondition :as precondition]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]))
 
@@ -16,6 +17,16 @@
     (emit/generate-scan-kernel-graph
      (lower/scan-kernel-graph
       node operations {:array-types {'values :float 'out :float}}))))
+
+(deftest direct-scalar-ranges-are-projected-without-evaluating-derived-expressions
+  (let [graph (emitted-graph)
+        conditions (graph-call/direct-scalar-range-preconditions graph)]
+    (is (seq conditions))
+    (is (every? #(= 'n (:expression %)) conditions))
+    (is (precondition/check! conditions {'n 1025}))
+    (doseq [n [-1 2147483648]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
+                            (precondition/check! conditions {'n n}))))))
 
 (deftest scalar-preconditions-precede-temporary-sizing
   (let [graph (assoc-in (emitted-graph) [:nodes 0 :operation :preconditions]

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -24,6 +24,9 @@
     (is (seq conditions))
     (is (every? #(= 'n (:expression %)) conditions))
     (is (precondition/check! conditions {'n 1025}))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (graph-call/direct-scalar-range-preconditions
+                  (get-in graph [:nodes 0 :operation]))))
     (doseq [n [-1 2147483648]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
                             (precondition/check! conditions {'n n}))))))


### PR DESCRIPTION
Project existing physical integer ABI ranges only for direct public scalar bindings. The batched matrix selector consumes these guards before surface arithmetic; no new type registry or expression evaluation is introduced.

This is deliberately partial: computed node arguments, artifact preconditions, launch limits and allocation products remain binding-preflight obligations. Public batch/mixed-width admission is unchanged. Tests cover oversized Long batch fallback and forced binding rejection.

32 focused tests / 741 assertions, followed by the six-assertion graph-only boundary check. Independent review found no blocker; its suggested explicit KernelGraph requirement was added. Full CI runs off the laptop.