### PR TITLE
Preserve staged contraction dependencies and mixed storage types

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -76,6 +76,15 @@ rules must decline staged nodes until their legality preserves those boundaries.
 Acceptance includes exact fact transport without reparsing, public mixed-storage
 execution, source return/effect preservation, and checked graph capacities/aliasing.
 
+The dependency prerequisite projects core, stage-lift and epilogue storage plus scalar
+captures once from ContractionFacts. SOAC and SegOp accessors share it; stage/epilogue
+binders have local scope, and declared maps replace placeholder indices before capture
+analysis. Decode expressions reading undeclared storage are explicitly rejected. A direct
+lowering test checks equation operands/effects and Byte input, Float scale/output/result,
+and integral scalar types. Floating declarations now specialize only under floating
+kernel policies, and contraction result aliases inherit the destination type. This
+repairs the existing dependency envelope, not direct TypedSOAC staged admission.
+
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -156,8 +156,9 @@
   scalars specialize to the selected kernel dtype. Physical narrowing belongs to a scheduled
   ABI conversion with a range check, not source type derivation.
   Array params: the tag's element dtype, with float-family (float/double)
-  mapped to the KERNEL dtype (a single-precision kernel reads float buffers regardless of a
+  mapped to a floating-point KERNEL dtype (a single-precision kernel reads float buffers regardless of a
   parametric (All [T]) param's default).
+  Integral kernel policies retain declared floating types rather than turning scales into bytes.
   Returns {:scalar-types {sym kw} :array-types {sym kw}}, attached as form metadata that
   opencl-pass reads. ONE derivation, both compile paths."
   [params tags dtype]
@@ -166,12 +167,14 @@
                                     (case (dtype/dtype-for-scalar-tag t)
                                       :long [p :long]
                                       :int [p :int]
-                                      (:double :float) [p dtype]
+                                      (:double :float) [p (if (dtype/fp-dtype? dtype)
+                                                           dtype (dtype/dtype-for-scalar-tag t))]
                                       nil))
                                   (map vector params tags)))
      :array-types (into {} (keep (fn [[p t]]
                                    (when-let [dt (dtype/dtype-for-array-tag t)]
-                                     [p (if (#{:float :double} dt) dtype dt)]))
+                                     [p (if (and (#{:float :double} dt) (dtype/fp-dtype? dtype))
+                                          dtype dt)]))
                                  (map vector params tags)))}))
 
 (def ^:private fatal-reasons

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -22,6 +22,8 @@
    the whole extraction fail. Trusting a declared layout while having checked only its axis
    symbols is how a transpose rewrite risked a silent miscompile."
   (:require [clojure.walk :as walk]
+            [clojure.set :as set]
+            [raster.compiler.core.util :as util]
             [raster.compiler.core.op-descriptor :as od]
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.axis-map :as am]
@@ -199,6 +201,45 @@
   (let [[_ out free-axes contract-axes body] form]
     (from-components {:out out :free-axes free-axes :contract-axes contract-axes
                       :body body :opts (form-opts form) :dtype dtype :form form})))
+
+(defn dependencies
+  "Project storage and scalar dependencies from the sole contraction payload.
+   Lexical stage/epilogue binders are local to their expressions, not global exclusions.
+   This projects dependencies only; it does not flatten numerical stage semantics."
+  [facts]
+  (when-not (facts? facts)
+    (throw (ex-info "dependency projection requires contraction facts" {:reason :contraction-facts-required})))
+  (doseq [operand (:operands facts)
+          :when (seq (aget-terms (:decode operand)))]
+    (throw (ex-info "decode storage captures require an explicit operand contract"
+                    {:reason :contraction-decode-storage-dependencies :operand operand})))
+  (let [axes (concat (:free-axes facts) (:contract-axes facts))
+        indices (set (map first axes))
+        stages (:stages facts)
+        epilogue (:epilogue facts)
+        reads (set (map :sym (concat (:operands facts)
+                                    (contract-stages/lift-operands stages)
+                                    (:operands epilogue))))
+        writes #{(:out facts)}
+        stage-indices (contract-stages/stage-index-exprs stages)
+        epilogue-indices (into {} (map (fn [{:keys [sym map]}] [sym (am/index-expr map)]))
+                              (:operands epilogue))
+        refs (apply set/union #{}
+                    (concat
+                     [(util/free-syms (:body facts) indices)
+                      (util/free-syms (:init facts))
+                      (util/free-syms (od/rewrite-aget-indices (:expr epilogue) epilogue-indices)
+                                      (cond-> indices (:acc epilogue) (conj (:acc epilogue))))]
+                     (map #(util/free-syms (second %)) axes)
+                     (map #(util/free-syms (:init %)) stages)
+                     (map #(util/free-syms
+                            (contract-stages/substitute-operand-indices (:lift %) stage-indices)
+                            (conj indices 'inner)) stages)
+                     (map #(util/free-syms (:decode %) (conj indices 'x)) (:operands facts))
+                     (map #(util/free-syms (am/index-expr (:map %)) indices)
+                          (:operands epilogue))
+                     (map #(util/free-syms (:sym %)) (:scalars epilogue))))]
+    {:reads reads :writes writes :scalars (set/difference refs reads writes)}))
 
 (defn scalar-reduction-view
   "Project the canonical one-component ProductReduction into the contraction facts needed by

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -14,6 +14,7 @@
   Each SegOp carries a KernelGrid with pre-computed launch config
   based on raster.runtime.hardware device properties."
   (:require [clojure.set :as set]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.runtime.hardware :as hw]
             [raster.compiler.core.hardware :as chw]
             [raster.compiler.core.util :as util]
@@ -155,8 +156,7 @@
   "Physical tensor inputs of a scheduled operation, including a SegContract schedule view."
   [operation]
   (if (instance? SegContract operation)
-    (let [facts (:facts operation)]
-      (disj (set (map :sym (:operands facts))) (:out facts)))
+    (:reads (contraction-facts/dependencies (:facts operation)))
     (or (:inputs operation) #{})))
 
 (defn operation-outputs
@@ -184,14 +184,7 @@
    checked projection of axis bounds rather than a duplicate record field."
   [operation]
   (if (instance? SegContract operation)
-    (let [facts (:facts operation)
-          arrays (set/union (operation-inputs operation) (operation-outputs operation))
-          axes (concat (:free-axes facts) (:contract-axes facts))
-          axis-indices (set (map first axes))
-          expressions (conj (mapv second axes) (:body facts))]
-      (set/difference
-       (reduce set/union #{} (map scalar-entry-references expressions))
-       arrays axis-indices))
+    (:scalars (contraction-facts/dependencies (:facts operation)))
     (let [space (:space operation)
           axes (into #{(:flat-idx space)} (map :name) (:dims space))
           arrays (set/union (operation-inputs operation) (operation-outputs operation))

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -9,6 +9,7 @@
     SoacReduce  — parallel fold with associative operator
     SoacScan    — parallel prefix scan (inclusive)"
   (:require [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.form :as form]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -320,7 +321,7 @@
   "Get the set of input array symbols for a SOAC node."
   [node]
   (if (contract? node)
-    (set (map :sym (:operands (:facts node))))
+    (:reads (contraction-facts/dependencies (:facts node)))
     (:inputs node)))
 
 (defn soac-outputs
@@ -345,10 +346,13 @@
   output buffers that must be defined before the SOAC runs. Pure par/map SOACs
   don't have external output buffers — their output IS their binding symbol."
   [node]
+  (if (contract? node)
+    (let [{:keys [reads writes scalars]} (contraction-facts/dependencies (:facts node))]
+      (set/union reads writes scalars))
   (set/union (or (:inputs node) #{})
              (if (:pure? node) #{} (set (filter symbol? (or (:outputs node) #{}))))
              (or (:scalars node) #{})
              (util/free-syms (:bound node))
              (if (soac-reduce? node)
                (reduce set/union #{} (map util/free-syms (reduction/neutrals (:reduction node))))
-               (if (:init node) (util/free-syms (:init node)) #{}))))
+               (if (:init node) (util/free-syms (:init node)) #{})))))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -139,9 +139,10 @@
                 (and (contains? array-ids id) (soac/soac-reduce? node)) [(:bound node)]
                 (contains? array-ids id) (unknown-vector-shape)
                 :else [])
-        declared-types (if (contains? array-ids id) array-types scalar-types)
-        value-dtype (or (get declared-types id)
-                        (when (symbol? id) (get declared-types (symbol (name id))))
+        type-id (if (and result? (soac/contract? node)) (get-in node [:facts :out]) id)
+        declared-types (if (contains? array-ids type-id) array-types scalar-types)
+        value-dtype (or (get declared-types type-id)
+                        (when (symbol? type-id) (get declared-types (symbol (name type-id))))
                         (:elem-type node)
                         dtype
                         :double)]

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -40,6 +40,10 @@
                           (concat [:min-elements 0] opts)))))
 
 (deftest declared-gpu-parameter-types-preserve-the-scalar-array-partition
+  (is (= {:scalar-types {'scale :float 'bias :double}
+          :array-types {'packed :byte 'scales :float 'result :double}}
+         (opencl-pass/derive-param-types '[packed scales result scale bias]
+                                         '[bytes floats doubles float double] :byte)))
   (is (= {:scalar-types {'in :long 'scale :float}
           :array-types {'packed :int 'metadata :byte 'values :float 'cache :half}}
          (opencl-pass/derive-param-types

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -8,7 +8,56 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.reduction :as reduction]))
+
+(deftest contraction-dependencies-include-stage-and-epilogue-storage
+  (let [facts (cf/from-components
+               {:out 'out :free-axes [['i 2]] :contract-axes [['blk 2] ['t 4]]
+                :dtype :byte
+                :body '(* inner (aget a (+ (* i 8) (* blk 4) t)))
+                :opts {:decode {'a '(+ x offset)}
+                       :stages [{:axis 'blk :extent 2 :dtype :float :init 0.0
+                                 :lift '(* inner beta (aget scale _))
+                                 :operands [{:sym 'scale :dtype :float
+                                             :map (am/of-axes [['i 2] ['blk 2]])}]}
+                                {:axis 't :extent 4 :dtype :int :init 0}]
+                       :epilogue {:acc 'acc :expr '(+ acc bias (aget residual i))
+                                  :operands [{:sym 'residual :dtype :float
+                                              :map (am/of-axes [['i 2]])}]
+                                  :scalars [{:sym 'bias :dtype :float}]}}})
+        deps {:reads #{'a 'scale 'residual} :writes #{'out}
+              :scalars #{'inner 'beta 'bias 'offset}}
+        node (soac/->SoacContract 0 'result facts)
+        scheduled (segop/->SegContract 0 facts :byte :ocl:0)]
+    (is (= deps (cf/dependencies facts)))
+    (is (= (:reads deps) (soac/soac-inputs node)))
+    (is (= (:reads deps) (segop/operation-inputs scheduled)))
+    (is (= (:scalars deps) (segop/operation-scalars scheduled)))
+    (is (= #{'a 'scale 'residual 'out 'inner 'beta 'bias 'offset}
+           (soac/node-all-free-syms node)))
+    (is (contains? (:scalars (cf/dependencies facts)) 'inner)
+        "the lift placeholder does not bind an identically named body capture")
+    (doseq [index ['_ '(ignored-index hidden)]]
+      (is (= deps (cf/dependencies
+                   (assoc-in facts [:epilogue :expr]
+                             (list '+ 'acc 'bias (list 'aget 'residual index)))))
+          "declared epilogue maps replace spelled index expressions before dependency projection"))))
+
+(deftest contraction-axis-binders-do-not-bind-their-own-extents
+  (let [facts (cf/from-components {:out 'out :free-axes [['i 'i]]
+                                    :contract-axes [['k 4]] :dtype :float
+                                    :body '(aget a (+ (* i 4) k))})]
+    (is (= #{'i} (:scalars (cf/dependencies facts))))))
+
+(deftest undeclared-decode-storage-cannot-become-a-scalar-capture
+  (let [facts (cf/from-components {:out 'out :free-axes [['i 2]]
+                                    :contract-axes [['k 4]] :dtype :byte
+                                    :body '(aget a (+ (* i 4) k))
+                                    :opts {:decode {'a '(+ x (aget hidden k))}}})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"decode storage captures"
+                         (cf/dependencies facts)))))
 
 (def ^:private ma (am/of-groups '[[[i 4]] [[blk 4] [t 32]]]))
 (def ^:private mb (am/of-groups '[[[j 6]] [[blk 4] [t 32]]]))

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -26,6 +26,29 @@
 
 (defn- stats-of [form] (:stats (slp/segop-lower-pass form {})))
 
+(deftest staged-contraction-equation-retains-storage-dependencies-and-result-type
+  (let [source
+        '(let* [result
+                (raster.par/contract out [[i 2]] [[blk 2] [t 4]]
+                  (raster.numeric/* (aget a (+ (* i 8) (* blk 4) t)) gain)
+                  :stages [{:axis blk :extent 2 :dtype :float :init 0.0
+                            :lift (raster.numeric/* inner (aget scales _))
+                            :operands [{:sym scales :dtype :float
+                                        :map {:groups [[[i 2]] [[blk 2]]]}}]}
+                           {:axis t :extent 4 :dtype :int :init 0}])]
+           result)
+        p (:form (slp/segop-lower-pass
+                   source {:dtype :byte :array-types {'a :byte 'scales :float 'out :float}
+                           :scalar-types {'gain :int}}))
+        equation (first (:equations p))
+        result (first (:results equation))]
+    (is (= ['a 'gain 'out 'scales] (:operands equation)))
+    (is (= #{:memory/read :memory/write} (:effects equation)))
+    (is (= {:dtype :byte :shape ['?]} (select-keys (get-in p [:values 'a]) [:dtype :shape])))
+    (doseq [id ['scales 'out result]]
+      (is (= {:dtype :float :shape ['?]} (select-keys (get-in p [:values id]) [:dtype :shape]))))
+    (is (= {:dtype :int :shape []} (select-keys (get-in p [:values 'gain]) [:dtype :shape])))))
+
 (deftest an-ordinary-binding-is-silent
   (testing "most bindings are not par forms. Reporting them as 'declined' would drown the signal —
             absence of a decline must keep meaning 'nothing to lower here'"


### PR DESCRIPTION
## Summary
- Project core, stage-lift and epilogue dependencies from canonical ContractionFacts, with correct scalar binder scopes.
- Retain independent floating storage/scalar types under integral kernel policies and derive contraction result aliases from destination types.
- Reject undeclared decode storage captures explicitly. This does not claim direct TypedSOAC staged admission.

## Validation
- Focused IR and boundary suite: 52 tests, 249 assertions, zero failures/errors.
- Existing parameter scalar/array partition regression passed.
- Read-only review completed with no remaining blocker.
- Rebase preserved the tested tree exactly; full suites and vendor compilation gates delegated to CI.