### PR TITLE
Typed packed-stage contraction candidate through common KernelBody emission

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -195,6 +195,22 @@ compare ordered ABI, scalar bindings, launch geometry and stage metadata for sca
 including a non-default output dtype. The staged algorithm is still source-emitted; this retires
 an input-representation duplication, not the remaining target emission path.
 
+The first typed packed-stage **candidate** now constructs ScheduledKernelBody directly from those
+facts. Two-level Int32-dot/Float-lift reductions use byte loads, explicit word packing, DP4A, nested
+typed carries and masked stores through the common target projector. Static AxisMap products bound
+required storage and index arithmetic; semantic decode declarations, unproved prefixes, arbitrary
+lift regions and unsupported domains decline. The required shapes are not proof that an arbitrary
+raw backend caller supplied enough storage. Production admission must retain the checked resident
+capacity boundary; the low-level OpenCL test binds known correctly sized buffers.
+
+Candidate validation covers signed-byte extremes, block widths 4/32/64, multiple blocks, distinct
+row scales and masked launch tails on OpenCL; CUDA/HIP compile fixtures exercise the same typed
+schedule. The old staged source emitter remains production-selected. Before promotion, compare
+old scalar/packed and typed candidates on the same workload, including finite-precision rounding
+and throughput, then migrate descriptor construction and remove the superseded emission. Four byte
+loads are not an aligned packed-word throughput claim. More general stages still need the checked
+recurrence and typed lift-region coverage described above.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/src/raster/compiler/passes/parallel/staged_contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_body.clj
@@ -1,0 +1,198 @@
+(ns raster.compiler.passes.parallel.staged-contraction-body
+  "A bounded packed staged-contraction schedule, expressed entirely as typed KernelBody.
+
+   Packing is four byte loads plus word operations, not a pointer reinterpretation. This is a
+   correctness-first schedule; aligned vector loads and throughput tuning are separate work."
+  (:require [clojure.walk :as walk]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.scalar-conversion :as conversion]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contract-stages :as stages]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled]
+            [raster.compiler.passes.parallel.index-expression :as index]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar]
+            [raster.compiler.passes.parallel.staged-contraction-schedule :as schedule]))
+
+(defn- decline! [rule message data]
+  (throw (ex-info message (assoc data :reason :staged-kernel-body-declined
+                                 :missing-rule rule))))
+
+(defn declined? [e]
+  (= :staged-kernel-body-declined (:reason (ex-data e))))
+
+(defn- require! [condition rule data]
+  (when-not condition (decline! rule "typed staged schedule is not proved" data)))
+
+(defn- extent! [amap domain]
+  (let [pairs (vec (mapcat identity (:groups amap)))
+        axes (mapv first pairs)]
+    (require! (and (seq pairs) (= (count axes) (count (set axes)))
+                   (every? (fn [[a n :as pair]]
+                             (and (= 2 (count pair)) (contains? domain a)
+                                  (= n (get domain a)))) pairs))
+              :operand-domain {:map amap :domain domain})
+    (let [n (reduce *' 1 (map second pairs))]
+      (require! (<= n Integer/MAX_VALUE) :address-range {:map amap :elements n})
+      (long n))))
+
+(defn lower
+  "Schedule source-free verified contraction facts. Unsupported domains decline explicitly.
+   Returns a ScheduledKernelBody with byte storage and Int32 packed dot accumulators."
+  [source & {:keys [workgroup-size] :or {workgroup-size 64}}]
+  (when-not (facts/facts? source)
+    (throw (ex-info "staged body requires verified contraction facts" {:reason :raster/bug})))
+  (let [{:keys [free-axes contract-axes out]} source
+        stage-list (:stages source)
+        [outer inner] stage-list
+        axes (vec (concat free-axes contract-axes))
+        axis-ids (mapv first axes)
+        domain (into {} axes)
+        operands (vec (get-in source [:opts :operands]))
+        lifts (stages/lift-operands stage-list)
+        arrays (vec (concat operands lifts))
+        array-ids (mapv :sym arrays)
+        legality (stages/stages-legal? stage-list contract-axes)
+        reduction (facts/scalar-reduction-view source)]
+    (require! (:ok legality) :stage-legality legality)
+    ;; Decode is semantic evidence on canonical facts, not necessarily copied into the optional
+    ;; scheduling declarations. A body-replacing packed leaf must not discard either source.
+    (require! (and (not (seq (get-in source [:opts :decode])))
+                   (not-any? :decode (:operands source)))
+              :decoded-operands {:operands (:operands source)})
+    (require! (and (= 2 (count stage-list)) (= :int (dtype/canon (:dtype inner)))
+                   (= :float (dtype/canon (:dtype outer)))
+                   (= :float (or (:out-dtype source) :float))
+                   (nil? (:epilogue source))
+                   (contains? '#{+ clojure.core/+ raster.numeric/+} (:combine reduction))
+                   (constant/zero-value? (:neutral reduction)))
+              :stage-contract {:stages stage-list :reduction reduction})
+    (require! (and (seq free-axes) (= (count axis-ids) (count (set axis-ids)))
+                   (every? symbol? axis-ids)
+                   (every? #(and (integer? %) (pos? %) (<= % Integer/MAX_VALUE))
+                           (map second axes))
+                   (integer? workgroup-size) (<= 1 workgroup-size 256)
+                   (zero? (bit-and workgroup-size (dec workgroup-size))))
+              :iteration-domain {:axes axes :workgroup-size workgroup-size})
+    (require! (and (= (count array-ids) (count (set array-ids)))
+                   (every? symbol? array-ids) (symbol? out)
+                   (= (count (concat axis-ids array-ids [out '_nseg 'inner]))
+                      (count (set (concat axis-ids array-ids [out '_nseg 'inner]))))
+                   (every? #(and (= :float (:dtype %)) (nil? (:decode %))) lifts))
+              :parameter-identities {:axes axis-ids :arrays arrays :output out})
+    (let [plan (schedule/inner-dp4a-plan
+                {:stages stage-list :body (:body source) :operands operands
+                 :dtype (:dtype source)})
+          _ (require! (:ok plan) :packed-admission plan)
+          n (reduce *' 1 (map second free-axes))
+          _ (require! (<= (*' workgroup-size (quot (+ n (dec workgroup-size)) workgroup-size))
+                          Integer/MAX_VALUE)
+                      :launch-range {:elements n})
+          sizes (merge (into {} (map (fn [{:keys [sym map]}] [sym (extent! map domain)]) operands))
+                       (into {} (map (fn [{:keys [sym map]}]
+                                       [sym (extent! map (dissoc domain (:axis inner)))]) lifts)))
+          ;; The stage contract gives lift reads their declared maps. Admit scalar factors only;
+          ;; arbitrary calls, local binders and casts need their own retained region contract.
+          factors (stages/linear-in-inner (:lift outer) 'inner)
+          lift-ids (set (map :sym lifts))
+          _ (require! (every? #(or (number? %)
+                                  (and (descriptor/aget-call? %)
+                                       (contains? lift-ids (descriptor/aget-array-sym %)))) factors)
+                      :lift-region {:lift (:lift outer)})
+          reserved (atom (set (filter symbol? (tree-seq coll? seq source))))
+          fresh (fn [prefix]
+                  (loop [id (gensym prefix)]
+                    (if (contains? @reserved id) (recur (gensym prefix))
+                        (do (swap! reserved conj id) id))))
+          group (fresh "stage_group") lane (fresh "stage_lane") segment (fresh "stage_segment")
+          mask (fresh "stage_active") packed-index (fresh "stage_word")
+          inner-carry (fresh "stage_dot") inner-result (fresh "stage_dot_result")
+          outer-carry (fresh "stage_sum") outer-result (fresh "stage_sum_result")
+          scope (set (concat axis-ids [group lane segment packed-index '_nseg]))
+          lower-index #(index/lower %1 (into scope %2) decline!)
+          builder (scalar/make-lowerer
+                   {:arrays (set array-ids)
+                    :array-types (merge (zipmap (map :sym operands) (repeat :byte))
+                                        (zipmap (map :sym lifts) (repeat :float)))
+                    :scalar-types {} :index-scope scope :lower-index lower-index :predicate mask
+                    :source-region [source @reserved inner-carry inner-result outer-carry]
+                    :id-prefix (str (fresh "stage_scalar")) :decline! decline!
+                    :conversion-policy (fn [from to]
+                                         (when (contains? #{[:byte :int] [:int :float]} [from to])
+                                           (conversion/policy from to :reject)))})
+          pack (fn [{:keys [sym map]}]
+                 (reduce
+                  (fn [word offset]
+                    (let [coordinate (walk/postwalk-replace
+                                      {(:axis inner) (list 'clojure.core/+ (list 'clojure.core/* packed-index 4) offset)}
+                                      (am/index-expr map))
+                          loaded ((:cast builder)
+                                  ((:load builder) sym [(lower-index coordinate scope)]) :int coordinate)
+                          byte-word ((:compute builder) :bit-and :int
+                                     [(:result loaded) (body/literal 255 :int)] {})
+                          shifted ((:compute builder) :shl :int
+                                   [(:result byte-word) (body/literal (* offset 8) :int)] {})
+                          joined ((:compute builder) :bit-or :int [(:result word) (:result shifted)] {})]
+                      {:operations (vec (concat (:operations word) (:operations loaded)
+                                                (:operations byte-word) (:operations shifted) (:operations joined)))
+                       :result (:result joined)}))
+                  {:operations [] :result (body/literal 0 :int)} (range 4)))
+          [a b] (mapv pack operands)
+          dot ((:compute builder) :dp4a :int [(:result a) (:result b) inner-carry] {})
+          lift-expr (walk/postwalk-replace
+                     {'inner inner-result}
+                     (stages/substitute-operand-indices (:lift outer) (stages/stage-index-exprs stage-list)))
+          lift ((:lower builder) lift-expr :float {inner-result :int})
+          add ((:compute builder) :+ :float [outer-carry (:result lift)] {})
+          parameter (fn [id kind type count role]
+                      (body/->KernelParameter id kind type [count] :global
+                                              (layout/row-major [count] type) role))
+          parameters (vec (concat (map #(parameter (:sym %) :input :byte (sizes (:sym %)) :operand) operands)
+                                  (map #(parameter (:sym %) :input :float (sizes (:sym %)) :lift) lifts)
+                                  [(parameter out :output :float (long n) :result)
+                                   (body/->KernelParameter '_nseg :scalar :int [] nil nil :bound)]))
+          arguments (vec (concat array-ids [out (long n)]))
+          kernel (body/make
+                  {:id [:staged-packed out]
+                   :parameters parameters :stable-reads (mapv body/stable-read array-ids)
+                   :indices (vec (concat
+                                  [(body/->IndexBinding group :group 0) (body/->IndexBinding lane :local 0)
+                                   (body/->IndexCompute segment (body/expression :add (body/expression :mul group workgroup-size) lane))]
+                                  (map-indexed
+                                   (fn [i [axis extent]]
+                                     (body/->IndexCompute axis
+                                      (body/expression :mod
+                                       (body/expression :floor-div segment (reduce *' 1 (map second (drop (inc i) free-axes)))) extent)))
+                                   free-axes)))
+                   :masks [(body/->Mask mask [(body/predicate :lt segment (long n))
+                                             (body/predicate :lt segment '_nseg)])]
+                   :operations
+                   [(body/->ForLoop
+                     (body/value (:axis outer) :int) 0 (:extent outer) 1
+                     [(body/->LoopArg (body/value outer-carry :float) (body/literal 0.0 :float))]
+                     (vec (concat
+                           [(body/->ForLoop
+                             (body/value packed-index :int) 0 (:packed-extent plan) 1
+                             [(body/->LoopArg (body/value inner-carry :int) (body/literal 0 :int))]
+                             (vec (concat (:operations a) (:operations b) (:operations dot)
+                                          [(body/->Yield [(:result dot)])]))
+                             [(body/value inner-result :int)] {})]
+                           (:operations lift) (:operations add) [(body/->Yield [(:result add)])]))
+                     [(body/value outer-result :float)] {})
+                    (body/->ScalarStore out [segment] outer-result mask)]
+                   :launch (launch/spec {:workgroup-size [workgroup-size]
+                                         :group-count [(quot (+ (long n) (dec workgroup-size)) workgroup-size)]})
+                   :schedule {:strategy :staged-packed :workgroup-size workgroup-size}
+                   :attributes {:kind :staged-packed :packing :byte-loads}})]
+      (scheduled/make
+       {:source source :body kernel :arguments arguments
+        :effects {:kind :staged-contraction :uses (scheduled/derive-uses kernel arguments)}
+        :legality {:kind :staged-packed :stage-legality legality :packed-plan plan
+                   :storage-elements sizes :output-elements (long n)}
+        :numerics {:mode :reassociated :policy :staged-int32-float
+                   :accumulator-dtype :float :rounding :nearest-even}}))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -6,6 +6,8 @@
             [raster.compiler.backend.gpu.gemm :as gemm-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
+            [raster.compiler.backend.gpu.kernel-body-target :as body-target]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as staged-fixtures]
             [raster.compiler.backend.gpu.layout-transform :as layout-transform]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
@@ -21,6 +23,7 @@
             [raster.compiler.passes.parallel.segmap-capacity-fixture :as capacity-fixture]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
+            [raster.compiler.passes.parallel.staged-contraction-body :as staged-body]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
@@ -417,6 +420,11 @@
                           (body-emit/emit-scalar-kernel
                            "word_shifts_i32" (body-fixtures/word-shifts-body :int 1)
                            {:target-dialect dialect}))
+           (write-source! directory suffix "candidate-staged-packed"
+                          (:source (body-target/emit-artifact
+                                    "candidate_staged_packed"
+                                    (staged-body/lower (staged-fixtures/packed-facts 3 5 3 32))
+                                    dialect)))
            (write-source! directory suffix "word-shifts-i64"
                           (body-emit/emit-scalar-kernel
                            "word_shifts_i64" (body-fixtures/word-shifts-body :long 1)

--- a/test/raster/compiler/backend/gpu/staged_contraction_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/staged_contraction_fixtures.clj
@@ -1,0 +1,18 @@
+(ns raster.compiler.backend.gpu.staged-contraction-fixtures
+  (:require [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contraction-facts :as facts]))
+
+(defn packed-facts [m n blocks width]
+  (let [a-map (am/of-axes [['i m] ['blk blocks] ['t width]])
+        b-map (am/of-axes [['j n] ['blk blocks] ['t width]])]
+    (facts/from-components
+     {:out 'out :free-axes [['i m] ['j n]]
+      :contract-axes [['blk blocks] ['t width]] :dtype :byte
+      :body (list 'raster.numeric/* (list 'aget 'a (am/index-expr a-map))
+                  (list 'aget 'b (am/index-expr b-map)))
+      :opts {:operands [{:sym 'a :map a-map} {:sym 'b :map b-map}]
+             :stages [{:axis 'blk :extent blocks :dtype :float :init 0.0
+                       :lift '(raster.numeric/* inner (aget da _) (aget db _))
+                       :operands [{:sym 'da :dtype :float :map (am/of-axes [['i m] ['blk blocks]])}
+                                  {:sym 'db :dtype :float :map (am/of-axes [['j n] ['blk blocks]])}]}
+                      {:axis 't :extent width :dtype :int :init 0}]}})))

--- a/test/raster/compiler/passes/parallel/staged_contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contraction_body_test.clj
@@ -1,0 +1,92 @@
+(ns raster.compiler.passes.parallel.staged-contraction-body-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as fixtures]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.passes.parallel.staged-contraction-body :as staged]
+            [raster.gpu.device-probe :as probe]))
+
+(deftest packed-schedule-is-source-free-and-preserves-byte-storage
+  (let [source (fixtures/packed-facts 3 5 3 32)
+        scheduled (with-redefs [facts/contraction-facts (fn [& _] (throw (Exception. "reparsed source")))]
+                    (staged/lower source))]
+    (is (nil? (:form source)))
+    (is (= source (:source scheduled)))
+    (is (= '[a b da db out 15] (:arguments scheduled)))
+    (is (= [288 480 9 15 15] (mapv (comp first :shape) (butlast (get-in scheduled [:body :parameters])))))
+    (is (= :reassociated (get-in scheduled [:numerics :mode])))
+    (doseq [dialect [:opencl-portable :opencl-intel :cuda :hip]]
+      (let [artifact (target/emit-artifact "staged_packed" scheduled dialect)]
+        (is (= [:byte :byte :float :float :float :int] (mapv :kernel-dtype (:abi artifact))))
+        (is (= '[a b da db out 15] (:arguments artifact)))
+        (is (re-find #"rstr_dp4a" (:source artifact)))))))
+
+(defn- decline-rule [source]
+  (try (staged/lower source) nil
+       (catch clojure.lang.ExceptionInfo e
+         (when-not (staged/declined? e) (throw e))
+         (:missing-rule (ex-data e)))))
+
+(deftest packed-schedule-declines-unproved-domains
+  (let [source (fixtures/packed-facts 3 5 3 32)]
+    (doseq [[label transform expected]
+            [[:seed #(assoc-in % [:stages 1 :init] 1) :stage-legality]
+             [:wide-carry #(assoc-in % [:stages 1 :dtype] :long) :stage-contract]
+             [:epilogue #(assoc % :epilogue {}) :stage-contract]
+             [:missing-layouts #(update % :opts dissoc :operands) :packed-admission]
+             [:zero-domain #(assoc-in % [:free-axes 0 1] 0) :iteration-domain]
+             [:symbolic-domain #(assoc-in % [:free-axes 0 1] 'rows) :iteration-domain]
+             [:decoded #(assoc-in % [:opts :operands 0 :decode] '(fn [x] (- x 1))) :packed-admission]
+             [:decode-options #(assoc-in % [:opts :decode] {'a '(- x 1)}) :decoded-operands]
+             [:decode-facts #(assoc-in % [:operands 0 :decode] '(- x 1)) :decoded-operands]
+             [:bad-index #(assoc-in % [:opts :operands 0 :map] (am/of-axes '[[j 5] [blk 3] [t 32]])) :packed-admission]
+             [:inner-lift #(assoc-in % [:stages 0 :operands 0 :map] (am/of-axes '[[t 32]])) :operand-domain]
+             [:undeclared-lift #(assoc-in % [:stages 0 :lift] '(* inner (aget other _))) :lift-region]
+             [:arbitrary-lift #(assoc-in % [:stages 0 :lift] '(* inner (Math/sin 2.0))) :lift-region]
+             [:alias #(assoc % :out 'a) :parameter-identities]]]
+      (testing (name label) (is (= expected (decline-rule (transform source))))))
+    (is (= :packed-admission (decline-rule (fixtures/packed-facts 1 1 1 131072))))
+    (is (= :launch-range (decline-rule (fixtures/packed-facts Integer/MAX_VALUE 1 1 4))))
+    (is (= :address-range (decline-rule (fixtures/packed-facts 1 1 600000000 4))))))
+
+(defn- reference [m n blocks width a b da db]
+  (vec (for [i (range m) j (range n)]
+         (reduce
+          (fn [sum blk]
+            (let [dot (reduce + (for [t (range width)]
+                                  (* (aget ^bytes a (+ (* i blocks width) (* blk width) t))
+                                     (aget ^bytes b (+ (* j blocks width) (* blk width) t)))))
+                  ;; Round each explicit stage operation, not a single host Double expression.
+                  scaled (float (* (float dot) (aget ^floats da (+ (* i blocks) blk))))
+                  lifted (float (* scaled (aget ^floats db (+ (* j blocks) blk))))]
+              (float (+ sum lifted))))
+          (float 0) (range blocks)))))
+
+(deftest typed-packed-stages-match-reference-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "typed staged packed contractions")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          op #(ns-resolve ocl %)
+          upload (op 'buffer-of-array)
+          free! (op 'free-buffer!)]
+      (doseq [width [4 32 64] blocks [1 3]]
+        (let [m 3 n 5
+              a (byte-array (take (* m blocks width) (cycle [-128 127 -1 0 3])))
+              b (byte-array (take (* n blocks width) (cycle [127 -128 0 -1 7 2])))
+              da (float-array (map #(Math/scalb 1.0 (int (- (mod % 5) 2))) (range (* m blocks))))
+              db (float-array (map #(Math/scalb 1.0 (int (- (mod % 3) 1))) (range (* n blocks))))
+              artifact (target/emit-artifact
+                        (str "typed_staged_" width "_" blocks)
+                        (staged/lower (fixtures/packed-facts m n blocks width)) :opencl-portable)
+              buffers (mapv (fn [[array dtype]] (upload array dtype))
+                            [[a :byte] [b :byte] [da :float] [db :float]
+                             [(float-array (repeat (* m n) -555.0)) :float]])]
+          (try
+            ((op 'register-kernel!) (:kernel-name artifact) artifact)
+            ((op 'launch-registered-bound!)
+             ((op 'bind-kernel-call) (call/make artifact (conj buffers {:type :int :value (* m n)}))))
+            (is (= (reference m n blocks width a b da db)
+                   (vec ((op 'buffer->array) (peek buffers)))) (str width "x" blocks))
+            (finally (doseq [buffer (reverse buffers)] (free! buffer)))))))))


### PR DESCRIPTION
## Scope
Build a bounded, source-free staged contraction schedule through ScheduledKernelBody and the common OpenCL/CUDA/HIP projector. Byte storage remains byte storage; packing uses explicit loads and typed word operations. The existing production staged emitter is unchanged.

Admission checks stage identities, Int32 accumulation prefixes, static iteration/address ranges, declared layouts, canonical and schedule decode facts, and restricted typed Float lifts. Required storage shapes are stated; this is not proof that arbitrary raw backend callers supplied enough storage.

## Validation
- Independent review completed; canonical decode admission gap fixed.
- 18 affected tests / 116 assertions green, including actual Intel Arc execution and Int/Long shifts.
- Final candidate namespace: 3 tests / 40 assertions green after extra domain negatives; six real OpenCL cases cover widths 4/32/64, multiple blocks, signed-byte extremes, scales and launch tails.
- Compiler fixture namespace loads; CUDA/HIP candidate fixtures added for CI.
- Full suites and vendor compilers delegated to CI to protect laptop memory.

## Remaining campaign
This is deliberately a candidate, not a performance claim or completed retirement. Compare old scalar/packed and typed paths, exercise non-dyadic rounding/cancellation, preserve checked resident capacity binding, then migrate production routing and retire superseded emission. More general stages need recurrence and typed lift-region proofs.