### PR TITLE
Compile public staged contractions through TypedSOAC and checked result views

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -639,3 +639,30 @@ by a six-assertion graph-only API check. Public batch admission remains a separa
 One small memory-capped REPL; focused affected tests locally. Full suites and hardware-free vendor
 compilers run on CircleCI. Review candidate/certificate boundaries; squash only exact reviewed heads
 with all required checks green. Never alter the concurrently edited main-checkout north-star file.
+
+### Public staged contractions and result-prefix storage
+
+The bounded Byte/Int32/Float staged contraction now enters the retained TypedSOAC closure from
+ordinary public `par/contract` syntax, including canonical derivation of operand maps. Declared
+Byte inputs and Float scale/output arrays remain independent under Float compilation policy.
+Frontend admission and KernelBody lowering share a non-emitting schedule-domain check; unsupported
+staged semantics are not silently flattened or accepted beyond the generated schedule's coverage.
+The compatibility ledger records this workload as typed and KernelBody-emitted. This does not
+retire all staged fallback schedules, generalize every precision/stage combination, or prove SOTA
+performance. Those remain explicit follow-ups to the common generated schedule vertical.
+
+Storage access requirements are lower bounds, aggregated across contractions. Known larger
+capacities are preserved. A map reading a smaller static prefix uses the existing indexed capture
+representation, not a weakened element-tensor shape. Logical prefix results get LinkPlan views
+over their physical destination allocation, with no additional copy or initializer. Emitted calls
+retain the semantic result/destination relation; planning and runtime independently check actual
+view identity, type, extent and prefix containment. Runtime view resolution is mandatory before
+binding such calls. A partial write establishes only its proven logical prefix, not the tail.
+
+Validation includes hardware-free CUDA/HIP public compilation, short-buffer and forged-view
+rejection, retained-call mutation checks, fresh-prefix initialization, and Arc execution of
+contraction alone, in-place prefix map, and disjoint-destination map with unchanged tail values.
+Known capacity is supplied at compilation for these larger-buffer cases. General runtime capacity
+adaptation and dynamic view specialization still need their own invocation/view contracts; exact
+invocation tensor-shape checks remain intact. Indexed captures can conservatively limit fusion;
+recovering pointwise fusion through explicit views belongs with the broader typed fusion work.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -388,6 +388,12 @@
                               (reduction/scalar? (:reduction %)))))
                (:operations equation))))
 
+(defn- graph-contraction-equation? [equation]
+  (let [algorithm (:algorithm equation)]
+    (and (soac-dialect/program-form? algorithm)
+         (= 1 (count (soac-dialect/equations algorithm)))
+         (= 'contract (soac-dialect/operation-kind (first (soac-dialect/equations algorithm)))))))
+
 (defn opencl-pass
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
@@ -1061,6 +1067,7 @@
                                                           (graph-reduction-equation? equation)]
                                                       (if (and typed-equation?
                                                                (or scalar-reduction?
+                                                                   (graph-contraction-equation? equation)
                                                                    (get-in equation
                                                                            [:attributes
                                                                             :kernel-graph])))
@@ -1115,14 +1122,15 @@
                                                   (= :body (first (:site equation)))))
                                          scalar-reduction?
                                          (graph-reduction-equation? equation)]
-                                     (if (and typed-equation? scalar-reduction?)
+                                     (if (and typed-equation?
+                                              (or scalar-reduction? (graph-contraction-equation? equation)))
                                        (do
                                          (swap! stats update :segop-reused (fnil inc 0))
                                          (emit-scheduled-graph!
                                           (:graph
                                            (equation-graph/make-for-equation
                                             parallel-program equation))
-                                          :ze-reduces
+                                          (if (graph-contraction-equation? equation) :ze-contracts :ze-reduces)
                                           (boolean (host-scalar-result?
                                                     parallel-program equation))
                                           equation))

--- a/src/raster/compiler/ir/buffer_view.clj
+++ b/src/raster/compiler/ir/buffer_view.clj
@@ -153,6 +153,23 @@
   (let [{:keys [shape strides]} (validate-view! view)]
     (= strides (dense-strides shape))))
 
+(defn contains-contiguous-view?
+  "Whether base covers a dense, same-dtype view in the identical allocation contract."
+  [base child]
+  (let [base (validate-view! base) child (validate-view! child)]
+    (and (= (:allocation base) (:allocation child))
+         (= (:dtype base) (:dtype child))
+         (contiguous? base) (contiguous? child)
+         (<= (:byte-offset base) (:byte-offset child))
+         (<= (+' (:byte-offset child) (:byte-length child))
+             (+' (:byte-offset base) (:byte-length base))))))
+
+(defn prefix-view?
+  "Whether child is a dense, same-dtype, zero-relative-offset view of base."
+  [base child]
+  (and (contains-contiguous-view? base child)
+       (= (:byte-offset base) (:byte-offset child))))
+
 (defn subview
   "Construct a view whose byte range is contained in `base`. Shape/strides describe the new
    logical interpretation; `byte-offset` is relative to the base view."

--- a/src/raster/compiler/ir/contraction_closure.clj
+++ b/src/raster/compiler/ir/contraction_closure.clj
@@ -83,12 +83,12 @@
   (zipmap (concat (:array-parameters attributes) (:capture-parameters attributes))
           (concat arrays captures)))
 
-(defn validate-values!
-  "Check independent storage types/capacities and scalar capture declarations.
-   Logical result shape is the free-axis space, not a shared flattened operand extent."
-  [attributes arrays captures values result]
-  (let [bound (bindings attributes arrays captures)
-        source (:contraction attributes)
+(defn storage-requirements
+  "Derive lexical storage requirements once from validated contraction maps.
+   Frontend value construction and closure validation share this projection."
+  [attributes]
+  (validate! attributes)
+  (let [source (:contraction attributes)
         domain (into {} (concat (:free-axes source) (:contract-axes source)))
         core (map #(assoc % :dtype (:dtype source)
                            :map (facts/operand-axis-map source %)) (:operands source))
@@ -97,22 +97,34 @@
                                    (let [visible (into {} (concat (:free-axes source)
                                                                  (take (inc index) (:contract-axes source))))]
                                      (map #(vector % visible) (:operands stage))))
-                                 (range) (:stages source)))
+                                 (range) (:stages source)))]
+    (mapv (fn [[{:keys [sym dtype] amap :map :as operand} visible-domain]]
+            (let [pairs (vec (mapcat identity (:groups amap)))
+                  ids (mapv first pairs)]
+              (when-not (and (seq pairs) (= (count ids) (count (set ids)))
+                             (every? #(= (second %) (get visible-domain (first %))) pairs))
+                (fail! :operand-map {:operand operand :domain visible-domain}))
+              (when-not (dtype/known? dtype)
+                (fail! :operand-storage-dtype {:operand operand}))
+              {:parameter sym :dtype (dtype/canon dtype)
+               :elements (reduce *' 1 (map second pairs))}))
+          operands)))
+
+(defn validate-values!
+  "Check independent storage types/capacities and scalar capture declarations.
+   Logical result shape is the free-axis space, not a shared flattened operand extent."
+  [attributes arrays captures values result]
+  (let [bound (bindings attributes arrays captures)
+        source (:contraction attributes)
         output-type (dtype/canon (or (:out-dtype source) (:dtype (first (:stages source)))))]
-    (doseq [[{:keys [sym dtype] amap :map :as operand} visible-domain] operands]
-      (let [pairs (vec (mapcat identity (:groups amap)))
-            ids (mapv first pairs)
-            value (get values (get bound sym))
-            shape (:shape value)]
-        (when-not (and (seq pairs) (= (count ids) (count (set ids)))
-                       (every? #(= (second %) (get visible-domain (first %))) pairs))
-          (fail! :operand-map {:operand operand :domain visible-domain}))
-        (let [required (reduce *' 1 (map second pairs))]
-          (when-not (and (dtype/known? dtype) (= :tensor (:kind value)) (plain-storage? value)
-                       (= (dtype/canon dtype) (:dtype value))
-                       (seq shape) (every? #(and (integer? %) (pos? %)) shape)
-                       (>= (reduce *' 1 shape) required))
-            (fail! :operand-storage {:operand operand :value value :required required})))))
+    (doseq [{:keys [parameter dtype elements] :as requirement} (storage-requirements attributes)
+            :let [value (get values (get bound parameter))
+                  shape (:shape value)]]
+      (when-not (and (= :tensor (:kind value)) (plain-storage? value)
+                     (= dtype (:dtype value))
+                     (seq shape) (every? #(and (integer? %) (pos? %)) shape)
+                     (>= (reduce *' 1 shape) elements))
+        (fail! :operand-storage {:operand requirement :value value :required elements})))
     (doseq [id captures :let [value (get values id)]]
       (when-not (and (= :tensor (:kind value)) (= [] (:shape value)) (plain-storage? value)
                      (dtype/known? (:dtype value)))

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -553,7 +553,7 @@
                          (nth operation 3))]
               (and (seq? body)
                    (contains? #{'scalar 'map 'scatter 'effect-map 'stencil 'reduce
-                                'segmented-reduce 'product-reduce 'segmented-fold-map 'scan}
+                                'segmented-reduce 'contract 'product-reduce 'segmented-fold-map 'scan}
                               (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))

--- a/src/raster/compiler/ir/emitted_parallel_program_call.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program_call.clj
@@ -102,6 +102,8 @@
       (checked-scalar values id value))
     step))
 
+(declare validate-result-views!)
+
 (defn validate-equation-call!
   [call]
   (when-not (emitted-equation-call? call)
@@ -135,13 +137,31 @@
       (fail! :emitted-program-equation-graph
              "emitted equation call graph differs from its certified operation"
              {:equation (:id equation)}))
+    (validate-result-views! equation (or (:result-views call) {}))
     call))
 
+(defn- validate-result-views!
+  [equation result-views]
+  (when-not (map? result-views)
+    (fail! :emitted-program-result-views "result views must be a map" {:result-views result-views}))
+  (let [algorithm (:algorithm (first (:operations equation)))
+        physical (physical-results algorithm)]
+    (doseq [[result destination] result-views]
+      (let [producer (some #(when (some #{result} (nth % 2)) %) (soac/equations algorithm))]
+        (when-not (and (some #{result} (:results equation))
+                       (= destination (get physical result))
+                       (contains? '#{contract map} (soac/operation-kind producer)))
+          (fail! :emitted-program-result-view
+                 "result view must retain a prefix-producing physical storage relation"
+                 {:equation (:id equation) :result result :destination destination}))))
+    result-views))
+
 (defn- prepare-equation-call
-  [equation values buffers scalars]
+  [equation values buffers scalars result-views]
   (let [emitted (emitted-equation/validate! (first (:operations equation)))
         graph (:graph emitted)
         result-storage (physical-results (:algorithm emitted))
+        result-views (validate-result-views! equation (select-keys result-views (:results equation)))
         buffers
         (reduce
          (fn [bindings result]
@@ -157,11 +177,15 @@
                                           :physical-result physical}))]
              (when (and (not= ::missing physical-binding)
                         (not= ::missing logical-binding)
-                        (not= physical-binding logical-binding))
+                        (not= physical-binding logical-binding)
+                        (not= physical (get result-views result)))
                (fail! :emitted-program-result-alias
                       "logical and physical result bindings disagree"
                       {:equation (:id equation) :result result :physical-result physical}))
-             (assoc bindings physical selected result selected)))
+             (assoc bindings physical selected result
+                    (if (contains? result-views result)
+                      (require-buffer bindings result :result-view)
+                      selected))))
          buffers (:results equation))
         runtime-arguments
         (mapv (fn [slot argument]
@@ -180,8 +204,9 @@
         bindings (executable/graph-bindings graph runtime-arguments)
         outputs (select-keys buffers (:results equation))]
     {:call (validate-equation-call!
-            (->EmittedEquationCall equation graph (:buffers bindings)
-                                   (:scalar-values bindings) outputs))
+            (assoc (->EmittedEquationCall equation graph (:buffers bindings)
+                                         (:scalar-values bindings) outputs)
+                   :result-views result-views))
      :buffers buffers}))
 
 (defn- evaluate-host-equations
@@ -257,6 +282,10 @@
              "emitted program call must retain one step per equation"
              {:expected (count (:equations parallel-program)) :actual (count steps)}))
     (doseq [[equation step] (map vector (:equations parallel-program) steps)]
+      (when (and (seq (:result-views step)) (not (emitted-equation-call? step)))
+        (fail! :emitted-program-result-views
+               "only emitted numerical equations may declare prefix result views"
+               {:equation (:id equation)}))
       (cond
         (evaluated-host-equation? step)
         (do (validate-host-step! (:values parallel-program) step)
@@ -266,6 +295,14 @@
 
         (emitted-equation-call? step)
         (do (validate-equation-call! step)
+            (doseq [[result physical] (:result-views step)]
+              (when-not (and (= (get buffers physical) (get (:buffers step) physical))
+                             (= (get buffers result) (get (:outputs step) result))
+                             (or (not (contains? outputs result))
+                                 (= (get buffers result) (get outputs result))))
+                (fail! :emitted-program-result-view-bindings
+                       "result-view tokens must agree with actual step and exported bindings"
+                       {:equation (:id equation) :result result :physical physical})))
             (when-not (= equation (:equation step))
               (fail! :emitted-program-call-step-equation
                      "emitted graph step changed equation identity" {:equation (:id equation)})))
@@ -417,9 +454,23 @@
    `buffers` may include preallocated intermediate and output storage in addition to inputs.
    `scalar-values` contains typed runtime scalars. `loop-scratch` maps loop output IDs to alternate
    carry buffers. `evaluate-host` is called only for effect-free scalar equations that do not
-   depend on device results."
-  [parallel-program buffers scalar-values loop-scratch evaluate-host]
+   depend on device results.
+   Optional `result-views` maps logical results to their prefix-producing physical destinations.
+   This declares a storage relation, not proof that arbitrary runtime tokens alias: LinkPlan
+   validates concrete views, and runtime preparation requires checked view resolution."
+  ([parallel-program buffers scalar-values loop-scratch evaluate-host]
+   (make parallel-program buffers scalar-values loop-scratch evaluate-host {}))
+  ([parallel-program buffers scalar-values loop-scratch evaluate-host result-views]
   (let [parallel-program (emitted-program/validate! parallel-program)
+        _ (when-not (and (map? result-views)
+                         (every? (set (mapcat :results
+                                             (filter #(emitted-equation/emitted-equation?
+                                                       (first (:operations %)))
+                                                     (:equations parallel-program))))
+                                 (keys result-views)))
+            (fail! :emitted-program-result-views
+                   "result-view declarations must name emitted numerical results"
+                   {:result-views result-views}))
         values (:values parallel-program)
         overlapping-runtime-values (set/intersection (set (keys buffers))
                                                      (set (keys scalar-values)))
@@ -468,7 +519,7 @@
 
              :else
              (let [{:keys [call buffers]}
-                   (prepare-equation-call equation values buffers scalars)]
+                   (prepare-equation-call equation values buffers scalars result-views)]
                {:buffers buffers :steps (conj steps call)})))
          {:buffers buffers :steps []}
          (:equations parallel-program))
@@ -485,4 +536,4 @@
     (validate!
      (->EmittedParallelProgramCall
       parallel-program (:steps planned) final-buffers scalars loop-scratch outputs
-      {:execution :stage-once-host-repetition :source-inspected false}))))
+      {:execution :stage-once-host-repetition :source-inspected false})))))

--- a/src/raster/compiler/ir/invocation_link.clj
+++ b/src/raster/compiler/ir/invocation_link.clj
@@ -7,6 +7,7 @@
    owned nodes, and the emitted call enters LinkPlan as a ProgramLinkInstance. No driver object,
    kernel name, or legacy resident descriptor participates."
   (:require [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
             [raster.compiler.ir.emitted-parallel-program :as emitted-program]
             [raster.compiler.ir.emitted-parallel-program-call :as program-call]
@@ -214,9 +215,22 @@
                abstract (or (get program-values physical-id) (get program-values result))
                [state token]
                (allocate-result state invocation-id physical-id abstract scalars :result)]
-           (-> state
-               (assoc-in [:buffers result] token)
-               (update-in [:storage token :compiler-values] conj result))))
+           (let [logical (get program-values result)
+                 shape (concrete-shape result logical scalars (:buffers state) (:storage state))
+                 backing (get-in state [:storage token])
+                 prefix? (< (reduce *' 1 shape) (reduce *' 1 (:shape backing)))
+                 producer (some #(when (some #{result} (nth % 2)) %)
+                                (soac/equations (:algorithm emitted)))]
+             (if (and prefix? (contains? '#{contract map} (soac/operation-kind producer)))
+               (let [view-token (storage-id invocation-id :result-view result)]
+                 (-> state
+                     (add-storage view-token result logical shape nil :unspecified)
+                     (assoc-in [:storage view-token :backing] token)
+                     (assoc-in [:storage view-token :result-view] [result physical-id])
+                     (assoc-in [:buffers result] view-token)))
+               (-> state
+                   (assoc-in [:buffers result] token)
+                   (update-in [:storage token :compiler-values] conj result))))))
        state (:results equation)))))
 
 (defn lower
@@ -251,13 +265,19 @@
         ;; kernel ABI consumes them. Retain them in the call so logical N-D values can be proved
         ;; element-equivalent to flattened result storage at the LinkPlan boundary.
         call (program-call/make parallel-program (:buffers realized) call-scalars
-                                (:loop-scratch realized) evaluate-host)
+                                (:loop-scratch realized) evaluate-host
+                                (into {} (keep :result-view) (vals (:storage realized))))
         resident-outputs (into [] (remove (comp typed-scalar? val)) (:outputs call))
         output-tokens (set (map val resident-outputs))
         storage (:storage realized)
         nodes
-        (mapv (fn [[token {:keys [shape source abstract]}]]
+        (mapv (fn [[token {:keys [shape source abstract backing]}]]
                 (link/node {:id token :dtype (:dtype abstract) :shape shape :device target
+                            :allocation-id (or backing token)
+                            :byte-size (when backing
+                                         (let [base-shape (get-in storage [backing :shape])]
+                                           (bview/required-byte-span (:dtype abstract) base-shape
+                                                                     (bview/dense-strides base-shape))))
                             :role (cond
                                     (and source (contains? output-tokens token)) :state
                                     source :state
@@ -279,6 +299,10 @@
       :nodes nodes
       :values values
       :instances [instance]
+      :aliases (into #{} (for [left nodes right nodes
+                              :when (and (not= (:id left) (:id right))
+                                         (bview/overlaps? (:view left) (:view right)))]
+                          #{(:id left) (:id right)}))
       :outputs (mapv val resident-outputs)
       :attributes {:source :typed-invocation
                    :invocation-plan invocation-id

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -856,6 +856,18 @@
 (defn- validate-program-buffer-contracts!
   [nodes values {:keys [id call roles]}]
   (let [program-values (get-in call [:program :values])]
+    (doseq [step (:steps call)
+            [result physical] (:result-views step)]
+      (let [logical-token (get (:buffers call) result)
+            physical-token (get (:buffers call) physical)
+            logical-view (:view (program-value-node! nodes values id result logical-token))
+            physical-view (:view (program-value-node! nodes values id physical physical-token))]
+        (when-not (and (= logical-token (get (:outputs step) result))
+                       (bview/prefix-view? physical-view logical-view))
+          (throw (ex-info "logical result view must be a prefix of its declared physical destination"
+                          {:reason :program-link-result-view :instance id :result result
+                           :physical-result physical :logical-view logical-view
+                           :physical-view physical-view})))))
     (doseq [[compiler-value value-id] (:buffers call)]
       (let [expected (get program-values compiler-value)
             link-value (get values value-id)
@@ -945,10 +957,25 @@
         (cond
           (program-call/evaluated-host-equation? step) []
           (program-call/emitted-equation-call? step)
-          [(program-graph-fact nodes values id step-index
-                               (get-in step [:equation :id])
-                               (:graph step) (:buffers step)
-                               (:scalar-values call) (:scalar-values step))]
+          [(assoc (program-graph-fact nodes values id step-index
+                                     (get-in step [:equation :id])
+                                     (:graph step) (:buffers step)
+                                     (:scalar-values call) (:scalar-values step))
+                  :produced-views
+                  (set (map (fn [[result _]]
+                              (:id (program-value-node! nodes values id result
+                                                        (get (:outputs step) result))))
+                            (:result-views step)))
+                  :partial-writes
+                  (set (keep (fn [[result physical]]
+                               (let [base (program-value-node! nodes values id physical
+                                                               (get (:buffers call) physical))
+                                     child (program-value-node! nodes values id result
+                                                                (get (:outputs step) result))]
+                                 (when (< (get-in child [:view :byte-length])
+                                          (get-in base [:view :byte-length]))
+                                   (:id base))))
+                             (:result-views step))))]
           (loop-call/structured-loop-call? step)
           (mapv (fn [iteration]
                   (let [{:keys [buffers scalar-values]}
@@ -984,14 +1011,24 @@
                                                        (contains? #{:input :constant :state} role))
                                                id)))
                                      nodes))
-        written (volatile! #{})]
-    (doseq [{:keys [instance step phase facts]} step-facts]
+        initially-initialized @initialized
+        written (volatile! #{})
+        initialized-view?
+        (fn [node-id]
+          (or (contains? @initialized node-id)
+              (let [view (get-in nodes [node-id :view])]
+                (and (bview/contiguous? view)
+                     (some (fn [initialized-id]
+                             (let [cover (get-in nodes [initialized-id :view])]
+                               (bview/contains-contiguous-view? cover view)))
+                           initially-initialized)))))]
+    (doseq [{:keys [instance step phase facts produced-views partial-writes]} step-facts]
       (let [by-node (reduce (fn [m {:keys [node access]}]
                               (update m node merge-access access)) {} facts)]
         (doseq [[node-id access] by-node
                 :let [role (get-in nodes [node-id :role])]]
           (when (and (contains? #{:read :read-write} access)
-                     (not (contains? @initialized node-id)))
+                     (not (initialized-view? node-id)))
             (throw (ex-info "link plan reads an internal node before an ordered producer writes it"
                             {:reason :link-read-before-write :instance instance :step step
                              :phase phase :node node-id})))
@@ -1000,7 +1037,8 @@
             (throw (ex-info "link plan writes a read-only node"
                             {:reason :link-write-read-only :instance instance :step step
                              :phase phase :node node-id :role role})))
-          (when (contains? #{:write :read-write} access)
+          (when (and (contains? #{:write :read-write} access)
+                     (not (contains? partial-writes node-id)))
             (vswap! initialized conj node-id)
             (vswap! written conj node-id)))
         (doseq [[left-id left-access] by-node
@@ -1011,10 +1049,14 @@
                           (contains? #{:write :read-write} right-access))]
           (throw (ex-info "one linked kernel step cannot access overlapping aliases when either writes"
                           {:reason :link-same-step-alias-hazard :instance instance :step step
-                           :phase phase :nodes #{left-id right-id}})))))
+                           :phase phase :nodes #{left-id right-id}}))))
+      ;; Only prefix-producing semantic operations contribute these checked views.
+      ;; A write through the larger pointer does not establish the untouched tail.
+      (vswap! initialized into produced-views)
+      (vswap! written into produced-views))
     (doseq [node-id outputs]
       (when-not (or (contains? @written node-id)
-                    (contains? @initialized node-id))
+                    (initialized-view? node-id))
         (throw (ex-info "link plan exports a node with no value"
                         {:reason :link-unproduced-output :node node-id}))))
     plan))

--- a/src/raster/compiler/passes/parallel/staged_contraction_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_admission.clj
@@ -1,0 +1,108 @@
+(ns raster.compiler.passes.parallel.staged-contraction-admission
+  "Shared, non-emitting admission for the generated packed staged schedule."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.contract-stages :as stages]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.passes.parallel.staged-contraction-schedule :as schedule]))
+
+(defn decline! [rule message data]
+  (throw (ex-info message (assoc data :reason :staged-kernel-body-declined
+                                 :missing-rule rule))))
+
+(defn declined? [e]
+  (= :staged-kernel-body-declined (:reason (ex-data e))))
+
+(defn- require! [condition rule data]
+  (when-not condition (decline! rule "typed staged schedule is not proved" data)))
+
+(defn- extent! [amap domain]
+  (let [pairs (vec (mapcat identity (:groups amap)))
+        axes (mapv first pairs)]
+    (require! (and (seq pairs) (= (count axes) (count (set axes)))
+                   (every? (fn [[a n :as pair]]
+                             (and (= 2 (count pair)) (contains? domain a)
+                                  (= n (get domain a)))) pairs))
+              :operand-domain {:map amap :domain domain})
+    (let [n (reduce *' 1 (map second pairs))]
+      (require! (<= n Integer/MAX_VALUE) :address-range {:map amap :elements n})
+      (long n))))
+
+(defn analyze!
+  "Check the packed schedule domain without constructing KernelBody or emitting code."
+  [source & {:keys [workgroup-size] :or {workgroup-size 64}}]
+  (when-not (facts/facts? source)
+    (throw (ex-info "staged body requires verified contraction facts" {:reason :raster/bug})))
+  (let [{:keys [free-axes contract-axes out]} source
+        stage-list (:stages source)
+        [outer inner] stage-list
+        axes (vec (concat free-axes contract-axes))
+        axis-ids (mapv first axes)
+        domain (into {} axes)
+        operands (vec (get-in source [:opts :operands]))
+        lifts (stages/lift-operands stage-list)
+        arrays (vec (concat operands lifts))
+        array-ids (mapv :sym arrays)
+        legality (stages/stages-legal? stage-list contract-axes)
+        reduction (facts/scalar-reduction-view source)]
+    (require! (:ok legality) :stage-legality legality)
+    ;; Decode is semantic evidence on canonical facts, not necessarily copied into the optional
+    ;; scheduling declarations. A body-replacing packed leaf must not discard either source.
+    (require! (and (not (seq (get-in source [:opts :decode])))
+                   (not-any? :decode (:operands source)))
+              :decoded-operands {:operands (:operands source)})
+    (require! (and (= 2 (count stage-list)) (= :int (dtype/canon (:dtype inner)))
+                   (= :float (dtype/canon (:dtype outer)))
+                   (= :float (or (:out-dtype source) :float))
+                   (nil? (:epilogue source))
+                   (contains? '#{+ clojure.core/+ raster.numeric/+} (:combine reduction))
+                   (constant/zero-value? (:neutral reduction)))
+              :stage-contract {:stages stage-list :reduction reduction})
+    (require! (and (seq free-axes) (= (count axis-ids) (count (set axis-ids)))
+                   (every? symbol? axis-ids)
+                   (every? #(and (integer? %) (pos? %) (<= % Integer/MAX_VALUE))
+                           (map second axes))
+                   (integer? workgroup-size) (<= 1 workgroup-size 256)
+                   (zero? (bit-and workgroup-size (dec workgroup-size))))
+              :iteration-domain {:axes axes :workgroup-size workgroup-size})
+    (require! (and (= (count array-ids) (count (set array-ids)))
+                   (every? symbol? array-ids) (symbol? out)
+                   (= (count (concat axis-ids array-ids [out '_nseg 'inner]))
+                      (count (set (concat axis-ids array-ids [out '_nseg 'inner]))))
+                   (every? #(and (= :float (:dtype %)) (nil? (:decode %))) lifts))
+              :parameter-identities {:axes axis-ids :arrays arrays :output out})
+    (let [plan (schedule/inner-dp4a-plan
+                {:stages stage-list :body (:body source) :operands operands
+                 :dtype (:dtype source)})
+          _ (require! (:ok plan) :packed-admission plan)
+          n (reduce *' 1 (map second free-axes))
+          _ (require! (<= (*' workgroup-size (quot (+ n (dec workgroup-size)) workgroup-size))
+                          Integer/MAX_VALUE)
+                      :launch-range {:elements n})
+          sizes (merge (into {} (map (fn [{:keys [sym map]}] [sym (extent! map domain)]) operands))
+                       (into {} (map (fn [{:keys [sym map]}]
+                                       [sym (extent! map (dissoc domain (:axis inner)))]) lifts)))
+          ;; The stage contract gives lift reads their declared maps. Admit scalar factors only;
+          ;; arbitrary calls, local binders and casts need their own retained region contract.
+          factors (stages/linear-in-inner (:lift outer) 'inner)
+          lift-ids (set (map :sym lifts))
+          _ (require! (every? #(or (number? %)
+                                  (and (descriptor/aget-call? %)
+                                       (contains? lift-ids (descriptor/aget-array-sym %)))) factors)
+                      :lift-region {:lift (:lift outer)})
+]
+      {:free-axes free-axes
+       :out out
+       :stage-list stage-list
+       :outer outer
+       :inner inner
+       :axis-ids axis-ids
+       :operands operands
+       :lifts lifts
+       :array-ids array-ids
+       :legality legality
+       :plan plan
+       :n n
+       :sizes sizes})))
+

--- a/src/raster/compiler/passes/parallel/staged_contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_body.clj
@@ -4,14 +4,10 @@
    Packing is four byte loads plus word operations, not a pointer reinterpretation. This is a
    correctness-first schedule; aligned vector loads and throughput tuning are separate work."
   (:require [clojure.walk :as walk]
-            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
-            [raster.compiler.core.numeric-constant :as constant]
-            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.scalar-conversion :as conversion]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as stages]
-            [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
@@ -21,94 +17,20 @@
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
             [raster.compiler.ir.soac-dialect :as soac]
-            [raster.compiler.passes.parallel.staged-contraction-schedule :as schedule]))
+            [raster.compiler.passes.parallel.staged-contraction-admission :as admission]))
 
-(defn- decline! [rule message data]
-  (throw (ex-info message (assoc data :reason :staged-kernel-body-declined
-                                 :missing-rule rule))))
-
-(defn declined? [e]
-  (= :staged-kernel-body-declined (:reason (ex-data e))))
+(def decline! admission/decline!)
+(def declined? admission/declined?)
 
 (defn- require! [condition rule data]
-  (when-not condition (decline! rule "typed staged schedule is not proved" data)))
-
-(defn- extent! [amap domain]
-  (let [pairs (vec (mapcat identity (:groups amap)))
-        axes (mapv first pairs)]
-    (require! (and (seq pairs) (= (count axes) (count (set axes)))
-                   (every? (fn [[a n :as pair]]
-                             (and (= 2 (count pair)) (contains? domain a)
-                                  (= n (get domain a)))) pairs))
-              :operand-domain {:map amap :domain domain})
-    (let [n (reduce *' 1 (map second pairs))]
-      (require! (<= n Integer/MAX_VALUE) :address-range {:map amap :elements n})
-      (long n))))
+  (when-not condition
+    (decline! rule "typed staged schedule is not proved" data)))
 
 (defn lower
-  "Schedule source-free verified contraction facts. Unsupported domains decline explicitly.
-   Returns a ScheduledKernelBody with byte storage and Int32 packed dot accumulators."
+  "Schedule verified staged contraction facts through shared non-emitting admission."
   [source & {:keys [workgroup-size] :or {workgroup-size 64}}]
-  (when-not (facts/facts? source)
-    (throw (ex-info "staged body requires verified contraction facts" {:reason :raster/bug})))
-  (let [{:keys [free-axes contract-axes out]} source
-        stage-list (:stages source)
-        [outer inner] stage-list
-        axes (vec (concat free-axes contract-axes))
-        axis-ids (mapv first axes)
-        domain (into {} axes)
-        operands (vec (get-in source [:opts :operands]))
-        lifts (stages/lift-operands stage-list)
-        arrays (vec (concat operands lifts))
-        array-ids (mapv :sym arrays)
-        legality (stages/stages-legal? stage-list contract-axes)
-        reduction (facts/scalar-reduction-view source)]
-    (require! (:ok legality) :stage-legality legality)
-    ;; Decode is semantic evidence on canonical facts, not necessarily copied into the optional
-    ;; scheduling declarations. A body-replacing packed leaf must not discard either source.
-    (require! (and (not (seq (get-in source [:opts :decode])))
-                   (not-any? :decode (:operands source)))
-              :decoded-operands {:operands (:operands source)})
-    (require! (and (= 2 (count stage-list)) (= :int (dtype/canon (:dtype inner)))
-                   (= :float (dtype/canon (:dtype outer)))
-                   (= :float (or (:out-dtype source) :float))
-                   (nil? (:epilogue source))
-                   (contains? '#{+ clojure.core/+ raster.numeric/+} (:combine reduction))
-                   (constant/zero-value? (:neutral reduction)))
-              :stage-contract {:stages stage-list :reduction reduction})
-    (require! (and (seq free-axes) (= (count axis-ids) (count (set axis-ids)))
-                   (every? symbol? axis-ids)
-                   (every? #(and (integer? %) (pos? %) (<= % Integer/MAX_VALUE))
-                           (map second axes))
-                   (integer? workgroup-size) (<= 1 workgroup-size 256)
-                   (zero? (bit-and workgroup-size (dec workgroup-size))))
-              :iteration-domain {:axes axes :workgroup-size workgroup-size})
-    (require! (and (= (count array-ids) (count (set array-ids)))
-                   (every? symbol? array-ids) (symbol? out)
-                   (= (count (concat axis-ids array-ids [out '_nseg 'inner]))
-                      (count (set (concat axis-ids array-ids [out '_nseg 'inner]))))
-                   (every? #(and (= :float (:dtype %)) (nil? (:decode %))) lifts))
-              :parameter-identities {:axes axis-ids :arrays arrays :output out})
-    (let [plan (schedule/inner-dp4a-plan
-                {:stages stage-list :body (:body source) :operands operands
-                 :dtype (:dtype source)})
-          _ (require! (:ok plan) :packed-admission plan)
-          n (reduce *' 1 (map second free-axes))
-          _ (require! (<= (*' workgroup-size (quot (+ n (dec workgroup-size)) workgroup-size))
-                          Integer/MAX_VALUE)
-                      :launch-range {:elements n})
-          sizes (merge (into {} (map (fn [{:keys [sym map]}] [sym (extent! map domain)]) operands))
-                       (into {} (map (fn [{:keys [sym map]}]
-                                       [sym (extent! map (dissoc domain (:axis inner)))]) lifts)))
-          ;; The stage contract gives lift reads their declared maps. Admit scalar factors only;
-          ;; arbitrary calls, local binders and casts need their own retained region contract.
-          factors (stages/linear-in-inner (:lift outer) 'inner)
-          lift-ids (set (map :sym lifts))
-          _ (require! (every? #(or (number? %)
-                                  (and (descriptor/aget-call? %)
-                                       (contains? lift-ids (descriptor/aget-array-sym %)))) factors)
-                      :lift-region {:lift (:lift outer)})
-          reserved (atom (set (filter symbol? (tree-seq coll? seq source))))
+  (let [{:keys [free-axes out stage-list outer inner axis-ids operands lifts array-ids legality plan n sizes]} (admission/analyze! source :workgroup-size workgroup-size)]
+    (let [reserved (atom (set (filter symbol? (tree-seq coll? seq source))))
           fresh (fn [prefix]
                   (loop [id (gensym prefix)]
                     (if (contains? @reserved id) (recur (gensym prefix))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2163,7 +2163,9 @@
                               (declare-result-conversion body fold-dtype)))
                           casts bodies)
         all-expressions (into (mapv :init locals) expressions)
-        [pointwise stable] ((juxt filter remove) #(pointwise-input? all-expressions % index) inputs)
+        [pointwise stable] ((juxt filter remove)
+                            #(and (not (contains? (:storage-inputs description) %))
+                                  (pointwise-input? all-expressions % index)) inputs)
         arrays (vec (sort-by pr-str pointwise))
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
         parameters (element-symbols (count arrays))
@@ -2775,6 +2777,31 @@
 
 (declare form->program*)
 
+(defn- preserve-map-storage-inputs
+  "Use existing indexed captures when a pointwise map reads a larger backing buffer.
+   Element operands retain their exact logical shape; no tensor type is weakened."
+  [descriptions values]
+  (let [requirements
+        (mapcat (fn [description]
+                  (when (= :contract (:kind description))
+                    (conj (mapv (juxt :parameter :elements)
+                                (contraction-closure/storage-requirements (:closure description)))
+                          [(get-in description [:facts :out])
+                           (reduce *' 1 (map second (get-in description [:facts :free-axes])))])))
+                descriptions)
+        capacities (merge (into {} (map (fn [[id accesses]] [id (apply max (map second accesses))]))
+                                (group-by first requirements))
+                          (into {} (keep (fn [[id value]]
+                                           (when (and (seq (:shape value))
+                                                      (every? integer? (:shape value)))
+                                             [id (reduce *' 1 (:shape value))]))) values))]
+    (mapv (fn [{:keys [kind extent inputs] :as description}]
+            (if (and (= :map kind) (integer? extent))
+              (assoc description :storage-inputs
+                     (set (filter #(when-let [capacity (get capacities %)]
+                                     (> capacity extent)) inputs)))
+              description)) descriptions)))
+
 (defn form->program
   "Construct and validate TypedSOAC islands directly from a let form.
 
@@ -2794,8 +2821,10 @@
     (let [[_ bindings & body] source
           pairs (vec (partition 2 bindings))
           array-types (binder-array-types pairs array-types dtype)
-          descriptions (normalize-extents (source-descriptions pairs dtype array-types)
-                                          shape-equalities values)]
+          descriptions (preserve-map-storage-inputs
+                         (normalize-extents (source-descriptions pairs dtype array-types)
+                                            shape-equalities values)
+                         values)]
       (when (and (even? (count bindings))
                  (seq descriptions)
                  (some #(contains? #{:map :scatter :effect-map :stencil :reduce :contract :segmented-reduce

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -14,6 +14,8 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [raster.compiler.ir.contraction-closure :as contraction-closure]
+            [raster.compiler.passes.parallel.staged-contraction-admission :as staged-admission]
             [raster.compiler.ir.index-algebra :as index-algebra]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
@@ -953,6 +955,35 @@
             :source-operation :reducing-scatter}
            io)))
 
+(defn- staged-contract-description
+  [id symbol source array-types]
+  (let [declared (fn [id]
+                   (some-> (or (get array-types id)
+                               (get array-types (clojure.core/symbol (name id)))) dtype/canon))
+        core-types (mapv (comp declared :sym) (:operands source))]
+    (when (and (seq core-types) (every? some? core-types) (apply = core-types)
+               (not= symbol (:out source)))
+      (let [operands (or (get-in source [:opts :operands])
+                         (mapv #(assoc % :map (contraction-facts/operand-axis-map source %))
+                               (:operands source)))
+            facts (contraction-facts/from-components
+                   (-> (select-keys source [:out :free-axes :contract-axes :body :opts])
+                       (assoc :dtype (first core-types))
+                       (assoc-in [:opts :operands] operands)))
+            {:keys [reads scalars]} (contraction-facts/dependencies facts)
+            attributes {:contraction facts
+                        :array-parameters (vec (sort-by pr-str reads))
+                        :capture-parameters (vec (sort-by pr-str scalars))}]
+        (when (try (staged-admission/analyze! facts) true
+                   (catch clojure.lang.ExceptionInfo e
+                     (if (staged-admission/declined? e) false (throw e))))
+          (contraction-closure/validate! attributes)
+          {:kind :contract :id id :sym symbol :facts facts :closure attributes
+           :inputs reads :outputs #{(:out facts)} :scalars scalars
+           :results [(effect-result-id id 0)]
+           :effect-only? true :host-binding symbol
+           :result-storage [{:destination (:out facts) :access :write :host-return :buffer}]})))))
+
 (defn- operation-description
   [id symbol expression default-dtype array-types]
   (cond
@@ -1276,6 +1307,8 @@
       ;; The direct slice is scalar segmented-reduction algebra plus an optional closed typed
       ;; result transform. Staged quantization carries additional schedule/load contracts and must
       ;; not be admitted by dropping those facts.
+      (if (seq (:stages facts))
+        (staged-contract-description id symbol facts array-types)
       (if (empty? contract-axes)
         ;; A static zero-reduction contraction is a map, not a fold from a fabricated zero.
         ;; Coordinate decomposition is the existing axis-flattening operation. Required input
@@ -1345,7 +1378,7 @@
            ;; transform that reads the destination (an accumulating GEMM) makes it read-write.
            :result-storage [{:destination out
                              :access (if (contains? epilogue-arrays out) :read-write :write)
-                             :host-return :buffer}]}))))
+                             :host-return :buffer}]})))))
 
     (or (par/par-scan-form? expression)
         (par/par-scan-exclusive-form? expression))
@@ -1923,7 +1956,7 @@
   [descriptions]
   (let [written (reduce set/union #{}
                         (map #(if (contains? #{:map :scatter :effect-map :stencil :reduce
-                                               :segmented-reduce :product-reduce
+                                               :segmented-reduce :contract :product-reduce
                                                :segmented-fold-map :scan} (:kind %))
                                 (:outputs %) #{})
                              descriptions))
@@ -1965,6 +1998,7 @@
     :stencil (and (= 1 (count (:result-storage description)))
                   (symbol? (get-in description [:result-storage 0 :destination])))
     :reduce true
+    :contract true
     :segmented-reduce (and (vector? (:segment-axes description))
                            (symbol? (get-in description [:result-storage 0 :destination])))
     :product-reduce (and (seq (:segment-axes description))
@@ -2294,6 +2328,11 @@
                  (vec (concat [(:accumulator component)] elements capture-parameters))
                  results)))))
 
+(defn- contract-equation
+  [{:keys [id results closure]}]
+  (list '= id results
+        (list 'contract closure (:array-parameters closure) (:capture-parameters closure))))
+
 (defn- segmented-reduce-equation
   [{:keys [id segment-axes reduce-index reduce-extent inputs scalars product results
            result-transform]}]
@@ -2472,13 +2511,13 @@
 (defn- terminal-results
   [descriptions body]
   (let [physical-outputs (physical-output-symbols descriptions)
-        operations (filter #(contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
+        operations (filter #(contains? #{:map :scatter :effect-map :stencil :reduce :contract :segmented-reduce
                                          :product-reduce :segmented-fold-map :scan} (:kind %))
                            descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
                                               (:map :scatter :effect-map :stencil) (:results %)
                                               :scan [(:sym %)]
-                                              :segmented-reduce (:results %)
+                                              (:contract :segmented-reduce) (:results %)
                                               :product-reduce (:results %)
                                               :segmented-fold-map (:results %)
                                               (:outputs %))
@@ -2488,7 +2527,7 @@
                         (:map :scatter :effect-map :stencil)
                         (if (:effect-only? %) [] (:results %))
                         :scan [(:sym %)]
-                        :segmented-reduce (if (:effect-only? %) [] (:results %))
+                        (:contract :segmented-reduce) (if (:effect-only? %) [] (:results %))
                         :product-reduce (if (:effect-only? %) [] (:results %))
                         :segmented-fold-map (if (:effect-only? %) [] (:results %))
                         (:outputs %))
@@ -2595,7 +2634,7 @@
   (or (get types id)
       (when (symbol? id) (get types (clojure.core/symbol (name id))))))
 
-(defn- equation-values
+(defn- ordinary-equation-values
   [equation default-dtype array-types scalar-types known-values]
   (let [[_ _ results] equation
         {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
@@ -2670,6 +2709,49 @@
                                          (dialect/extent-shape extent)))])
                    results result-dtypes)))))
 
+(defn- equation-values
+  [equation default-dtype array-types scalar-types known-values]
+  (if (= 'contract (dialect/operation-kind equation))
+    (let [{:keys [attributes arrays captures]} (dialect/operation-parts equation)
+          source (:contraction attributes)
+          bindings (contraction-closure/bindings attributes arrays captures)
+          requirements (group-by :parameter (contraction-closure/storage-requirements attributes))]
+      (merge
+       (into {} (map (fn [[parameter requirements]]
+                       (let [id (get bindings parameter)]
+                         [id (or (get known-values id)
+                                 (tensor-value (value-dtype id default-dtype array-types)
+                                               [(apply max (map :elements requirements))]))])) requirements))
+       (into {} (map (fn [id]
+                       [id (or (get known-values id)
+                               (when-let [declared (declared-type scalar-types id)]
+                                 (tensor-value declared [])))])) captures)
+       {(first (nth equation 2))
+        (tensor-value (or (:out-dtype source) (:dtype (first (:stages source))))
+                      (mapv second (:free-axes source)))}))
+    (ordinary-equation-values equation default-dtype array-types scalar-types known-values)))
+
+(defn- contraction-storage-values
+  "Aggregate access lower bounds, without replacing a declared buffer's capacity.
+   Closure validation separately checks every access against these storage values."
+  [equations default-dtype array-types known-values]
+  (let [requirements
+        (mapcat (fn [equation]
+                  (when (= 'contract (dialect/operation-kind equation))
+                    (let [{:keys [attributes arrays captures]} (dialect/operation-parts equation)
+                          bindings (contraction-closure/bindings attributes arrays captures)]
+                      (conj (mapv (fn [{:keys [parameter elements]}]
+                                    [(get bindings parameter) elements])
+                                  (contraction-closure/storage-requirements attributes))
+                            [(get-in attributes [:contraction :out])
+                             (reduce *' 1 (map second (get-in attributes [:contraction :free-axes])))]))))
+                equations)]
+    (into {} (map (fn [[id accesses]]
+                    [id (or (get known-values id)
+                            (tensor-value (value-dtype id default-dtype array-types)
+                                          [(apply max (map second accesses))]))]))
+          (group-by first requirements))))
+
 (defn- merge-value
   ([values id contract] (merge-value values id contract {}))
   ([values id contract shape-equalities]
@@ -2716,17 +2798,18 @@
                                           shape-equalities values)]
       (when (and (even? (count bindings))
                  (seq descriptions)
-                 (some #(contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
+                 (some #(contains? #{:map :scatter :effect-map :stencil :reduce :contract :segmented-reduce
                                      :product-reduce :segmented-fold-map :scan}
                                    (:kind %))
                        descriptions)
                  (supported-descriptions? descriptions))
         (let [operation-descriptions
-              (filterv #(contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
+              (filterv #(contains? #{:map :scatter :effect-map :stencil :reduce :contract :segmented-reduce
                                      :product-reduce :segmented-fold-map :scan} (:kind %))
                        descriptions)
               physical-outputs (physical-output-symbols descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
+                                               :contract (contract-equation %)
                                                :scatter (scatter-equation %)
                                                :effect-map (effect-map-equation %)
                                                :stencil (stencil-equation %)
@@ -2767,11 +2850,12 @@
                                   (update :equation-descriptions conj description)
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
-                          (:map :scatter :effect-map :stencil :reduce :segmented-reduce
+                          (:map :scatter :effect-map :stencil :reduce :contract :segmented-reduce
                                 :product-reduce :segmented-fold-map :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)
+                                        :contract (contract-equation description)
                                         :map (map-equation description)
                                         :scatter (scatter-equation description)
                                         :effect-map (effect-map-equation description)
@@ -2812,7 +2896,9 @@
                                      [destination
                                       (tensor-value
                                        (value-dtype destination dtype array-types)
-                                       [(list 'unknown-dimension destination)])])
+                                       (if (= :contract (:kind description))
+                                         [(reduce *' 1 (map second (get-in description [:facts :free-axes])))]
+                                         [(list 'unknown-dimension destination)]))])
                                    (:result-storage description))))
                     equation-descriptions)
               inferred-values (reduce (fn [contracts equation]
@@ -2820,7 +2906,9 @@
                                                    (equation-values equation dtype array-types'
                                                                     scalar-types
                                                                     contracts)))
-                                      destination-values equations)
+                                      (merge destination-values
+                                             (contraction-storage-values equations dtype array-types' values))
+                                      equations)
               values (reduce-kv #(merge-value %1 %2 %3 shape-equalities)
                                 inferred-values values)
               equation-facts
@@ -2834,7 +2922,9 @@
                                 (contains? graph-shape-scalar-ids (:sym description))
                                 (update :attributes assoc :graph-shape-definition true)
                                 storage
-                                (-> (assoc :effects #{:memory/write}
+                                (-> (assoc :effects (if (= :contract (:kind description))
+                                                     #{:memory/read :memory/write}
+                                                     #{:memory/write})
                                            :aliases (into {}
                                                           (map (fn [result {:keys [destination]}]
                                                                  [result destination])

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -35,6 +35,29 @@
                                     [parameter (:dtype (get values (get bound parameter)))]))
                            (:capture-parameters attributes))})))
 
+(defn contraction-host-form
+  "Materialize retained contraction semantics for the host boundary only.
+   The numerical GPU route consumes contraction-binding, never this source spelling."
+  [program equation]
+  (let [{:keys [facts bindings]} (contraction-binding program equation)
+        form (contraction-facts/surface-form facts)
+        renamings (vec (remove (fn [[parameter value]] (= parameter value))
+                              (sort-by (comp pr-str key) bindings)))
+        occupied (into #{} (filter symbol?) (tree-seq coll? seq [form bindings]))]
+    (if (seq renamings)
+      ;; External SSA names are simultaneous bindings. Read all of them before
+      ;; introducing lexical parameters: a->b, b->a must not capture either read.
+      (let [temporaries (mapv (fn [_]
+                               (first (remove occupied
+                                              (repeatedly #(gensym "contract_arg__")))))
+                             renamings)
+            reads (mapcat (fn [temporary [_ value]] [temporary value])
+                          temporaries renamings)
+            parameters (mapcat (fn [[parameter _] temporary] [parameter temporary])
+                               renamings temporaries)]
+        (list 'let* (vec (concat reads parameters)) form))
+      form)))
+
 (defn scalar-folds->source
   "Project explicit scalar Fold terms to Raster's interpreted host vocabulary."
   [expression]

--- a/src/raster/compiler/passes/parallel/typed_soac_resident.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_resident.clj
@@ -26,9 +26,11 @@
 (defn- emit-equation
   [{:keys [kind id results attributes arrays captures parameters locals body-results]}]
   (list '= id (vec results)
+        (if (= :contract kind)
+          (list 'contract attributes (vec arrays) (vec captures))
         (list (symbol (name kind)) attributes (vec arrays) (vec captures)
               (dialect/lambda-form (vec parameters) (dialect/emit-locals locals)
-                                   (vec body-results)))))
+                                   (vec body-results))))))
 
 (defn- parameter-parts
   [info]
@@ -43,10 +45,11 @@
   [equations]
   (reduce
    (fn [uses equation]
-     (let [{:keys [id arrays captures attributes]} (operation-info equation)]
+     (let [{:keys [id kind arrays captures attributes]} (operation-info equation)]
        (-> uses
            (into (map (fn [value] [value {:equation id :role :array}]) arrays))
-           (into (map (fn [value] [value {:equation id :role :capture}]) captures))
+           (into (map (fn [value] [value {:equation id :role (if (= :contract kind)
+                                                             :contract-capture :capture)}]) captures))
            ;; The transform has its own typed scalar boundary. Rewriting the primary
            ;; lambda cannot turn a transform scalar into a resident buffer load.
            (into (map (fn [value] [value {:equation id :role :result-transform}])
@@ -103,7 +106,7 @@
               :else value))]
     (expand id #{})))
 
-(defn- rewrite-consumer
+(defn- rewrite-lambda-consumer
   [info values scalar-defs dependent roots]
   (let [{:keys [accumulators elements capture-parameters]} (parameter-parts info)
         capture-substitutions
@@ -144,6 +147,13 @@
            :body-results (mapv #(util/subst-syms body-substitutions %) global-bodies)
            :attributes (assoc-in (:attributes info) [:attributes :stable-array-captures]
                                  (vec (filter stable-after referenced-values))))))
+
+(defn- rewrite-consumer
+  [info values scalar-defs dependent roots]
+  ;; A contraction's scalar closure is not a resident-buffer lambda. Its capture uses
+  ;; are explicit escape sites above, so unrelated resident reductions can still proceed.
+  (if (= :contract (:kind info)) info
+      (rewrite-lambda-consumer info values scalar-defs dependent roots)))
 
 (defn realize
   "Return `[program stats]`, realizing every eligible non-escaping scalar reduction.

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -42,7 +42,7 @@
   [equation]
   (let [{:keys [kind attributes arrays captures destinations lambda element-lambda]}
         (dialect/operation-parts equation)]
-    (if (= 'segmented-fold-map kind)
+    (if (contains? #{'segmented-fold-map 'contract} kind)
       {:locals [] :bodies []}
       (let [{:keys [locals body-results]}
             (dialect/lambda-parts (or lambda element-lambda))
@@ -389,6 +389,12 @@
            :site [:binding result]
            :source source}))
 
+      contract
+      (let [host-binding (or (get-in placement-facts [:attributes :host-binding]) (first results))
+            source (projection/contraction-host-form program equation)]
+        {:equation-id equation-id :placement placement :pairs [[host-binding source]]
+         :site [:binding host-binding] :source source})
+
       segmented-reduce
       (let [host-binding (or (get-in placement-facts [:attributes :host-binding])
                              (first results))
@@ -621,7 +627,7 @@
                      (resident/realize typed-result)
                      [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
                (if (not-any? #(contains? #{:map :scatter :effect-map :stencil :reduce
-                                           :segmented-reduce :product-reduce
+                                           :segmented-reduce :contract :product-reduce
                                            :segmented-fold-map :scan}
                                          (:kind (fusion/equation-info %)))
                              (dialect/equations typed-result))

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -186,7 +186,9 @@
               prepared-program
               (parallel-program/prepare-with!
                (:call instance)
-               {:bind! (fn [key graph buffers scalars]
+               {:buffer-view (fn [value-id]
+                               (:view (resident-link-value plan node-views value-id)))
+                :bind! (fn [key graph buffers scalars]
                          (let [resident-buffers
                                (into {}
                                      (map (fn [[compiler-value value-id]]

--- a/src/raster/gpu/parallel_program.clj
+++ b/src/raster/gpu/parallel_program.clj
@@ -6,6 +6,8 @@
    consume the exact carry bindings selected by the call IR."
   (:refer-clojure :exclude [run!])
   (:require [raster.compiler.ir.emitted-parallel-program-call :as program-call]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.structured-loop-call :as loop-call]))
 
 (declare release-prepared!)
@@ -101,9 +103,29 @@
 
    Preparation is transactional: a failed binding releases all earlier handles in reverse order.
    `run-prepared!` streams loop replay from the bounded binding table, so preparation remains
-   constant in the loop trip count."
-  [call {:keys [bind! run! release!] :as executor}]
+   constant in the loop trip count. Calls with logical result views additionally require the
+   executor's `:buffer-view` resolver from a buffer token to its checked live BufferView; exact
+   logical extent and prefix aliasing are checked before the first bind."
+  [call {:keys [bind! run! release! buffer-view] :as executor}]
   (let [call (program-call/validate! call)]
+    (doseq [step (:steps call)
+            [result physical] (:result-views step)]
+      (when-not (ifn? buffer-view)
+        (throw (ex-info "result views require checked runtime buffer-view resolution"
+                        {:reason :parallel-program-result-view-resolver :result result})))
+      (let [view (bview/validate-view! (buffer-view (get (:buffers call) result)))
+            base (bview/validate-view! (buffer-view (get (:buffers call) physical)))
+            expected (get-in call [:program :values result])
+            expected-elements (reduce *' 1 (map #(graph-call/resolve-integer (:scalar-values call) %)
+                                                 (:shape expected)))]
+        (when-not (and (= (:dtype expected) (:dtype view))
+                       (= expected-elements (reduce *' 1 (:shape view))))
+          (throw (ex-info "runtime result view differs from its logical tensor contract"
+                          {:reason :parallel-program-result-view-shape :result result
+                           :expected expected :actual view})))
+        (when-not (bview/prefix-view? base view)
+          (throw (ex-info "runtime result view is not a prefix of its physical destination"
+                          {:reason :parallel-program-result-view :result result :physical physical})))))
     (doseq [[operation function] [[:bind! bind!] [:run! run!] [:release! release!]]]
       (when-not (ifn? function)
         (throw (ex-info "parallel program executor requires callable operations"

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -3,13 +3,12 @@
  "Exact fast-lane compiler signatures for representative ML and scientific workloads. Improvements update this debt downward; unexpected route, fallback, or emitter drift fails CI. Large numerical/performance comparisons live in the cold benchmark lane."
  :workloads
  {:staged-byte-float-contraction-gpu
-  {:route {:backend :opencl :source-dialect :compatibility :typed-validated false
-           :declines {[:soac-fused-stats :typed-soac-declined :typed-soac-source-coverage] 1}}
-   :fusion {:vertical 0 :horizontal 0 :iterations 0 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 0
-              :typed-scalar-equations 0 :backend-reused 1 :backend-relowered 0 :fallback 0}
-   :emission {:kernel-count 1 :targets [:opencl-c] :strategies [:staged-segred]
-              :fallback-reasons [] :declines {} :routes {:segcontract 1}}}
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true :declines {}}
+   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 1
+              :typed-scalar-equations 0 :backend-reused 0 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
+              :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
 
   :dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -19,7 +19,7 @@
 (def ^:private target :ze:compatibility-ledger)
 
 ;; This is staged contraction syntax, not the explicit-map Q4 projection below.
-;; Track the frontend gap separately from candidate KernelBody/device coverage.
+;; Track public frontend admission separately from candidate KernelBody/device coverage.
 (deftm staged-byte-float-contract!
   [a :- (Array byte) b :- (Array byte) da :- (Array float)
    db :- (Array float) out :- (Array float)] :- Void
@@ -90,7 +90,7 @@
 
     :staged-byte-float-contraction-gpu
     (pipeline/compile-report #'staged-byte-float-contract!
-                             :target-device target :dtype :byte)
+                             :target-device target :dtype :float)
 
     :symbolic-dense-contraction-gpu
     (let [compilation (equation-first/compile

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -5,6 +5,12 @@
             [raster.compiler.compatibility-ledger-test :as ledger]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.emitted-parallel-program :as emitted-program]
+            [raster.compiler.ir.emitted-parallel-program-call :as program-call]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.link-plan :as link-plan]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.gpu.parallel-program :as program-runtime]
             [raster.core :refer [deftm]]
             [raster.dl.attention :as attention]
             [raster.numeric]
@@ -163,6 +169,44 @@
       (is (str/includes? (:source (first kernels)) "rstr_dp4a"))
       (is (= 0 (get-in linked [:attributes :driver-allocations])))
       (is (empty? (:outputs linked)) "the public Void destination remains a state buffer")
+      (let [call (:call (first (:instances linked)))
+            equation (get-in call [:program :equations 0])
+            algorithm (get-in equation [:operations 0 :algorithm])
+            result (first (:results equation))
+            physical (first (soac/physical-results algorithm (first (soac/equations algorithm))))
+            make-call #(program-call/make (:program call)
+                                          (assoc (:buffers call) result :unrelated-result)
+                                          (:scalar-values call) {} nil %)
+            forged (make-call {result physical})
+            binds (atom 0)
+            executor {:bind! (fn [& _] (swap! binds inc)) :run! identity :release! identity}
+            reason (fn [f] (try (f) nil (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))]
+        (is (= :emitted-program-result-views (reason #(make-call {:not-a-result physical}))))
+        (is (= :parallel-program-result-view-resolver
+               (reason #(program-runtime/prepare-with! forged executor))))
+        (is (= :emitted-program-result-view-bindings
+               (reason #(program-call/validate!
+                         (assoc-in forged [:steps 0 :buffers physical] :wrong-kernel-buffer)))))
+        (is (= :emitted-program-result-view-bindings
+               (reason #(program-call/validate!
+                         (assoc-in forged [:steps 0 :outputs result] :wrong-logical-buffer)))))
+        (is (= :parallel-program-result-view-shape
+               (reason #(program-runtime/prepare-with!
+                         forged (assoc executor :buffer-view
+                                       (fn [token]
+                                         (bview/view
+                                          (bview/allocation {:id :shared :byte-size 8 :device target
+                                                             :memory-space :device :ownership :owned})
+                                          {:dtype :float :shape [(if (= token :unrelated-result) 1 2)]})))))))
+        (is (= :parallel-program-result-view
+               (reason #(program-runtime/prepare-with!
+                         forged (assoc executor :buffer-view
+                                       (fn [token]
+                                         (bview/view
+                                          (bview/allocation {:id token :byte-size 8 :device target
+                                                             :memory-space :device :ownership :owned})
+                                          {:dtype :float :shape [2]})))))))
+        (is (zero? @binds) "unrelated result views must fail before staging any graph"))
       (doseq [[slot short-buffer] [[0 (byte-array 7)] [2 (float-array 1)]
                                   [4 (float-array 1)]]]
         (is (thrown? clojure.lang.ExceptionInfo
@@ -172,6 +216,36 @@
                               (float-array 4) (float-array 2)] slot short-buffer)))
             "core, scale and destination capacities are checked before allocation"))
       (is (= (:emitted compilation) (emitted-program/validate! (:emitted compilation)))))))
+
+(deftest staged-result-views-initialize-only-the-written-prefix
+  (let [output (float-array 4)
+        compilation (equation-first/compile
+                     #'ledger/staged-byte-float-contract!
+                     {:target cuda-target :dtype :float
+                      :values {'out (av/tensor {:dtype :float :shape [4]})}})
+        linked (equation-first/lower compilation [(byte-array 8) (byte-array 16)
+                                                  (float-array 2) (float-array 4) output])
+        call (:call (first (:instances linked)))
+        result (first (get-in call [:steps 0 :equation :results]))
+        prefix (get (:buffers call) result)
+        base (get (:buffers call) 'out)
+        fresh (-> linked
+                  (assoc-in [:nodes base :source] nil)
+                  (assoc-in [:nodes base :role] :internal)
+                  (assoc :outputs [prefix]))
+        reason (fn [plan] (try (link-plan/validate! plan) nil
+                              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))]
+    (is (not= base prefix))
+    (is (= (get-in linked [:nodes base :view :allocation])
+           (get-in linked [:nodes prefix :view :allocation]))
+        "result views share storage without another allocation")
+    (is (nil? (get-in linked [:nodes prefix :source])))
+    (is (nil? (reason fresh)) "the contraction produces its entire logical prefix")
+    (is (= :link-unproduced-output (reason (assoc fresh :outputs [base])))
+        "writing a prefix cannot initialize or export the untouched tail")
+    (is (= :program-link-result-view
+           (reason (assoc-in fresh [:nodes prefix :view :byte-offset] 4)))
+        "a claimed prefix may not be shifted into another part of the allocation")))
 
 (deftest public-elementwise-map-uses-portable-kernel-body
   (doseq [[target module-target]

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [raster.arrays]
+            [raster.compiler.compatibility-ledger-test :as ledger]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.emitted-parallel-program :as emitted-program]
             [raster.core :refer [deftm]]
@@ -146,6 +147,31 @@
         (is (= 1 (count (:outputs linked))))
         (is (= (:emitted compilation)
                (emitted-program/validate! (:emitted compilation))))))))
+
+(deftest public-staged-contraction-preserves-independent-types-on-cuda-and-hip
+  (doseq [[target module-target] [[cuda-target :cuda-c] [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'ledger/staged-byte-float-contract! {:target target :dtype :float})
+          linked (equation-first/lower compilation
+                                       [(byte-array 8) (byte-array 16)
+                                        (float-array 2) (float-array 4) (float-array 2)])
+          kernels (:kernels compilation)]
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 1 (count kernels)))
+      (is (= module-target (:target (first kernels))))
+      (is (every? #(get-in % [:attributes :kernel-body]) kernels))
+      (is (str/includes? (:source (first kernels)) "rstr_dp4a"))
+      (is (= 0 (get-in linked [:attributes :driver-allocations])))
+      (is (empty? (:outputs linked)) "the public Void destination remains a state buffer")
+      (doseq [[slot short-buffer] [[0 (byte-array 7)] [2 (float-array 1)]
+                                  [4 (float-array 1)]]]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (equation-first/lower
+                      compilation
+                      (assoc [(byte-array 8) (byte-array 16) (float-array 2)
+                              (float-array 4) (float-array 2)] slot short-buffer)))
+            "core, scale and destination capacities are checked before allocation"))
+      (is (= (:emitted compilation) (emitted-program/validate! (:emitted compilation)))))))
 
 (deftest public-elementwise-map-uses-portable-kernel-body
   (doseq [[target module-target]

--- a/test/raster/compiler/ir/buffer_view_test.clj
+++ b/test/raster/compiler/ir/buffer_view_test.clj
@@ -21,6 +21,19 @@
                           (view/view allocation {:id :other-name :dtype :float
                                                  :shape [1024]})))))
 
+(deftest prefix-views-require-the-same-allocation-and-typed-range
+  (let [base (view/view allocation {:dtype :float :shape [16]})
+        prefix (view/subview base {:shape [8]})
+        shifted (view/subview base {:shape [8] :byte-offset 4})]
+    (is (view/prefix-view? base prefix))
+    (is (not (view/prefix-view? prefix base)))
+    (is (view/contains-contiguous-view? base shifted))
+    (is (not (view/prefix-view? base shifted)))
+    (is (not (view/prefix-view? base (assoc-in prefix [:allocation :id] :unrelated))))
+    (is (not (view/prefix-view? base (assoc-in prefix [:allocation :ownership] :borrowed))))
+    (is (not (view/prefix-view? base (view/view allocation {:dtype :int :shape [8]}))))
+    (is (not (view/prefix-view? base (view/view allocation {:dtype :float :shape [8] :strides [2]}))))))
+
 (deftest strided-views-state-their-physical-span
   (let [columns (view/view allocation {:id :columns :dtype :float
                                        :shape [4 8] :strides [64 2]})]

--- a/test/raster/compiler/ir/contraction_closure_device_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_device_test.clj
@@ -1,9 +1,34 @@
 (ns raster.compiler.ir.contraction-closure-device-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.segop-opencl :as emitter]
+            [raster.compiler.compatibility-ledger-test :as ledger]
+            [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.contraction-closure-test :as fixture]
             [raster.gpu.core :as gpu]
+            [raster.gpu.link :as link]
             [raster.gpu.device-probe :as probe]))
+
+(deftest public-staged-contraction-compiles-links-and-runs
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "public typed staged contraction")
+    (let [output (float-array (repeat 2 -555.0))
+          compilation (equation-first/compile
+                       #'ledger/staged-byte-float-contract! {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower
+                compilation [(byte-array (repeat 8 1))
+                             (byte-array (concat (repeat 8 2) (repeat 8 3)))
+                             (float-array (repeat 2 0.5))
+                             (float-array (repeat 4 0.25)) output])
+          output-id (some (fn [[id node]] (when (identical? output (:source node)) id))
+                          (:nodes plan))]
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 0 (get-in plan [:attributes :driver-allocations])))
+      (is (some? output-id) "resolve the state buffer by source identity, not kernel ABI spelling")
+      (let [executable (link/instantiate! plan)]
+        (try
+          (link/run! executable)
+          (is (= [2.0 3.0] (vec (link/download executable output-id))))
+          (finally (link/close! executable)))))))
 
 (deftest retained-contraction-runs-through-the-resident-graph-binder
   (if-not @probe/opencl-available?

--- a/test/raster/compiler/ir/contraction_closure_device_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_device_test.clj
@@ -3,10 +3,72 @@
             [raster.compiler.backend.gpu.segop-opencl :as emitter]
             [raster.compiler.compatibility-ledger-test :as ledger]
             [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.contraction-closure-test :as fixture]
+            [raster.core :refer [deftm]]
             [raster.gpu.core :as gpu]
             [raster.gpu.link :as link]
             [raster.gpu.device-probe :as probe]))
+
+(deftm staged-prefix-map!
+  [a :- (Array byte) b :- (Array byte) da :- (Array float)
+   db :- (Array float) out :- (Array float)] :- Void
+  (ledger/staged-byte-float-contract! a b da db out)
+  (raster.par/map! out index 2 float
+                   (raster.numeric/* (raster.arrays/aget out index) 2.0)))
+
+(deftest public-staged-prefix-map-preserves-the-backing-buffer-tail
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "public staged contraction and prefix map")
+    (let [output (float-array [0.0 0.0 -555.0 -777.0])
+          compilation (equation-first/compile
+                       #'staged-prefix-map!
+                       {:target :ocl:0 :dtype :float
+                        :values {'out (av/tensor {:dtype :float :shape [4]})}})
+          plan (equation-first/lower
+                compilation [(byte-array (repeat 8 1))
+                             (byte-array (concat (repeat 8 2) (repeat 8 3)))
+                             (float-array (repeat 2 0.5))
+                             (float-array (repeat 4 0.25)) output])
+          output-id (some (fn [[id node]] (when (identical? output (:source node)) id))
+                          (:nodes plan))]
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (some? output-id))
+      (let [executable (link/instantiate! plan)]
+        (try
+          (link/run! executable)
+          (is (= [4.0 6.0 -555.0 -777.0] (vec (link/download executable output-id))))
+          (finally (link/close! executable)))))))
+
+(deftm staged-prefix-copy!
+  [a :- (Array byte) b :- (Array byte) da :- (Array float)
+   db :- (Array float) out :- (Array float) destination :- (Array float)] :- Void
+  (ledger/staged-byte-float-contract! a b da db out)
+  (raster.par/map! destination index 2 float
+                   (raster.numeric/* (raster.arrays/aget out index) 2.0)))
+
+(deftest public-staged-prefix-map-supports-a-disjoint-destination
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "public staged contraction and disjoint prefix map")
+    (let [output (float-array [0.0 0.0 -555.0 -777.0])
+          destination (float-array [-333.0 -444.0])
+          compilation (equation-first/compile
+                       #'staged-prefix-copy!
+                       {:target :ocl:0 :dtype :float
+                        :values {'out (av/tensor {:dtype :float :shape [4]})}})
+          plan (equation-first/lower
+                compilation [(byte-array (repeat 8 1))
+                             (byte-array (concat (repeat 8 2) (repeat 8 3)))
+                             (float-array (repeat 2 0.5))
+                             (float-array (repeat 4 0.25)) output destination])
+          node-for (fn [source]
+                     (some (fn [[id node]] (when (identical? source (:source node)) id)) (:nodes plan)))
+          executable (link/instantiate! plan)]
+      (try
+        (link/run! executable)
+        (is (= [2.0 3.0 -555.0 -777.0] (vec (link/download executable (node-for output)))))
+        (is (= [4.0 6.0] (vec (link/download executable (node-for destination)))))
+        (finally (link/close! executable))))))
 
 (deftest public-staged-contraction-compiles-links-and-runs
   (if-not @probe/opencl-available?

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -56,6 +56,23 @@
                  (frontend/form->program
                   source (assoc options :values {'a (av/tensor {:dtype :byte :shape [287]})}))))))
 
+(deftest contraction-prefix-composes-with-a-map-over-larger-storage
+  (let [source (list 'let*
+                     ['contract-effect (raster.compiler.ir.contraction-facts/surface-form
+                                        (fixtures/packed-facts 3 5 3 32))
+                      'map-effect '(raster.par/map! out index 15 float
+                                     (raster.numeric/* (raster.arrays/aget out index) 2.0))]
+                     'out)
+        p (frontend/form->program
+           source {:dtype :float :array-types '{a :byte b :byte da :float db :float out :float}
+                   :values {'out (av/tensor {:dtype :float :shape [30]})}})
+        map-op (soac/operation-parts (second (soac/equations p)))]
+    (is (= '[contract map] (mapv soac/operation-kind (soac/equations p))))
+    (is (= [30] (get-in (soac/facts p) [:values 'out :shape])))
+    (is (empty? (:arrays map-op)))
+    (is (= ['out] (:captures map-op)))
+    (is (= p (soac/validate! p)))))
+
 (deftest unsupported-staged-schedules-do-not-become-authoritative-typed-islands
   (let [source (fixtures/packed-facts 3 5 3 32)
         options {:dtype :float :array-types '{a :byte b :byte da :float db :float out :float}

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -13,6 +13,7 @@
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.staged-contraction-body :as staged]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]))
 
 (defn- program []
@@ -34,6 +35,41 @@
                                  :equations {'contraction equation-facts}})
      [(list '= 'contraction '[result] (list 'contract attributes '[a b da db] []))]
      '[result])))
+
+(deftest public-contractions-share-capacity-not-exact-access-shapes
+  (let [first-source (fixtures/packed-facts 3 5 3 32)
+        second-source (assoc (fixtures/packed-facts 1 2 2 32) :out 'other)
+        source (list 'let* ['first-effect (raster.compiler.ir.contraction-facts/surface-form first-source)
+                           'second-effect (raster.compiler.ir.contraction-facts/surface-form second-source)]
+                     'out)
+        options {:dtype :float :array-types '{a :byte b :byte da :float db :float
+                                              out :float other :float}}
+        inferred (frontend/form->program source options)
+        supplied (frontend/form->program
+                  source (assoc options :values {'a (av/tensor {:dtype :byte :shape [576]})
+                                                 'out (av/tensor {:dtype :float :shape [30]})}))]
+    (is (= 2 (count (soac/equations inferred))))
+    (is (= [288] (get-in (soac/facts inferred) [:values 'a :shape])))
+    (is (= [576] (get-in (soac/facts supplied) [:values 'a :shape])))
+    (is (= [30] (get-in (soac/facts supplied) [:values 'out :shape])))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (frontend/form->program
+                  source (assoc options :values {'a (av/tensor {:dtype :byte :shape [287]})}))))))
+
+(deftest unsupported-staged-schedules-do-not-become-authoritative-typed-islands
+  (let [source (fixtures/packed-facts 3 5 3 32)
+        options {:dtype :float :array-types '{a :byte b :byte da :float db :float out :float}
+                 :scalar-types {'scale :float}}
+        form-for (fn [facts]
+                   (list 'let* ['effect (raster.compiler.ir.contraction-facts/surface-form facts)] 'out))]
+    (doseq [unsupported [(-> source
+                            (assoc-in [:stages 1 :dtype] :float)
+                            (assoc-in [:opts :stages 1 :dtype] :float))
+                         (-> source
+                             (assoc-in [:stages 0 :lift] '(* inner scale))
+                             (assoc-in [:opts :stages 0 :lift] '(* inner scale)))]]
+      (is (nil? (frontend/form->program (form-for unsupported) options))
+          "unsupported valid staged semantics remain available to the compatibility route"))))
 
 (deftest typed-contraction-retains-the-canonical-payload-through-ssa
   (let [p (program)
@@ -94,6 +130,19 @@
       (is false "outer lift cannot read an inner-stage coordinate")
       (catch clojure.lang.ExceptionInfo e
         (is (= :stage-lift-scope (:missing-rule (ex-data e))))))))
+
+(deftest host-contraction-renaming-is-simultaneous
+  (let [p (soac/remap-values (program) {'a 'b 'b 'a 'da 'db 'db 'da})
+        [_ bindings _] (projection/contraction-host-form p (first (soac/equations p)))]
+    (is (= [:external-b :external-a :external-db :external-da :external-out]
+           (eval (list 'let* '[a :external-a b :external-b da :external-da
+                              db :external-db out :external-out]
+                       (list 'let* bindings '[a b da db out])))))
+    (let [identity-program (program)
+          equation (first (soac/equations identity-program))]
+      (is (= (projection/contraction-host-form identity-program equation)
+             (raster.compiler.ir.contraction-facts/surface-form
+              (:facts (projection/contraction-binding identity-program equation))))))))
 
 (deftest retained-contraction-binds-generated-storage-without-source-reparse
   (let [p (soac/remap-values (program) {'a [:arg 0] 'b [:arg 1] 'da [:arg 2]

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -47,6 +47,26 @@
                   :bindings {'x x 'w w 'y y}
                   :scalars {'n 16}}))
 
+(deftest initialized-alias-coverage-is-directional
+  (let [make-node (fn [id shape offset source]
+                    (link/node {:id id :dtype :float :shape shape :device :ze:0
+                                :role :internal :allocation-id :shared :byte-size 16
+                                :byte-offset offset :source source}))
+        base (make-node :base [4] 0 (float-array 4))
+        prefix (make-node :prefix [2] 0 nil)
+        plan #(link/make {:id :coverage :target :ze:0
+                          :nodes (into %1 [(n :x :input (float-array 16))
+                                           (n :w :constant (float-array 16)) (n :tmp :internal)])
+                          :instances [(instance :unrelated :x :w :tmp)]
+                          :aliases #{#{:base :prefix}} :outputs [%2]})]
+    (is (link/link-plan? (plan [base prefix] :prefix)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (plan [(make-node :base [4] 0 nil)
+                        (make-node :prefix [2] 0 (float-array 2))] :base)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (plan [(make-node :base [2] 8 nil)
+                        (make-node :prefix [3] 0 (float-array 3))] :base)))))
+
 (defn- valid-plan []
   (let [x (float-array 16) w0 (float-array 16) w1 (float-array 16)]
     (link/make


### PR DESCRIPTION
## Summary

- Admit the bounded public Byte/Int32/Float staged contraction into retained TypedSOAC and production KernelBody graph emission, preserving independently declared storage types under Float policy.
- Share a non-emitting schedule admission check; retain honest non-admission for unsupported staged semantics.
- Aggregate storage access minima while preserving larger supplied capacities. Use existing indexed map captures for static prefix reads.
- Bind logical prefix results through shared-allocation LinkPlan views. Check semantic relation, actual step/export bindings, exact logical extent, and physical aliasing before staging. Track partial writes without initializing the untouched tail.
- Move the compatibility ledger workload from the staged fallback to generated KernelBody emission.

## Validation

- Final focused closure, Arc device, BufferView, LinkPlan, and ledger suites: 24 tests, 129 assertions, zero failures/errors.
- Public CUDA/HIP compilation and negative view/bounds tests: 2 tests, 42 assertions.
- Existing remapping, native LinkPlan, stage-once and transactional staging checks: 5 tests, 31 assertions.
- Existing frontend suite: 55 tests, 249 assertions.
- Arc checks cover contraction alone, in-place prefix map and disjoint destination with preserved poisoned tails.
- Independent review found and verified fixes for capture safety, capacity semantics, schedule admission, fresh-load helper, forged runtime views, retained-call mutations and initialization coverage.
- Full suite and hardware-free vendor compilation are delegated to CI; one capped REPL used locally.

## Scope

This does not remove every staged fallback or claim competitive/SOTA performance. Larger-buffer examples supply capacity at compilation; general dynamic runtime view specialization remains follow-up work. Indexed captures can conservatively constrain fusion. The full eight-item compiler campaign remains active.
