### PR TITLE
Retain staged contraction closures in TypedSOAC

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -85,6 +85,15 @@ and integral scalar types. Floating declarations now specialize only under float
 kernel policies, and contraction result aliases inherit the destination type. This
 repairs the existing dependency envelope, not direct TypedSOAC staged admission.
 
+The next dialect slice represents a `contract` equation as a lexical closure over the
+same ContractionFacts, with ordered external array/capture value IDs. SSA renames those
+IDs, not the nested stage expressions or axis binders. Validation checks independent
+storage dtypes/capacities, scalar closure, output shape and explicit read/write storage
+contracts. Existing flat fusion rules recognize but do not rewrite this operation.
+The binding projection retains the original facts for the generated staged body and
+maps its arguments onto graph value IDs. This is a prerequisite: the public frontend
+still needs admission and production routing before its compatibility ledger can close.
+
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -93,6 +93,10 @@ contracts. Existing flat fusion rules recognize but do not rewrite this operatio
 The binding projection retains the original facts for the generated staged body and
 maps its arguments onto graph value IDs. This is a prerequisite: the public frontend
 still needs admission and production routing before its compatibility ledger can close.
+Closure validation is not an independent arithmetic type checker: it checks declared
+storage/scalar types and lexical scope. The existing scheduling and scalar-body lowerers
+must still prove instruction types and numerical legality. Unlowered representations,
+layouts and sharding decline, and outer lifts cannot refer to inner-stage coordinates.
 
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:

--- a/src/raster/compiler/ir/contraction_closure.clj
+++ b/src/raster/compiler/ir/contraction_closure.clj
@@ -7,6 +7,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as stages]
             [raster.compiler.ir.contraction-facts :as facts]))
@@ -14,6 +15,13 @@
 (defn- fail! [rule data]
   (throw (ex-info "typed contraction closure is not proved"
                   (assoc data :reason :typed-soac-contraction :missing-rule rule))))
+
+(defn plain-storage?
+  "The current closure has no view/representation lowering. Do not erase such facts."
+  [value]
+  (and (= {:kind :plain} (:representation value))
+       (nil? (:logical-layout value))
+       (nil? (:sharding value))))
 
 (defn attributes?
   [x]
@@ -52,7 +60,17 @@
                    (symbol? (:out contraction))
                    (not (contains? (set indices) (:out contraction)))
                    (not (contains? (:reads dependencies) (:out contraction))))
-      (fail! :lexical-boundary {:dependencies dependencies :attributes attributes})))
+      (fail! :lexical-boundary {:dependencies dependencies :attributes attributes}))
+    (doseq [[index stage] (map-indexed vector stage-list)
+            :when (:lift stage)]
+      (let [visible (into (set (concat array-parameters capture-parameters ['inner]))
+                          (map first (concat (:free-axes contraction)
+                                             (take (inc index) (:contract-axes contraction)))))
+            lift (stages/substitute-operand-indices
+                  (:lift stage) (stages/stage-index-exprs stage-list))
+            unbound (util/free-syms lift visible)]
+        (when (seq unbound)
+          (fail! :stage-lift-scope {:axis (:axis stage) :unbound unbound :visible visible})))))
   attributes)
 
 (defn bindings
@@ -74,27 +92,32 @@
         domain (into {} (concat (:free-axes source) (:contract-axes source)))
         core (map #(assoc % :dtype (:dtype source)
                            :map (facts/operand-axis-map source %)) (:operands source))
-        operands (concat core (stages/lift-operands (:stages source)))
+        operands (concat (map #(vector % domain) core)
+                         (mapcat (fn [index stage]
+                                   (let [visible (into {} (concat (:free-axes source)
+                                                                 (take (inc index) (:contract-axes source))))]
+                                     (map #(vector % visible) (:operands stage))))
+                                 (range) (:stages source)))
         output-type (dtype/canon (or (:out-dtype source) (:dtype (first (:stages source)))))]
-    (doseq [{:keys [sym dtype] amap :map :as operand} operands]
+    (doseq [[{:keys [sym dtype] amap :map :as operand} visible-domain] operands]
       (let [pairs (vec (mapcat identity (:groups amap)))
             ids (mapv first pairs)
             value (get values (get bound sym))
             shape (:shape value)]
         (when-not (and (seq pairs) (= (count ids) (count (set ids)))
-                       (every? #(= (second %) (get domain (first %))) pairs))
-          (fail! :operand-map {:operand operand :domain domain}))
+                       (every? #(= (second %) (get visible-domain (first %))) pairs))
+          (fail! :operand-map {:operand operand :domain visible-domain}))
         (let [required (reduce *' 1 (map second pairs))]
-          (when-not (and (dtype/known? dtype) (= :tensor (:kind value))
+          (when-not (and (dtype/known? dtype) (= :tensor (:kind value)) (plain-storage? value)
                        (= (dtype/canon dtype) (:dtype value))
                        (seq shape) (every? #(and (integer? %) (pos? %)) shape)
                        (>= (reduce *' 1 shape) required))
             (fail! :operand-storage {:operand operand :value value :required required})))))
     (doseq [id captures :let [value (get values id)]]
-      (when-not (and (= :tensor (:kind value)) (= [] (:shape value))
+      (when-not (and (= :tensor (:kind value)) (= [] (:shape value)) (plain-storage? value)
                      (dtype/known? (:dtype value)))
         (fail! :scalar-capture {:id id :value value})))
-    (when-not (and (= :tensor (:kind result)) (= output-type (:dtype result))
+    (when-not (and (= :tensor (:kind result)) (plain-storage? result) (= output-type (:dtype result))
                    (= (mapv second (:free-axes source)) (:shape result)))
       (fail! :result-type {:result result :dtype output-type
                           :shape (mapv second (:free-axes source))})))

--- a/src/raster/compiler/ir/contraction_closure.clj
+++ b/src/raster/compiler/ir/contraction_closure.clj
@@ -1,0 +1,101 @@
+(ns raster.compiler.ir.contraction-closure
+  "Lexical binding of canonical contraction facts into the typed value graph.
+
+   The facts retain their axis and scalar binders. Only the ordered external values are
+   renamed by SSA; no substitution into nested stage expressions is necessary. This is
+   a checked closure over ContractionFacts, not another contraction representation."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contract-stages :as stages]
+            [raster.compiler.ir.contraction-facts :as facts]))
+
+(defn- fail! [rule data]
+  (throw (ex-info "typed contraction closure is not proved"
+                  (assoc data :reason :typed-soac-contraction :missing-rule rule))))
+
+(defn attributes?
+  [x]
+  (and (map? x) (facts/facts? (:contraction x))
+       (every? #(and (vector? %) (every? symbol? %)
+                    (= (count %) (count (set %))))
+               [(:array-parameters x) (:capture-parameters x)])))
+
+(defn validate!
+  "Validate lexical closure and the currently admitted static staged semantics.
+   Numerical/layout extensions must retain their own contracts before admission."
+  [{:keys [contraction array-parameters capture-parameters] :as attributes}]
+  (when-not (attributes? attributes) (fail! :attributes {:attributes attributes}))
+  (let [dependencies (facts/dependencies contraction)
+        axes (vec (concat (:free-axes contraction) (:contract-axes contraction)))
+        indices (mapv first axes)
+        stage-list (:stages contraction)
+        legality (stages/stages-legal? stage-list (:contract-axes contraction))]
+    (when-not (and (seq (:free-axes contraction)) (> (count stage-list) 1)
+                   (= (count indices) (count (set indices)))
+                   (every? symbol? indices)
+                   (every? #(and (integer? %) (pos? %)) (map second axes)))
+      (fail! :static-domain {:axes axes :stages stage-list}))
+    (when-not (:ok legality) (fail! :stage-legality legality))
+    (when-not (and (contains? '#{+ clojure.core/+ raster.numeric/+} (:combine contraction))
+                   (constant/zero-value? (:init contraction))
+                   (nil? (:epilogue contraction))
+                   (empty? (get-in contraction [:opts :decode]))
+                   (not-any? :decode (:operands contraction)))
+      (fail! :numerical-contract {:contraction contraction}))
+    (when-not (and (= (:reads dependencies) (set array-parameters))
+                   (= (:scalars dependencies) (set capture-parameters))
+                   (empty? (set/intersection (set array-parameters) (set capture-parameters)))
+                   (empty? (set/intersection (set indices)
+                                            (set (concat array-parameters capture-parameters))))
+                   (symbol? (:out contraction))
+                   (not (contains? (set indices) (:out contraction)))
+                   (not (contains? (:reads dependencies) (:out contraction))))
+      (fail! :lexical-boundary {:dependencies dependencies :attributes attributes})))
+  attributes)
+
+(defn bindings
+  "Map lexical array/capture parameters to ordered authoritative value IDs."
+  [attributes arrays captures]
+  (validate! attributes)
+  (when-not (and (= (count arrays) (count (:array-parameters attributes)))
+                 (= (count captures) (count (:capture-parameters attributes))))
+    (fail! :binding-arity {:arrays arrays :captures captures :attributes attributes}))
+  (zipmap (concat (:array-parameters attributes) (:capture-parameters attributes))
+          (concat arrays captures)))
+
+(defn validate-values!
+  "Check independent storage types/capacities and scalar capture declarations.
+   Logical result shape is the free-axis space, not a shared flattened operand extent."
+  [attributes arrays captures values result]
+  (let [bound (bindings attributes arrays captures)
+        source (:contraction attributes)
+        domain (into {} (concat (:free-axes source) (:contract-axes source)))
+        core (map #(assoc % :dtype (:dtype source)
+                           :map (facts/operand-axis-map source %)) (:operands source))
+        operands (concat core (stages/lift-operands (:stages source)))
+        output-type (dtype/canon (or (:out-dtype source) (:dtype (first (:stages source)))))]
+    (doseq [{:keys [sym dtype] amap :map :as operand} operands]
+      (let [pairs (vec (mapcat identity (:groups amap)))
+            ids (mapv first pairs)
+            value (get values (get bound sym))
+            shape (:shape value)]
+        (when-not (and (seq pairs) (= (count ids) (count (set ids)))
+                       (every? #(= (second %) (get domain (first %))) pairs))
+          (fail! :operand-map {:operand operand :domain domain}))
+        (let [required (reduce *' 1 (map second pairs))]
+          (when-not (and (dtype/known? dtype) (= :tensor (:kind value))
+                       (= (dtype/canon dtype) (:dtype value))
+                       (seq shape) (every? #(and (integer? %) (pos? %)) shape)
+                       (>= (reduce *' 1 shape) required))
+            (fail! :operand-storage {:operand operand :value value :required required})))))
+    (doseq [id captures :let [value (get values id)]]
+      (when-not (and (= :tensor (:kind value)) (= [] (:shape value))
+                     (dtype/known? (:dtype value)))
+        (fail! :scalar-capture {:id id :value value})))
+    (when-not (and (= :tensor (:kind result)) (= output-type (:dtype result))
+                   (= (mapv second (:free-axes source)) (:shape result)))
+      (fail! :result-type {:result result :dtype output-type
+                          :shape (mapv second (:free-axes source))})))
+  attributes)

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -82,6 +82,7 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-closure :as contraction]
             [raster.compiler.ir.scan :as scan-ir]))
 
 (defn value-id?
@@ -490,6 +491,7 @@
              [sta stencil-attributes?]
              [ra reduce-attributes?]
              [sra segmented-reduce-attributes?]
+             [cta contraction/attributes?]
              [pra product-reduce-attributes?]
              [fa fold-attributes?]
              [sfma segmented-fold-map-attributes?]
@@ -540,6 +542,7 @@
              (stencil ?sta [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (segmented-reduce ?sra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (contract ?cta [(?:* ?id:array)] [(?:* ?id:capture)])
              (product-reduce ?pra [(?:* ?id:array)] [(?:* ?id:capture)]
                              ?l:element ?l:combine)
              (segmented-fold-map ?sfma [(?:* ?id:array)] [(?:* ?id:capture)]
@@ -621,6 +624,10 @@
       (let [[_ attributes arrays captures destinations lambda] operation]
         {:kind kind :attributes attributes :arrays arrays :captures captures
          :destinations destinations :lambda lambda})
+
+      (= 'contract kind)
+      (let [[_ attributes arrays captures] operation]
+        {:kind kind :attributes attributes :arrays arrays :captures captures})
 
       :else
       (let [[_ attributes arrays captures lambda] operation]
@@ -884,7 +891,7 @@
                  {:equation equation-id :index index :index-expression index-expression
                   :radius radius :load form}))))))
 
-(defn- validate-equation!
+(defn- validate-lambda-equation!
   [equation]
   (let [[_ equation-id results operation] equation
         {:keys [kind attributes arrays captures destinations lambda element-lambda combine-lambda
@@ -1406,7 +1413,22 @@
              {:equation equation-id :operation kind}))
     equation))
 
-(defn- validate-equation-types!
+(defn- validate-equation!
+  [equation]
+  (if (= 'contract (operation-kind equation))
+    (let [{:keys [attributes arrays captures]} (operation-parts equation)
+          results (nth equation 2)]
+      (when-not (and (distinct-vector? results) (= 1 (count results))
+                     (distinct-vector? arrays) (distinct-vector? captures)
+                     (empty? (set/intersection (set arrays) (set captures))))
+        (fail! :typed-soac-contraction-operands
+               "a contraction requires one result and distinct ordered storage/capture values"
+               {:equation equation}))
+      (contraction/bindings attributes arrays captures)
+      equation)
+    (validate-lambda-equation! equation)))
+
+(defn- validate-lambda-equation-types!
   [values equation]
   (let [[_ equation-id results] equation
         {:keys [kind attributes arrays]} (operation-parts equation)
@@ -1552,6 +1574,14 @@
 
       nil)))
 
+(defn- validate-equation-types!
+  [values equation]
+  (if (= 'contract (operation-kind equation))
+    (let [{:keys [attributes arrays captures]} (operation-parts equation)]
+      (contraction/validate-values! attributes arrays captures values
+                                   (get values (first (nth equation 2)))))
+    (validate-lambda-equation-types! values equation)))
+
 (defn- validate-result-storage!
   [program-facts equation]
   (let [[_ equation-id results] equation
@@ -1559,7 +1589,7 @@
         storage (result-storage program-facts equation-id)]
     (when storage
       (when-not (contains? #{'map 'scatter 'effect-map 'stencil 'segmented-reduce 'scan
-                             'product-reduce 'segmented-fold-map} kind)
+                             'product-reduce 'segmented-fold-map 'contract} kind)
         (fail! :typed-soac-result-storage-operation
                "physical result storage is valid only for writing tensor operations"
                {:equation equation-id :operation kind :storage storage}))
@@ -1582,6 +1612,12 @@
                  {:equation equation-id :operation-destinations
                   (:destinations (operation-parts equation))
                   :storage-destinations destinations}))
+        (when (and (= 'contract kind)
+                   (seq (set/intersection (set destinations)
+                                          (set (operation-inputs equation)))))
+          (fail! :typed-soac-stable-read-alias
+                 "contraction read storage must not alias its output"
+                 {:equation equation-id :destinations destinations}))
         (when (and (contains? #{'stencil 'segmented-fold-map 'scan} kind)
                    (seq (set/intersection
                          (set destinations)
@@ -1612,6 +1648,14 @@
         (doseq [[result destination] (map vector results destinations)
                 :let [logical (get-in program-facts [:values result])
                       physical (get-in program-facts [:values destination])]]
+          (when (and (= 'contract kind)
+                     (not (and (seq (:shape physical))
+                                (every? #(and (integer? %) (pos? %)) (:shape physical))
+                                (>= (reduce *' 1 (:shape physical))
+                                    (reduce *' 1 (:shape logical))))))
+            (fail! :typed-soac-contraction-output-capacity
+                   "contraction destination must cover its free-axis result space"
+                   {:equation equation-id :logical logical :physical physical}))
           (when-not physical
             (fail! :typed-soac-result-storage-value
                    "a physical result destination requires an AbstractValue"
@@ -1661,6 +1705,13 @@
     (doseq [equation equations]
       (validate-equation! equation)
       (validate-equation-types! values equation)
+      (when (and (= 'contract (operation-kind equation))
+                 (seq (operation-inputs equation))
+                 (not (contains? (get-in program-facts [:equations (second equation) :effects])
+                                 :memory/read)))
+        (fail! :typed-soac-contraction-read-effect
+               "contraction storage reads must remain explicit in equation effects"
+               {:equation (second equation)}))
       (validate-result-storage! program-facts equation))
     (let [definitions (mapcat #(nth % 2) equations)
           definition-set (set definitions)
@@ -1771,13 +1822,16 @@
                                    (update-in [:result-transform :scalars]
                                               #(mapv (fn [scalar]
                                                        (update scalar :value rename)) %)))
-                      attributes (if (= 'scalar kind)
+                      attributes (if (contains? #{'scalar 'contract} kind)
                                    attributes
                                    (update attributes :extent
                                            #(if (value-id? %) (rename %) %)))
                       operation (case kind
                                   scalar
                                   (list kind attributes (mapv rename captures) lambda)
+
+                                  contract
+                                  (list kind attributes (mapv rename arrays) (mapv rename captures))
 
                                   product-reduce
                                   (list kind attributes (mapv rename arrays)

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -165,12 +165,20 @@
                                 :local-definitions local-definitions
                                 :body-results body-results}))))
 
+(def ^:private contract-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (contract ?attributes [??arrays] [??captures]))
+                      (success {:kind :contract :id equation-id :results results
+                                :attributes attributes :arrays arrays :captures captures}))))
+
 (defn equation-info
   "Return a normalized equation description, using Pattern as the dialect matcher."
   [equation]
   (when-let [matched
              (some #(when (map? %) %)
-                   [(scalar-equation-rule equation)
+                   [(contract-equation-rule equation)
+                    (scalar-equation-rule equation)
                     (map-equation-rule equation)
                     (scatter-equation-rule equation)
                     (effect-map-equation-rule equation)
@@ -181,14 +189,15 @@
                     (segmented-fold-map-equation-rule equation)
                     (scan-equation-rule equation)])]
     (let [{:keys [lambda element-lambda map-lambda]} (dialect/operation-parts equation)]
-      (merge (dissoc matched :local-definitions)
-             (dialect/lambda-parts (or lambda element-lambda map-lambda))))))
+      (if (= :contract (:kind matched))
+        matched
+        (merge (dissoc matched :local-definitions)
+               (dialect/lambda-parts (or lambda element-lambda map-lambda)))))))
 
 (defn- equation-references
   [equation]
-  (let [{:keys [arrays captures]} (equation-info equation)]
-    (into (vec (concat arrays captures))
-          (filter dialect/value-id? (dialect/operation-extents equation)))))
+  (into (dialect/operation-inputs equation)
+        (filter dialect/value-id? (dialect/operation-extents equation))))
 
 (defn- element-symbols
   [n]

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -9,8 +9,31 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.contraction-closure :as contraction-closure]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.soac-dialect :as dialect]))
+
+(defn contraction-binding
+  "Project a retained contraction closure without rebuilding its numerical payload.
+   Scheduling consumes :facts; ordered kernel arguments use the returned lexical bindings.
+   This deliberately does not project staged facts through a flat scalar reduction."
+  [program equation]
+  (let [program (dialect/validate! program)
+        {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)]
+    (when-not (and (= 'contract kind) (some #{equation} (dialect/equations program)))
+      (throw (ex-info "contraction binding requires a member contraction equation"
+                      {:reason :typed-soac-contraction-projection :equation equation})))
+    (let [source (:contraction attributes)
+          bound (assoc (contraction-closure/bindings attributes arrays captures)
+                       (:out source) (first (dialect/physical-results program equation)))
+          values (:values (dialect/facts program))]
+      {:facts source :bindings bound
+       :array-types (into {} (map (fn [parameter]
+                                   [parameter (:dtype (get values (get bound parameter)))]))
+                          (conj (:array-parameters attributes) (:out source)))
+       :scalar-types (into {} (map (fn [parameter]
+                                    [parameter (:dtype (get values (get bound parameter)))]))
+                           (:capture-parameters attributes))})))
 
 (defn scalar-folds->source
   "Project explicit scalar Fold terms to Raster's interpreted host vocabulary."

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -67,6 +67,15 @@
              [:short-scale #(assoc-in % ['da :shape] [8])]
              [:wrong-core-type #(assoc-in % ['a :dtype] :float)]
              [:wrong-scale-type #(assoc-in % ['da :dtype] :byte)]
+             [:encoded-input #(assoc-in % ['a :representation] {:kind :quantized})]
+             [:strided-input #(assoc-in % ['a :logical-layout] {:strides [2]})]
+             [:sharded-input #(assoc-in % ['a :sharding] {:axis 0})]
+             [:encoded-output #(-> %
+                                   (assoc-in ['result :representation] {:kind :quantized})
+                                   (assoc-in ['out :representation] {:kind :quantized}))]
+             [:strided-output #(-> %
+                                   (assoc-in ['result :logical-layout] {:strides [2]})
+                                   (assoc-in ['out :logical-layout] {:strides [2]}))]
              [:short-output #(assoc-in % ['out :shape] [14])]
              [:wrong-result-shape #(assoc-in % ['result :shape] [15])]]]
       (testing (name label)
@@ -74,7 +83,12 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (soac/validate! (rewrite-attributes #(assoc % :array-parameters '[a b da])))))
     (is (thrown? clojure.lang.ExceptionInfo
-                 (soac/validate! (rewrite-attributes #(assoc-in % [:contraction :stages 1 :init] 1)))))))
+                 (soac/validate! (rewrite-attributes #(assoc-in % [:contraction :stages 1 :init] 1)))))
+    (try
+      (soac/validate! (rewrite-attributes #(assoc-in % [:contraction :stages 0 :lift] '(* inner t))))
+      (is false "outer lift cannot read an inner-stage coordinate")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :stage-lift-scope (:missing-rule (ex-data e))))))))
 
 (deftest retained-contraction-binds-generated-storage-without-source-reparse
   (let [p (soac/remap-values (program) {'a [:arg 0] 'b [:arg 1] 'da [:arg 2]

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -1,0 +1,93 @@
+(ns raster.compiler.ir.contraction-closure-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as fixtures]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.contraction-closure :as closure]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled]
+            [raster.compiler.passes.parallel.staged-contraction-body :as staged]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-projection :as projection]))
+
+(defn- program []
+  (let [source (fixtures/packed-facts 3 5 3 32)
+        values (into {} (map (fn [[id dtype shape]]
+                              [id (av/tensor {:dtype dtype :shape shape})]))
+                     [['a :byte [288]] ['b :byte [480]] ['da :float [9]]
+                      ['db :float [15]] ['out :float [15]] ['result :float [3 5]]])
+        attributes {:contraction source :array-parameters '[a b da db]
+                    :capture-parameters []}
+        equation-facts (assoc (soac/default-equation-facts)
+                             :effects #{:memory/read :memory/write}
+                             :aliases {'result 'out}
+                             :attributes {:result-storage
+                                          [{:destination 'out :access :write :host-return :buffer}]})]
+    (soac/make
+     (soac/default-program-facts {:values values :inputs '[a b da db]
+                                 :effects #{:memory/read :memory/write}
+                                 :equations {'contraction equation-facts}})
+     [(list '= 'contraction '[result] (list 'contract attributes '[a b da db] []))]
+     '[result])))
+
+(deftest typed-contraction-retains-the-canonical-payload-through-ssa
+  (let [p (program)
+        source (get-in (soac/operation-parts (first (soac/equations p)))
+                       [:attributes :contraction])
+        value-map (zipmap '[a b da db out result]
+                         [[:arg 0] [:arg 1] [:arg 2] [:arg 3] [:output 0] [:result 0]])
+        renamed (soac/remap-values p value-map)
+        equation (first (soac/equations renamed))
+        {:keys [attributes arrays captures]} (soac/operation-parts equation)]
+    (is (= 'contract (soac/operation-kind equation)))
+    (is (identical? source (:contraction attributes)) "no stage reconstruction or flattening")
+    (is (= [[:arg 0] [:arg 1] [:arg 2] [:arg 3]] (soac/operation-inputs equation)))
+    (is (= [[:output 0]] (soac/physical-results renamed equation)))
+    (is (= {'a [:arg 0] 'b [:arg 1] 'da [:arg 2] 'db [:arg 3]}
+           (closure/bindings attributes arrays captures)))
+    (is (= [:float :int] (mapv :dtype (:stages source))))
+    (is (= renamed (first (fusion/fusion-fixpoint renamed)))
+        "flat fusion rules leave the staged closure intact")
+    (is (= renamed (soac/validate! renamed)))))
+
+(deftest typed-contraction-checks-independent-storage-and-closure
+  (let [p (program)
+        with-values (fn [f]
+                      (list 'soac-program (update (soac/facts p) :values f)
+                            (soac/equations p) (soac/outputs p)))
+        rewrite-attributes (fn [f]
+                             (let [[equals id results [_ attributes arrays captures]]
+                                   (first (soac/equations p))]
+                               (list 'soac-program (soac/facts p)
+                                     [(list equals id results
+                                            (list 'contract (f attributes) arrays captures))]
+                                     (soac/outputs p))))]
+    (doseq [[label transform]
+            [[:short-core #(assoc-in % ['a :shape] [287])]
+             [:short-scale #(assoc-in % ['da :shape] [8])]
+             [:wrong-core-type #(assoc-in % ['a :dtype] :float)]
+             [:wrong-scale-type #(assoc-in % ['da :dtype] :byte)]
+             [:short-output #(assoc-in % ['out :shape] [14])]
+             [:wrong-result-shape #(assoc-in % ['result :shape] [15])]]]
+      (testing (name label)
+        (is (thrown? clojure.lang.ExceptionInfo (soac/validate! (with-values transform))))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (soac/validate! (rewrite-attributes #(assoc % :array-parameters '[a b da])))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (soac/validate! (rewrite-attributes #(assoc-in % [:contraction :stages 1 :init] 1)))))))
+
+(deftest retained-contraction-binds-generated-storage-without-source-reparse
+  (let [p (soac/remap-values (program) {'a [:arg 0] 'b [:arg 1] 'da [:arg 2]
+                                      'db [:arg 3] 'out [:output 0] 'result [:result 0]})
+        {:keys [facts bindings array-types]} (projection/contraction-binding p (first (soac/equations p)))
+        lowered (staged/lower facts)
+        arguments (mapv #(get bindings % %) (:arguments lowered))
+        bound (scheduled/make (-> (into {} lowered)
+                                  (assoc :arguments arguments)
+                                  (assoc-in [:effects :uses]
+                                            (scheduled/derive-uses (:body lowered) arguments))))]
+    (is (= '{a :byte b :byte da :float db :float out :float} array-types))
+    (doseq [dialect [:opencl-portable :opencl-intel :cuda :hip]]
+      (let [graph (target/emit-static-dense-graph "typed_closure" bound dialect)]
+        (is (= [[:arg 0] [:arg 1] [:arg 2] [:arg 3] [:output 0]] (:arguments graph)))
+        (is (= [:byte :byte :float :float :float] (mapv :dtype (:abi graph))))))))


### PR DESCRIPTION
## Summary
- Add a contract operation to the existing functional TypedSOAC dialect, retaining canonical ContractionFacts behind lexical array/capture parameters.
- Rename external SSA values without rebuilding stage expressions; project bindings to existing generated staged KernelBody and checked graphs.
- Validate independent plain-storage types/capacities, output storage, effects and stage-local lexical scope. Recognize contractions in fusion without applying flat rewrites.

## Scope
This is the dialect/binding prerequisite, not public frontend admission or production route migration. Existing schedule/body validators still own arithmetic typing and numerical admission. Unlowered layouts, representations and sharding are rejected.

## Validation
- 41 focused dialect, closure and fusion tests / 244 assertions, zero failures/errors.
- Generated graph binding checked for portable/Intel OpenCL, CUDA and HIP.
- Review identified storage-facet and inner-axis capture holes; both fixed with regression tests and re-reviewed with no remaining blocker.
- Full suites and vendor compiler gates run in CI.