### PR TITLE
Preserve explicit OpenCL compilation requirements through artifacts and runtime

### DIFF
--- a/design/kernel-compilation-contract.md
+++ b/design/kernel-compilation-contract.md
@@ -1,0 +1,26 @@
+# Target compilation requirements
+
+A KernelArtifact may carry checked compiler requirements in its existing
+`:attributes :compilation` map:
+
+```clojure
+{:language-standard "CL3.0"
+ :extensions #{"cl_khr_integer_dot_product"}}
+```
+
+Absent or empty requirements retain backend defaults. Explicit requirements currently
+support OpenCL C only, with CL1.2, CL2.0, or CL3.0 and optional extension-name sets.
+They do not permit arbitrary command-line flags or changes to numerical policy.
+
+The OpenCL runtime checks exact device extension tokens before creating a program,
+then passes the requested language standard to the compiler. Extension presence
+alone does not prove that an overload is supported or hardware accelerated; the
+emitter must retain feature guards and schedule selection still needs evidence.
+
+Requirements participate in leaf and graph tuning fingerprints and dispatch
+entry-point collision checks. The public tensor ABI remains unchanged. Level Zero
+currently rejects explicit requirements because its offline compiler and SPIR-V
+cache do not yet consume this contract; silently ignoring it would be incorrect.
+
+This is a prerequisite for target-selected intrinsic lowering, not a new semantic
+IR, an optimized kernel promotion, or a change to the default OpenCL dialect.

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -31,6 +31,31 @@
   (and x (= "raster.compiler.ir.kernel_artifact.KernelArtifact"
             (.getName (class x)))))
 
+(defn compilation
+  "Checked target compiler requirements, stored in the existing artifact attributes.
+   Empty requirements preserve runtime defaults. Explicit OpenCL language/extension requirements
+   are not arbitrary compiler flags or permission to change numerical policy."
+  [artifact]
+  (let [contract (get-in artifact [:attributes :compilation] {})]
+    (when-not (and (map? contract)
+                   (every? #{:language-standard :extensions} (keys contract))
+                   (or (empty? contract)
+                       (and (= :opencl-c (:target artifact))
+                            (contains? #{"CL1.2" "CL2.0" "CL3.0"} (:language-standard contract))
+                            (set? (:extensions contract #{}))
+                            (every? #(and (string? %) (re-matches #"cl_[A-Za-z0-9_]+" %))
+                                    (:extensions contract #{})))))
+      (throw (ex-info "invalid kernel compilation requirements"
+                      {:reason :kernel-artifact-compilation :target (:target artifact)
+                       :compilation contract})))
+    contract))
+
+(defn compilation-identity
+  "Add compiler requirements to an existing executable fingerprint only when nonempty."
+  [identity artifact]
+  (let [contract (compilation artifact)]
+    (cond-> identity (seq contract) (assoc :compilation contract))))
+
 (defn validate!
   "Validate `artifact` and return it unchanged. Validation includes the emitted target C-family
    signature, so no unverified KernelArtifact can enter a runtime registry."
@@ -75,6 +100,7 @@
       (when-not (map? value)
         (throw (ex-info (str "kernel artifact " k " must be a map")
                         {:kernel-name kernel-name k value}))))
+    (compilation artifact)
     artifact))
 
 (defn make

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -5,7 +5,8 @@
    scheduling value above both: every alternative implements the same logical call and differs
    only in its emitted schedule. Selection is pure data evaluated after symbolic ABI scalars
    become concrete and before a backend binder sees the selected executable."
-  (:require [raster.compiler.ir.kernel-executable :as kexec]
+  (:require [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.kernel-precondition :as precondition]))
 
@@ -184,7 +185,9 @@
       ;; denotes the same emitted module/signature; otherwise backend registration is ambiguous.
       (doseq [[kernel-name entries] (group-by first named-artifacts)]
         (let [implementations (set (map (fn [[_ artifact]]
-                                          (select-keys artifact [:target :source :abi :arguments :preconditions]))
+                                          (kart/compilation-identity
+                                           (select-keys artifact [:target :source :abi :arguments :preconditions])
+                                           artifact))
                                         entries))]
           (when-not (= 1 (count implementations))
             (throw (ex-info "kernel dispatch reuses an entry point for conflicting modules"

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -6,7 +6,8 @@
    winners at sampled runtime scalar values into a piecewise selector, and atomically caches it.
    Applying a result rechecks the full identity: device, emitted sources, ABI, numerical mode, and
    layout. A stale or cross-device result therefore cannot silently select a kernel."
-  (:require [raster.compiler.ir.kernel-dispatch :as kdispatch]
+  (:require [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.gpu.measurement :as measurement]
             [raster.gpu.tuning-cache :as cache])
@@ -57,12 +58,15 @@
                                    {:id (:id node)
                                     :uses (:uses node)
                                     :dependencies (:dependencies node)
-                                    :artifact (select-keys (:operation node)
+                                    :artifact (kart/compilation-identity (select-keys (:operation node)
                                                            [:kernel-name :target :source :abi
-                                                            :arguments :launch :preconditions :temporaries])})
+                                                            :arguments :launch :preconditions :temporaries])
+                                                                         (:operation node))})
                                  (:nodes executable))}
-                   (select-keys executable
-                                [:kernel-name :target :source :launch :preconditions :temporaries]))]
+                   (kart/compilation-identity
+                    (select-keys executable
+                                 [:kernel-name :target :source :launch :preconditions :temporaries])
+                    executable))]
     {:kind (kexec/kind executable)
      :strategy (kdispatch/alternative-strategy executable)
      :target (kexec/target executable)

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -19,7 +19,8 @@
             MemoryLayout MemorySegment SymbolLookup ValueLayout
             AddressLayout]
            [java.lang.invoke MethodHandle])
-  (:require [raster.compiler.core.dtype :as dt]
+  (:require [clojure.string :as str]
+            [raster.compiler.core.dtype :as dt]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
@@ -912,11 +913,24 @@
   [dispatch-id]
   (get @kernel-dispatch-registry dispatch-id))
 
+(defn- compilation-options
+  [compilation device-info]
+  (let [requirements (kart/compilation {:target :opencl-c :attributes {:compilation compilation}})
+        supported (set (str/split (:extensions device-info "") #"\s+"))
+        missing (seq (remove supported (:extensions requirements)))
+        _ (when missing
+            (throw (ex-info "OpenCL device lacks required compiler extensions"
+                            {:reason :opencl-compilation-requirements :missing (set missing)})))]
+    (when-let [standard (:language-standard requirements)] (str "-cl-std=" standard))))
+
 (defn- compile-program!
   "Compile OpenCL C source to a cl_program. Returns the program handle."
-  ^MemorySegment [^String source]
+  ^MemorySegment [^String source compilation]
   (ensure-init!)
-  (let [{:keys [context device arena]} @state
+  (let [{:keys [context device arena device-info]} @state
+        options (if-let [options (compilation-options compilation device-info)]
+                  (.allocateFrom ^Arena arena ^String options)
+                  MemorySegment/NULL)
         err-seg (.allocate ^Arena arena I32)
         ;; Create string pointer
         src-seg (.allocateFrom ^Arena arena source)
@@ -933,10 +947,11 @@
         dev-seg (.allocateFrom ^Arena arena PTR device)
         ret (int (.invokeWithArguments ^MethodHandle @h-clBuildProgram
                                        (into-array Object [program (int 1) dev-seg
-                                                           MemorySegment/NULL MemorySegment/NULL MemorySegment/NULL])))]
+                                                           options MemorySegment/NULL MemorySegment/NULL])))]
     (when (not= CL_SUCCESS ret)
       ;; Get build log for diagnostics
-      (let [log-size-seg (.allocate ^Arena arena I64)
+      (try
+        (let [log-size-seg (.allocate ^Arena arena I64)
             _ (.invokeWithArguments ^MethodHandle @h-clGetProgramBuildInfo
                                     (into-array Object [program device (int CL_PROGRAM_BUILD_LOG)
                                                         (long 0) MemorySegment/NULL log-size-seg]))
@@ -946,8 +961,10 @@
                                     (into-array Object [program device (int CL_PROGRAM_BUILD_LOG)
                                                         log-size log-buf log-size-seg]))
             build-log (.getString log-buf 0)]
-        (throw (ex-info (str "clBuildProgram failed: " build-log)
-                        {:error ret :build-log build-log}))))
+          (throw (ex-info (str "clBuildProgram failed: " build-log)
+                          {:error ret :build-log build-log})))
+        (finally
+          (.invokeWithArguments ^MethodHandle @h-clReleaseProgram (into-array Object [program])))))
     program))
 
 (defn- ensure-kernel-loaded!
@@ -967,7 +984,7 @@
             _ (when-not source
                 (throw (ex-info "Kernel has no :source for OpenCL compilation"
                                 {:kernel-name kernel-name})))
-            program (compile-program! source)
+            program (compile-program! source (kart/compilation info))
             err-seg (.allocate ^Arena arena I32)
             kname-seg (.allocateFrom ^Arena arena ^String kernel-name)
             kernel-handle (.invokeWithArguments ^MethodHandle @h-clCreateKernel

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1791,6 +1791,10 @@
    (register-kernel! kernel-name kernel-info *current-arena*))
   ([kernel-name kernel-info arena-id]
    (let [_ (when (kart/kernel-artifact? kernel-info) (kart/validate! kernel-info))
+         _ (when (seq (kart/compilation kernel-info))
+             (throw (ex-info "Level Zero offline compilation does not yet consume explicit compiler requirements"
+                             {:reason :unsupported-compilation-contract :backend :ze
+                              :compilation (kart/compilation kernel-info)})))
          info (cond-> kernel-info
                 arena-id (assoc :arena-id arena-id))]
      (swap! kernel-registry assoc kernel-name info))))

--- a/test/raster/compiler/ir/kernel_artifact_test.clj
+++ b/test/raster/compiler/ir/kernel_artifact_test.clj
@@ -30,6 +30,25 @@
     (is (= "+" (kart/attribute a :c-op)))
     (is (identical? a (kart/validate! a)))))
 
+(deftest compilation-contract-is-explicit-and-not-arbitrary-flags
+  (is (= {} (kart/compilation (kart/make base))))
+  (doseq [standard ["CL1.2" "CL2.0" "CL3.0"]]
+    (let [contract {:language-standard standard :extensions #{"cl_khr_integer_dot_product"}}
+          a (kart/make (assoc-in base [:attributes :compilation] contract))]
+      (is (= contract (kart/compilation a)))
+      (is (= {:source "same" :compilation contract}
+             (kart/compilation-identity {:source "same"} a)))))
+  (is (= {:source "same"} (kart/compilation-identity {:source "same"} (kart/make base))))
+  (doseq [bad [nil [] {:flags "-cl-fast-relaxed-math"} {:language-standard "CL9.0"}
+               {:language-standard "CL3.0 -DUNSAFE"}
+               {:language-standard "CL3.0" :extensions ["cl_khr_integer_dot_product"]}
+               {:language-standard "CL3.0" :extensions #{"cl_x -DUNSAFE"}}]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"compilation requirements"
+                         (kart/make (assoc-in base [:attributes :compilation] bad)))))
+  (is (thrown? clojure.lang.ExceptionInfo
+               (kart/compilation {:target :cuda-c
+                                  :attributes {:compilation {:language-standard "CL3.0"}}}))))
+
 (deftest artifact-refuses-an-unverified-module-or-call
   (testing "source and ABI parameter order cannot diverge"
     (is (thrown-with-msg?

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -10,6 +10,7 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.core :as gpu]
+            [raster.gpu.dispatch-tuning :as tuning]
             [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.ze-runtime :as ze]))
 
@@ -36,6 +37,28 @@
 
 (def ^:private subgroup
   (artifact "dispatch_subgroup" :subgroup-score-reuse 16))
+
+(deftest compiler-requirements-cannot-collide-under-one-entry-point
+  (let [cl3 (-> reference
+                (assoc-in [:attributes :strategy] :cl3)
+                (assoc-in [:attributes :compilation] {:language-standard "CL3.0"}))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting modules"
+                         (kdispatch/make {:id "compilation-conflict"
+                                          :alternatives [reference cl3]
+                                          :default-strategy :reference
+                                          :selector {:kind :fixed-strategy :strategy :reference}})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not yet consume"
+                         (ze/register-kernel! "compile_contract_rejected" cl3)))
+    (is (nil? (ze/kernel-registry-entry "compile_contract_rejected")))))
+
+(deftest opencl-compilation-options-check-exact-device-extension-tokens
+  (let [options (ns-resolve 'raster.gpu.ocl-runtime 'compilation-options)
+        req {:language-standard "CL3.0" :extensions #{"cl_khr_integer_dot_product"}}]
+    (is (nil? (options {} {})))
+    (is (= "-cl-std=CL3.0"
+           (options req {:extensions "cl_other cl_khr_integer_dot_product\ncl_last"})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"lacks required"
+                         (options req {:extensions "cl_khr_integer_dot_product_suffix"})))))
 
 (def ^:private dispatch
   (kdispatch/make
@@ -116,6 +139,15 @@
                 (kgraph/->ValueUse 'out :write)] #{'width} [:stage-one])]
       :effects (:effects reference)
       :attributes {:strategy :two-stage}})))
+
+(deftest graph-node-compilation-requirements-invalidate-tuning
+  (let [graph (staged-graph)
+        changed (assoc-in graph [:nodes 1 :operation :attributes :compilation]
+                          {:language-standard "CL3.0"})
+        before (tuning/executable-signature graph)
+        after (tuning/executable-signature changed)]
+    (is (not= (:source-hash before) (:source-hash after)))
+    (is (= (dissoc before :source-hash) (dissoc after :source-hash)))))
 
 (deftest runtime-scalars-select-an-abi-compatible-artifact
   (is (kdispatch/kernel-dispatch? dispatch))

--- a/test/raster/gpu/dispatch_tuning_test.clj
+++ b/test/raster/gpu/dispatch_tuning_test.clj
@@ -30,6 +30,15 @@
 (def ^:private reference (artifact "tune_reference" :reference 64))
 (def ^:private subgroup (artifact "tune_subgroup" :subgroup 16))
 
+(deftest compilation-requirements-invalidate-executable-identity
+  (let [explicit (assoc-in reference [:attributes :compilation] {:language-standard "CL3.0"})
+        feature (assoc-in explicit [:attributes :compilation :extensions] #{"cl_khr_integer_dot_product"})
+        signatures (mapv tuning/executable-signature [reference explicit feature])]
+    (is (= 3 (count (set (map :source-hash signatures)))))
+    (is (= 1 (count (set (map :abi-hash signatures)))))
+    (is (= (tuning/executable-signature reference)
+           (tuning/executable-signature (assoc-in reference [:attributes :compilation] {}))))))
+
 (def ^:private dispatch
   (kdispatch/make
    {:id "dispatch-tuning-test"

--- a/test/raster/gpu/ocl_compilation_test.clj
+++ b/test/raster/gpu/ocl_compilation_test.clj
@@ -1,0 +1,64 @@
+(ns raster.gpu.ocl-compilation-test
+  "Hardware-free checks at the native OpenCL compilation boundary."
+  (:require [clojure.test :refer [deftest is]]
+            [raster.gpu.ocl-runtime])
+  (:import [java.lang.foreign Arena MemorySegment ValueLayout]
+           [java.lang.invoke MethodHandles MethodType]))
+
+(defn- handle [arity f]
+  (.bindTo (.findVirtual (MethodHandles/lookup) clojure.lang.IFn "invoke"
+                        (MethodType/genericMethodType arity)) f))
+
+(defn- runtime-var [sym] (ns-resolve 'raster.gpu.ocl-runtime sym))
+
+(deftest compiler-options-and-failed-program-ownership
+  (with-open [arena (Arena/ofConfined)]
+    (let [calls (atom [])
+          fail? (atom false)
+          diagnostic-fail? (atom false)
+          program (.allocate arena 8)
+          compile! (runtime-var 'compile-program!)
+          native (fn [arity f] (delay (handle arity f)))
+          replacements
+          {(runtime-var 'ensure-init!) (fn [])
+           (runtime-var 'state) (atom {:arena arena :context MemorySegment/NULL
+                                      :device MemorySegment/NULL :device-info {}})
+           (runtime-var 'h-clCreateProgramWithSource)
+           (native 5 (fn [_ _ _ _ err]
+                       (swap! calls conj :create)
+                       (.set ^MemorySegment err ValueLayout/JAVA_INT 0 (int 0))
+                       program))
+           (runtime-var 'h-clBuildProgram)
+           (native 6 (fn [_ _ _ options _ _]
+                       (swap! calls conj [:build (when-not (= MemorySegment/NULL options)
+                                                  (.getString ^MemorySegment options 0))])
+                       (if @fail? -11 0)))
+           (runtime-var 'h-clGetProgramBuildInfo)
+           (native 6 (fn [_ _ _ size buffer result-size]
+                       (when @diagnostic-fail? (throw (ex-info "diagnostic failure" {})))
+                       (.set ^MemorySegment result-size ValueLayout/JAVA_LONG 0 (long 5))
+                       (when (pos? size) (.setString ^MemorySegment buffer 0 "oops"))
+                       0))
+           (runtime-var 'h-clReleaseProgram)
+           (native 1 (fn [p] (swap! calls conj [:release p]) 0))}]
+      (with-redefs-fn replacements
+        (fn []
+          (is (= program (compile! "source" {})))
+          (is (= [:create [:build nil]] @calls))
+          (reset! calls [])
+          (is (= program (compile! "source" {:language-standard "CL3.0"})))
+          (is (= [:create [:build "-cl-std=CL3.0"]] @calls))
+          (reset! calls [])
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"lacks required"
+                               (compile! "source" {:language-standard "CL3.0"
+                                                    :extensions #{"cl_missing"}})))
+          (is (empty? @calls) "requirements fail before creating a native program")
+          (reset! fail? true)
+          (doseq [diagnostic-failure [false true]]
+            (reset! diagnostic-fail? diagnostic-failure)
+            (reset! calls [])
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                 (if diagnostic-failure #"diagnostic failure" #"clBuildProgram failed: oops")
+                                 (compile! "invalid source" {})))
+            (is (= [:create [:build nil] [:release program]] @calls)
+                "failed builds release exactly once, even when log retrieval throws")))))))


### PR DESCRIPTION
## Summary
- Carry checked language standards and extension requirements in existing KernelArtifact attributes; no new semantic IR or default dialect change.
- Include requirements in leaf/graph tuning identity and dispatch entry-point collision checks.
- Forward explicit OpenCL build options, reject missing extensions before program creation, and release failed programs even when diagnostics throw.
- Fail closed on Level Zero until offline compilation/cache support consumes the contract.

## Validation
- Focused capped REPL: 31 tests, 151 assertions, zero failures/errors.
- Hardware-free native-boundary tests cover options, rejection ordering, and failure ownership.
- Intel Arc explicit CL3.0 compilation smoke passed with a source guard requiring OpenCL C 3.0.
- Independent review: no blockers. Full suite and vendor compile gates delegated to CI.

No native-dot schedule is promoted by this prerequisite.