### PR TITLE
Validate typed staged kernels against retained scalar and packed emission

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -211,6 +211,23 @@ and throughput, then migrate descriptor construction and remove the superseded e
 loads are not an aligned packed-word throughput claim. More general stages still need the checked
 recurrence and typed lift-region coverage described above.
 
+The follow-up device comparison binds the same logical Byte ABI for typed, retained scalar and
+retained packed emission, with independently poisoned outputs. Dyadic scale cases compare exactly;
+non-dyadic cancellation compares against explicitly stage-rounded host arithmetic with tolerance
+relative to contribution magnitudes. An all-zero result must fail that tolerance. Prepared kernel
+handles are released after synchronous execution.
+
+A small shared-laptop Arc probe (OpenCL profiling events, 3 warmup rounds and 12 interleaved timed
+samples per candidate, 64 work-items/group, uploads/compilation excluded) gave the following median
+milliseconds for `[rows outputs blocks block-width]`: `[1 128 32 32]` typed 0.052708, retained scalar
+0.039166, retained packed 0.032708; `[4 128 32 32]` typed 0.041770, scalar 0.039062, packed 0.031458.
+All outputs matched the independent reference. Samples were noisy (e.g. typed second-case range
+0.040104–0.072187 ms); this is a directional probe, not a reproducible performance baseline or
+regression in the unchanged production route. Do not promote the byte-load candidate on this
+evidence. Investigate a generic, explicitly typed/aligned packed storage load (with byte fallback),
+then repeat resident comparisons before retiring the production source emitter. Do not introduce
+a quantization-specific memory ABI or bypass the common body verifier to obtain that load.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/test/raster/compiler/passes/parallel/staged_contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contraction_body_test.clj
@@ -1,10 +1,13 @@
 (ns raster.compiler.passes.parallel.staged-contraction-body-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.segop-opencl :as old-emitter]
             [raster.compiler.backend.gpu.staged-contraction-fixtures :as fixtures]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.staged-contraction-body :as staged]
             [raster.gpu.device-probe :as probe]))
 
@@ -85,8 +88,86 @@
                              [(float-array (repeat (* m n) -555.0)) :float]])]
           (try
             ((op 'register-kernel!) (:kernel-name artifact) artifact)
-            ((op 'launch-registered-bound!)
-             ((op 'bind-kernel-call) (call/make artifact (conj buffers {:type :int :value (* m n)}))))
+            (let [prepared ((op 'bind-kernel-call)
+                            (call/make artifact (conj buffers {:type :int :value (* m n)})))]
+              (try ((op 'launch-registered-bound!) prepared)
+                   (finally ((op 'destroy-prepared!) prepared))))
             (is (= (reference m n blocks width a b da db)
                    (vec ((op 'buffer->array) (peek buffers)))) (str width "x" blocks))
             (finally (doseq [buffer (reverse buffers)] (free! buffer)))))))))
+
+(defn- legacy-artifact [source packed?]
+  (let [emitted (old-emitter/generate-staged-contraction-kernel
+                 (assoc (select-keys source [:free-axes :contract-axes :stages :body :dtype])
+                        :inputs '[a b] :operands (get-in source [:opts :operands])
+                        :out-dtype :float :tensorize-inner? packed?) 'out)
+        n (:out-elems emitted)]
+    (artifact/make
+     {:kernel-name (:kernel-name emitted) :target :opencl-c
+      :source (:source emitted) :abi (:abi emitted) :arguments ['a 'b 'da 'db 'out n]
+      :launch (launch/spec {:workgroup-size [64] :group-count [(quot (+ n 63) 64)]})
+      :effects {:kind :tensor-contraction} :attributes {:out-elems n}
+      :provenance {:dialect :test :comparison :retained-staged-source}})))
+
+(defn- execute-artifact [compiled host-inputs n]
+  (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+        op #(ns-resolve ocl %)
+        ;; Storage follows the logical ABI. The retained packed source takes an Int pointer view
+        ;; of the same Byte allocation; the new body needs no pointer reinterpretation or copy.
+        buffers (mapv (fn [values slot] ((op 'buffer-of-array) values (:dtype slot)))
+                      (conj host-inputs (float-array (repeat n -555.0)))
+                      (butlast (:abi compiled)))]
+    (try
+      ((op 'register-kernel!) (:kernel-name compiled) compiled)
+      (let [prepared ((op 'bind-kernel-call) (call/make compiled (conj buffers {:type :int :value n})))]
+        (try ((op 'launch-registered-bound!) prepared)
+             (finally ((op 'destroy-prepared!) prepared))))
+      (vec ((op 'buffer->array) (peek buffers)))
+      (finally (doseq [buffer (reverse buffers)] ((op 'free-buffer!) buffer))))))
+
+(deftest typed-and-retained-stages-agree-with-nondyadic-cancellation
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "typed versus retained staged emission")
+    (let [m 3 n 5 blocks 3 width 32
+          source (fixtures/packed-facts m n blocks width)
+          a (byte-array (repeat (* m blocks width) 127))
+          b (byte-array (repeat (* n blocks width) 127))
+          ;; First two block contributions nearly cancel; the third leaves a small residual.
+          da (float-array (take (* m blocks) (cycle [0.1 -0.1 0.00001])))
+          db (float-array (mapcat #(repeat blocks (float (+ 0.3 (* 0.13 %)))) (range n)))
+          expected (reference m n blocks width a b da db)
+          candidates [[:typed (target/emit-artifact "typed_staged_cancellation" (staged/lower source)
+                                                   :opencl-portable) [a b da db]]
+                      [:scalar (legacy-artifact source false) [a b da db]]
+                      [:packed (legacy-artifact source true) [a b da db]]]
+          ;; Bound relative to the contributions, not the near-zero cancelled result. Contraction
+          ;; into FMA is permitted by existing OpenCL builds; this is not bitwise-equivalence proof.
+          tolerances (vec (for [i (range m) j (range n)]
+                            (+ 1.0e-5 (* 1.0e-6 16129 width
+                                          (reduce + (for [blk (range blocks)]
+                                                      (Math/abs (* (double (aget da (+ (* i blocks) blk)))
+                                                                   (double (aget db (+ (* j blocks) blk)))))))))))
+          close? (fn [actual]
+                   (and (= (count expected) (count actual))
+                        (every? true? (map #(<= (Math/abs (- (double %1) (double %2))) %3)
+                                           actual expected tolerances))))]
+      (is (not (close? (repeat (* m n) 0.0))) "dropping the residual block must fail")
+      (doseq [[label compiled inputs] candidates]
+        (let [actual (execute-artifact compiled inputs (* m n))]
+          (is (close? actual)
+              (str label ": expected " expected ", actual " actual)))))))
+
+(deftest typed-and-retained-stages-agree-exactly-for-dyadic-scales
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "exact typed versus retained staged emission")
+    (let [m 3 n 5 blocks 3 width 32
+          source (fixtures/packed-facts m n blocks width)
+          a (byte-array (take (* m blocks width) (cycle [-128 127 -1 0 3])))
+          b (byte-array (take (* n blocks width) (cycle [127 -128 0 -1 7 2])))
+          da (float-array (map #(Math/scalb 1.0 (int (- (mod % 5) 2))) (range (* m blocks))))
+          db (float-array (map #(Math/scalb 1.0 (int (- (mod % 3) 1))) (range (* n blocks))))
+          expected (reference m n blocks width a b da db)]
+      (doseq [[label compiled]
+              [[:typed (target/emit-artifact "typed_staged_dyadic" (staged/lower source) :opencl-portable)]
+               [:scalar (legacy-artifact source false)] [:packed (legacy-artifact source true)]]]
+        (is (= expected (execute-artifact compiled [a b da db] (* m n))) (name label))))))


### PR DESCRIPTION
## Scope
Test-only follow-up to #447, plus the campaign evidence record. Production routing remains unchanged.

Compare the typed candidate with retained scalar and packed staged emission through the same logical Byte-buffer ABI. Each candidate has independently poisoned output. Dyadic fixtures compare exactly; non-dyadic cancellation uses an explicitly stage-rounded host reference and contribution-relative tolerance. An explicit zero-output negative prevents tolerance from hiding a dropped residual block. Prepared kernel handles are released.

## Validation
- 5 tests / 47 assertions green on Intel Arc, including all three emitter paths.
- Independent review caught and fixed an overly permissive cancellation fixture.
- Rebased onto the squash of #447; tested source tree unchanged.
- Full suite and CPU OpenCL delegated to CI.

## Performance evidence
A small interleaved resident profiling probe found the candidate slower than retained packed emission on two shapes, with substantial laptop noise. Timings and limitations are recorded in the campaign. This blocks default promotion pending generic typed packed-load work and repeat measurements; it is not a regression in the unchanged production route or a SOTA claim.