### PR TITLE
Route retained typed contractions through certified graph emission

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -98,6 +98,14 @@ storage/scalar types and lexical scope. The existing scheduling and scalar-body 
 must still prove instruction types and numerical legality. Unlowered representations,
 layouts and sharding decline, and outer lifts cannot refer to inner-stage coordinates.
 
+Production graph lowering now transports that closure as a bound SegContract, with
+canonical dependency accessors used by graph construction. Before generated staged
+emission, the existing graph projection certificate and an exact operation/binding
+comparison both run; the resulting ScheduledKernelBody is checked against that node.
+This route uses the common C-family graph emitter and resident graph binder. A small
+Arc device test exercises vector SSA IDs and distinct row/column outputs. Public
+frontend admission and the compatibility-ledger transition remain the next step.
+
 Read-only inventory at #383 identifies these priorities; dynamic reachability must be measured
 before treating a definition as live or dead:
 

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -36,6 +36,7 @@
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
+            [raster.compiler.passes.parallel.staged-contraction-body :as staged-body]
             [raster.compiler.passes.parallel.product-reduction-body :as product-body]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
             [raster.compiler.passes.parallel.segscan-body :as segscan-body]
@@ -610,12 +611,28 @@
               (throw (ex-info "kernel graph scalar has inconsistent emitted ABI dtypes"
                               {:reason :kernel-graph-scalar-dtype
                                :argument argument :slots (mapv first pairs)}))))
+        ;; Public graph slots are not physical kernel parameters. Preserve established names
+        ;; where possible, but vector SSA identities need generated names that cannot capture
+        ;; a later caller's symbol (or collide with another graph slot).
+        interface-ids (concat (map :id external-buffers) scalar-arguments)
+        reserved-names (set (keep #(when (instance? clojure.lang.Named %) (name %)) interface-ids))
+        interface-names
+        (:names
+         (reduce (fn [{:keys [used] :as state} [ordinal id]]
+                   (let [named? (instance? clojure.lang.Named id)
+                         chosen (loop [candidate (if named? (name id) (str "graph_value_" ordinal))]
+                                  (if (or (contains? used candidate)
+                                          (and (not named?) (contains? reserved-names candidate)))
+                                    (recur (str candidate "_")) candidate))]
+                     (-> state (update :used conj chosen) (assoc-in [:names id] chosen))))
+                 {:used #{} :names {}} (map-indexed vector interface-ids)))
         pointer-abi (mapv (fn [{:keys [id dtype role]}]
                             (kabi/slot id (case role
                                             :input :input
                                             :output :output
                                             :inout :inout)
                                        dtype
+                                       :c-name (get interface-names id)
                                        :role (case role
                                                :input :operand
                                                :output :result
@@ -644,6 +661,7 @@
                                         :argument argument :scheduled (:dtype declared)
                                         :target supplied-dtype})))
                              (kabi/slot argument :scalar logical-dtype
+                                        :c-name (get interface-names argument)
                                         :kernel-dtype kernel-dtype :role role)))
                          scalar-arguments)
         explicit-scalars
@@ -922,6 +940,23 @@
      (kernel-body-c-dialect/target target)
      scalar-types)))
 
+(defn- generate-staged-contraction-graph
+  [graph {:keys [target-dialect scalar-types scheduled-equation-algorithm
+                 scheduled-equation-body]
+          :or {target-dialect :opencl-intel scalar-types {}}}]
+  (let [emitted (kgraph/map-operations
+                 graph
+                 (fn [node]
+                   (kernel-body-target/emit-artifact
+                    (str "graph_staged_" (gensym ""))
+                    (staged-body/schedule-for-node node graph scheduled-equation-algorithm
+                                                   scheduled-equation-body)
+                    target-dialect)))]
+    (finalize-emitted-graph emitted
+                            (kernel-body-c-dialect/target
+                             (kernel-body-c-dialect/resolve! target-dialect))
+                            scalar-types)))
+
 (defn generate-kernel-graph
   "Target-lower one scheduled KernelGraph through the backend's single graph-emission boundary.
 
@@ -934,6 +969,11 @@
         opencl? (kernel-body-c-dialect/opencl?
                  (kernel-body-c-dialect/resolve! target-dialect))]
     (cond
+      (and (seq (:nodes graph))
+           (every? #(instance? raster.compiler.ir.segop.SegContract (:operation %))
+                   (:nodes graph)))
+      (generate-staged-contraction-graph graph opts)
+
       (scan/associative-scan? (get-in graph [:attributes :scan-algebra]))
       (apply generate-scan-kernel-graph graph (mapcat identity opts))
 

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -444,15 +444,15 @@
   (when-not (vector? segops)
     (throw (ex-info "scheduled SegOps must be an ordered vector" {:segops segops})))
   (doseq [operation segops]
-    (when-not (segop/segop? operation)
+    (when-not (segop/segop-node? operation)
       (throw (ex-info "scheduled SegOp graph contains a non-SegOp operation"
                       {:operation operation :actual (type operation)}))))
   (let [input-ids (set inputs)
         output-ids (set outputs)
         external-ids (set/union input-ids output-ids)
         operation-ids (reduce set/union #{}
-                              (map #(set/union (set (or (segop/segop-inputs %) #{}))
-                                               (set (or (segop/segop-outputs %) #{})))
+                              (map #(set/union (set (segop/operation-inputs %))
+                                               (set (segop/operation-outputs %)))
                                    segops))
         temporary-ids (set (keys temporaries))
         expected-temporaries (set/difference operation-ids external-ids)]
@@ -484,8 +484,8 @@
                              (ordered temporary-ids))
           nodes (loop [ops segops index 0 previous [] result []]
                   (if-let [op (first ops)]
-                    (let [ins (set (or (segop/segop-inputs op) #{}))
-                          outs (set (or (segop/segop-outputs op) #{}))
+                    (let [ins (set (segop/operation-inputs op))
+                          outs (set (segop/operation-outputs op))
                           uses (mapv #(operation-use ins outs %)
                                      (ordered (set/union ins outs)))
                           ;; A scheduled-node identity is not a SegOp identity. The position makes

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -116,6 +116,8 @@
 ;; contract-route from these facts + the device descriptor at emission time — putting them here
 ;; would mix target-specific emission into semantic lowering. What this node guarantees is that
 ;; the backend receives the SAME facts segop-lower verified, instead of re-parsing the form.
+;; Typed closure lowering adds :bindings, mapping lexical facts parameters to external SSA
+;; values. This is a binding environment, not a second copy of operand/shape/type inference.
 
 (defrecord SegScan
            [id          ;; int
@@ -156,14 +158,15 @@
   "Physical tensor inputs of a scheduled operation, including a SegContract schedule view."
   [operation]
   (if (instance? SegContract operation)
-    (:reads (contraction-facts/dependencies (:facts operation)))
+    (into #{} (map #(get (:bindings operation) % %))
+          (:reads (contraction-facts/dependencies (:facts operation))))
     (or (:inputs operation) #{})))
 
 (defn operation-outputs
   "Physical tensor outputs of a scheduled operation, including a SegContract schedule view."
   [operation]
   (if (instance? SegContract operation)
-    #{(get-in operation [:facts :out])}
+    #{(let [out (get-in operation [:facts :out])] (get (:bindings operation) out out))}
     (set (or (:outputs operation) #{}))))
 
 (defn- scalar-entry-references
@@ -184,7 +187,8 @@
    checked projection of axis bounds rather than a duplicate record field."
   [operation]
   (if (instance? SegContract operation)
-    (:scalars (contraction-facts/dependencies (:facts operation)))
+    (into #{} (map #(get (:bindings operation) % %))
+          (:scalars (contraction-facts/dependencies (:facts operation))))
     (let [space (:space operation)
           axes (into #{(:flat-idx space)} (map :name) (:dims space))
           arrays (set/union (operation-inputs operation) (operation-outputs operation))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -365,6 +365,8 @@
                           (first (soac-dialect/equations scheduling-algorithm)))
                     lowered (case kind
                               scalar {:operations []}
+                              contract {:operations (soac-lower/lower-typed-contract
+                                                      scheduling-algorithm device-id)}
                               map {:operations (soac-lower/lower-typed-map
                                                 scheduling-algorithm device-id :dtype dtype)}
                               scatter {:operations (soac-lower/lower-typed-scatter

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -26,7 +26,21 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]
+            [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]
             [raster.compiler.passes.parallel.segred-body :as segred-body]))
+
+(defn lower-typed-contract
+  "Retain one typed contraction and its lexical bindings as a semantic SegContract.
+   Scheduling, target selection and emission remain downstream."
+  [program device-id]
+  (let [equations (soac-dialect/equations (soac-dialect/validate! program))]
+    (when-not (= 1 (count equations))
+      (throw (ex-info "contraction lowering requires one typed equation"
+                      {:reason :typed-soac-contraction-equation-count})))
+    (let [equation (first equations)
+          {:keys [facts bindings]} (typed-projection/contraction-binding program equation)]
+      [(assoc (segop/->SegContract (second equation) facts (:dtype facts) device-id)
+              :bindings bindings)])))
 
 (declare lower-reduce)
 (declare lower-map)

--- a/src/raster/compiler/passes/parallel/staged_contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_body.clj
@@ -15,8 +15,12 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.typed-soac-projection :as projection]
+            [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.passes.parallel.staged-contraction-schedule :as schedule]))
 
 (defn- decline! [rule message data]
@@ -196,3 +200,30 @@
                    :storage-elements sizes :output-elements (long n)}
         :numerics {:mode :reassociated :policy :staged-int32-float
                    :accumulator-dtype :float :rounding :nearest-even}}))))
+
+(defn schedule-for-node
+  "Refine an exact retained typed contraction graph node through the existing staged body.
+   Graph/algorithm agreement is checked before lexical bindings reach the emitted ABI."
+  [node graph algorithm scheduled-program]
+  (equation-graph/validate-projection! graph algorithm scheduled-program)
+  (let [equations (soac/equations algorithm)
+        operation (:operation node)]
+    (require! (and (= 1 (count equations))
+                   (some #{node} (:nodes graph))
+                   (instance? raster.compiler.ir.segop.SegContract operation))
+              :typed-node {:node node})
+    (let [equation (first equations)
+          {:keys [facts bindings]} (projection/contraction-binding algorithm equation)
+          expected (assoc (segop/->SegContract (second equation) facts (:dtype facts)
+                                              (:device-id operation))
+                          :bindings bindings)]
+      (require! (= expected operation) :typed-operation
+                {:expected expected :operation operation})
+      (let [lowered (lower facts)
+            arguments (mapv #(get bindings % %) (:arguments lowered))
+            rebound (scheduled/make
+                     (-> (into {} lowered)
+                         (assoc :source operation :arguments arguments)
+                         (assoc-in [:effects :uses]
+                                   (scheduled/derive-uses (:body lowered) arguments))))]
+        (scheduled/validate-against-node! rebound node graph)))))

--- a/test/raster/compiler/ir/contraction_closure_device_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_device_test.clj
@@ -1,0 +1,33 @@
+(ns raster.compiler.ir.contraction-closure-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.segop-opencl :as emitter]
+            [raster.compiler.ir.contraction-closure-test :as fixture]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as probe]))
+
+(deftest retained-contraction-runs-through-the-resident-graph-binder
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "retained typed staged contraction graph")
+    (let [{:keys [algorithm body graph]}
+          (fixture/production-graph {'a [:arg 0] 'b [:arg 1] 'da [:arg 2]
+                                     'db [:arg 3] 'out [:output 0] 'result [:result 0]})
+          emitted (emitter/generate-kernel-graph
+                   graph :target-dialect :opencl-portable
+                   :scheduled-equation-algorithm algorithm :scheduled-equation-body body)
+          expected (vec (for [i (range 1 4) j (range 1 6)] (float (* 12 i j))))]
+      (gpu/with-gpu-session [sess :ocl:0]
+        (gpu/alloc! sess {:a [:byte 288 (byte-array (mapcat #(repeat 96 %) (range 1 4)))]
+                          :b [:byte 480 (byte-array (mapcat #(repeat 96 %) (range 1 6)))]
+                          :da [:float 9 (float-array (repeat 9 0.5))]
+                          :db [:float 15 (float-array (repeat 15 0.25))]
+                          :out [:float 15 (float-array (repeat 15 -555.0))]})
+        (let [handle (gpu/bind-kernel-graph!
+                      sess :typed-contraction emitted
+                      {[:arg 0] :a [:arg 1] :b [:arg 2] :da [:arg 3] :db [:output 0] :out} {})]
+          (try
+            (let [event (gpu/submit-kernel-graph! sess handle)]
+              (try
+                (gpu/await-event! sess event)
+                (is (= expected (vec (gpu/download sess :out))))
+                (finally (gpu/release-event! sess event))))
+            (finally (gpu/release-kernel-graph! sess handle))))))))

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -2,10 +2,15 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.staged-contraction-fixtures :as fixtures]
             [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.backend.gpu.segop-opencl :as emitter]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.contraction-closure :as closure]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
+            [raster.compiler.ir.parallel-program :as parallel]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.staged-contraction-body :as staged]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]))
@@ -105,3 +110,55 @@
       (let [graph (target/emit-static-dense-graph "typed_closure" bound dialect)]
         (is (= [[:arg 0] [:arg 1] [:arg 2] [:arg 3] [:output 0]] (:arguments graph)))
         (is (= [:byte :byte :float :float :float] (mapv :dtype (:abi graph))))))))
+
+(defn production-graph
+  "Small shared retained-contraction fixture for structural and device boundary tests."
+  [value-map]
+  (let [algorithm (soac/remap-values (program) value-map)
+        facts (soac/facts algorithm)
+        operations (lower/lower-typed-contract algorithm :ocl:0)
+        equation (parallel/->ProgramEquation
+                  'contraction [:binding 'result] nil (:inputs facts) (soac/outputs algorithm)
+                  algorithm operations (:effects facts) {} {})
+        body (parallel/make {:dialect :segop :values (:values facts) :inputs (:inputs facts)
+                             :equations [equation] :outputs (soac/outputs algorithm)
+                             :effects (:effects facts) :operation? segop/segop-node?})
+        graph (equation-graph/make algorithm body)]
+    {:algorithm algorithm :body body :graph graph :operations operations}))
+
+(deftest typed-contraction-uses-the-production-graph-emission-boundary
+  (let [{:keys [algorithm body graph operations]}
+        (production-graph {'a [:arg 0] 'b [:arg 1] 'da [:arg 2]
+                           'db [:arg 3] 'out [:output 0] 'result [:result 0]})]
+    (is (= #{[:arg 0] [:arg 1] [:arg 2] [:arg 3]} (segop/operation-inputs (first operations))))
+    (is (= #{[:output 0]} (segop/operation-outputs (first operations))))
+    (doseq [dialect [:opencl-portable :opencl-intel :cuda :hip]]
+      (let [emitted (emitter/generate-kernel-graph
+                     graph :target-dialect dialect :scheduled-equation-algorithm algorithm
+                     :scheduled-equation-body body)]
+        (is (= 1 (count (:nodes emitted))))
+        (is (re-find #"rstr_dp4a" (get-in emitted [:nodes 0 :operation :source])))))
+    (doseq [[node graph' algorithm']
+            [[(assoc-in (first (:nodes graph)) [:operation :bindings 'a] [:arg 1]) graph algorithm]
+             [(first (:nodes graph)) (update-in graph [:inputs 0 :elements] dec) algorithm]
+             [(first (:nodes graph)) graph (soac/remap-values algorithm {[:arg 0] [:different 0]})]]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (staged/schedule-for-node node graph' algorithm' body))))
+    (let [tampered (assoc-in body [:equations 0 :operations 0 :facts :init] 1.0)
+          tampered-graph (equation-graph/make algorithm tampered)]
+      (try
+        (staged/schedule-for-node (first (:nodes tampered-graph)) tampered-graph algorithm tampered)
+        (is false "a graph rebuilt from a modified operation must not certify that operation")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :typed-operation (:missing-rule (ex-data e)))))))))
+
+(deftest graph-only-abi-names-cannot-capture-user-symbols
+  (let [{:keys [algorithm body graph]}
+        (production-graph {'a [:arg 0] 'b 'graph_value_0})
+        emitted (emitter/generate-kernel-graph
+                 graph :target-dialect :opencl-portable :scheduled-equation-algorithm algorithm
+                 :scheduled-equation-body body)
+        names (mapv :c-name (:abi emitted))]
+    (is (= (count names) (count (set names))))
+    (is (= "graph_value_0" (:c-name (first (filter #(= 'graph_value_0 (:name %)) (:abi emitted))))))
+    (is (some #{[:arg 0]} (:arguments emitted)))))


### PR DESCRIPTION
## Summary
- Lower retained TypedSOAC contractions to bound SegContract operations without reconstructing their stage semantics.
- Use canonical dependency accessors for graph construction and certify generated staged bodies against the retained algorithm, graph and exact operation/bindings.
- Emit through the common C-family graph boundary, including collision-safe graph ABI names for vector SSA IDs.

## Validation
- Focused dialect, graph and fusion suite: 53 tests / 299 assertions passed.
- After preserving collection normalization in graph construction, affected graph/closure subset: 15 tests / 86 assertions passed.
- Real Arc resident graph execution: all 15 row/column-distinct results matched, with poisoned output and explicit resource cleanup.
- All four source dialects covered; independent binding, capacity, algorithm and recertified-operation tampering rejected.
- Reviewed; naming collision finding fixed and re-reviewed. Full suites/vendor compiler gates delegated to CI.

## Remaining boundary
Public source frontend admission is still disabled. This establishes its production routing destination; the compatibility workload remains open until public compile/execution validation lands.