### PR TITLE
Admit uniformly Long batched typed matrix contractions

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -498,6 +498,13 @@ extra mixed-width rejection cases; forward/input-gradient/weight-gradient and a 
 AD/SGD update also passed (two tests, 12 assertions). These are correctness results, not measured
 projection throughput or a claim that every oversized workload has an executable fallback.
 
+Graph admission can now reuse direct public/node scalar ABI ranges from the existing scalar-range
+facts. The batched matrix selector consumes these guards, including its private Int grid-Z count,
+before surface arithmetic. This helper deliberately does not evaluate computed arguments or
+replace artifact preconditions and allocation preflight. Oversized Long batches select fallback;
+forced graph binding still rejects them. Focused validation: 32 tests / 741 assertions, followed
+by a six-assertion graph-only API check. Public batch admission remains a separate follow-up.
+
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -20,6 +20,7 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.layout-stage :as layout-stage]
@@ -946,10 +947,11 @@
      :selector
      {:kind :runtime-expression-cases
       :cases (block-io/fallback-cases
-              (block-io/matrix-preconditions
-               m n k (cond-> []
-                       (get batching :row true) (conj (klaunch/product m k))
-                       (get batching :col true) (conj (klaunch/product k n))))
+              (into (graph-call/direct-scalar-range-preconditions graph)
+                    (block-io/matrix-preconditions
+                     m n k (cond-> []
+                             (get batching :row true) (conj (klaunch/product m k))
+                             (get batching :col true) (conj (klaunch/product k n)))))
               :f32-scalar)
       :default :xmx-batched}}))
 

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -40,7 +40,7 @@
   This is deliberately partial: computed node arguments, allocation products and artifact
   preconditions still require ordinary binding preflight. No expression is evaluated here."
   [graph]
-  (let [graph (executable/validate! graph)
+  (let [graph (executable/validate! (kgraph/validate! graph))
         public (scalar-interface graph)
         public-ids (set (map second public))
         bindings (concat public

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -8,7 +8,8 @@
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as kgraph]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.scalar-range :as scalar-range]))
 
 (defrecord ScheduledKernelCall [id call dependencies])
 (defrecord KernelGraphCall [graph buffers scalar-values nodes])
@@ -33,6 +34,28 @@
   [graph]
   (filterv (fn [[slot _]] (= :scalar (:kind slot)))
            (mapv vector (:abi graph) (:arguments graph))))
+
+(defn direct-scalar-range-preconditions
+  "Project physical integer ranges for direct public scalar bindings into selector conditions.
+  This is deliberately partial: computed node arguments, allocation products and artifact
+  preconditions still require ordinary binding preflight. No expression is evaluated here."
+  [graph]
+  (let [graph (executable/validate! graph)
+        public (scalar-interface graph)
+        public-ids (set (map second public))
+        bindings (concat public
+                         (mapcat (fn [{:keys [operation]}]
+                                   (map vector (:abi operation) (:arguments operation)))
+                                 (:nodes graph)))]
+    (vec
+     (distinct
+      (mapcat (fn [[slot argument]]
+                (when (and (= :scalar (:kind slot)) (contains? public-ids argument))
+                  (when-let [{:keys [lower upper]} (scalar-range/for-dtype (:kernel-dtype slot))]
+                    [{:expression argument :op :>=
+                      :value (if (= :bound (:role slot)) (max 0 lower) lower)}
+                     {:expression argument :op :<= :value upper}])))
+              bindings)))))
 
 (defn- validate-scalar-values!
   [graph scalar-values]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1221,9 +1221,9 @@
                                      (when (= :scalar (:kind slot))
                                        [argument (:dtype slot)])))
                            (map vector abi arguments))
-        ;; All-Long unbatched shapes retain wide layout/combine extents; matrix coordinates
-        ;; use explicit checked specialization. Mixed-width products and batch admission
-        ;; remain separate gates, never implicit narrowing conversions.
+        ;; Uniform Long shapes retain wide layout/combine extents; matrix coordinates and
+        ;; grid-Z counts use checked specialization plus ABI-derived admission guards.
+        ;; Mixed-width products remain a separate gate, never implicit narrowing conversions.
         wide-dimensions (delay
                           (filterv #(not= :int (klaunch/typed-expression-dtype % scalar-types))
                                    (cond-> (vec (:dimensions matrix-view))
@@ -1258,9 +1258,9 @@
                  :matrix (get-in options [:desc :matrix])}}
 
       (and (seq @wide-dimensions)
-           (or (:batched? matrix-view)
-               (not-every? #(= :long (klaunch/typed-expression-dtype % scalar-types))
-                           (:dimensions matrix-view))))
+           (not-every? #(= :long (klaunch/typed-expression-dtype % scalar-types))
+                       (cond-> (vec (:dimensions matrix-view))
+                         (:batched? matrix-view) (conj (:batch matrix-view)))))
       {:alternatives []
        :decline {:reason :mixed-dpas-index-width-not-lowered
                  :dimensions @wide-dimensions :required-dtype :int}}

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -458,14 +458,23 @@
         interface (update (executable/common-view base) :abi
                           #(mapv (fn [slot] (if (= :scalar (:kind slot))
                                              (assoc slot :dtype :long :kernel-dtype :long) slot)) %))
-        graph (:graph (gemm/emit-batched-matrix-alternative
-                       (assoc spec :external-interface interface)))
+        {graph :graph selector :selector}
+        (gemm/emit-batched-matrix-alternative (assoc spec :external-interface interface))
         values (zipmap '[batch m n k] (mapv #(hash-map :type :long :value %) [2 8 32 32]))
         bindings (mapcat #(get-in % [:operation :attributes :scheduled-kernel-body :scalar-bindings])
                          (:nodes graph))]
     (is (every? #(= :long (:dtype %)) bindings))
     (is (= #{:identity :checked-range} (set (map :conversion bindings))))
     (is (map? (graph-call/temporary-specs graph values)))
+    (doseq [[batch fallback?] [[2 false] [2147483648 true]]]
+      (let [scalars (assoc (into {} (map (fn [[id value]] [id (:value value)])) values)
+                           'batch batch)]
+        (is (= fallback?
+               (boolean
+                (some (fn [{:keys [expression op value]}]
+                        (precondition/compare-value?
+                         op (launch/resolve-expression scalars expression) value))
+                      (:cases selector)))))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical ABI range"
                           (graph-call/temporary-specs graph (assoc-in values ['batch :value] 2147483648))))))
 

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
+            [raster.compiler.ir.kernel-precondition :as precondition]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]))
 
@@ -16,6 +17,16 @@
     (emit/generate-scan-kernel-graph
      (lower/scan-kernel-graph
       node operations {:array-types {'values :float 'out :float}}))))
+
+(deftest direct-scalar-ranges-are-projected-without-evaluating-derived-expressions
+  (let [graph (emitted-graph)
+        conditions (graph-call/direct-scalar-range-preconditions graph)]
+    (is (seq conditions))
+    (is (every? #(= 'n (:expression %)) conditions))
+    (is (precondition/check! conditions {'n 1025}))
+    (doseq [n [-1 2147483648]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
+                            (precondition/check! conditions {'n n}))))))
 
 (deftest scalar-preconditions-precede-temporary-sizing
   (let [graph (assoc-in (emitted-graph) [:nodes 0 :operation :preconditions]

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -24,6 +24,9 @@
     (is (seq conditions))
     (is (every? #(= 'n (:expression %)) conditions))
     (is (precondition/check! conditions {'n 1025}))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (graph-call/direct-scalar-range-preconditions
+                  (get-in graph [:nodes 0 :operation]))))
     (doseq [n [-1 2147483648]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"precondition failed"
                             (precondition/check! conditions {'n n}))))))

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -25,6 +25,13 @@
                    (clojure.core/aget B (+ (* l n) j))))]
      step))
 
+(def ^:private both-batched-source
+  '(let* [step (raster.par/contract
+                C [[b batch] [i m] [j n]] [[l k]]
+                (* (clojure.core/aget A (+ (* (+ (* b m) i) k) l))
+                   (clojure.core/aget B (+ (* (+ (* b k) l) n) j))))]
+     step))
+
 (defn- typed-dispatch
   ([device-id] (typed-dispatch device-id :int))
   ([device-id scalar-dtype]
@@ -42,10 +49,11 @@
      :precision :mixed-f16-f32))))
 
 (defn- typed-batched-dispatch
-  [device-id scalar-dtype]
+  [device-id scalar-dtype both-batched?]
   (let [{:keys [form]}
         (pipeline/schedule-parallel-form
-         batched-source {:target-device device-id
+         (if both-batched? both-batched-source batched-source)
+                        {:target-device device-id
                          :dtype :float
                          :array-types {'A :float 'B :float 'C :float}
                          :scalar-types {'batch scalar-dtype 'm scalar-dtype
@@ -115,7 +123,7 @@
     result))
 
 (defn- batched-reference
-  [^floats a ^floats b batch m n k]
+  [^floats a ^floats b batch m n k both-batched?]
   (let [result (float-array (* batch m n))]
     (dotimes [batch-index batch]
       (dotimes [i m]
@@ -128,7 +136,8 @@
                      (recur (inc l)
                             (+ sum
                                (* (f16 (aget a (+ (* (+ (* batch-index m) i) k) l)))
-                                  (f16 (aget b (+ (* l n) j))))))
+                                  (f16 (aget b (+ (if both-batched? (* batch-index k n) 0)
+                                                  (* l n) j))))))
                      sum)))))))
     result))
 
@@ -230,15 +239,17 @@
 (deftest batched-typed-contraction-executes-with-shared-weights
   (if-not @gpu-probe/gpu-available?
     (gpu-probe/gpu-skip! "batched typed contraction matrix KernelExecutable")
-    (doseq [scalar-dtype [:int :long]]
+    (doseq [scalar-dtype [:int :long]
+            both-batched? [false true]]
      (let [device-id :ze:0
           batch 2
           m 8
           n 32
           k 32
           a (input-array (* batch m k) 41)
-          b (input-array (* k n) 43)
-          scheduled (typed-batched-dispatch device-id scalar-dtype)
+          b-elements (* (if both-batched? batch 1) k n)
+          b (input-array b-elements 43)
+          scheduled (typed-batched-dispatch device-id scalar-dtype both-batched?)
           runtime-arguments
           [:a :b :c
            {:type scalar-dtype :value batch}
@@ -249,14 +260,14 @@
       (is (= :xmx-batched (executable/strategy selected)))
       (gpu/with-gpu-session [session device-id]
         (gpu/alloc! session {:a [:float (* batch m k) a]
-                             :b [:float (* k n) b]
+                             :b [:float b-elements b]
                              :c [:float (* batch m n) nil]})
         (let [handle (gpu/bind-kernel-executable!
                       session :typed-batched-contraction selected runtime-arguments)]
           (try
             (gpu/run-kernel-graph! session handle)
             (is (< (relative-l1 (gpu/download session :c)
-                                (batched-reference a b batch m n k))
+                                (batched-reference a b batch m n k both-batched?))
                    1.0e-3))
             (finally
               (gpu/release-kernel-graph! session handle)))))))))

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -42,13 +42,14 @@
      :precision :mixed-f16-f32))))
 
 (defn- typed-batched-dispatch
-  [device-id]
+  [device-id scalar-dtype]
   (let [{:keys [form]}
         (pipeline/schedule-parallel-form
          batched-source {:target-device device-id
                          :dtype :float
                          :array-types {'A :float 'B :float 'C :float}
-                         :scalar-types {'batch :int 'm :int 'n :int 'k :int}})
+                         :scalar-types {'batch scalar-dtype 'm scalar-dtype
+                                        'n scalar-dtype 'k scalar-dtype}})
         equation (first (:equations form))]
     (contract-route/route-typed-contraction-dispatch
      (:algorithm equation) (first (:operations equation))
@@ -229,20 +230,21 @@
 (deftest batched-typed-contraction-executes-with-shared-weights
   (if-not @gpu-probe/gpu-available?
     (gpu-probe/gpu-skip! "batched typed contraction matrix KernelExecutable")
-    (let [device-id :ze:0
+    (doseq [scalar-dtype [:int :long]]
+     (let [device-id :ze:0
           batch 2
           m 8
           n 32
           k 32
           a (input-array (* batch m k) 41)
           b (input-array (* k n) 43)
-          scheduled (typed-batched-dispatch device-id)
+          scheduled (typed-batched-dispatch device-id scalar-dtype)
           runtime-arguments
           [:a :b :c
-           {:type :int :value batch}
-           {:type :int :value m}
-           {:type :int :value n}
-           {:type :int :value k}]
+           {:type scalar-dtype :value batch}
+           {:type scalar-dtype :value m}
+           {:type scalar-dtype :value n}
+           {:type scalar-dtype :value k}]
           selected (dispatch/select-alternative scheduled runtime-arguments)]
       (is (= :xmx-batched (executable/strategy selected)))
       (gpu/with-gpu-session [session device-id]
@@ -257,7 +259,7 @@
                                 (batched-reference a b batch m n k))
                    1.0e-3))
             (finally
-              (gpu/release-kernel-graph! session handle))))))))
+              (gpu/release-kernel-graph! session handle)))))))))
 
 (deftest typed-result-transform-executes-inside-the-matrix-store
   (if-not @gpu-probe/gpu-available?

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1164,10 +1164,14 @@
           (is (= (kernel-graph/boundary-contract (:source refinement))
                  (kernel-graph/boundary-contract (:graph refinement)))))))))
 
-(deftest long-dimensions-admit-only-guarded-unbatched-matrix-schedules
+(deftest uniform-long-dimensions-use-guarded-matrix-schedules
   (doseq [batched? [false true]
-          widths [{'m :long 'n :long 'k :long} {'m :int 'n :int 'k :long}]]
-    (let [declined? (some #{:int} (vals widths))
+          widths (cond-> [{'m :long 'n :long 'k :long} {'m :int 'n :int 'k :long}]
+                   batched? (into [{'batch :int 'm :long 'n :long 'k :long}
+                                   {'batch :long 'm :int 'n :int 'k :int}]))]
+    (let [scalar-types (merge {'batch :long} widths)
+          effective-types (if batched? scalar-types widths)
+          declined? (> (count (set (vals effective-types))) 1)
           contract (if batched?
                      '(raster.par/contract C [[b batch] [i m] [j n]] [[l k]]
                         (* (aget A (+ (* (+ (* b m) i) k) l)) (aget B (+ (* l n) j))))
@@ -1177,7 +1181,7 @@
                           (list 'let* ['step contract] 'step)
                           {:target-device :ze:0 :dtype :float
                            :array-types {'A :float 'B :float 'C :float}
-                           :scalar-types (assoc widths 'batch :long)})
+                           :scalar-types scalar-types})
           dispatch (contract-route/route-typed-contraction-dispatch
                      (-> form :equations first :algorithm)
                      (-> form :equations first :operations first)
@@ -1196,26 +1200,31 @@
           (is (= (if batched? #{:portable-segred :xmx-batched}
                                #{:portable-segred :xmx-direct :xmx-split-k})
                  (set (map kdispatch/alternative-strategy (:alternatives dispatch)))))
-          (doseq [[dimensions expected] [[{'m 16 'n 32 'k 32} (if batched? :xmx-batched :xmx-direct)]
-                                         [{'m 16 'n 16 'k 32} :portable-segred]
-                                         [{'m 2147483648 'n 32 'k 32} :portable-segred]]
-                  :let [dimensions (assoc dimensions 'batch 2)
+          (doseq [[dimensions expected]
+                  (cond-> [[{'m 16 'n 32 'k 32} (if batched? :xmx-batched :xmx-direct)]
+                           [{'m 16 'n 16 'k 32} :portable-segred]
+                           [{'m 2147483648 'n 32 'k 32} :portable-segred]
+                           [{'m 3 'n 32 'k 48} (if batched? :portable-segred :xmx-direct)]]
+                    batched? (conj [{'batch 2147483648 'm 16 'n 32 'k 32} :portable-segred]))
+                  :let [dimensions (merge {'batch 2} dimensions)
                         values (mapv (fn [slot argument]
                                        (if (= :scalar (:kind slot))
                                          {:type :long :value (get dimensions argument)} argument))
                                      abi arguments)]]
             (is (= expected (kdispatch/alternative-strategy
                              (kdispatch/select-alternative dispatch values)))))
-          (doseq [dimensions [{'m 16 'n 16 'k 32} {'m 2147483648 'n 32 'k 32}]]
+          (doseq [dimensions (cond-> [{'m 16 'n 16 'k 32} {'m 2147483648 'n 32 'k 32}]
+                               batched? (conj {'batch 2147483648 'm 16 'n 32 'k 32}
+                                              {'batch 2 'm 3 'n 32 'k 48}))]
             (is (thrown? clojure.lang.ExceptionInfo
                          (kernel-graph-call/temporary-specs
                           (kdispatch/alternative dispatch (if batched? :xmx-batched :xmx-direct))
                           (into {} (map (fn [[id value]] [id {:type :long :value value}]))
-                                (cond-> dimensions batched? (assoc 'batch 2)))))))))
+                                (if batched? (merge {'batch 2} dimensions) dimensions))))))))
       (let [scalar-slots (filter #(= :scalar (:kind %))
                                  (:abi (first (:alternatives dispatch))))]
         (is (= (if batched? 4 3) (count scalar-slots)))
-        (is (= (set (vals widths)) (set (map :dtype scalar-slots))))))))
+        (is (= (set (vals effective-types)) (set (map :dtype scalar-slots))))))))
 
 (deftest dynamic-f32-contraction-owns-its-dpas-graph-alternatives
   (let [source

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1167,7 +1167,7 @@
 (deftest long-dimensions-admit-only-guarded-unbatched-matrix-schedules
   (doseq [batched? [false true]
           widths [{'m :long 'n :long 'k :long} {'m :int 'n :int 'k :long}]]
-    (let [declined? (or batched? (some #{:int} (vals widths)))
+    (let [declined? (some #{:int} (vals widths))
           contract (if batched?
                      '(raster.par/contract C [[b batch] [i m] [j n]] [[l k]]
                         (* (aget A (+ (* (+ (* b m) i) k) l)) (aget B (+ (* l n) j))))
@@ -1193,12 +1193,14 @@
           (is (= :mixed-dpas-index-width-not-lowered
                  (get-in dispatch [:attributes :matrix-graph-decline :reason]))))
         (let [{:keys [abi arguments]} (executable/common-view (kdispatch/default-alternative dispatch))]
-          (is (= #{:portable-segred :xmx-direct :xmx-split-k}
+          (is (= (if batched? #{:portable-segred :xmx-batched}
+                               #{:portable-segred :xmx-direct :xmx-split-k})
                  (set (map kdispatch/alternative-strategy (:alternatives dispatch)))))
-          (doseq [[dimensions expected] [[{'m 16 'n 32 'k 32} :xmx-direct]
+          (doseq [[dimensions expected] [[{'m 16 'n 32 'k 32} (if batched? :xmx-batched :xmx-direct)]
                                          [{'m 16 'n 16 'k 32} :portable-segred]
                                          [{'m 2147483648 'n 32 'k 32} :portable-segred]]
-                  :let [values (mapv (fn [slot argument]
+                  :let [dimensions (assoc dimensions 'batch 2)
+                        values (mapv (fn [slot argument]
                                        (if (= :scalar (:kind slot))
                                          {:type :long :value (get dimensions argument)} argument))
                                      abi arguments)]]
@@ -1207,9 +1209,9 @@
           (doseq [dimensions [{'m 16 'n 16 'k 32} {'m 2147483648 'n 32 'k 32}]]
             (is (thrown? clojure.lang.ExceptionInfo
                          (kernel-graph-call/temporary-specs
-                          (kdispatch/alternative dispatch :xmx-direct)
+                          (kdispatch/alternative dispatch (if batched? :xmx-batched :xmx-direct))
                           (into {} (map (fn [[id value]] [id {:type :long :value value}]))
-                                dimensions)))))))
+                                (cond-> dimensions batched? (assoc 'batch 2)))))))))
       (let [scalar-slots (filter #(= :scalar (:kind %))
                                  (:abi (first (:alternatives dispatch))))]
         (is (= (if batched? 4 3) (count scalar-slots)))


### PR DESCRIPTION
Extend guarded matrix admission to uniform Long batch/M/N/K expressions. ABI-derived scalar guards preserve private Int grid-Z limits; existing slice alignment, checked specialization and allocation preflight remain authoritative. Mixed widths remain declined, including batch-only mismatches.

Validation: public Int/Long B=2 execution with shared weights and both operands batched; oversized batch fallback and forced-binding rejection; misaligned slice fallback; batch-only mixed-width negatives. Expanded focused checks: 2 tests / 45 assertions. Device namespace: 5 tests / 32 assertions before both-batched additions. Independent review found no blocker; suggested coverage was added.

This is guarded admission, not a guarantee all shapes allocate or execute and not a performance claim. Full CI runs off the laptop.