### PR TITLE
Preserve typed word-shift semantics across C-family targets

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -178,6 +178,16 @@ shared scalar lowering. DP4A instruction acceptance itself proves no accumulatio
 the schedule's prefix gate. General scalar integer stages additionally need a checked recurrence
 proof (including zero trips and cross-carry dependencies), not weakened KernelBody validation.
 
+A REPL packing probe lowers four byte reads and existing bit operations into verified KernelBody
+without reinterpreting the public byte-buffer ABI. Its target emission exposed an adjacent shift
+contract gap: C-family word shifts now explicitly mask counts to the retained Int/Long width,
+shift unsigned words, and restore arithmetic-right sign bits. Byte shifts decline centrally until
+source lowering supplies an explicit promotion/result contract. This does not authorize narrowing
+Long source shifts to Int. The shared fixture covers sign-bit packing and signed/count extrema on
+OpenCL, with CUDA/HIP source compilation in CI. It is a portability prerequisite, not evidence that
+four byte loads match the throughput of an aligned packed-word load or that staged emission is
+already unified.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -541,12 +541,21 @@
       (and integral? (contains? #{:min :max} op))
       (str (name op) "(" (str/join ", " arguments) ")")
 
-      ;; Signed right shift is not the target-neutral unsigned-shift contract.
-      (= :ushr op)
+      ;; Word shifts have the JVM/WASM width-masked count contract, independent of the
+      ;; source language's choice to widen an operand. Unsigned shifts also avoid signed
+      ;; left-shift overflow; arithmetic right shift explicitly restores the sign bits.
+      (contains? #{:shl :shr :ushr} op)
       (let [[value amount] arguments
-            unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* operand-type)]
-        (str "(" (target-type operand-type) ")((" unsigned-type ")(" value ") >> "
-             amount ")"))
+            unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* operand-type)
+            word (str "((" unsigned-type ")(" value "))")
+            count (str "(((" unsigned-type ")(" amount ")) & "
+                       (dec (* 8 (dtype/bytes-of operand-type))) ")")
+            shifted (case op
+                      :shl (str "(" word " << " count ")")
+                      :ushr (str "(" word " >> " count ")")
+                      :shr (str "((" value " < 0) ? ~(~" word " >> " count ") : ("
+                                word " >> " count "))"))]
+        (str "(" (target-type operand-type) ")(" shifted ")"))
 
       ;; OpenCL's integral abs returns an unsigned type, while KernelBody currently declares a
       ;; same-signed-type result. Refuse the mismatch until the IR states that representation step.

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -71,9 +71,11 @@
    :bit-and {:arity 2 :kind :infix :wasm {:i32 :i32.and :i64 :i64.and} :c "&" :wgsl "&"}
    :bit-or  {:arity 2 :kind :infix :wasm {:i32 :i32.or :i64 :i64.or} :c "|" :wgsl "|"}
    :bit-xor {:arity 2 :kind :infix :wasm {:i32 :i32.xor :i64 :i64.xor} :c "^" :wgsl "^"}
-   :shl     {:arity 2 :kind :infix :wasm {:i32 :i32.shl :i64 :i64.shl} :c "<<" :wgsl "<<"}
-   :shr     {:arity 2 :kind :infix :wasm {:i32 :i32.shr_s :i64 :i64.shr_s} :c ">>" :wgsl ">>"}
-   :ushr    {:arity 2 :kind :infix :wasm {:i32 :i32.shr_u :i64 :i64.shr_u} :c ">>" :wgsl ">>"}
+   ;; Canonical word shifts mask counts by the retained operand width. Byte promotion is a
+   ;; source-lowering decision, not an implicit eight-bit shift/result convention.
+   :shl     {:arity 2 :kind :infix :scalar-dtypes #{:int :long} :wasm {:i32 :i32.shl :i64 :i64.shl} :c "<<" :wgsl "<<"}
+   :shr     {:arity 2 :kind :infix :scalar-dtypes #{:int :long} :wasm {:i32 :i32.shr_s :i64 :i64.shr_s} :c ">>" :wgsl ">>"}
+   :ushr    {:arity 2 :kind :infix :scalar-dtypes #{:int :long} :wasm {:i32 :i32.shr_u :i64 :i64.shr_u} :c ">>" :wgsl ">>"}
    ;; integer remainder / modulo / quotient
    :rem  {:arity 2 :kind :special :wasm {:i32 :i32.rem_s} :c "%" :wgsl "%"}
    :mod  {:arity 2 :kind :special :c :floored-mod :wgsl :floored-mod}
@@ -250,6 +252,7 @@
         numeric? (or integral? floating?)]
     (and op
          (cond
+           (:scalar-dtypes (descriptor op)) (contains? (:scalar-dtypes (descriptor op)) dtype)
            (contains? integral-ops op) integral?
            (contains? floating-ops op) floating?
            :else numeric?))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -413,6 +413,14 @@
                           (body-emit/emit-scalar-kernel
                            "trapping_arithmetic" (body-fixtures/trapping-arithmetic-body)
                            {:target-dialect dialect}))
+           (write-source! directory suffix "word-shifts-i32"
+                          (body-emit/emit-scalar-kernel
+                           "word_shifts_i32" (body-fixtures/word-shifts-body :int 1)
+                           {:target-dialect dialect}))
+           (write-source! directory suffix "word-shifts-i64"
+                          (body-emit/emit-scalar-kernel
+                           "word_shifts_i64" (body-fixtures/word-shifts-body :long 1)
+                           {:target-dialect dialect}))
            (write-source! directory suffix "swizzled-workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "swizzled_workgroup_memory"

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -4,6 +4,29 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]))
 
+(defn word-shifts-body
+  "Typed word shifts share an input row and store left/arithmetic-right/logical-right results."
+  [type width]
+  (body/make
+   {:id [:word-shifts type width]
+    :parameters [(body/->KernelParameter 'x :input type [width] :global
+                                        (layout/row-major [width] type) :input)
+                 (body/->KernelParameter 'counts :input type [width] :global
+                                        (layout/row-major [width] type) :input)
+                 (body/->KernelParameter 'out :output type [(* 3 width)] :global
+                                        (layout/row-major [(* 3 width)] type) :result)]
+    :indices [(body/->IndexBinding 'lane :local 0)]
+    :operations
+    (into [(body/->ScalarLoad (body/value 'x-value type) 'x ['lane] nil nil :cached)
+           (body/->ScalarLoad (body/value 'count-value type) 'counts ['lane] nil nil :cached)]
+          (map-indexed
+           (fn [position op]
+             (body/->ScalarStore 'out [(body/expression :add
+                                                      (body/expression :mul 'lane 3) position)]
+                                  (body/scalar-expression op type ['x-value 'count-value]) nil))
+           [:shl :shr :ushr]))
+    :launch (launch/spec {:workgroup-size [width] :group-count [1]})}))
+
 (defn workgroup-memory-body
   "A workgroup reverses one row through explicitly allocated local storage and a barrier."
   [width]

--- a/test/raster/compiler/backend/gpu/kernel_body_shift_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_shift_test.clj
@@ -1,0 +1,70 @@
+(ns raster.compiler.backend.gpu.kernel-body-shift-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as fixtures]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.gpu.device-probe :as probe]))
+
+(deftest word-shifts-have-explicit-width-and-sign-spelling
+  (doseq [type [:int :long] target [:opencl-portable :cuda :hip]]
+    (let [source (emit/emit-scalar-kernel "word_shifts" (fixtures/word-shifts-body type 1)
+                                          {:target-dialect target})]
+      (is (str/includes? source (str " & " (if (= :int type) 31 63))))
+      (is (str/includes? source " < 0) ? ~(~"))
+      (is (str/includes? source (case target
+                                 :opencl-portable (if (= :int type) "uint" "ulong")
+                                 (if (= :int type) "unsigned int" "unsigned long long"))))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not defined for its operand dtype"
+                        (fixtures/word-shifts-body :byte 1)))
+  (doseq [op [:shl :shr :ushr]]
+    (is (not (intrinsics/accepts-scalar-dtype? op :byte)))))
+
+(defn- reference [type x n]
+  (let [n (bit-and n (if (= :int type) 31 63))
+        narrow (if (= :int type) unchecked-int identity)
+        unsigned-x (if (= :int type) (bit-and x 0xffffffff) x)]
+    (mapv narrow [(bit-shift-left x n)
+                  (bit-shift-right x n)
+                  (unsigned-bit-shift-right unsigned-x n)])))
+
+(deftest word-shifts-match-width-specific-reference-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "typed Int/Long shifts")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          resolve-op #(ns-resolve ocl %)
+          upload (resolve-op 'buffer-of-array)
+          download (resolve-op 'buffer->array)
+          free! (resolve-op 'free-buffer!)]
+      (doseq [type [:int :long]]
+        (let [minimum (if (= :int type) Integer/MIN_VALUE Long/MIN_VALUE)
+              maximum (if (= :int type) Integer/MAX_VALUE Long/MAX_VALUE)
+              pairs (vec (for [x [minimum -255 -1 0 1 255 maximum]
+                               n [minimum maximum -1 0 1 24 31 32 33 63 64 65]] [x n]))
+              width (count pairs)
+              array-of (if (= :int type) int-array long-array)
+              kernel-body (fixtures/word-shifts-body type width)
+              kernel-name (str "word_shifts_" (name type))
+              compiled (artifact/make
+                        {:kernel-name kernel-name :target :opencl-c
+                         :source (emit/emit-scalar-kernel kernel-name kernel-body
+                                                         {:target-dialect :opencl-portable
+                                                          :parameter-names {'out "rstr_output"}})
+                         :abi [(abi/slot 'x :input type :c-name "rstr_x" :role :input)
+                               (abi/slot 'counts :input type :c-name "rstr_counts" :role :input)
+                               (abi/slot 'out :output type :c-name "rstr_output" :role :result)]
+                         :arguments '[x counts out] :launch (:launch kernel-body)
+                         :effects {:kind :word-shifts} :provenance {:dialect :test}})
+              x (upload (array-of (map first pairs)) type)
+              counts (upload (array-of (map second pairs)) type)
+              out (upload (array-of (repeat (* 3 width) -555)) type)]
+          (try
+            ((resolve-op 'register-kernel!) kernel-name compiled)
+            ((resolve-op 'launch-registered-bound!)
+             ((resolve-op 'bind-kernel-call) (call/make compiled [x counts out])))
+            (is (= (vec (mapcat (fn [[x n]] (reference type x n)) pairs))
+                   (vec (download out))) (name type))
+            (finally (free! out) (free! counts) (free! x))))))))


### PR DESCRIPTION
## Summary
- Mask canonical shift counts to the verified Int/Long width, emit unsigned left/logical-right shifts, and explicitly preserve arithmetic-right sign extension.
- State the supported scalar widths in the existing intrinsic descriptors. Byte shifts require explicit source promotion; this does not authorize narrowing Long source operations.
- Add shared hardware-free CUDA/HIP fixtures and an OpenCL numerical oracle covering 504 outputs across values/count extrema, negative and oversized counts, and sign-bit packing.

## Validation
- Independent review found no blocker; added signed count extrema and rejection checks for all three Byte shifts.
- 59 focused tests / 513 assertions pass in one capped REPL, including real Intel OpenCL execution.
- Full suite and vendor source compilation delegated to CircleCI.

This emerged from the typed staged-contraction byte-packing probe. It does not yet retire staged source emission or demonstrate packed-load performance parity.