### PR TITLE
Track the public staged-contraction frontend gap in the workload ledger

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -60,6 +60,22 @@ Exit: public product workloads use the typed route without reconstructed facts o
 
 ## 2. Retire the remaining compatibility paths — active
 
+The public staged Byte→Int32→Float contraction is now a separate compatibility-ledger
+workload. Unlike the explicit-map Q4 row projection (already KernelBody), it declines
+direct TypedSOAC admission and reaches retained `:staged-segred` emission. Its current
+compatibility path requires explicit `:dtype :byte`; default Float policy emits Float
+operand pointers despite declared Byte inputs, which the resident binder correctly
+rejects. Do not count fixture-only staged KernelBody emission as this public vertical.
+
+The next admission must retain the existing `SoacContract`/`ContractionFacts` payload,
+including nested stage boundaries, typed lifts and storage dependencies, through the
+typed program and projection. Flat ProductReduction components are simultaneous
+accumulators, not nested stages. Check operand/lift/output types independently; do not
+relax the frontend option gate or flatten stages into a scalar fold. Existing fusion
+rules must decline staged nodes until their legality preserves those boundaries.
+Acceptance includes exact fact transport without reparsing, public mixed-storage
+execution, source return/effect preservation, and checked graph capacities/aliasing.
+
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:
 

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -2,7 +2,16 @@
  :description
  "Exact fast-lane compiler signatures for representative ML and scientific workloads. Improvements update this debt downward; unexpected route, fallback, or emitter drift fails CI. Large numerical/performance comparisons live in the cold benchmark lane."
  :workloads
- {:dense-relu-jvm
+ {:staged-byte-float-contraction-gpu
+  {:route {:backend :opencl :source-dialect :compatibility :typed-validated false
+           :declines {[:soac-fused-stats :typed-soac-declined :typed-soac-source-coverage] 1}}
+   :fusion {:vertical 0 :horizontal 0 :iterations 0 :placements 0}
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 0
+              :typed-scalar-equations 0 :backend-reused 1 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 1 :targets [:opencl-c] :strategies [:staged-segred]
+              :fallback-reasons [] :declines {} :routes {:segcontract 1}}}
+
+  :dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}
    :lowering {:segops 2 :kernel-graphs 0 :structured-loops 0

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -18,6 +18,20 @@
 (def ^:private ledger-path "test/raster/compiler/compatibility_ledger.edn")
 (def ^:private target :ze:compatibility-ledger)
 
+;; This is staged contraction syntax, not the explicit-map Q4 projection below.
+;; Track the frontend gap separately from candidate KernelBody/device coverage.
+(deftm staged-byte-float-contract!
+  [a :- (Array byte) b :- (Array byte) da :- (Array float)
+   db :- (Array float) out :- (Array float)] :- Void
+  (raster.par/contract out [[i 1] [j 2]] [[blk 2] [t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* blk 4) t))
+                      (raster.arrays/aget b (+ (* j 8) (* blk 4) t)))
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0
+              :lift (* inner (aget da _) (aget db _))
+              :operands [{:sym da :dtype :float :map {:groups [[[i 1] [blk 2]]]}}
+                         {:sym db :dtype :float :map {:groups [[[j 2] [blk 2]]]}}]}
+             {:axis t :extent 4 :dtype :int :init 0}]))
+
 (deftm prefix-sum-gpu
   [input :- (Array float) n :- Long] :- (Array float)
   (let [output (float-array n)]
@@ -73,6 +87,10 @@
   (case id
     :dense-relu-jvm
     (pipeline/compile-report #'nn/predict-fn)
+
+    :staged-byte-float-contraction-gpu
+    (pipeline/compile-report #'staged-byte-float-contract!
+                             :target-device target :dtype :byte)
 
     :symbolic-dense-contraction-gpu
     (let [compilation (equation-first/compile
@@ -134,6 +152,7 @@
   (let [{:keys [schema-version workloads]} (edn/read-string (slurp ledger-path))]
     (is (= 1 schema-version))
     (is (= #{:dense-relu-jvm
+             :staged-byte-float-contraction-gpu
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu


### PR DESCRIPTION
Stacked on #456; retarget after squash.

## Summary
- Add a real public par/contract :stages workload, distinct from the existing explicit-map Q4 row projection.
- Record its current compatibility frontend and retained staged-segred emission in the exact compiler ledger.
- Document the typed fact-transport and separate storage dtype obligations; do not loosen admission or claim fixture emission completes the public vertical.

## Validation
- New workload exact signature matches both Arc target and the existing synthetic ledger target.
- Public resident execution with explicit Byte policy returned [2.0 2.0]; default Float policy correctly fails pointer binding (documented gap).
- Independent review found no blockers.
- Focused compilation only locally; full ledger and suites delegated to CI.