### PR TITLE
Prove staged sum identities and packed accumulator prefixes

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -161,6 +161,15 @@ The next caller audit distinguishes a remaining source edge from demonstrated ru
 | JVM SIMD / scalar | `pipeline` → `par_simd` or source expansion | Bound SegOps coexist with traversal of the retained source projection. |
 | CPU C/SIMD | `cpu/aot` → `cpu/csimd` | Bound SegOps preferred; compatibility reconstruction and distinct vector emission remain. |
 
+Before migrating staged contractions, their numerical admission must preserve the claimed
+flat-equivalence law: stage initializers are proven zero using the shared checked-constant
+semantics, and packed signed-byte accumulation requires every prefix to fit the DP4A instruction's
+Int32 result, even when the surrounding accumulator is Long. The reusable interval-prefix proof
+uses unbounded host arithmetic. This closes those admission gaps, not the remaining source
+emitter's general integer overflow semantics or the typed staged lowering itself. Finite-precision
+equivalence still needs a per-stage conversion/rounding contract; exact-arithmetic distribution
+is not a proof of bitwise equivalence.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -31,6 +31,7 @@
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scalar-range :as scalar-range]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
@@ -1646,6 +1647,19 @@
        :body body :declared (mapv :sym operands)}
       (not int-acc?) {:ok false :reason :inner-stage-accumulator-not-integral
                       :dtype (:dtype inner-stage)}
+      ;; The hardware operation consumes AND returns int32, even when the enclosing carry is
+      ;; Long. Prove every prefix, not merely the final sum of a sampled input. This also keeps
+      ;; scalar and packed accumulation exact for all admitted signed-byte operands.
+      (not (scalar-range/contained-in-dtype?
+            (scalar-range/accumulation-prefixes
+             (when (or (nil? (:init inner-stage))
+                       (constant/zero-value? (:init inner-stage)))
+               (scalar-range/literal 0 :int))
+             (scalar-range/arithmetic :* (repeat 2 (scalar-range/for-dtype :byte)))
+             (:extent inner-stage))
+            :int))
+      {:ok false :reason :unproved-dp4a-accumulator-range
+       :dtype (:dtype inner-stage) :extent (:extent inner-stage)}
       :else
       (or
        ;; the declared map must PROVABLY be the operand's actual index expression
@@ -1719,7 +1733,7 @@
         _ (when-not (:ok legal)
             (throw (ex-info (str "staged contraction: illegal stages (" (:reason legal) ")")
                             (assoc legal :stages stages :contract-axes contract-axes))))
-        stages (vec stages)
+        stages (mapv #(update % :init constant/literal-or-original) stages)
         ;; TENSORIZE THE INNER STAGE: the innermost accumulation is already an exact int32 sum over
         ;; a short K-contiguous run, which is exactly dp4a's shape. Requested explicitly (a schedule
         ;; choice), then GATED — a rejection falls back to the scalar nest, never to a wrong kernel.

--- a/src/raster/compiler/ir/contract_stages.clj
+++ b/src/raster/compiler/ir/contract_stages.clj
@@ -43,6 +43,7 @@
    and may reference its own axis plus extra operand arrays, each with a declared axis-map (so a
    scale is indexed by ITS map, not by pattern-matching — same rule as the epilogue seam)."
   (:require [raster.compiler.core.op-descriptor :as od]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.core.dtype :as dt]
             [clojure.set :as set]
@@ -95,6 +96,8 @@
      • accumulator dtypes must not NARROW going outward: a float inner accumulator feeding an
        integral outer accumulator truncates every partial sum. (int → float, the quant case, is
        the whole point and is fine.)
+     • initial accumulators must be proven zero (an omitted init means zero). Seeded folds
+       have extra terms that the flat equivalent does not represent.
      • no layout/distribution-changing op in a lift."
   [stages contract-axes & {:keys [inner] :or {inner 'inner}}]
   (let [stages (vec stages)
@@ -144,6 +147,12 @@
                :else nil)))
          (butlast stages)))
        ;; dtypes must not narrow outward (inner → outer)
+       ;; The flat equivalent distributes products over sums, not seeded folds. A nonzero
+       ;; seed contributes once per enclosing iteration and is absent from that equivalent.
+       (first (keep (fn [{:keys [axis init]}]
+                      (when-not (or (nil? init) (constant/zero-value? init))
+                        {:ok false :reason :nonzero-stage-identity :axis axis :init init}))
+                    stages))
        ;; an accumulator dtype the compiler cannot spell is a REFUSAL, not a silent substitution
        (first (keep (fn [{:keys [axis dtype]}]
                       (when-not (dt/known? dtype)

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -57,6 +57,13 @@
              {:lower (reduce min products) :upper (reduce max products)})
         nil))))
 
+(defn accumulation-prefixes
+  "Enclose every prefix of up to `count` additions of values in `term`, starting at `initial`.
+   Unknown or nonintegral counts decline; proof arithmetic remains unbounded."
+  [initial term count]
+  (when (and (integer? count) (not (neg? count)))
+    (arithmetic :+ [initial (arithmetic :* [term {:lower 0 :upper count}])])))
+
 (defn hull
   "The least interval containing every non-nil input interval, or nil when an input is
   unknown.  It is used for control-flow joins rather than as an assertion mechanism."

--- a/test/raster/compiler/ir/contract_stages_test.clj
+++ b/test/raster/compiler/ir/contract_stages_test.clj
@@ -26,6 +26,18 @@
       (is (= 128 (cs/contract-extent s)))
       (is (= [] (cs/lift-operands s))))))
 
+(deftest staged-sums-require-zero-identities
+  (doseq [position [0 1] init [1 -1 0.5 'seed '(int 4294967296) ##NaN ##Inf]]
+    (is (= :nonzero-stage-identity
+           (:reason (cs/stages-legal? (assoc-in q8-stages [position :init] init)
+                                      '[[blk 4] [t 32]])))))
+  (doseq [init [nil 0 0.0 -0.0 '(int 0) '(float 0)]]
+    (is (:ok (cs/stages-legal? (mapv #(assoc % :init init) q8-stages)
+                               '[[blk 4] [t 32]]))))
+  (is (= :nonzero-stage-identity
+         (:reason (cs/stages-legal? '[{:axis l :extent 1 :dtype :float :init 1}]
+                                    '[[l 1]])))))
+
 (deftest two-stage-block-quant
   (testing "the q8_0 shape is legal"
     (is (:ok (cs/stages-legal? q8-stages '[[blk 4] [t 32]]))))

--- a/test/raster/compiler/ir/scalar_range_test.clj
+++ b/test/raster/compiler/ir/scalar_range_test.clj
@@ -3,6 +3,19 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.scalar-range :as ranges]))
 
+(deftest accumulation-proof-includes-intermediate-prefixes
+  (let [term (ranges/arithmetic :* (repeat 2 (ranges/for-dtype :byte)))
+        prove #(ranges/accumulation-prefixes (ranges/literal 0 :long) term %)]
+    (is (= {:lower -16256 :upper 16384} term))
+    (is (ranges/contained-in-dtype? (prove 131068) :int))
+    (is (not (ranges/contained-in-dtype? (prove 131072) :int)))
+    (is (= 2147483648 (:upper (prove 131072))))
+    (is (= (*' Long/MAX_VALUE 16384) (:upper (prove Long/MAX_VALUE))))
+    (doseq [n [nil 'n -1 1.5]] (is (nil? (prove n)))))
+  (is (= {:lower -5 :upper 10}
+         (ranges/accumulation-prefixes {:lower 10 :upper 10}
+                                      {:lower -3 :upper -2} 5))))
+
 (deftest typed-index-ranges-cover-every-small-domain-value
   (doseq [width [1 2 7 12] divisor [1 2 3 5]
           op [:floor-div :mod]]

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -56,6 +56,20 @@
     (testing "route-contraction validated it on the way out (it returned at all)"
       (is (some? (:kernel-name r))))))
 
+(deftest staged-route-validates-and-normalizes-identities
+  (let [replace-stages (fn [f]
+                         (let [form (staged-form :byte)
+                               opts (apply hash-map (drop 5 form))]
+                           (concat (take 5 form)
+                                   (mapcat identity (update opts :stages f)))))]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"nonzero-stage-identity"
+         (cr/route-contraction (replace-stages #(assoc-in % [1 :init] 1)) :dtype :byte)))
+    (let [r (cr/route-contraction
+             (replace-stages #(assoc-in % [1 :init] '(int 0))) :dtype :byte)]
+      (is (re-find #"int acc_1 = 0;" (:source r)))
+      (is (= 0 (get-in r [:stages 1 :init]))))))
+
 (deftest staging-beats-dtype-in-the-dispatch
   (testing "an int8 staged contraction must NOT be captured by the flat int8 leaves — they have a
             single accumulator and cannot express a per-block scale at all"
@@ -141,6 +155,23 @@
                    (list 'aget 'b (idx (get ms 'b))))]
             (drop 5 (staged-form :byte))
             [:operands [{:sym 'a :map (get ms 'a)} {:sym 'b :map (get ms 'b)}]])))
+
+(deftest packed-inner-stage-proves-all-int32-prefixes
+  (let [gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/staged-inner-dp4a-legal?)
+        spec (fn [extent accumulator]
+               (let [maps (mapv (fn [axis] {:groups [[[axis 1]] [['t extent]]]}) '[i j])
+                     index (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)]
+                 {:dtype :byte
+                  :stages [{:axis 't :extent extent :dtype accumulator :init 0}]
+                  :body (list '* (list 'aget 'a (index (first maps)))
+                              (list 'aget 'b (index (second maps))))
+                  :operands (mapv (fn [sym m] {:sym sym :map m}) '[a b] maps)}))]
+    (doseq [accumulator [:int :long]]
+      (is (:ok (gate (spec 131068 accumulator))))
+      (is (= :unproved-dp4a-accumulator-range
+             (:reason (gate (spec 131072 accumulator))))))
+    (is (= :unproved-dp4a-accumulator-range
+           (:reason (gate (assoc-in (spec 32 :long) [:stages 0 :init] 'unknown)))))))
 
 (deftest prefer-peak-tensorizes-the-inner-stage
   (let [form (staged-form-with-maps)


### PR DESCRIPTION
## Summary
- Require proven zero stage initializers so staged scheduling preserves its stated flat-equivalence law; normalize checked constant seeds before source emission.
- Use shared exact interval analysis to prove every signed-byte accumulation prefix fits the DP4A Int32 result, including when the surrounding carry is Long.
- Keep typed staged lowering and general integer overflow semantics explicitly unfinished on the campaign.

## Validation
- 24 focused unit tests, 190 assertions, pass in the existing capped REPL.
- Existing staged device namespace: 6 tests, 20 assertions, pass; Intel GPU availability explicitly confirmed true.
- Independent review found no numerical blocker; added the requested cast-zero emitter regression and corrected the roadmap table placement.
- Full suite and vendor compile gates delegated to CircleCI.