### PR TITLE
Build staged contraction routes directly from verified facts

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -188,6 +188,13 @@ OpenCL, with CUDA/HIP source compilation in CI. It is a portability prerequisite
 four byte loads match the throughput of an aligned packed-word load or that staged emission is
 already unified.
 
+Staged route construction now reads the body and output dtype from the same verified contraction
+facts as its axes and stages. It no longer reconstructs or reparses a compatibility form just to
+build the existing staged emitter's spec. Regression tests disable both source entry points and
+compare ordered ABI, scalar bindings, launch geometry and stage metadata for scalar and packed paths,
+including a non-default output dtype. The staged algorithm is still source-emitted; this retires
+an input-representation duplication, not the remaining target emission path.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -351,7 +351,8 @@
 
    `contract-form` may be nil when verified `:facts` and a scheduled operation are supplied.
    Ordinary typed matrix, register-tiled, portable and full-reduction routes need no source
-   spelling. Staged, SegMap and source fallbacks require one explicitly; the int8 compatibility
+   spelling. Staged routing also consumes verified facts directly; source fallbacks require a
+   compatibility spelling explicitly. The int8 compatibility
    leaf performs its temporary projection locally until it consumes the typed scalar vocabulary.
 
    Canonical f16 products first become a target-neutral KernelBody and are then lowered by the
@@ -422,8 +423,7 @@
       ;; contraction algebra at all. The flat leaves below cannot represent it — they have one
       ;; accumulator. 1 stage is the flat case and is left to them.
         (and (seq stages) (> (count stages) 1))
-        (let [contract-form (compatibility-form! contract-form :staged-segred)
-              ;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
+        (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
             ;; assumes `+`. A form carrying :combine max routed here and was SILENTLY SUMMED —
             ;; contraction-facts surfaces :combine and nothing read it. Refuse rather than ignore.
               _ (let [cmb (:combine (cf/scalar-reduction-view contract-facts))]
@@ -441,11 +441,10 @@
                   ;; input is the form, so there is no separately-computed value to pass
                   ;; inconsistently (which is what made the span rule unfireable)
                     :contract-axes (:contract-axes contract-facts)
-                    :body (nth contract-form 4)
-                    :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
+                    :body (:body contract-facts)
+                    :inputs (vec (sort-by name (contract-operand-arrays (:body contract-facts))))
                     :operands operands
-                    :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
-                                                :float)}
+                    :dtype dtype :out-dtype (or (:out-dtype contract-facts) :float)}
               tz? (and prefer-peak? (seq operands)
                        (:ok (staged-schedule/inner-dp4a-plan spec)))
               k (sco/generate-staged-contraction-kernel

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -12,6 +12,7 @@
         which is the one failure mode that produces plausible wrong numbers instead of an error."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.passes.parallel.contract-route :as cr]
+            [raster.compiler.ir.contraction-facts :as facts]
             [raster.par :as par]
             [raster.numeric]))
 
@@ -172,6 +173,27 @@
              (:reason (gate (spec 131072 accumulator))))))
     (is (= :unproved-dp4a-accumulator-range
            (:reason (gate (assoc-in (spec 32 :long) [:stages 0 :init] 'unknown)))))))
+
+(deftest staged-route-does-not-reconstruct-or-reparse-source
+  (let [[_ output free-axes contract-axes body & options] (staged-form-with-maps)
+        verified (facts/from-components
+                  {:out output :free-axes free-axes :contract-axes contract-axes
+                   :body body :opts (assoc (apply hash-map options) :out-dtype :double)
+                   :dtype :byte})]
+    (is (nil? (:form verified)))
+    (doseq [peak? [false true]]
+      (let [legacy (cr/route-contraction (concat (staged-form-with-maps) [:out-dtype :double])
+                                        :dtype :byte :prefer-peak? peak?)
+            typed (with-redefs-fn
+                    {#'facts/contraction-facts (fn [& _] (throw (ex-info "source reparsed" {})))
+                     #'cr/compatibility-form! (fn [& _] (throw (ex-info "source reconstructed" {})))}
+                    #(cr/route-contraction nil :facts verified :dtype :byte :prefer-peak? peak?))]
+        (is (= :staged-segred (:strategy typed)))
+        (is (= :double (:out-dtype typed)))
+        (is (= (select-keys legacy [:abi :arguments :scalar-args :array-params :lift-operands
+                                   :dtype :out-dtype :out-elems :stages :tensorized :packed :wg :grid])
+               (select-keys typed [:abi :arguments :scalar-args :array-params :lift-operands
+                                  :dtype :out-dtype :out-elems :stages :tensorized :packed :wg :grid])))))))
 
 (deftest prefer-peak-tensorizes-the-inner-stage
   (let [form (staged-form-with-maps)

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -50,8 +50,8 @@
 (deftest rms-norm-gpu-lowers
   (when (gpu-available?)
     (testing "the existing typed library deftm rms-norm! lowers to a correct OpenCL kernel"
-      ;; Proves the GPU emitter reads the deftm's DECLARED types (Double eps/gain-offset stay
-      ;; float not int-by-name-regex; Long features types the index integer), types loop recur
+      ;; The float specialization retains Float scalar storage for eps/gain-offset while
+      ;; features retains its declared Long ABI; it also types loop recur
       ;; counters from var-types (int, not float), and enables fp64 when the body uses double.
       ;; A real library op (par/map-void! over rows, reduce+map inside), not a hand-shaped kernel.
       (let [rows 4 feat 256
@@ -62,7 +62,7 @@
           (gpu/compile! sess :rn #'nn/rms-norm!)
           (gpu/alloc! sess {:x [:float (alength x) x] :w [:float feat w] :out [:float (* rows feat) nil]})
           (gpu/prepare! sess :rn {"x" :x "weight" :w "out" :out}
-                        [{:type :float :value 1.0e-6} {:type :int :value feat} {:type :float :value 1.0}]
+                        [{:type :float :value 1.0e-6} {:type :long :value feat} {:type :float :value 1.0}]
                         rows {:kernel-phase :rn})  ; scalars ordered by name: eps, features, gain-offset
           (gpu/invoke-bound! sess :rn)
           (is (< (maxerr ycpu (gpu/download sess :out)) 1e-3))
@@ -115,7 +115,7 @@
                             :positions [:int nrows positions]})
           ;; scalars by name: head-dim heads theta; nrows is represented in the launch bound.
           (gpu/prepare! sess :rope {"x" :x "out" :out "positions" :positions}
-                        [{:type :int :value hd} {:type :int :value heads} {:type :float :value theta}]
+                        [{:type :long :value hd} {:type :long :value heads} {:type :float :value theta}]
                         (* nrows heads (quot hd 2)) {:kernel-phase :rope})
           (gpu/invoke-bound! sess :rope)
           (is (< (maxerr ycpu (gpu/download sess :out)) 1e-4))
@@ -137,8 +137,8 @@
                             :out [:float (* nq hd) nil] :sc [:float (* nq cl) nil]})
           ;; scalars by name: cache-len group head-dim n-kv scale ; par bound = n-q
           (gpu/prepare! sess :at {"q" :q "k" :k "v" :v "out" :out "sc" :sc}
-                        [{:type :int :value cl} {:type :int :value group} {:type :int :value hd}
-                         {:type :int :value nkv} {:type :float :value scale}]
+                        [{:type :long :value cl} {:type :long :value group} {:type :long :value hd}
+                         {:type :long :value nkv} {:type :float :value scale}]
                         nq {:kernel-phase :at})
           (gpu/invoke-bound! sess :at)
           (is (< (maxerr ycpu (gpu/download sess :out)) 1e-4))
@@ -165,7 +165,7 @@
         (try
           (gpu/compile! sess :g #'qk/i8gemv-dp4a!)
           (gpu/alloc! sess {:wp [:int (alength wp) wp] :xp [:int (alength xp) xp] :y [:float out nil]})
-          (gpu/invoke! sess :g {"wp" :wp "xp" :xp "y" :y} [{:type :int :value kw}] out)
+          (gpu/invoke! sess :g {"wp" :wp "xp" :xp "y" :y} [{:type :long :value kw}] out)
           (let [ygpu (gpu/download sess :y)]
             (is (every? (fn [o] (= (int (aget yref o)) (int (aget ^floats ygpu o)))) (range out))))
           (finally (gpu/close-session! sess)))))))
@@ -181,7 +181,7 @@
             ycpu (float-array out)
             _ (qk/qmatmul-q4k-composable! xq xs bsums wq da db aq bq ycpu in out 0 out)
             sym {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp "da" :da "db" :db "aq" :aq "bq" :bq "y" :y}
-            scal [{:type :int :value in}]
+            scal [{:type :long :value in}]
             sess (gpu/make-session :ze:0)]
         (try
           (gpu/compile! sess :q4kdp #'qk/qmatmul-q4k-dp4a-rows!)
@@ -191,11 +191,11 @@
                             :aq [:byte (alength aq) aq] :bq [:byte (alength bq) bq]
                             :y [:float out nil]})
           ;; synchronous bound dispatch
-          (gpu/prepare! sess :q4kdp sym (conj scal {:type :int :value out}) out)
+          (gpu/prepare! sess :q4kdp sym (conj scal {:type :long :value out}) out)
           (gpu/invoke-bound! sess :q4kdp)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3) "sync bound")
           ;; async bound dispatch: zero result, batch-launch, sync, then read
-          (gpu/prepare! sess :q4kdp sym (conj scal {:type :int :value out}) out {:async? true})
+          (gpu/prepare! sess :q4kdp sym (conj scal {:type :long :value out}) out {:async? true})
           (dotimes [_ 3] (gpu/invoke-bound! sess :q4kdp))
           (gpu/sync! sess)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3) "async bound + sync!")
@@ -224,8 +224,8 @@
                             :awp [:int (alength ^ints (:wp a)) (:wp a)] :ada [:float (alength ^floats (:da a)) (:da a)] :adb [:float (alength ^floats (:db a)) (:db a)] :aaq [:byte (alength ^bytes (:aq a)) (:aq a)] :abq [:byte (alength ^bytes (:bq a)) (:bq a)] :ay [:float out nil]
                             :bxp [:int (alength ^ints (:xp b)) (:xp b)] :bxs [:float (alength ^floats (:xs b)) (:xs b)] :bbs [:int (alength ^ints (:bsums b)) (:bsums b)]
                             :bwp [:int (alength ^ints (:wp b)) (:wp b)] :bda [:float (alength ^floats (:da b)) (:da b)] :bdb [:float (alength ^floats (:db b)) (:db b)] :baq [:byte (alength ^bytes (:aq b)) (:aq b)] :bbq [:byte (alength ^bytes (:bq b)) (:bq b)] :by [:float out nil]})
-          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
-          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :long :value in} {:type :long :value out}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :long :value in} {:type :long :value out}] out {:kernel-phase :mm})
           (gpu/invoke-bound! sess :a)
           (gpu/invoke-bound! sess :b)
           (is (< (maxerr (:ycpu a) (gpu/download sess :ay)) 1e-3) "binding A correct")
@@ -264,9 +264,9 @@
           (gpu/prepare! sess :quant {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}
                         [] (* nsb 8) {:kernel-phase :quant :index 0})
           (gpu/prepare! sess :quant2 {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}
-                        [{:type :int :value in}] (* nsb 8) {:kernel-phase :quant :index 1})
+                        [{:type :long :value in}] (* nsb 8) {:kernel-phase :quant :index 1})
           (gpu/prepare! sess :mm {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp "da" :da "db" :db "aq" :aq "bq" :bq "y" :y}
-                        [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
+                        [{:type :long :value in} {:type :long :value out}] out {:kernel-phase :mm})
           (gpu/record-graph! sess [:quant :quant2 :mm])
           (gpu/replay! sess)
           (let [ygpu (gpu/download sess :y)
@@ -304,15 +304,15 @@
                             :y [:float (* nrows out) nil]})
           (let [bindings {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}]
             (gpu/prepare! sess :quant-rows-max bindings
-                          [{:type :int :value in} {:type :int :value width}] (* nrows nsub)
+                          [{:type :long :value in} {:type :long :value width}] (* nrows nsub)
                           {:kernel-phase :quant-rows :index 0})
             (gpu/prepare! sess :quant-rows-pack bindings
-                          [{:type :int :value in} {:type :int :value width}]
+                          [{:type :long :value in} {:type :long :value width}]
                           (* nrows nsub) {:kernel-phase :quant-rows :index 1}))
           (gpu/prepare! sess :q4k-rows
                         {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp
                          "da" :da "db" :db "aq" :aq "bq" :bq "y" :y}
-                        [{:type :int :value in} {:type :int :value out}]
+                        [{:type :long :value in} {:type :long :value out}]
                         (* nrows out) {:kernel-phase :q4k-rows})
           (gpu/record-graph! sess [:quant-rows-max :quant-rows-pack :q4k-rows])
           (gpu/replay! sess)
@@ -336,8 +336,8 @@
           (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a-rows!)
           (gpu/alloc! sess {:axp [:int (alength ^ints (:xp a)) (:xp a)] :axs [:float (alength ^floats (:xs a)) (:xs a)] :abs [:int (alength ^ints (:bsums a)) (:bsums a)] :awp [:int (alength ^ints (:wp a)) (:wp a)] :ada [:float (alength ^floats (:da a)) (:da a)] :adb [:float (alength ^floats (:db a)) (:db a)] :aaq [:byte (alength ^bytes (:aq a)) (:aq a)] :abq [:byte (alength ^bytes (:bq a)) (:bq a)] :ay [:float out nil]
                             :bxp [:int (alength ^ints (:xp b)) (:xp b)] :bxs [:float (alength ^floats (:xs b)) (:xs b)] :bbs [:int (alength ^ints (:bsums b)) (:bsums b)] :bwp [:int (alength ^ints (:wp b)) (:wp b)] :bda [:float (alength ^floats (:da b)) (:da b)] :bdb [:float (alength ^floats (:db b)) (:db b)] :baq [:byte (alength ^bytes (:aq b)) (:aq b)] :bbq [:byte (alength ^bytes (:bq b)) (:bq b)] :by [:float out nil]})
-          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
-          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :long :value in} {:type :long :value out}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :long :value in} {:type :long :value out}] out {:kernel-phase :mm})
           (gpu/record-graph! sess [:a :b])
           (gpu/replay! sess)
           (is (< (maxerr (:y a) (gpu/download sess :ay)) 1e-3) "graph op A")
@@ -368,7 +368,7 @@
           (gpu/invoke! sess :q4kdp
                        {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp "da" :da "db" :db
                         "aq" :aq "bq" :bq "y" :y}
-                       [{:type :int :value in} {:type :int :value out}] out)
+                       [{:type :long :value in} {:type :long :value out}] out)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3))
           (finally (gpu/close-session! sess)))))))
 
@@ -391,7 +391,7 @@
                             :y [:float out nil]})
           (gpu/invoke! sess :q6kdp
                        {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp "sc" :sc "ds" :ds "y" :y}
-                       [{:type :int :value in}] out)
+                       [{:type :long :value in}] out)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3))
           (finally (gpu/close-session! sess)))))))
 
@@ -413,6 +413,6 @@
                             :y [:float out nil]})
           (gpu/invoke! sess :q6k
                        {"xq" :xq "xs" :xs "bsums" :bsums "wq" :wq "sc" :sc "ds" :ds "y" :y}
-                       [{:type :int :value in}] out)
+                       [{:type :long :value in}] out)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3))
           (finally (gpu/close-session! sess)))))))


### PR DESCRIPTION
## Summary
Staged routing now takes the original body and output dtype from verified contraction facts, alongside its axes and stages. It no longer reconstructs or reparses a compatibility form merely to build the existing emitter spec.

## Validation
- Source-free regression constructs facts/from-components without a form and disables both parsing/projection entry points.
- Scalar and packed routes preserve ordered ABI, arguments, stages, launch metadata, and a nondefault Double output dtype.
- 22 focused routing/fail-loud tests, 77 assertions, plus 6 existing Intel staged device tests, 20 assertions: all pass.
- Independent review found no blocker; full suite/vendor gates in CircleCI.

Stacked on #445. This removes representation duplication, not the remaining staged algorithm source emitter.