### PR TITLE
Compare resident kernels with rotating device-event samples

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -60,6 +60,16 @@ an end-to-end series when packing, transfers or page routing are required. Do no
 costs behind a resident-only comparison. Include cold compilation/tuning in amortization
 reports but never silently mix it into warm execution samples.
 
+For a bounded warm resident A/B/C comparison, bind all candidates with profiling enabled,
+validate each independently, then use `gpu/measure-bound-kernel-graphs-interleaved!` with an
+ordered vector of `{:id :candidate-name :handle handle :before-sample! restore-fn}`. The optional
+restore callback runs before every replay outside device timing. `:rounds` defaults to 12 and
+`:warmup-rounds` to 3. Each round rotates the starting candidate; complete cycles balance ordinal
+position. Persist both chronological `:samples` and per-candidate `:measurements` with the identities
+above. This controls one ordering confound, not cache/thermal drift. The summary's `:stationary?`
+is only the existing coefficient-of-variation heuristic; it neither proves stationarity nor
+selects a winner. No tuning cache or production selector is changed by this measurement API.
+
 Pin external revisions before measurement. Retain individual shapes and failures; publish
 any aggregate only alongside them. Tune on a declared training set and measure held-out
 shapes, with a stated budget for each implementation. Do not update reference baselines

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -2227,6 +2227,22 @@
        :device-wall-ms (:wall-ms prof)
        :host-wall-ms (/ (- t1 t0) 1.0e6)})))
 
+(defn- graph-device-sampler
+  [sess graph before-sample!]
+  (let [device-id (:device-id @sess)
+        replay-fn (rt-resolve device-id "replay-graph!")
+        read-ts-fn (rt-resolve device-id "read-graph-timestamps!")]
+    (fn []
+      (when before-sample! (before-sample!))
+      (replay-fn graph)
+      (let [wall-ms (:wall-ms (read-ts-fn graph))]
+        (when-not (and (number? wall-ms)
+                      (Double/isFinite (double wall-ms))
+                      (not (neg? (double wall-ms))))
+          (throw (ex-info "device graph profiler returned no finite wall duration"
+                          {:device-id device-id :wall-ms wall-ms})))
+        (* 1.0e6 (double wall-ms))))))
+
 (defn measure-graph!
   "Repeatedly measure a PROFILING runtime graph with backend device events.
 
@@ -2239,19 +2255,7 @@
    measurement/measure!, including :budget-ms, :warmup-iterations, :flush-fn, :cold-warm,
    :compile-ms, and :hashes."
   [sess graph & {:keys [before-sample!] :as opts}]
-  (let [device-id (:device-id @sess)
-        replay-fn (rt-resolve device-id "replay-graph!")
-        read-ts-fn (rt-resolve device-id "read-graph-timestamps!")
-        sample-fn (fn []
-                    (when before-sample! (before-sample!))
-                    (replay-fn graph)
-                    (let [wall-ms (:wall-ms (read-ts-fn graph))]
-                      (when-not (and (number? wall-ms)
-                                     (Double/isFinite (double wall-ms))
-                                     (not (neg? (double wall-ms))))
-                        (throw (ex-info "device graph profiler returned no finite wall duration"
-                                        {:device-id device-id :wall-ms wall-ms})))
-                      (* 1.0e6 (double wall-ms))))
+  (let [sample-fn (graph-device-sampler sess graph before-sample!)
         measurement-opts (-> opts
                              (dissoc :before-sample!)
                              (assoc :timing-source :device-event))]
@@ -2282,6 +2286,33 @@
       (throw (ex-info "bound kernel graph was not recorded with :profile? true"
                       {:handle handle})))
     (apply measure-graph! sess runtime-graph (mapcat identity opts))))
+
+(defn measure-bound-kernel-graphs-interleaved!
+  "Device-event comparison of already-bound profiling graphs without exposing runtime handles.
+
+   candidates: ordered vector of {:id keyword :handle KernelGraphHandle :before-sample! fn?}.
+   Restoration runs before every replay, including warmup, outside the measured device interval.
+   The caller owns independent correctness validation, candidate identity and handle lifetime.
+   Compilation and transfers are not timed; this is a warm resident comparison, not end-to-end
+   performance or automatic schedule selection. Options are measure-interleaved! round bounds
+   and cv-threshold; timing-source is always :device-event."
+  [sess candidates & {:as opts}]
+  (when-not (vector? candidates)
+    (throw (ex-info "interleaved graph candidates must be an ordered vector" {})))
+  (when (seq (remove #{:rounds :warmup-rounds :cv-threshold} (keys opts)))
+    (throw (ex-info "unsupported interleaved graph measurement option" {:options (keys opts)})))
+  (let [samplers
+        (mapv (fn [{:keys [id handle before-sample!]}]
+                (when-not (or (nil? before-sample!) (ifn? before-sample!))
+                  (throw (ex-info "before-sample! must be callable" {:candidate id})))
+                (let [{:keys [runtime-graph profile?]} (resolve-kernel-graph-entry sess handle)]
+                  (when-not profile?
+                    (throw (ex-info "bound kernel graph was not recorded with :profile? true"
+                                    {:handle handle})))
+                  {:id id :sample-fn (graph-device-sampler sess runtime-graph before-sample!)}))
+              candidates)]
+    (apply measurement/measure-interleaved! samplers
+           (mapcat identity (assoc opts :timing-source :device-event)))))
 
 (defn sync-to-arrays!
   "Download GPU buffers back into JVM arrays.

--- a/src/raster/gpu/measurement.clj
+++ b/src/raster/gpu/measurement.clj
@@ -61,8 +61,8 @@
     (when-let [invalid (first (remove finite-nonnegative? samples))]
       (throw (ex-info "measurement samples must be finite, non-negative nanoseconds"
                       {:sample invalid})))
-    (when-not (and (number? cv-threshold) (not (neg? (double cv-threshold))))
-      (throw (ex-info "measurement cv-threshold must be non-negative"
+    (when-not (finite-nonnegative? cv-threshold)
+      (throw (ex-info "measurement cv-threshold must be finite and non-negative"
                       {:cv-threshold cv-threshold})))
     (when-not (#{:warm :cold} cold-warm)
       (throw (ex-info "measurement cold-warm must be :warm or :cold"
@@ -95,6 +95,51 @@
                      (double compile-ms)
                      hashes
                      samples))))
+
+(defn measure-interleaved!
+  "Compare already-prepared device sample functions in rotating round-robin order.
+
+   Candidates are an ordered vector of {:id keyword :sample-fn fn}. Each callback returns
+   device nanoseconds and owns required restoration/synchronization. Compilation, allocation,
+   validation and persistence belong to the caller. Warmup samples are checked but not reported.
+   Fixed rounds bound the number of callbacks, not wall time. Raw chronological samples and
+   per-candidate Measurement values are returned; no winner or performance admission is inferred.
+   Rotation balances ordinal position over complete cycles, not cache or thermal conditions.
+   Summary :stationary? is the existing CV heuristic, not a drift test or admission proof."
+  [candidates & {:keys [rounds warmup-rounds timing-source cv-threshold]
+                 :or {rounds 12 warmup-rounds 3 timing-source :device-event
+                      cv-threshold 0.05}}]
+  (when-not (and (vector? candidates) (seq candidates)
+                 (every? #(and (keyword? (:id %)) (ifn? (:sample-fn %))) candidates)
+                 (= (count candidates) (count (set (map :id candidates)))))
+    (throw (ex-info "interleaved measurement requires unique named sample functions" {})))
+  (doseq [[field n minimum] [[:rounds rounds 1] [:warmup-rounds warmup-rounds 0]]]
+    (when-not (and (integer? n) (<= minimum n Integer/MAX_VALUE))
+      (throw (ex-info "invalid interleaved measurement round count" {:field field :value n}))))
+  ;; Validate summary metadata before performing any device work.
+  (summarize [0.0] :timing-source timing-source :cv-threshold cv-threshold)
+  (let [n (count candidates)
+        run-round
+        (fn [phase round]
+          (mapv (fn [position]
+                  (let [{:keys [id sample-fn]} (nth candidates (mod (+ round position) n))
+                        sample (sample-fn)]
+                    (when-not (finite-nonnegative? sample)
+                      (throw (ex-info "invalid interleaved device sample"
+                                      {:candidate id :phase phase :round round :sample sample})))
+                    {:candidate id :round round :position position :ns (double sample)}))
+                (range n)))]
+    (dotimes [round warmup-rounds] (run-round :warmup round))
+    (let [samples (into [] (mapcat #(run-round :measurement %)) (range rounds))]
+      {:order :rotating-round-robin
+       :candidate-order (mapv :id candidates)
+       :rounds rounds :warmup-rounds warmup-rounds
+       :samples samples
+       :measurements
+       (into {} (for [{:keys [id]} candidates]
+                  [id (summarize (mapv :ns (filter #(= id (:candidate %)) samples))
+                                 :warmup-iterations warmup-rounds
+                                 :timing-source timing-source :cv-threshold cv-threshold)]))})))
 
 (defn measure!
   "Measure an explicit device-sample function under a bounded, do_bench-style discipline.
@@ -149,4 +194,3 @@
                  :timing-source timing-source
                  :compile-ms compile-ms
                  :hashes hashes))))
-

--- a/test/raster/gpu/interleaved_measurement_test.clj
+++ b/test/raster/gpu/interleaved_measurement_test.clj
@@ -1,0 +1,43 @@
+(ns raster.gpu.interleaved-measurement-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.gpu.measurement :as measurement]))
+
+(deftest samples-rotate-and-preserve-chronology
+  (let [calls (atom [])
+        candidates (mapv (fn [id] {:id id :sample-fn #(do (swap! calls conj id) (count @calls))})
+                         [:a :b :c])
+        result (measurement/measure-interleaved! candidates :rounds 3 :warmup-rounds 1
+                                                  :timing-source :synthetic)]
+    (is (= [:a :b :c :a :b :c :b :c :a :c :a :b] @calls))
+    (is (= [4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0] (mapv :ns (:samples result))))
+    (is (= [0 0 0 1 1 1 2 2 2] (mapv :round (:samples result))))
+    (doseq [id [:a :b :c]]
+      (is (= #{0 1 2} (set (map :position (filter #(= id (:candidate %)) (:samples result)))))))
+    (is (= [4.0 9.0 11.0] (get-in result [:measurements :a :samples-ns])))
+    (is (= :synthetic (get-in result [:measurements :a :timing-source])))
+    (is (= 1 (get-in result [:measurements :a :warmup-iterations])))))
+
+(deftest rejects-invalid-options-before-device-work
+  (let [calls (atom 0)
+        candidate {:id :a :sample-fn #(swap! calls inc)}]
+    (doseq [candidates [[] [candidate candidate] [{:id :a :sample-fn nil}]]]
+      (is (thrown? clojure.lang.ExceptionInfo (measurement/measure-interleaved! candidates))))
+    (doseq [opts [[:rounds 0] [:rounds 1.5] [:warmup-rounds -1]
+                  [:rounds (inc (bigint Integer/MAX_VALUE))] [:timing-source "host"]
+                  [:cv-threshold -1] [:cv-threshold Double/NaN]
+                  [:cv-threshold Double/POSITIVE_INFINITY]]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (apply measurement/measure-interleaved! [candidate] opts))))
+    (is (zero? @calls))))
+
+(deftest invalid-samples-fail-in-warmup-and-measurement
+  (doseq [warmup [0 1] sample [nil -1 Double/NaN Double/POSITIVE_INFINITY]]
+    (let [calls (atom 0)
+          failure (try (measurement/measure-interleaved!
+                        [{:id :bad :sample-fn #(do (swap! calls inc) sample)}]
+                        :warmup-rounds warmup :rounds 2)
+                       nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+      (is (= :bad (:candidate failure)))
+      (is (= (if (zero? warmup) :measurement :warmup) (:phase failure)))
+      (is (= 1 @calls)))))

--- a/test/raster/gpu/measurement_test.clj
+++ b/test/raster/gpu/measurement_test.clj
@@ -79,3 +79,31 @@
           :pending-inputs (atom #{}) :closed? (atom false)})]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"require :before-sample!"
                           (link/measure! executable :budget-ms 1)))))
+
+(deftest interleaved-bound-graphs-use-device-events-and-restore-before-every-replay
+  (let [calls (atom [])
+        session (atom {:device-id :probe})
+        candidates (mapv (fn [id] {:id id :handle id
+                                  :before-sample! #(swap! calls conj [:restore id])}) [:a :b])]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'resolve-kernel-graph-entry)
+       (fn [_ handle] {:profile? (not= :unprofiled handle) :runtime-graph handle})
+       #'raster.gpu.core/rt-resolve
+       (fn [_ name]
+         (case name
+           "replay-graph!" #(swap! calls conj [:replay %])
+           "read-graph-timestamps!" (fn [id] (swap! calls conj [:timestamp id]) {:wall-ms 0.001})))}
+      (fn []
+        (doseq [opts [[:timing-source :host] [:rounds 0]]]
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (apply gpu/measure-bound-kernel-graphs-interleaved! session candidates opts))))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (gpu/measure-bound-kernel-graphs-interleaved!
+                      session (assoc-in candidates [1 :handle] :unprofiled))))
+        (is (empty? @calls))
+        (let [result (gpu/measure-bound-kernel-graphs-interleaved!
+                      session candidates :warmup-rounds 1 :rounds 2)]
+          (is (= (vec (mapcat (fn [id] [[:restore id] [:replay id] [:timestamp id]])
+                             [:a :b :a :b :b :a])) @calls))
+          (is (= [1000.0 1000.0] (get-in result [:measurements :a :samples-ns])))
+          (is (= :device-event (get-in result [:measurements :b :timing-source]))))))))


### PR DESCRIPTION
## Summary
- Add bounded rotating-round-robin sampling with chronological raw samples and existing per-candidate Measurement summaries.
- Connect already-bound profiling graphs through a shared device sampler, preserving restore/replay/timestamp ordering and keeping backend graph handles private.
- Reject nonfinite CV thresholds; document that CV is a heuristic, not a stationarity proof or automatic promotion.
- This is infrastructure for paired typed/retained packed-kernel measurements, not a performance result or production route change.

## Validation
- Focused capped JVM: 10 tests, 75 assertions, zero failures/errors.
- Tests cover rotation, warmup exclusion, invalid samples/options before device work, restore ordering, device nanosecond conversion and no host timing substitution.
- Independent review clear. Rebased onto merged #450; tested and rebased trees identical.
- Full suite/vendor gates delegated to CI. No new GPU performance claim.