### PR TITLE
Bind generated dense KernelBody candidates through checked graphs

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -203,6 +203,15 @@ lift regions and unsupported domains decline. The required shapes are not proof 
 raw backend caller supplied enough storage. Production admission must retain the checked resident
 capacity boundary; the low-level OpenCL test binds known correctly sized buffers.
 
+The generic `emit-static-dense-graph` projection now places a ScheduledKernelBody behind the
+existing KernelGraph binding boundary. It derives every external buffer's required capacity from
+positive static dense shapes, preserving logical storage dtypes, exact source/effects, public
+scalar dependencies and target-private scalar expressions. Unknown/strided storage is rejected;
+this is neither a new memory ABI nor an access proof for arbitrary producers. Tests exercise
+operand, lift and output shortages through both session and descriptor binding, writable aliases,
+and device replay with poisoned output. The staged candidate can use this boundary without
+changing production schedule selection; performance admission remains outstanding.
+
 Candidate validation covers signed-byte extremes, block widths 4/32/64, multiple blocks, distinct
 row scales and masked launch tails on OpenCL; CUDA/HIP compile fixtures exercise the same typed
 schedule. The old staged source emitter remains production-selected. Before promotion, compare

--- a/src/raster/compiler/backend/gpu/kernel_body_target.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_target.clj
@@ -8,10 +8,13 @@
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.kernel-body-opencl :as scalar-target]
             [raster.compiler.backend.gpu.matrix-target :as matrix-target]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
 
 (defn- record-kind?
@@ -159,3 +162,58 @@
                            :legality (:legality scheduled)
                            :numerics (:numerics scheduled)
                            :target-facts (:target-facts emitted)})})))))
+
+(defn emit-static-dense-graph
+  "Place one ScheduledKernelBody behind the existing checked graph binding boundary.
+
+   Every external buffer receives its required element capacity, derived from positive static
+   dense parameter shapes. Strided layouts, unknown extents and repeated public buffer identities
+   are not admitted by this convenience projection. It preserves the exact source operation,
+   effects, ordered public ABI and target-private scalar bindings; it does not select a schedule
+   or prove source/body equivalence on behalf of the scheduling pass."
+  ([kernel-name scheduled target-dialect]
+   (emit-static-dense-graph kernel-name scheduled target-dialect {}))
+  ([kernel-name scheduled target-dialect options]
+   (let [scheduled (scheduled-body/validate! scheduled)
+         parameters (into {} (map (juxt :id identity)) (get-in scheduled [:body :parameters]))
+         required-elements
+         (into {}
+               (for [[id {:keys [kind dtype shape layout] :as parameter}] parameters
+                     :when (not= :scalar kind)]
+                 (do
+                   (when-not (and (seq shape) (every? #(and (integer? %) (pos? %)) shape)
+                                  (layout/row-major-unit? layout))
+                     (throw (ex-info "single-body graph requires positive static dense storage"
+                                     {:reason :kernel-body-graph-storage :parameter parameter})))
+                   (let [elements (reduce *' 1 shape)
+                         bytes (*' elements (dtype/bytes-of dtype))]
+                     (when (> bytes Long/MAX_VALUE)
+                       (throw (ex-info "single-body graph storage exceeds addressable byte capacity"
+                                       {:reason :kernel-body-graph-capacity :parameter parameter
+                                        :required-elements elements :required-bytes bytes})))
+                     [id (long elements)]))))
+         artifact (emit-artifact kernel-name scheduled target-dialect options)
+         {:keys [abi arguments]} (graph/public-interface (:abi artifact) (:arguments artifact))
+         pointers (filterv #(not= :scalar (:kind (first %))) (mapv vector abi arguments))
+         buffers (mapv (fn [[slot argument]]
+                         (graph/buffer argument (:dtype slot) (required-elements (:name slot))
+                                       :device (:kind slot))) pointers)
+         node (graph/->ScheduledKernel
+               [:scheduled-body kernel-name] (:source scheduled)
+               (mapv #(graph/->ValueUse (:value %) (:access %)) (get-in scheduled [:effects :uses]))
+               (graph/scalar-argument-uses (:abi artifact) (:arguments artifact)) [])
+         semantic-graph
+         (graph/make
+          {:inputs (filterv #(contains? #{:input :inout} (:role %)) buffers)
+           :outputs (filterv #(contains? #{:output :inout} (:role %)) buffers)
+           :scalars (graph/interface-scalars abi arguments)
+           :abi abi :arguments arguments :nodes [node]
+           :effects (:effects scheduled)
+           :provenance {:lowering :scheduled-kernel-body-graph}
+           :attributes {:storage-contract :static-dense}})]
+     (scheduled-body/validate-against-node! scheduled node semantic-graph)
+     (let [emitted (graph/map-operations semantic-graph (constantly artifact))]
+       (when-not (graph/dataflow-equivalent? semantic-graph emitted)
+         (throw (ex-info "single-body target projection changed graph dataflow"
+                         {:reason :kernel-body-graph-dataflow})))
+       emitted))))

--- a/test/raster/compiler/ir/scheduled_kernel_body_test.clj
+++ b/test/raster/compiler/ir/scheduled_kernel_body_test.clj
@@ -38,6 +38,72 @@
   (try (thunk) nil
        (catch clojure.lang.ExceptionInfo exception (:reason (ex-data exception)))))
 
+(deftest static-dense-body-graph-retains-source-and-required-capacities
+  (let [value (-> (fixture)
+                  (assoc-in [:body :parameters 0 :shape] [2 3])
+                  (assoc-in [:body :operations 0 :coordinates] [0 0])
+                  (assoc-in [:body :parameters 0 :layout] (layout/row-major [2 3] :float)))]
+    (doseq [dialect [:opencl-portable :opencl-intel :cuda :hip]]
+      (let [emitted (target/emit-static-dense-graph "dense_graph" value dialect)
+            leaf (get-in emitted [:nodes 0 :operation])]
+        (is (= '[input output] (:arguments emitted)))
+        (is (= [6 1] (mapv :elements (concat (:inputs emitted) (:outputs emitted)))))
+        (is (= (:effects value) (:effects emitted)))
+        (is (identical? value (get-in leaf [:attributes :scheduled-kernel-body])))
+        (is (= (:source (target/emit-artifact "dense_graph" value dialect)) (:source leaf)))
+        (is (empty? (:temporaries emitted)))))))
+
+(deftest static-dense-body-graph-declines-unproved-storage
+  (doseq [shape [[0] ['n]]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (target/emit-static-dense-graph
+                  "unknown_graph"
+                  (-> (fixture)
+                      (assoc-in [:body :parameters 0 :shape] shape)
+                      (assoc-in [:body :parameters 0 :layout] (layout/row-major shape :float)))
+                  :opencl-portable))))
+  (is (= :kernel-body-graph-storage
+         (reason-of #(target/emit-static-dense-graph
+                      "strided_graph"
+                      (assoc-in (fixture) [:body :parameters 0 :layout :strides] [2])
+                      :opencl-portable))))
+  (is (= :kernel-body-graph-capacity
+         (reason-of #(target/emit-static-dense-graph
+                      "oversized_graph"
+                      (-> (fixture)
+                          (assoc-in [:body :parameters 0 :shape] [Long/MAX_VALUE])
+                          (assoc-in [:body :parameters 0 :layout]
+                                    (layout/row-major [Long/MAX_VALUE] :float)))
+                      :opencl-portable)))))
+
+(deftest static-dense-body-graph-preserves-public-and-derived-scalars
+  (let [base (fixture)
+        value (scheduled/make
+               (-> base
+                   (update :body update :parameters into
+                           [(body/->KernelParameter 'n :scalar :int [] nil nil :bound)
+                            (body/->KernelParameter 'next-n :scalar :int [] nil nil :bound)])
+                   (assoc :arguments ['input 'output 'rows (launch/sum 'rows 1)])
+                   (dissoc :scalar-bindings)))
+        emitted (target/emit-static-dense-graph "scalar_graph" value :opencl-portable)]
+    (is (= '[input output rows] (:arguments emitted)))
+    (is (= [(graph/scalar 'rows :int)] (:scalars emitted)))
+    (is (= #{'rows} (set (get-in emitted [:nodes 0 :scalar-uses]))))
+    (is (= ['input 'output 'rows (launch/sum 'rows 1)]
+           (get-in emitted [:nodes 0 :operation :arguments])))))
+
+(deftest static-dense-body-graph-preserves-inout-storage
+  (let [base (fixture)
+        value (scheduled/make
+               (-> base
+                   (assoc-in [:body :parameters 1 :kind] :inout)
+                   (assoc-in [:effects :uses 1 :access] :read-write)))
+        emitted (target/emit-static-dense-graph "inout_graph" value :opencl-portable)]
+    (is (= '[input output] (mapv :id (:inputs emitted))))
+    (is (= ['output] (mapv :id (:outputs emitted))))
+    (is (= [1] (mapv :elements (:outputs emitted))))
+    (is (= [:input :inout] (mapv :kind (:abi emitted))))))
+
 (deftest scheduled-body-binds-one-operation-to-one-complete-kernel-plan
   (let [value (fixture)]
     (is (scheduled/scheduled-kernel-body? value))

--- a/test/raster/compiler/passes/parallel/staged_contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contraction_body_test.clj
@@ -32,6 +32,21 @@
          (when-not (staged/declined? e) (throw e))
          (:missing-rule (ex-data e)))))
 
+(deftest packed-candidate-uses-generic-checked-graph-storage
+  (let [source (fixtures/packed-facts 3 5 3 32)
+        scheduled (staged/lower source)]
+    (doseq [dialect [:opencl-portable :opencl-intel :cuda :hip]]
+      (let [graph (target/emit-static-dense-graph "packed_graph" scheduled dialect)
+            leaf (get-in graph [:nodes 0 :operation])]
+        (is (= '[a b da db out] (:arguments graph)))
+        (is (= [288 480 9 15 15]
+               (mapv :elements (concat (:inputs graph) (:outputs graph)))))
+        (is (= [:byte :byte :float :float :float] (mapv :dtype (:abi graph))))
+        (is (empty? (:scalars graph)))
+        (is (= '[a b da db out 15] (:arguments leaf)) "launch count stays target-private")
+        (is (= source (get-in leaf [:attributes :scheduled-kernel-body :source])))
+        (is (= (:effects scheduled) (:effects graph)))))))
+
 (deftest packed-schedule-declines-unproved-domains
   (let [source (fixtures/packed-facts 3 5 3 32)]
     (doseq [[label transform expected]

--- a/test/raster/gpu/kernel_body_graph_test.clj
+++ b/test/raster/gpu/kernel_body_graph_test.clj
@@ -1,0 +1,105 @@
+(ns raster.gpu.kernel-body-graph-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as fixtures]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.passes.parallel.staged-contraction-body :as staged]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as probe]))
+
+(defn- candidate []
+  (target/emit-static-dense-graph
+   "checked_packed" (staged/lower (fixtures/packed-facts 3 5 3 32)) :opencl-portable))
+
+(defn- session [graph short-id]
+  (let [specs (concat (:inputs graph) (:outputs graph))
+        buffers (into {} (for [{:keys [id dtype elements]} specs
+                               :let [n (if (= id short-id) (dec elements) elements)]]
+                           [id {:id id :dtype dtype :n-elements n
+                                :byte-size (* n (dtype/bytes-of dtype))}]))]
+    (atom {:device-id :ocl:0 :session-id :body-graph-test
+           :buffers buffers
+           :allocations (into {} (for [[id buffer] buffers]
+                                   [id (bview/allocation
+                                        {:id id :byte-size (:byte-size buffer)
+                                         :memory-space :device :device :ocl:0
+                                         :coherence :explicit-transfer :ownership :owned})]))
+           :kernel-graphs {} :events {} :closed? false})))
+
+(defn- bind! [boundary sess graph bindings]
+  (case boundary
+    :session (gpu/bind-kernel-graph! sess :checked graph bindings {})
+    :descriptor
+    (gpu/bind-step!
+     sess {:convention :executable :phase :checked :kernel-name "checked_packed"
+           :artifact graph
+           :argument-specs (mapv (fn [slot sym] {:kind (:kind slot) :sym sym})
+                                 (:abi graph) (:arguments graph))}
+     [] bindings)))
+
+(defn- mocked-runtime [calls]
+  (fn [_ name]
+    (case name
+      "register-kernel!" (fn [& _] (swap! calls conj :register))
+      "bind-kernel-call" (fn [call] (swap! calls conj call) {:call call})
+      "record-graph!" (fn [& _] (swap! calls conj :record) {})
+      "make-buffer" (fn [& _] (throw (ex-info "unexpected allocation" {})))
+      (throw (ex-info "unexpected runtime request" {:name name})))))
+
+(deftest generated-body-capacities-are-enforced-before-driver-work
+  (let [graph (candidate)
+        bindings (zipmap (:arguments graph) (:arguments graph))
+        calls (atom [])]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) (mocked-runtime calls)}
+      (fn []
+        (doseq [boundary [:session :descriptor]
+                id (:arguments graph)]
+          (testing (str boundary " undersized " id)
+            (let [failure (try (bind! boundary (session graph id) graph bindings) nil
+                               (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+              (is (= id (:graph-buffer failure)))
+              (is (and (integer? (:elements failure))
+                       (= (dec (:elements failure)) (:view-elements failure)))))
+            (is (empty? @calls) "no register, bind, allocation or recording")))))))
+
+(deftest generated-body-alias-contracts-survive-both-binders
+  (let [graph (candidate)
+        bindings (zipmap (:arguments graph) (:arguments graph))
+        calls (atom [])]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) (mocked-runtime calls)}
+      (fn []
+        (doseq [boundary [:session :descriptor]]
+          (testing (str boundary)
+            ;; db and out both contain 15 Floats. A capacity-only check cannot catch this.
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"overlapping writable|overlaps a writable"
+                         (bind! boundary (session graph nil) graph (assoc bindings 'out 'db))))
+            (is (empty? @calls))
+            (bind! boundary (session graph nil) graph bindings)
+            (is (some map? @calls) "valid storage reaches a bound leaf")
+            (is (= 15 (->> @calls (filter map?) first :arguments last :value))
+                "the private launch scalar is supplied by the graph")
+            (reset! calls [])))))))
+
+(deftest generated-body-graph-replays-on-device
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "generated dense body graph replay")
+    (let [graph (candidate)]
+      (gpu/with-gpu-session [sess :ocl:0]
+        (gpu/alloc! sess {:a [:byte 288 (byte-array (repeat 288 2))]
+                          :b [:byte 480 (byte-array (repeat 480 -3))]
+                          :da [:float 9 (float-array (repeat 9 0.5))]
+                          :db [:float 15 (float-array (repeat 15 0.25))]
+                          :out [:float 15 nil]})
+        (let [handle (gpu/bind-kernel-graph!
+                      sess :checked graph {'a :a 'b :b 'da :da 'db :db 'out :out} {})]
+          (try
+            (doseq [_ (range 2)]
+              (gpu/upload! sess :out (float-array (repeat 15 -555.0)))
+              (let [event (gpu/submit-kernel-graph! sess handle)]
+                (try (gpu/await-event! sess event)
+                     (is (= (vec (repeat 15 -72.0)) (vec (gpu/download sess :out))))
+                     (finally (gpu/release-event! sess event)))))
+            (finally (gpu/release-kernel-graph! sess handle))))))))


### PR DESCRIPTION
## Summary
- Project positive static dense ScheduledKernelBody storage into the existing KernelGraph interface, with required capacities for every operand, lift and output.
- Preserve exact source/effects, logical dtypes, ordered public ABI, private scalar expressions and common target emission. Reject unknown/strided storage and address-space overflow.
- Keep production schedule selection unchanged: the packed candidate still needs performance admission.

## Validation
- One capped REPL on Intel Arc OpenCL: 19 tests, 177 assertions, zero failures/errors and no device skips in the final run.
- Checks all four target projections, renamed pointer arguments, public/private scalars, inout storage, operand/lift/output shortages through both public binders, writable alias rejection, and device replay with output poisoned before each submission.
- Independent code review: no blockers.
- Full suite and CUDA/HIP/OpenCL compile gates delegated to CI.