### PR TITLE
Emit native OpenCL integer dot through the shared typed pipeline

### DIFF
--- a/bench/native_dot_validation.clj
+++ b/bench/native_dot_validation.clj
@@ -1,0 +1,77 @@
+(ns native-dot-validation
+  "Explicit device validation; run on an OpenCL device with packed integer dot support.
+   No silent capability skip and no dependency on this device in the ordinary CI suite."
+  (:refer-clojure :exclude [run!])
+  (:require [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.gpu.ocl-runtime :as ocl]))
+
+(defn reference [a b acc]
+  (let [lane (fn [word shift]
+               (let [x (bit-and 255 (unsigned-bit-shift-right (long word) shift))]
+                 (if (< x 128) x (- x 256))))]
+    (unchecked-int
+     (reduce + (long acc) (for [shift [0 8 16 24]]
+                           (* (lane a shift) (lane b shift)))))))
+
+(defn cases []
+  (vec (for [a [0 -1 0x7f7f7f7f (unchecked-int 0x80808080)
+                 (unchecked-int 0x80ff017f) 0x7f010080]
+             b [0 -1 0x7f7f7f7f (unchecked-int 0x80808080)
+                 (unchecked-int 0xff017f80)]
+             acc [0 -1 1 Integer/MIN_VALUE Integer/MAX_VALUE]]
+         [a b acc])))
+
+(defn run! []
+  (let [kernel-body
+        (body/make
+         {:id :native-dot-validation
+          :parameters [(body/->KernelParameter 'a :scalar :int [] nil nil :a)
+                       (body/->KernelParameter 'b :scalar :int [] nil nil :b)
+                       (body/->KernelParameter 'acc :scalar :int [] nil nil :acc)
+                       (body/->KernelParameter 'out :output :int [1] :global
+                                               (layout/row-major [1] :int) :result)]
+          :operations [(body/->ScalarCompute
+                        (body/value 'dot :int)
+                        (body/scalar-expression :dp4a :int ['a 'b 'acc]))
+                       (body/->ScalarStore 'out [0] 'dot nil)]
+          :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+          :provenance {:dialect :validation} :attributes {}})
+        module (emit/emit-scalar-module
+                "native_dot_edges" kernel-body
+                {:target-dialect :opencl-portable
+                 :parameter-names {'out "rstr_output"}
+                 :target-features {:intrinsic-implementations {:dp4a :opencl-packed-dot}}})
+        compiled (artifact/make
+                  {:kernel-name "native_dot_edges" :target :opencl-c :source (:source module)
+                   :abi [(abi/slot 'a :scalar :int :c-name "rstr_a")
+                         (abi/slot 'b :scalar :int :c-name "rstr_b")
+                         (abi/slot 'acc :scalar :int :c-name "rstr_acc")
+                         (abi/slot 'out :output :int :c-name "rstr_output")]
+                   :arguments '[a b acc out] :launch (:launch kernel-body)
+                   :effects {:kind :native-dot-validation}
+                   :attributes {:compilation (:compilation module)}})
+        output (ocl/buffer-of-array (int-array [42]) :int)]
+    (try
+      (ocl/register-kernel! "native_dot_edges" compiled)
+      (doseq [[a b acc :as inputs] (cases)]
+        (let [expected (reference a b acc)
+              _ (ocl/array->buffer! output (int-array [(bit-xor expected 1)]))
+              bound (ocl/bind-kernel-call
+                     (call/make compiled [{:type :int :value a} {:type :int :value b}
+                                          {:type :int :value acc} output]))]
+          (try
+            (ocl/launch-registered-bound! bound)
+            (let [actual (first (ocl/buffer->array output))]
+              (when-not (= expected actual)
+                (throw (ex-info "native integer dot differs from wrapping reference"
+                                {:inputs inputs :expected expected :actual actual}))))
+            (finally (ocl/destroy-prepared! bound)))))
+      {:cases (count (cases)) :passed? true :device (ocl/selected-device-info)
+       :compilation (:compilation module)}
+      (finally (ocl/free-buffer! output)))))

--- a/design/kernel-compilation-contract.md
+++ b/design/kernel-compilation-contract.md
@@ -24,3 +24,25 @@ cache do not yet consume this contract; silently ignoring it would be incorrect.
 
 This is a prerequisite for target-selected intrinsic lowering, not a new semantic
 IR, an optimized kernel promotion, or a change to the default OpenCL dialect.
+
+## Explicit intrinsic candidates
+
+The shared typed emitter accepts an opt-in physical implementation selection:
+
+```clojure
+{:target-features {:intrinsic-implementations {:dp4a :opencl-packed-dot}}}
+```
+
+The canonical intrinsic registry owns the helper and its compiler requirements.
+Only consumed helpers contribute requirements. `emit-scalar-module` returns source
+and requirements together; `emit-artifact` transports both automatically. The
+source-only `emit-scalar-kernel` API rejects selections with nonempty requirements.
+The native OpenCL helper uses signed packed dot followed by unsigned accumulation
+and bit reinterpretation, preserving Int32 wrap rather than saturating the result.
+
+This explicit candidate does not infer device acceleration or change automatic
+selection. Its source feature guard additionally requires packed-dot frontend
+support. `native-dot-validation/run!` (under the bench alias) explicitly validates
+150 mixed-sign and accumulator-limit cases on a capable device, poisoning output
+before each execution; unsupported devices fail rather than silently skip this
+opt-in experiment. Generic CI remains independent of this hardware capability.

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -1935,6 +1935,32 @@
      body)
     @result))
 
+(defn intrinsic-helper-module
+  "Select intrinsic implementations and their compiler requirements together.
+   Selection is explicit target policy, not semantic or type inference."
+  [body-str target-dialect implementations]
+  (let [helpers
+        (keep (fn [[id {:keys [c c-helper-src target-helper-src] :as descriptor}]]
+                (when (and (:fn c)
+                           (re-find (re-pattern (str "\\b" (java.util.regex.Pattern/quote (:fn c)) "\\(")) body-str))
+                  (if-let [selected (get implementations id)]
+                    (let [implementation (get-in descriptor [:implementations selected])]
+                      (when-not (contains? (:dialects implementation) target-dialect)
+                        (throw (ex-info "unsupported intrinsic implementation for target"
+                                        {:intrinsic id :implementation selected :target target-dialect})))
+                      implementation)
+                    {:source (or (get target-helper-src target-dialect) c-helper-src)})))
+              intrinsics/table)
+        contracts (keep :compilation helpers)
+        standards (set (keep :language-standard contracts))]
+    (when (> (count standards) 1)
+      (throw (ex-info "conflicting intrinsic compilation standards" {:standards standards})))
+    {:source (str/join "\n" (distinct (keep :source helpers)))
+     :compilation (if (seq contracts)
+                    {:language-standard (first standards)
+                     :extensions (into #{} (mapcat :extensions) contracts)}
+                    {})}))
+
 (defn intrinsic-helper-sources
   "The C helper DEFINITIONS for every registry intrinsic whose C function is CALLED in
    `body-str`, each once, in table order. Registry-driven: an intrinsic that carries a
@@ -1948,14 +1974,7 @@
   ([body-str]
    (intrinsic-helper-sources body-str nil))
   ([body-str target-dialect]
-   (->> intrinsics/table
-       (keep (fn [[_ {:keys [c c-helper-src target-helper-src]}]]
-               (let [helper-src (or (get target-helper-src target-dialect) c-helper-src)]
-                 (when (and helper-src (:fn c)
-                          (re-find (re-pattern (str "\\b" (java.util.regex.Pattern/quote (:fn c)) "\\(")) body-str))
-                   helper-src))))
-       distinct
-       (str/join "\n"))))
+   (:source (intrinsic-helper-module body-str target-dialect {}))))
 
 (defn helper-sources
   "Target helper definitions required by an already-emitted C-family body."

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1244,7 +1244,7 @@
             (merge parameters allocations) (:views kernel-body))))
 
 (defn- emit-scalar-kernel*
-  [kernel-name kernel-body {:keys [parameter-names]}]
+  [kernel-name kernel-body {:keys [parameter-names target-features]}]
   (let [kernel-body (body/validate! kernel-body)
         operations (vec (scalar-body-operations (:operations kernel-body)))
         unsupported (remove #(contains? scalar-operation-kinds
@@ -1343,6 +1343,9 @@
                       1 (str (target-type (get types (:id index))) " " name " = "
                              (emit-index-expression (:expression index) names) ";"))))))
         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
+        intrinsic-module (ce/intrinsic-helper-module
+                          operation-source (:id *scalar-dialect*)
+                          (:intrinsic-implementations target-features))
         helper-source
         (c-dialect/helper-source
          *scalar-dialect*
@@ -1354,8 +1357,7 @@
               (when (and (c-dialect/opencl? *scalar-dialect*)
                          (str/includes? operation-source "atomic_add_float("))
                 ce/opencl-atomic-add-float-helper)
-              (ce/intrinsic-helper-sources operation-source
-                                           (:id *scalar-dialect*))))
+              (:source intrinsic-module)))
         storage-declarations (concat parameters (:allocations kernel-body))
         stable-reads (set (map :buffer (:stable-reads kernel-body)))
         uses-half? (some #(= :half (dtype/canon (:dtype %))) storage-declarations)
@@ -1369,7 +1371,8 @@
                           (get-in kernel-body [:schedule :subgroup-size]))
         attribute (c-dialect/subgroup-attribute
                    *scalar-dialect* subgroup-size uses-subgroups?)]
-    (str (c-dialect/preamble *scalar-dialect*
+    {:compilation (:compilation intrinsic-module)
+     :source (str (c-dialect/preamble *scalar-dialect*
                              {:uses-half? uses-half? :uses-double? uses-double?
                               :uses-subgroups? uses-subgroups?})
          helper-source
@@ -1385,9 +1388,9 @@
                         parameters))
          ") {\n"
          allocation-source index-source operation-source
-         "}\n")))
+         "}\n")}))
 
-(defn emit-scalar-kernel
+(defn emit-scalar-module
   "Lower a verified scalar/control KernelBody directly to a C-family target dialect.
 
   The body already fixes schedules, types, layouts, masks, convergence and numerical conversion
@@ -1396,7 +1399,7 @@
   selection cannot alter the scheduled body. `target-features` may only select a capability-gated
   physical implementation (for example Ampere `cp.async`) with the same verified semantics."
   ([kernel-name kernel-body]
-   (emit-scalar-kernel kernel-name kernel-body {}))
+   (emit-scalar-module kernel-name kernel-body {}))
   ([kernel-name kernel-body {:keys [target-dialect subgroup-attribute target-features] :as options
                              :or {target-dialect :opencl-intel subgroup-attribute :intel}}]
    (let [target-dialect (if (and (= :opencl-intel target-dialect)
@@ -1407,3 +1410,14 @@
                (merge (c-dialect/resolve! target-dialect)
                       (select-keys target-features [:compute-capability :architecture]))]
        (emit-scalar-kernel* kernel-name kernel-body options)))))
+
+(defn emit-scalar-kernel
+  "Source-only projection. Runtime artifacts must consume emit-scalar-module requirements too."
+  ([kernel-name kernel-body] (emit-scalar-kernel kernel-name kernel-body {}))
+  ([kernel-name kernel-body options]
+   (let [module (emit-scalar-module kernel-name kernel-body options)]
+     (when (seq (:compilation module))
+       (throw (ex-info "explicit compilation requirements need emit-scalar-module"
+                       {:reason :discarded-compilation-contract
+                        :compilation (:compilation module)})))
+     (:source module))))

--- a/src/raster/compiler/backend/gpu/kernel_body_target.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_target.clj
@@ -122,16 +122,16 @@
            (let [names (validate-target-names!
                         kernel-name kernel-body
                         (scalar-parameter-names kernel-body parameter-names))]
-             {:source (scalar-target/emit-scalar-kernel
+             (merge (scalar-target/emit-scalar-module
                        kernel-name kernel-body
                        {:target-dialect target-dialect
                         :target-features target-features
                         :parameter-names names})
-              :target (c-dialect/target dialect)
+              {:target (c-dialect/target dialect)
               :target-dialect (:id dialect)
               :parameter-names names
               :parameter-alignments {}
-              :target-facts (scalar-target-facts kernel-body dialect target-features)}))
+              :target-facts (scalar-target-facts kernel-body dialect target-features)})))
          names (validate-target-names! kernel-name kernel-body (:parameter-names emitted))
          projected-abi (project-abi scheduled names (:parameter-alignments emitted))]
      (scheduled-body/validate-artifact-projection!
@@ -161,7 +161,9 @@
                            :body-family (if matrix? :matrix :scalar-control)
                            :legality (:legality scheduled)
                            :numerics (:numerics scheduled)
-                           :target-facts (:target-facts emitted)})})))))
+                           :target-facts (:target-facts emitted)}
+                          (when (seq (:compilation emitted))
+                            {:compilation (:compilation emitted)}))})))))
 
 (defn emit-static-dense-graph
   "Place one ScheduledKernelBody behind the existing checked graph binding boundary.

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -118,6 +118,17 @@
    ;; The VECTOR schedules (AVX2 maddubs, wasm i32x4.dot) are :wi8-dot above.
    :dp4a {:arity 3 :kind :dp4a
           :c {:fn "rstr_dp4a"}
+          :implementations
+          {:opencl-packed-dot
+           {:dialects #{:opencl-intel :opencl-portable}
+            :compilation {:language-standard "CL3.0"
+                          :extensions #{"cl_khr_integer_dot_product"}}
+            :source (str "#pragma OPENCL EXTENSION cl_khr_integer_dot_product : enable\n"
+                         "#if !defined(__opencl_c_integer_dot_product_input_4x8bit_packed)\n"
+                         "#error packed_integer_dot_unavailable\n#endif\n"
+                         "inline int rstr_dp4a(int a, int b, int acc) {\n"
+                         "    return as_int(as_uint(acc) + as_uint(dot_4x8packed_ss_int(as_uint(a), as_uint(b))));\n"
+                         "}\n")}}
           :target-helper-src
           {:cuda (str "__device__ __forceinline__ int rstr_dp4a(int a, int b, int acc) {\n"
                       "    return __dp4a(a, b, acc);\n"

--- a/test/raster/compiler/backend/gpu/intrinsic_compilation_test.clj
+++ b/test/raster/compiler/backend/gpu/intrinsic_compilation_test.clj
@@ -1,0 +1,37 @@
+(ns raster.compiler.backend.gpu.intrinsic-compilation-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.c-emit :as c]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as scalar]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as fixtures]
+            [raster.compiler.passes.parallel.staged-contraction-body :as staged]))
+
+(def selection {:dp4a :opencl-packed-dot})
+
+(deftest helpers-carry-only-consumed-requirements
+  (is (= {:source "" :compilation {}}
+         (c/intrinsic-helper-module "x + y" :opencl-portable selection)))
+  (let [module (c/intrinsic-helper-module "rstr_dp4a(a,b,c)" :opencl-portable selection)]
+    (is (= {:language-standard "CL3.0" :extensions #{"cl_khr_integer_dot_product"}}
+           (:compilation module)))
+    (is (re-find #"dot_4x8packed_ss_int" (:source module)))
+    (is (re-find #"as_uint\(acc\)" (:source module)))
+    (is (not (re-find #"dot_acc_sat" (:source module)))))
+  (doseq [dialect [:cuda :hip]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unsupported intrinsic"
+                         (c/intrinsic-helper-module "rstr_dp4a(a,b,c)" dialect selection)))))
+
+(deftest typed-body-projection-preserves-native-helper-contract
+  (let [scheduled (staged/lower (fixtures/packed-facts 1 128 32 32))
+        ordinary (target/emit-artifact "ordinary_dot" scheduled :opencl-portable)
+        native (target/emit-artifact "native_dot" scheduled :opencl-portable
+                                     {:target-features {:intrinsic-implementations selection}})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"need emit-scalar-module"
+                         (scalar/emit-scalar-kernel "cannot_drop_contract" (:body scheduled)
+                           {:target-dialect :opencl-portable
+                            :target-features {:intrinsic-implementations selection}})))
+    (is (nil? (get-in ordinary [:attributes :compilation])))
+    (is (= "CL3.0" (get-in native [:attributes :compilation :language-standard])))
+    (is (re-find #"dot_4x8packed_ss_int" (:source native)))
+    (is (= (select-keys ordinary [:abi :arguments :effects :launch])
+           (select-keys native [:abi :arguments :effects :launch])))))


### PR DESCRIPTION
## Summary
- Add an explicit native packed-dot implementation to the canonical intrinsic registry, with source and compiler requirements selected together.
- Propagate requirements through scalar module and ScheduledKernelBody artifact emission; source-only callers reject requirement-dropping selections.
- Preserve default emission and all public tensor ABI/storage contracts. This is opt-in candidate support, not automatic schedule promotion.

## Validation
- Focused capped REPL: 15 tests, 220 assertions, zero failures/errors.
- Real Intel Arc: 150 mixed-sign/accumulator-limit cases using independent wrapping reference and poisoned outputs all passed.
- Real typed contraction graph with signed-byte extremes matched all 128 outputs exactly.
- Independent review: no blockers. Full suite and vendor gates delegated to CI.

Paired performance measurements follow separately; no claim of superiority or SOTA performance.