### PR TITLE
Share staged workloads across numerical, ledger and vendor compiler coverage

### DIFF
--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -12,6 +12,7 @@
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as staged-public]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
@@ -274,6 +275,10 @@
                 :capabilities capabilities})
     (vec
      (concat
+      (:kernels (equation-first/compile
+                 #'staged-public/floating-three-stage! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'staged-public/checked-long-stage! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -10,6 +10,14 @@
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
 
+  :staged-floating-contraction-gpu
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true :declines {}}
+   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 1
+              :typed-scalar-equations 0 :backend-reused 0 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
+              :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
+
   :dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer [deftest is use-fixtures]]
             [raster.arrays]
             [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as staged-public]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.dl.attention :as attention]
@@ -92,6 +93,10 @@
     (pipeline/compile-report #'staged-byte-float-contract!
                              :target-device target :dtype :float)
 
+    :staged-floating-contraction-gpu
+    (pipeline/compile-report #'staged-public/floating-three-stage!
+                             :target-device target :dtype :float)
+
     :symbolic-dense-contraction-gpu
     (let [compilation (equation-first/compile
                        #'contract/contract-mm {:target target :dtype :float})
@@ -153,6 +158,7 @@
     (is (= 1 schema-version))
     (is (= #{:dense-relu-jvm
              :staged-byte-float-contraction-gpu
+             :staged-floating-contraction-gpu
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -1,0 +1,26 @@
+(ns raster.compiler.fixtures.staged-contracts
+  "Public staged workloads shared by numerical tests, the debt ledger and vendor compile gates."
+  (:require [raster.core :refer [deftm]]
+            [raster.arrays]
+            [raster.numeric]
+            [raster.par]))
+
+(deftm floating-three-stage!
+  [a :- (Array float) b :- (Array float) weights :- (Array float)
+   out :- (Array float) scale :- Float] :- Void
+  (raster.par/contract out [[i 2] [j 3]] [[blk 2] [sub 3] [t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 24) (* blk 12) (* sub 4) t))
+                      (raster.arrays/aget b (+ (* j 24) (* blk 12) (* sub 4) t)))
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift (* inner scale)}
+             {:axis sub :extent 3 :dtype :float :init 0.0 :lift (* inner (aget weights _))
+              :operands [{:sym weights :dtype :float :map {:groups [[[j 3] [blk 2] [sub 3]]]}}]}
+             {:axis t :extent 4 :dtype :float :init 0.0}]))
+
+(deftm checked-long-stage!
+  [a :- (Array float) b :- (Array float) out :- (Array float) gain :- Long] :- Void
+  (raster.par/contract out [[i 1]] [[blk 2] [t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* blk 4) t))
+                      (raster.arrays/aget b (+ (* blk 4) t)))
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0
+              :lift (* inner (double (clojure.core/+ gain 1)))}
+             {:axis t :extent 4 :dtype :float :init 0.0}]))

--- a/test/raster/compiler/passes/parallel/staged_scalar_body_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_scalar_body_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.kernel-body-target :as target]
             [raster.compiler.equation-first :as equation-first]
-            [raster.core :refer [deftm]]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
             [raster.runtime.hardware :as hardware]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contraction-facts :as facts]
@@ -38,33 +38,13 @@
                                    :map (am/of-axes '[[j 3] [blk 2] [sub 3]])}]}
                       {:axis 't :extent 4 :dtype :float :init 0.0}]}})))
 
-(deftm public-three-stage!
-  [a :- (Array float) b :- (Array float) weights :- (Array float)
-   out :- (Array float) scale :- Float] :- Void
-  (raster.par/contract out [[i 2] [j 3]] [[blk 2] [sub 3] [t 4]]
-    (raster.numeric/* (raster.arrays/aget a (+ (* i 24) (* blk 12) (* sub 4) t))
-                      (raster.arrays/aget b (+ (* j 24) (* blk 12) (* sub 4) t)))
-    :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift (* inner scale)}
-             {:axis sub :extent 3 :dtype :float :init 0.0 :lift (* inner (aget weights _))
-              :operands [{:sym weights :dtype :float :map {:groups [[[j 3] [blk 2] [sub 3]]]}}]}
-             {:axis t :extent 4 :dtype :float :init 0.0}]))
-
-(deftm public-long-stage!
-  [a :- (Array float) b :- (Array float) out :- (Array float) gain :- Long] :- Void
-  (raster.par/contract out [[i 1]] [[blk 2] [t 4]]
-    (raster.numeric/* (raster.arrays/aget a (+ (* blk 4) t))
-                      (raster.arrays/aget b (+ (* blk 4) t)))
-    :stages [{:axis blk :extent 2 :dtype :float :init 0.0
-              :lift (* inner (double (clojure.core/+ gain 1)))}
-             {:axis t :extent 4 :dtype :float :init 0.0}]))
-
 (deftest public-stages-retain-checked-integer-arithmetic
   ;; Compile only: deliberately overflowing a device trap would poison the shared device context.
   (hardware/register-target-device! :cuda:checked-stage-test
                                     {:type :cuda :capabilities {:compute-capability [8 0]
                                                                :warp-size 32 :subgroup-sizes [32]
                                                                :max-workgroup-size 1024}})
-  (let [compilation (equation-first/compile #'public-long-stage!
+  (let [compilation (equation-first/compile #'fixtures/checked-long-stage!
                                           {:target :cuda:checked-stage-test :dtype :float})
         body (get-in compilation [:kernels 0 :attributes :kernel-body])]
     (is (= :none (get-in compilation [:stats :fallback])))
@@ -75,7 +55,7 @@
                                     {:type :cuda :capabilities {:compute-capability [8 0]
                                                                :warp-size 32 :subgroup-sizes [32]
                                                                :max-workgroup-size 1024}})
-  (let [compilation (equation-first/compile #'public-three-stage!
+  (let [compilation (equation-first/compile #'fixtures/floating-three-stage!
                                             {:target :cuda:scalar-stage-test :dtype :float})
         plan (equation-first/lower compilation [(float-array 48) (float-array 72)
                                                  (float-array 18) (float-array 6) (float 0.25)])]
@@ -88,7 +68,7 @@
   (if-not @probe/opencl-available?
     (probe/opencl-skip! "public floating staged contraction")
     (let [output (float-array (repeat 6 -555.0))
-          compilation (equation-first/compile #'public-three-stage! {:target :ocl:0 :dtype :float})
+          compilation (equation-first/compile #'fixtures/floating-three-stage! {:target :ocl:0 :dtype :float})
           plan (equation-first/lower compilation
                                      [(float-array (repeat 48 1.0)) (float-array (repeat 72 2.0))
                                       (float-array (repeat 18 0.5)) output (float 0.25)])


### PR DESCRIPTION
## Summary

Follow-up to #462. Share the public floating three-stage and checked-Long workloads across numerical tests and CUDA/HIP source compilation gates. The shared fixture namespace does not load test namespaces or register devices.

Add the floating workload to the compatibility ledger with its measured exact signature: typed validated, one typed reuse, zero backend reuse/relowering/fallback, one KernelBody kernel. This is route coverage, not a performance claim.

## Validation

- Moved-fixture numerical suite: 16 tests, 71 assertions, zero failures/errors; includes Arc public LinkPlan execution.
- New ledger signature independently compared with the checked-in EDN: exact match.
- Both shared public vars compiled for synthetic HIP: fallback `:none`, one kernel each.
- Existing numerical tests compile both vars for synthetic CUDA.
- Both public vars are now explicitly included in the existing nvcc/hipcc fixture generator; CI owns real vendor compilation and full suites.
- Independent read-only review found no blocker.

No production code change. Full compiler campaign and remaining staged-emitter retirement are unchanged.
