### PR TITLE
Prove static loop exit increments and unify counted-loop target emission

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -228,6 +228,15 @@ evidence. Investigate a generic, explicitly typed/aligned packed storage load (w
 then repeat resident comparisons before retiring the production source emitter. Do not introduce
 a quantization-specific memory ABI or bypass the common body verifier to obtain that load.
 
+One general target-cleanup slice exposes canonical counted loops when their literal bounds prove
+the final induction increment representable. The shared exact range helper includes that exit
+increment, not just indices observed inside the loop. Ordinary and asynchronous pipelined loops
+share one syntax helper; unknown bounds and explicit IndexCasts (including retained Long bounds)
+keep the existing unsigned-distance guard. Scalar yields and event rotation stay before advance.
+This does not strengthen recurrence facts or alter accumulation order, and the noisy laptop probes
+do not establish a throughput improvement. Device tests cover zero/nonunit/reversed loop counts,
+staged reductions and the existing asynchronous workgroup pipeline.
+
 Public matmul/dA/dB probes on CPU OpenCL select generated portable contractions, not the
 handwritten gather fallback. Their artifact adapter previously reported semantic `:segcontract`
 provenance as the emission route. The follow-up propagates the actual emitter's route through

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -11,6 +11,7 @@
             [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.scalar-range :as scalar-range]
             [raster.compiler.ir.kernel-body :as body]))
 
 (defn- record-kind? [simple-name value]
@@ -742,6 +743,29 @@
   (let [prefix (apply str (repeat depth "  "))]
     (apply str (map #(str prefix % "\n") (str/split-lines source)))))
 
+(defn- counted-loop-syntax
+  "A canonical counted loop only when its terminal increment is representable. Dynamic and
+   signed-edge domains retain the guarded advance; no overflow policy is weakened."
+  [operation index-name index-type names depth]
+  (let [{:keys [lower upper step]} operation
+        ordinary? (and (every? integer? [lower upper step])
+                       (every? #(scalar-range/literal % index-type) [lower upper step])
+                       (scalar-range/contained-in-dtype?
+                        (scalar-range/counted-loop-index-range lower upper step) index-type))
+        upper-source (emit-index-expression upper names)
+        step-source (if (integer? step) (str step) (emit-index-expression step names))
+        unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* index-type)]
+    {:loop-header (str "for (" (target-type index-type) " " index-name " = "
+                       (emit-index-expression lower names) "; " index-name " < " upper-source ";"
+                       (when ordinary? (str " " index-name " += " step-source)) ") {")
+     :checked-advance
+     (when-not ordinary?
+       (str (indent-lines
+             (inc depth)
+             (str "if ((" unsigned-type ")(" upper-source ") - (" unsigned-type ")(" index-name
+                  ") <= (" unsigned-type ")(" step-source ")) break;"))
+            (indent-lines (inc depth) (str index-name " += " step-source ";"))))}))
+
 (declare emit-scalar-operations)
 
 (defn- add-value
@@ -926,23 +950,8 @@
           [body-source body-context] (emit-scalar-operations body-operations loop-context
                                                              (inc depth))
           index-type (get-in loop-context [:types (:id index)])
-          unsigned-index-type (c-dialect/unsigned-type-name *scalar-dialect* index-type)
-          upper-source (emit-index-expression (:upper operation) (:names context))
-          step-source (if (integer? (:step operation))
-                        (str (:step operation))
-                        (emit-index-expression (:step operation) (:names context)))
-          loop-header (str "for (" (target-type index-type)
-                           " " index-name " = "
-                           (emit-index-expression (:lower operation) (:names context)) "; "
-                           index-name " < "
-                           upper-source ";) {")
-          checked-advance
-          (str (indent-lines
-                (inc depth)
-                (str "if ((" unsigned-index-type ")(" upper-source ") - ("
-                     unsigned-index-type ")(" index-name ") <= ("
-                     unsigned-index-type ")(" step-source ")) break;"))
-               (indent-lines (inc depth) (str index-name " += " step-source ";")))]
+          {:keys [loop-header checked-advance]}
+          (counted-loop-syntax operation index-name index-type (:names context) depth)]
       [(str initializers
             (when (get-in operation [:attributes :unroll])
               (indent-lines depth "#pragma unroll"))
@@ -1037,21 +1046,8 @@
                             (:events binding-group) temporaries))
                      binding-groups next-event-names))))
           index-type (get-in loop-context [:types (:id index)])
-          unsigned-index-type (c-dialect/unsigned-type-name *scalar-dialect* index-type)
-          upper-source (emit-index-expression (:upper operation) (:names context))
-          step-source (str (:step operation))
-          loop-header (str "for (" (target-type index-type)
-                           " " index-name " = "
-                           (emit-index-expression (:lower operation) (:names context)) "; "
-                           index-name " < "
-                           upper-source ";) {")
-          checked-advance
-          (str (indent-lines
-                (inc depth)
-                (str "if ((" unsigned-index-type ")(" upper-source ") - ("
-                     unsigned-index-type ")(" index-name ") <= ("
-                     unsigned-index-type ")(" step-source ")) break;"))
-               (indent-lines (inc depth) (str index-name " += " step-source ";")))
+          {:keys [loop-header checked-advance]}
+          (counted-loop-syntax operation index-name index-type (:names context) depth)
           output-groups
           (mapv (fn [result binding-group]
                   (assoc binding-group :id result))

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -57,6 +57,17 @@
              {:lower (reduce min products) :upper (reduce max products)})
         nil))))
 
+(defn counted-loop-index-range
+  "Static positive-step counted-loop indices, INCLUDING the increment which exits the loop.
+   Unknown bounds/steps return nil. Exact host arithmetic avoids overflow in the proof itself.
+   Empty loops include only the initializer; no increment is evaluated. This is an index proof,
+   not a proof about loop-carried accumulators or whether runtime scalar bounds fit their ABI."
+  [lower upper step]
+  (when (and (integer? lower) (integer? upper) (integer? step) (pos? step))
+    (let [distance (max 0 (-' upper lower))
+          trips (quot (+' distance (dec step)) step)]
+      {:lower lower :upper (+' lower (*' trips step))})))
+
 (defn accumulation-prefixes
   "Enclose every prefix of up to `count` additions of values in `term`, starting at `initial`.
    Unknown or nonintegral counts decline; proof arithmetic remains unbounded."

--- a/test/raster/compiler/backend/gpu/static_loop_emission_test.clj
+++ b/test/raster/compiler/backend/gpu/static_loop_emission_test.clj
@@ -1,0 +1,90 @@
+(ns raster.compiler.backend.gpu.static-loop-emission-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as fixtures]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled]
+            [raster.gpu.device-probe :as probe]))
+
+(defn- loop-body [pipeline? type lower upper step]
+  (let [kernel (if pipeline? (fixtures/pipelined-staging-body 4 :preferred)
+                  (body/make
+                   {:id :counted-loop-test
+                    :operations [(body/->ForLoop (body/value 'iteration :int) 0 1 1 []
+                                                  [(body/->Yield [])] [] {})]
+                    :launch (launch/spec {:workgroup-size [1] :group-count [1]})}))
+        position (if pipeline? 4 0)
+        index-id (get-in kernel [:operations position :index :id])
+        bound #(if (and (= type :long) (integer? %)) (body/index-cast % :long :exact) %)]
+    (-> kernel
+        (update :parameters conj (body/->KernelParameter 'bound :scalar type [] nil nil :bound))
+        (update-in [:operations position] assoc :index (body/value index-id type)
+                   :lower (bound lower) :upper (bound upper) :step step)
+        body/validate!)))
+
+(deftest static-counted-loops-use-proved-canonical-advance
+  (doseq [pipeline? [false true] type [:int]
+          dialect [:opencl-portable :cuda :hip]
+          [lower upper step] [[0 8 1] [0 8 3] [8 8 3] [9 8 3] [-5 4 3]]]
+    (let [source (emit/emit-scalar-kernel "counted_loop"
+                                         (loop-body pipeline? type lower upper step)
+                                         {:target-dialect dialect})]
+      (is (str/includes? source (str " += " step ") {")))
+      (is (not (str/includes? source "break;"))))))
+
+(deftest signed-limits-and-unknown-bounds-keep-the-safe-policy
+  (doseq [pipeline? [false true] type [:int :long] dialect [:opencl-portable :cuda :hip]]
+    (let [maximum (if (= type :int) Integer/MAX_VALUE Long/MAX_VALUE)
+          source #(emit/emit-scalar-kernel "counted_edge" (loop-body pipeline? type %1 %2 %3)
+                                           {:target-dialect dialect})]
+      ;; Long bounds carry explicit IndexCasts in KernelBody. They deliberately retain checks;
+      ;; this slice does not strip casts or introduce another constant evaluator.
+      (is (str/includes? (source (dec maximum) maximum 1)
+                         (if (= type :int) " += 1) {" "break;")))
+      (is (str/includes? (source (dec maximum) maximum 2) "break;"))
+      (is (str/includes? (source 0 'bound 1) "break;"))
+      (is (str/includes? (source (body/index-cast 0 type :exact) 8 1) "break;")))))
+
+(deftest counted-loop-exit-preserves-carried-values-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "canonical counted-loop carries")
+    (let [cases [[0 8 1] [0 8 3] [8 8 3] [9 8 3] [-5 4 3]]
+          kernel (body/make
+                  {:id :counted-loop-carried-values
+                   :parameters [(body/->KernelParameter 'out :output :float [5] :global
+                                                        (layout/row-major [5] :float) :result)]
+                   :operations
+                   (vec (mapcat
+                         (fn [position [lower upper step]]
+                           (let [[index carry next-value result]
+                                 (mapv #(symbol (str % position)) ["i" "carry" "next" "result"])]
+                             [(body/->ForLoop
+                               (body/value index :int) lower upper step
+                               [(body/->LoopArg (body/value carry :float) (body/literal 7.0 :float))]
+                               [(body/->ScalarCompute (body/value next-value :float)
+                                                      (body/scalar-expression :+ :float [carry (body/literal 1.0 :float)]))
+                                (body/->Yield [next-value])]
+                               [(body/value result :float)] {})
+                              (body/->ScalarStore 'out [position] result nil)]))
+                         (range) cases))
+                   :launch (launch/spec {:workgroup-size [1] :group-count [1]})})
+          refinement (scheduled/make
+                      {:source {:kind :counted-loop-fixture :cases cases} :body kernel :arguments '[out]
+                       :effects {:kind :counted-loop-fixture :uses (scheduled/derive-uses kernel '[out])}
+                       :legality {:kind :fixture} :numerics {:mode :exact :policy :small-exact-floats}})
+          compiled (target/emit-artifact "counted_loop_carries" refinement :opencl-portable)
+          ocl (find-ns 'raster.gpu.ocl-runtime)
+          op #(ns-resolve ocl %)
+          out ((op 'buffer-of-array) (float-array (repeat 5 -555.0)) :float)]
+      (try
+        ((op 'register-kernel!) (:kernel-name compiled) compiled)
+        (let [prepared ((op 'bind-kernel-call) (call/make compiled [out]))]
+          (try ((op 'launch-registered-bound!) prepared)
+               (finally ((op 'destroy-prepared!) prepared))))
+        (is (= [15.0 10.0 7.0 7.0 10.0] (vec ((op 'buffer->array) out))))
+        (finally ((op 'free-buffer!) out))))))

--- a/test/raster/compiler/ir/scalar_range_test.clj
+++ b/test/raster/compiler/ir/scalar_range_test.clj
@@ -3,6 +3,21 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.scalar-range :as ranges]))
 
+(deftest counted-loop-proof-includes-the-terminal-increment
+  (doseq [[lower upper step terminal]
+          [[0 8 1 8] [0 8 3 9] [8 8 3 8] [9 8 3 9] [-5 4 3 4]
+           [(dec Integer/MAX_VALUE) Integer/MAX_VALUE 1 Integer/MAX_VALUE]
+           [(dec Integer/MAX_VALUE) Integer/MAX_VALUE 2 (inc (long Integer/MAX_VALUE))]
+           [Long/MIN_VALUE Long/MAX_VALUE 1 Long/MAX_VALUE]
+           [(dec Long/MAX_VALUE) Long/MAX_VALUE 2 (inc (bigint Long/MAX_VALUE))]]]
+    (is (= {:lower lower :upper terminal} (ranges/counted-loop-index-range lower upper step))))
+  (doseq [[lower upper step] [[0 'n 1] ['n 4 1] [0 4 'step] [0 4 0] [0 4 -1] [0 4 1.0]]]
+    (is (nil? (ranges/counted-loop-index-range lower upper step))))
+  (doseq [lower (range -4 5) upper (range -4 5) step [1 2 3]]
+    (let [indices (vec (take-while #(< % upper) (iterate #(+ % step) lower)))
+          terminal (if (seq indices) (+ (peek indices) step) lower)]
+      (is (= {:lower lower :upper terminal} (ranges/counted-loop-index-range lower upper step))))))
+
 (deftest accumulation-proof-includes-intermediate-prefixes
   (let [term (ranges/arithmetic :* (repeat 2 (ranges/for-dtype :byte)))
         prove #(ranges/accumulation-prefixes (ranges/literal 0 :long) term %)]


### PR DESCRIPTION
## Scope
Use one counted-loop syntax helper for ForLoop and PipelinedFor. A reusable exact interval proof includes the terminal induction increment. Bare literal bounds use canonical for-header advancement only when all values fit the retained index dtype; dynamic/casted bounds and overflowing terminal increments retain the existing unsigned-distance check.

No cast stripping, new type inference, recurrence proof weakening, scalar reassociation, or change to event/carry update order. Long IndexCast bounds deliberately keep checked advancement.

## Validation
- Independent review: no blocker.
- Final focused run: 16 tests / 502 assertions, all green.
- Exhaustive small domains and signed Int/Long edge arithmetic.
- Both loop forms emit across OpenCL/CUDA/HIP; dynamic/cast cases stay guarded.
- Actual Intel Arc: zero/reversed/nonunit carried-value loops, staged scalar/packed/typed parity, and workgroup/async/pipelined execution.
- Full and vendor-compiler suites delegated to CI. Agent REPL closed because host memory fell to 3.1GiB available with full swap.

This removes duplicate target code and exposes proved ordinary counted loops. Shared-laptop timing probes are noisy; no throughput improvement is claimed.