### PR TITLE
Fix portable integer-dot accumulation overflow

### DIFF
--- a/bench/native_dot_validation.clj
+++ b/bench/native_dot_validation.clj
@@ -2,14 +2,19 @@
   "Explicit device validation; run on an OpenCL device with packed integer dot support.
    No silent capability skip and no dependency on this device in the ordinary CI suite."
   (:refer-clojure :exclude [run!])
-  (:require [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
+  (:require [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-call :as call]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.gpu.ocl-runtime :as ocl]))
+            [raster.gpu.ocl-runtime :as ocl])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
 
 (defn reference [a b acc]
   (let [lane (fn [word shift]
@@ -27,7 +32,40 @@
              acc [0 -1 1 Integer/MIN_VALUE Integer/MAX_VALUE]]
          [a b acc])))
 
-(defn run! []
+(defn run-c!
+  "Hardware-free portable-helper oracle under C undefined-behavior sanitization.
+   Requires a C compiler with UBSan; compiler absence/failure is an error, not a skip."
+  ([] (run-c! "cc"))
+  ([compiler]
+   (let [directory (Files/createTempDirectory "raster-dot-ubsan-" (make-array FileAttribute 0))
+         binary (.resolve directory "dot-validation")
+         source (str "#include <limits.h>\n_Static_assert(INT_MAX == 2147483647, \"32 bit int required\");\nstatic "
+                     (:c-helper-src (intrinsics/descriptor 'dp4a))
+                     "\nint main(void) {\nvolatile int cases[][4] = {\n"
+                     (str/join ",\n" (for [[a b acc] (cases)]
+                                          (str "{" a "," b "," acc "," (reference a b acc) "}")))
+                     "};\nfor (unsigned i=0; i<sizeof(cases)/sizeof(cases[0]); ++i) {\n"
+                     "if (rstr_dp4a(cases[i][0],cases[i][1],cases[i][2]) != cases[i][3]) return 1;\n"
+                     "}\nreturn 0; }\n")]
+     (try
+       (let [compiled (shell/sh compiler "-x" "c" "-std=c11" "-O2"
+                                "-fsanitize=undefined" "-fno-sanitize-recover=undefined"
+                                "-o" (str binary) "-" :in source)]
+         (when-not (zero? (:exit compiled))
+           (throw (ex-info "portable dot sanitizer compilation failed" compiled))))
+       (let [result (shell/sh (str binary))]
+         (when-not (zero? (:exit result))
+           (throw (ex-info "portable dot sanitizer validation failed" result)))
+         {:implementation :portable :cases (count (cases)) :passed? true :sanitizer :undefined})
+       (finally
+         (Files/deleteIfExists binary)
+         (Files/deleteIfExists directory))))))
+
+(defn run!
+  ([] (run! :native))
+  ([implementation]
+  (when-not (contains? #{:native :portable} implementation)
+    (throw (ex-info "unknown dot validation implementation" {:implementation implementation})))
   (let [kernel-body
         (body/make
          {:id :native-dot-validation
@@ -46,7 +84,8 @@
                 "native_dot_edges" kernel-body
                 {:target-dialect :opencl-portable
                  :parameter-names {'out "rstr_output"}
-                 :target-features {:intrinsic-implementations {:dp4a :opencl-packed-dot}}})
+                 :target-features (when (= :native implementation)
+                                    {:intrinsic-implementations {:dp4a :opencl-packed-dot}})})
         compiled (artifact/make
                   {:kernel-name "native_dot_edges" :target :opencl-c :source (:source module)
                    :abi [(abi/slot 'a :scalar :int :c-name "rstr_a")
@@ -69,9 +108,10 @@
             (ocl/launch-registered-bound! bound)
             (let [actual (first (ocl/buffer->array output))]
               (when-not (= expected actual)
-                (throw (ex-info "native integer dot differs from wrapping reference"
-                                {:inputs inputs :expected expected :actual actual}))))
+                (throw (ex-info "integer dot differs from wrapping reference"
+                                {:implementation implementation
+                                 :inputs inputs :expected expected :actual actual}))))
             (finally (ocl/destroy-prepared! bound)))))
-      {:cases (count (cases)) :passed? true :device (ocl/selected-device-info)
+      {:implementation implementation :cases (count (cases)) :passed? true :device (ocl/selected-device-info)
        :compilation (:compilation module)}
-      (finally (ocl/free-buffer! output)))))
+      (finally (ocl/free-buffer! output))))))

--- a/design/kernel-compilation-contract.md
+++ b/design/kernel-compilation-contract.md
@@ -46,3 +46,12 @@ support. `native-dot-validation/run!` (under the bench alias) explicitly validat
 150 mixed-sign and accumulator-limit cases on a capable device, poisoning output
 before each execution; unsupported devices fail rather than silently skip this
 opt-in experiment. Generic CI remains independent of this hardware capability.
+
+The portable helper also performs unsigned wrapping accumulation, then reconstructs
+the signed result using only representable casts. The signed four-byte dot itself
+fits Int32; adding the accumulator directly in signed C does not. The validation
+runner accepts `:portable` for device execution, and `run-c!` runs the same 150
+cases under an optimizing C compiler with undefined-behavior sanitization, without
+requiring a GPU. This sanitizer check reproduces signed overflow with the former
+helper and passes with the corrected helper. Prior benchmark files identify the
+older source revision and must not be treated as measurements of this correction.

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -147,7 +147,8 @@
                              "    int b1 = (int)((ub >> 8) & 255u); b1 = b1 < 128 ? b1 : b1 - 256;\n"
                              "    int b2 = (int)((ub >> 16) & 255u); b2 = b2 < 128 ? b2 : b2 - 256;\n"
                              "    int b3 = (int)((ub >> 24) & 255u); b3 = b3 < 128 ? b3 : b3 - 256;\n"
-                             "    return acc + a0*b0 + a1*b1 + a2*b2 + a3*b3;\n"
+                             "    unsigned int sum = (unsigned int)acc + (unsigned int)(a0*b0 + a1*b1 + a2*b2 + a3*b3);\n"
+                             "    return sum <= 2147483647u ? (int)sum : -1 - (int)(~sum);\n"
                              "}\n")
           :wasm :scalar-lanes}
    ;; broader elementary set — all wasm via composition/polynomial (see

--- a/test/raster/compiler/backend/gpu/intrinsic_compilation_test.clj
+++ b/test/raster/compiler/backend/gpu/intrinsic_compilation_test.clj
@@ -8,6 +8,14 @@
 
 (def selection {:dp4a :opencl-packed-dot})
 
+(deftest portable-dot-retains-wrapping-accumulation
+  (let [{:keys [source compilation]}
+        (c/intrinsic-helper-module "rstr_dp4a(a,b,c)" :opencl-portable {})]
+    (is (= {} compilation))
+    (is (re-find #"unsigned int sum = \(unsigned int\)acc" source))
+    (is (re-find #"sum <= 2147483647u \? \(int\)sum : -1 - \(int\)\(~sum\)" source))
+    (is (not (re-find #"return acc \+" source)))))
+
 (deftest helpers-carry-only-consumed-requirements
   (is (= {:source "" :compilation {}}
          (c/intrinsic-helper-module "x + y" :opencl-portable selection)))


### PR DESCRIPTION
Stacked on #455; retarget/rebase after preceding squashes.

## Correctness
The canonical portable helper previously accumulated in signed int. UBSan reproduced INT_MAX + 1 overflow. It now computes the bounded signed four-byte dot, adds in unsigned arithmetic, and reconstructs the signed result using representable casts. This preserves the JVM wrapping contract without saturation or out-of-range casts.

## Validation
- 16 focused tests, 224 assertions: all pass.
- 150 poisoned-output cases on Arc in portable mode: all pass.
- Same 150 cases with optimized C and UBSan: all pass; replacing the helper with the old expression reproduces sanitizer failure.
- Hardware-free sanitizer runner retained for repeatability; requires a C compiler, not a GPU.
- Independent review: no blockers. Full suite/vendor compilation delegated to CI.

Prior benchmark results remain revision-specific; this change does not promote a schedule.