### PR TITLE
Move staged DP4A admission out of target emission

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -170,6 +170,14 @@ emitter's general integer overflow semantics or the typed staged lowering itself
 equivalence still needs a per-stage conversion/rounding contract; exact-arithmetic distribution
 is not a proof of bitwise equivalence.
 
+DP4A staged admission now belongs to `passes.parallel.staged-contraction-schedule`, not the
+OpenCL emitter. Both routing and the retained source generator consume the same checked packed
+maps; the old emitter-owned admission entry is removed. The next production slice is typed
+packed-stage loops and lifts, using existing ScalarLoad/ScalarCompute/ForLoop operations and
+shared scalar lowering. DP4A instruction acceptance itself proves no accumulation bounds: retain
+the schedule's prefix gate. General scalar integer stages additionally need a checked recurrence
+proof (including zero trips and cross-carry dependencies), not weakened KernelBody validation.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -31,7 +31,7 @@
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.reduction :as reduction]
-            [raster.compiler.ir.scalar-range :as scalar-range]
+            [raster.compiler.passes.parallel.staged-contraction-schedule :as staged-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
@@ -1597,91 +1597,6 @@
                    (str "    int " (ce/c-symbol sym) " = " div " % " (bc bound) ";")))
                v))))
 
-(defn staged-inner-dp4a-legal?
-  "Can the INNERMOST stage of a staged contraction be tensorized with dp4a (4 int8 MACs into an
-   int32 in one op)? Returns {:ok true :packed-maps {sym amap} :packed-extent n} or
-   {:ok false :reason kw}.
-
-   This is the int8 PEAK leaf for block-quant, and it is the same structure llama.cpp hand-writes:
-   the inner stage is already an exact int32 accumulation over a short K-contiguous run, which is
-   precisely dp4a's shape. Because the stage list says which axis the inner accumulation runs over,
-   there is nothing to recognize — the gate only has to CHECK.
-
-   Required, and the failure each check prevents:
-     • declared operand axis-maps. Tensorizing needs to know each operand's innermost axis; per the
-       compiler's declare-don't-pattern-match rule that is data, not inference.
-     • each map must VERIFIABLY equal the operand's actual index in the body (am/index-matches?).
-       Assuming a layout while having checked only the axis symbols is how a transpose rewrite
-       silently miscompiled before; a leaf may only assume what it has proved.
-     • the inner stage's axis must be the INNERMOST axis of both maps — dp4a packs 4 consecutive
-       elements along the contraction, so both operands must be contiguous in it (the :nt layout).
-     • int8 operands, integral inner accumulator (widening as a dtype pair).
-     • the inner extent must be a literal multiple of 4, else the packed load is mis-strided."
-  [{:keys [stages body operands dtype]}]
-  (let [inner-stage (peek (vec stages))
-        int-acc? (contains? #{:int :long :int32} (:dtype inner-stage))
-        agets (into {} (map (juxt :sym :idx)) (descriptor/aget-reads body))
-        ;; THE BODY IS DISCARDED when this leaf fires — the whole summand is replaced by one
-        ;; rstr_dp4a call — so the gate must account for EVERY term first. The requirement lives in
-        ;; ir/contraction-facts as `body-product-of`, shared with every other body-replacing leaf,
-        ;; rather than re-derived per gate.
-        exact-product? (some? (cf/body-product-of body (map :sym operands)))]
-    (cond
-      (not= 2 (count operands)) {:ok false :reason :dp4a-needs-two-declared-operands}
-      (not (every? :map operands)) {:ok false :reason :operand-without-a-declared-map}
-      (not (and (dt/known? dtype) (= :byte (dt/canon dtype))))
-      {:ok false :reason :dp4a-needs-int8-operands :dtype dtype}
-      ;; A :decode is a LOAD-LAMBDA applied by substituting into the body — and this leaf discards
-      ;; the body, replacing the whole summand with one rstr_dp4a call. So a zero-point would be
-      ;; silently dropped: Σ a·b instead of Σ(a−za)(b−zb), wrong by a constant-plus-linear term with
-      ;; no diagnostic. Load-bearing, since q4_0/q8_0 carry zero-points 8 and 128. Same underlying
-      ;; reason as :body-has-unmodeled-terms below — the body is not evaluated here.
-      (some :decode operands)
-      {:ok false :reason :decode-on-a-body-replacing-leaf
-       :detail "this leaf replaces the body with a single hardware op, so a per-operand :decode (e.g. a zero-point) would be silently dropped"
-       :decoded (mapv :sym (filter :decode operands))}
-
-      (not exact-product?)
-      {:ok false :reason :body-has-unmodeled-terms
-       :detail "this leaf replaces the body with a single hardware op; any term beyond the two declared operands would be silently dropped"
-       :body body :declared (mapv :sym operands)}
-      (not int-acc?) {:ok false :reason :inner-stage-accumulator-not-integral
-                      :dtype (:dtype inner-stage)}
-      ;; The hardware operation consumes AND returns int32, even when the enclosing carry is
-      ;; Long. Prove every prefix, not merely the final sum of a sampled input. This also keeps
-      ;; scalar and packed accumulation exact for all admitted signed-byte operands.
-      (not (scalar-range/contained-in-dtype?
-            (scalar-range/accumulation-prefixes
-             (when (or (nil? (:init inner-stage))
-                       (constant/zero-value? (:init inner-stage)))
-               (scalar-range/literal 0 :int))
-             (scalar-range/arithmetic :* (repeat 2 (scalar-range/for-dtype :byte)))
-             (:extent inner-stage))
-            :int))
-      {:ok false :reason :unproved-dp4a-accumulator-range
-       :dtype (:dtype inner-stage) :extent (:extent inner-stage)}
-      :else
-      (or
-       ;; the declared map must PROVABLY be the operand's actual index expression
-       (first (keep (fn [{:keys [sym map]}]
-                      (let [idx (get agets sym)]
-                        (cond
-                          (nil? idx) {:ok false :reason :declared-operand-not-read-by-the-body :sym sym}
-                          (not (am/index-matches? map idx))
-                          {:ok false :reason :declared-map-does-not-match-the-body-index
-                           :sym sym :declared (am/index-expr map) :actual idx}
-                          (not= (:axis inner-stage) (am/innermost-axis map))
-                          {:ok false :reason :inner-stage-axis-is-not-contiguous
-                           :sym sym :innermost (am/innermost-axis map) :axis (:axis inner-stage)}
-                          :else nil)))
-                    operands))
-       (let [p-sym (gensym "p__")
-             packed (into {} (for [{:keys [sym map]} operands]
-                               [sym (am/pack-innermost map 4 p-sym)]))]
-         (if (some nil? (vals packed))
-           {:ok false :reason :inner-extent-not-a-multiple-of-4 :extent (:extent inner-stage)}
-           {:ok true :packed-maps packed :p-sym p-sym
-            :packed-extent (quot (long (:extent inner-stage)) 4)}))))))
 
 (defn generate-staged-contraction-kernel
   "STAGED contraction → OpenCL: a reduction accumulating in N levels, each with its own
@@ -1738,7 +1653,7 @@
         ;; a short K-contiguous run, which is exactly dp4a's shape. Requested explicitly (a schedule
         ;; choice), then GATED — a rejection falls back to the scalar nest, never to a wrong kernel.
         tz (when tensorize-inner?
-             (let [g (staged-inner-dp4a-legal? spec)]
+             (let [g (staged-schedule/inner-dp4a-plan spec)]
                (when-not (:ok g)
                  (throw (ex-info (str "staged contraction: cannot tensorize inner stage ("
                                       (:reason g) ")") g)))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -36,6 +36,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
+            [raster.compiler.passes.parallel.staged-contraction-schedule :as staged-schedule]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]))
 
@@ -446,7 +447,7 @@
                     :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
                                                 :float)}
               tz? (and prefer-peak? (seq operands)
-                       (:ok (sco/staged-inner-dp4a-legal? spec)))
+                       (:ok (staged-schedule/inner-dp4a-plan spec)))
               k (sco/generate-staged-contraction-kernel
                  (assoc spec :tensorize-inner? (boolean tz?)) out-sym)]
           {:strategy :staged-segred
@@ -1695,7 +1696,7 @@
                    (and (number? k-extent) (zero? (mod (long k-extent) 4))
                         (:ok (cf/check-layout (cf/contraction-facts form :dtype :byte)
                                               (:dp4a cf/leaf-layouts)))
-                        (:ok (sco/staged-inner-dp4a-legal? (spec form true)))))
+                        (:ok (staged-schedule/inner-dp4a-plan (spec form true)))))
         emit (fn [form tz? pre-steps]
                (let [k (sco/generate-staged-contraction-kernel (spec form tz?) out-sym)]
                  (cond-> {:strategy (if tz? :dp4a :quant-naive)

--- a/src/raster/compiler/passes/parallel/staged_contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_schedule.clj
@@ -1,0 +1,96 @@
+(ns raster.compiler.passes.parallel.staged-contraction-schedule
+  "Schedule admission for staged contractions, independent of target source emission.
+   Operand maps, body equivalence and numerical bounds are checked here; emitters consume the
+   resulting packed index maps. No quantization-format registry or alternate scalar IR."
+  (:require [raster.compiler.core.dtype :as dt]
+            [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contraction-facts :as cf]
+            [raster.compiler.ir.scalar-range :as scalar-range]))
+
+(defn inner-dp4a-plan
+  "Can the INNERMOST stage of a staged contraction be tensorized with dp4a (4 int8 MACs into an
+   int32 in one op)? Returns {:ok true :packed-maps {sym amap} :packed-extent n} or
+   {:ok false :reason kw}.
+
+   This is the int8 PEAK leaf for block-quant, and it is the same structure llama.cpp hand-writes:
+   the inner stage is already an exact int32 accumulation over a short K-contiguous run, which is
+   precisely dp4a's shape. Because the stage list says which axis the inner accumulation runs over,
+   there is nothing to recognize — the gate only has to CHECK.
+
+   Required, and the failure each check prevents:
+     • declared operand axis-maps. Tensorizing needs to know each operand's innermost axis; per the
+       compiler's declare-don't-pattern-match rule that is data, not inference.
+     • each map must VERIFIABLY equal the operand's actual index in the body (am/index-matches?).
+       Assuming a layout while having checked only the axis symbols is how a transpose rewrite
+       silently miscompiled before; a leaf may only assume what it has proved.
+     • the inner stage's axis must be the INNERMOST axis of both maps — dp4a packs 4 consecutive
+       elements along the contraction, so both operands must be contiguous in it (the :nt layout).
+     • int8 operands, integral inner accumulator (widening as a dtype pair).
+     • the inner extent must be a literal multiple of 4, else the packed load is mis-strided."
+  [{:keys [stages body operands dtype]}]
+  (let [inner-stage (peek (vec stages))
+        int-acc? (contains? #{:int :long :int32} (:dtype inner-stage))
+        agets (into {} (map (juxt :sym :idx)) (descriptor/aget-reads body))
+        ;; THE BODY IS DISCARDED when this leaf fires — the whole summand is replaced by one
+        ;; rstr_dp4a call — so the gate must account for EVERY term first. The requirement lives in
+        ;; ir/contraction-facts as `body-product-of`, shared with every other body-replacing leaf,
+        ;; rather than re-derived per gate.
+        exact-product? (some? (cf/body-product-of body (map :sym operands)))]
+    (cond
+      (not= 2 (count operands)) {:ok false :reason :dp4a-needs-two-declared-operands}
+      (not (every? :map operands)) {:ok false :reason :operand-without-a-declared-map}
+      (not (and (dt/known? dtype) (= :byte (dt/canon dtype))))
+      {:ok false :reason :dp4a-needs-int8-operands :dtype dtype}
+      ;; A :decode is a LOAD-LAMBDA applied by substituting into the body — and this leaf discards
+      ;; the body, replacing the whole summand with one rstr_dp4a call. So a zero-point would be
+      ;; silently dropped: Σ a·b instead of Σ(a−za)(b−zb), wrong by a constant-plus-linear term with
+      ;; no diagnostic. Load-bearing, since q4_0/q8_0 carry zero-points 8 and 128. Same underlying
+      ;; reason as :body-has-unmodeled-terms below — the body is not evaluated here.
+      (some :decode operands)
+      {:ok false :reason :decode-on-a-body-replacing-leaf
+       :detail "this leaf replaces the body with a single hardware op, so a per-operand :decode (e.g. a zero-point) would be silently dropped"
+       :decoded (mapv :sym (filter :decode operands))}
+
+      (not exact-product?)
+      {:ok false :reason :body-has-unmodeled-terms
+       :detail "this leaf replaces the body with a single hardware op; any term beyond the two declared operands would be silently dropped"
+       :body body :declared (mapv :sym operands)}
+      (not int-acc?) {:ok false :reason :inner-stage-accumulator-not-integral
+                      :dtype (:dtype inner-stage)}
+      ;; The hardware operation consumes AND returns int32, even when the enclosing carry is
+      ;; Long. Prove every prefix, not merely the final sum of a sampled input. This also keeps
+      ;; scalar and packed accumulation exact for all admitted signed-byte operands.
+      (not (scalar-range/contained-in-dtype?
+            (scalar-range/accumulation-prefixes
+             (when (or (nil? (:init inner-stage))
+                       (constant/zero-value? (:init inner-stage)))
+               (scalar-range/literal 0 :int))
+             (scalar-range/arithmetic :* (repeat 2 (scalar-range/for-dtype :byte)))
+             (:extent inner-stage))
+            :int))
+      {:ok false :reason :unproved-dp4a-accumulator-range
+       :dtype (:dtype inner-stage) :extent (:extent inner-stage)}
+      :else
+      (or
+       ;; the declared map must PROVABLY be the operand's actual index expression
+       (first (keep (fn [{:keys [sym map]}]
+                      (let [idx (get agets sym)]
+                        (cond
+                          (nil? idx) {:ok false :reason :declared-operand-not-read-by-the-body :sym sym}
+                          (not (am/index-matches? map idx))
+                          {:ok false :reason :declared-map-does-not-match-the-body-index
+                           :sym sym :declared (am/index-expr map) :actual idx}
+                          (not= (:axis inner-stage) (am/innermost-axis map))
+                          {:ok false :reason :inner-stage-axis-is-not-contiguous
+                           :sym sym :innermost (am/innermost-axis map) :axis (:axis inner-stage)}
+                          :else nil)))
+                    operands))
+       (let [p-sym (gensym "p__")
+             packed (into {} (for [{:keys [sym map]} operands]
+                               [sym (am/pack-innermost map 4 p-sym)]))]
+         (if (some nil? (vals packed))
+           {:ok false :reason :inner-extent-not-a-multiple-of-4 :extent (:extent inner-stage)}
+           {:ok true :packed-maps packed :p-sym p-sym
+            :packed-extent (quot (long (:extent inner-stage)) 4)}))))))

--- a/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
@@ -18,6 +18,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.contract-stages :as cs]
             [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.passes.parallel.staged-contraction-schedule :as staged-schedule]
             [raster.compiler.backend.gpu.segop-opencl :as sco]))
 
 (def ^:private gpu?
@@ -293,17 +294,17 @@
               :inputs '[a b] :dtype :byte :out-dtype :float
               :operands [{:sym 'a :map good-a} {:sym 'b :map good-b}]}]
     (testing "the honest case is legal"
-      (is (:ok (sco/staged-inner-dp4a-legal? spec))))
+      (is (:ok (staged-schedule/inner-dp4a-plan spec))))
     (testing "a MISDECLARED operand map is caught, not trusted — assuming a layout while having
               checked only the axis symbols is how a transpose rewrite silently miscompiled before"
       (is (= :declared-map-does-not-match-the-body-index
-             (:reason (sco/staged-inner-dp4a-legal?
+             (:reason (staged-schedule/inner-dp4a-plan
                        (assoc-in spec [:operands 0 :map]
                                  (am/of-groups [[['i M]] [['t B] ['blk NB]]])))))))
     (testing "an operand that is NOT contiguous in the inner stage axis cannot be packed"
       (let [nn-b (am/of-groups [[['blk NB] ['t B]] [['j N]]])]   ; b[(blk t), j] — j innermost
         (is (= :inner-stage-axis-is-not-contiguous
-               (:reason (sco/staged-inner-dp4a-legal?
+               (:reason (staged-schedule/inner-dp4a-plan
                          (-> spec
                              (assoc-in [:operands 1 :map] nn-b)
                              (assoc :body (list 'raster.numeric/*
@@ -311,7 +312,7 @@
                                                 (list 'aget 'b (am/index-expr nn-b)))))))))))
     (testing "a float inner accumulator is not a dp4a shape"
       (is (= :inner-stage-accumulator-not-integral
-             (:reason (sco/staged-inner-dp4a-legal?
+             (:reason (staged-schedule/inner-dp4a-plan
                        (assoc-in spec [:stages 1 :dtype] :float))))))
     (testing "requesting tensorize when illegal THROWS — it never silently degrades to scalar,
               because a silent degradation is an invisible perf cliff"

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -141,7 +141,7 @@
   ;; Σ(a−za)(b−zb). Load-bearing, since q4_0/q8_0 zero-points are 8 and 128.
   (let [am (requiring-resolve 'raster.compiler.ir.axis-map/of-groups)
         idx (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)
-        gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/staged-inner-dp4a-legal?)
+        gate (requiring-resolve 'raster.compiler.passes.parallel.staged-contraction-schedule/inner-dp4a-plan)
         ma (am [['[i 4]] ['[blk 4] '[t 32]]])
         mb (am [['[j 4]] ['[blk 4] '[t 32]]])
         base {:stages [{:axis 'blk :extent 4 :dtype :float :init 0.0 :lift 'inner}

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -157,7 +157,7 @@
             [:operands [{:sym 'a :map (get ms 'a)} {:sym 'b :map (get ms 'b)}]])))
 
 (deftest packed-inner-stage-proves-all-int32-prefixes
-  (let [gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/staged-inner-dp4a-legal?)
+  (let [gate (requiring-resolve 'raster.compiler.passes.parallel.staged-contraction-schedule/inner-dp4a-plan)
         spec (fn [extent accumulator]
                (let [maps (mapv (fn [axis] {:groups [[[axis 1]] [['t extent]]]}) '[i j])
                      index (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)]
@@ -219,7 +219,7 @@
     (let [ma {:groups [['[i 4]] ['[blk 4] '[t 32]]]}
           mb {:groups [['[j 4]] ['[blk 4] '[t 32]]]}
           idx (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)
-          gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/staged-inner-dp4a-legal?)
+          gate (requiring-resolve 'raster.compiler.passes.parallel.staged-contraction-schedule/inner-dp4a-plan)
           base {:stages [{:axis 'blk :extent 4 :dtype :float :init 0.0 :lift 'inner}
                          {:axis 't :extent 32 :dtype :int :init 0}]
                 :operands [{:sym 'a :map ma} {:sym 'b :map mb}]


### PR DESCRIPTION
## Summary
- Move the existing packed-stage legality and index-map derivation into a target-independent scheduling pass.
- Route selection and the retained OpenCL source generator consume that single owner; remove the old emitter-owned entry rather than adding a compatibility shim.
- Record the next typed packed-stage lowering boundary and the distinct proof obligation for general scalar integer recurrences.

## Validation
- Independent review confirmed the function is unchanged apart from its name/whitespace, all callsites migrated, and no new dependency cycle.
- 21 route/fail-loud tests, 70 assertions, pass.
- 6 staged Intel GPU tests, 20 assertions, pass in the existing capped REPL.
- Full suite and CUDA/HIP compilation run in CircleCI.

Stacked on #442. This is schedule ownership cleanup, not a claim that the staged source emitter is retired.