### PR TITLE
Generate staged contraction epilogues through typed scalar SSA

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -689,3 +689,19 @@ common resident binding, public compilation/execution, all four source dialects,
 declines, and retained checked integer arithmetic. Broader integer stage schedules, dynamic domains,
 cooperative scheduling, target capability-driven alternatives and external performance comparisons
 remain follow-ups; the older staged fallback is not yet fully retired.
+
+### Staged scalar result transforms
+
+Floating staged contractions can now execute their scalar epilogue after the entire nested
+reduction, through the same strict scalar builder. The retained closure checks accumulator scope
+and excludes closed reduction indices; shared storage requirements include declared epilogue
+operand maps over free axes. Explicit scalar declarations must agree with authoritative capture
+types, both at schedule admission and after SSA value binding. No stage/epilogue source template
+or operator registry is added.
+
+The generated path retains the current output dtype and casts the completed scalar transform
+explicitly. Destination-reading transforms still require an inout storage proof and decline before
+frontend admission. Decoded operands and broader integer stage schedules remain separate work.
+Public validation includes post-reduction placement on Arc, all common source dialects, short
+epilogue-buffer rejection before allocation, and CUDA/HIP vendor fixtures using the same public
+workload. Whole staged-emitter retirement remains contingent on the uncovered numerical contracts.

--- a/src/raster/compiler/ir/contraction_closure.clj
+++ b/src/raster/compiler/ir/contraction_closure.clj
@@ -7,6 +7,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as stages]
@@ -30,6 +31,28 @@
                     (= (count %) (count (set %))))
                [(:array-parameters x) (:capture-parameters x)])))
 
+(defn result-expression
+  "Resolve a result transform's declared operand maps without changing its scalar binders."
+  [source]
+  (let [epilogue (:epilogue source)]
+    (descriptor/rewrite-aget-indices
+     (:expr epilogue)
+     (into {} (map (fn [{:keys [sym map]}] [sym (am/index-expr map)])) (:operands epilogue)))))
+
+(defn validate-result-scalar-types!
+  "Check explicit result-transform capture declarations against authoritative scalar types."
+  [source scalar-types]
+  (let [declarations (get-in source [:epilogue :scalars])
+        ids (mapv :sym declarations)]
+    (when-not (and (every? symbol? ids) (= (count ids) (count (set ids))))
+      (fail! :result-transform-scalars {:declarations declarations}))
+    (doseq [{:keys [sym dtype]} declarations]
+      (when-not (and (dtype/known? dtype)
+                     (= (dtype/canon dtype) (some-> (get scalar-types sym) dtype/canon)))
+        (fail! :result-transform-scalar-type
+               {:scalar sym :declared dtype :actual (get scalar-types sym)}))))
+  source)
+
 (defn validate!
   "Validate lexical closure and the currently admitted static staged semantics.
    Numerical/layout extensions must retain their own contracts before admission."
@@ -48,7 +71,6 @@
     (when-not (:ok legality) (fail! :stage-legality legality))
     (when-not (and (contains? '#{+ clojure.core/+ raster.numeric/+} (:combine contraction))
                    (constant/zero-value? (:init contraction))
-                   (nil? (:epilogue contraction))
                    (empty? (get-in contraction [:opts :decode]))
                    (not-any? :decode (:operands contraction)))
       (fail! :numerical-contract {:contraction contraction}))
@@ -61,6 +83,18 @@
                    (not (contains? (set indices) (:out contraction)))
                    (not (contains? (:reads dependencies) (:out contraction))))
       (fail! :lexical-boundary {:dependencies dependencies :attributes attributes}))
+    (when-let [epilogue (:epilogue contraction)]
+      (let [acc (:acc epilogue)
+            external (set (concat array-parameters capture-parameters))
+            visible (into (conj external acc) (map first (:free-axes contraction)))
+            unbound (util/free-syms (result-expression contraction) visible)]
+        (when-not (and (symbol? acc) (some? (:expr epilogue))
+                       (not (contains? external acc))
+                       (not (contains? (set indices) acc))
+                       (not= (:out contraction) acc)
+                       (or (nil? (:dtype epilogue)) (dtype/known? (:dtype epilogue)))
+                       (empty? unbound))
+          (fail! :result-transform-scope {:epilogue epilogue :unbound unbound :visible visible}))))
     (doseq [[index stage] (map-indexed vector stage-list)
             :when (:lift stage)]
       (let [visible (into (set (concat array-parameters capture-parameters ['inner]))
@@ -97,7 +131,9 @@
                                    (let [visible (into {} (concat (:free-axes source)
                                                                  (take (inc index) (:contract-axes source))))]
                                      (map #(vector % visible) (:operands stage))))
-                                 (range) (:stages source)))]
+                                 (range) (:stages source))
+                         (map #(vector % (into {} (:free-axes source)))
+                              (get-in source [:epilogue :operands])))]
     (mapv (fn [[{:keys [sym dtype] amap :map :as operand} visible-domain]]
             (let [pairs (vec (mapcat identity (:groups amap)))
                   ids (mapv first pairs)]
@@ -117,6 +153,9 @@
   (let [bound (bindings attributes arrays captures)
         source (:contraction attributes)
         output-type (dtype/canon (or (:out-dtype source) (:dtype (first (:stages source)))))]
+    (validate-result-scalar-types!
+     source (into {} (map (fn [id] [id (:dtype (get values (bound id)))]))
+                  (:capture-parameters attributes)))
     (doseq [{:keys [parameter dtype elements] :as requirement} (storage-requirements attributes)
             :let [value (get values (get bound parameter))
                   shape (:shape value)]]

--- a/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
@@ -21,15 +21,19 @@
     (decline! :static-domain "scalar staged schedule requires static extents" {:source source}))
   (when-not (and (contains? '#{+ clojure.core/+ raster.numeric/+} (:combine source))
                  (constant/zero-value? (:init source))
-                 (nil? (:epilogue source))
                  (empty? (get-in source [:opts :decode]))
                  (not-any? :decode (:operands source)))
     (decline! :numerical-contract "scalar staged schedule does not implement these numerical extensions"
               {:source source}))
   (let [{:keys [reads scalars]} (facts/dependencies source)
+        _ (when (some #(= (:out source) (:sym %)) (get-in source [:epilogue :operands]))
+            (decline! :result-transform-inout
+                      "destination-reading result transforms require an inout storage proof"
+                      {:source source}))
         attributes {:contraction source :array-parameters (vec (sort-by pr-str reads))
                     :capture-parameters (vec (sort-by pr-str scalars))}
         _ (closure/validate! attributes)
+        _ (closure/validate-result-scalar-types! source scalar-types)
         requirements (closure/storage-requirements attributes)
         stage-list (:stages source)
         axes (vec (concat (:free-axes source) (:contract-axes source)))

--- a/src/raster/compiler/passes/parallel/staged_scalar_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_body.clj
@@ -5,6 +5,7 @@
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.contract-stages :as stages]
+            [raster.compiler.ir.contraction-closure :as closure]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
@@ -66,6 +67,22 @@
                                         [(body/->Yield [(:result sum)])]))
                            [(body/value result dt)] {})]}))
         computation (build-stage 0)
+        result-transform
+        (when-let [epilogue (:epilogue source)]
+          (let [legality (body/scalar-region-legal? epilogue)
+                _ (when-not (:ok legality)
+                    (decline! :result-transform "staged result transform is not a scalar store region"
+                              legality))
+                dt (dtype/canon (or (:dtype epilogue) out-type))
+                expression (walk/postwalk-replace
+                            {(:acc epilogue) (:result computation)}
+                            (closure/result-expression source))
+                expression (if (and (seq? expression)
+                                    (not (or (:tag (meta expression)) (:raster.type/tag (meta expression)))))
+                             (vary-meta expression assoc :raster.type/tag (dtype/scalar-tag-for-dtype dt))
+                             expression)
+                lowered ((:lower builder) expression dt {(:result computation) (:dtype computation)})]
+            ((:cast builder) lowered out-type expression)))
         arrays (:array-parameters attributes)
         captures (:capture-parameters attributes)
         parameter (fn [id kind dt elements]
@@ -90,8 +107,9 @@
                                       (reduce *' 1 (map second (drop (inc i) (:free-axes source))))) extent)))
                                  (:free-axes source))))
                  :masks [(body/->Mask mask [(body/predicate :lt segment n)])]
-                 :operations (conj (:operations computation)
-                                   (body/->ScalarStore (:out source) [segment] (:result computation) mask))
+                 :operations (conj (into (:operations computation) (:operations result-transform))
+                                   (body/->ScalarStore (:out source) [segment]
+                                                        (or (:result result-transform) (:result computation)) mask))
                  :launch (launch/spec {:workgroup-size [workgroup-size]
                                        :group-count [(quot (+ n (dec workgroup-size)) workgroup-size)]})
                  :schedule {:strategy :staged-scalar :workgroup-size workgroup-size}}]

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -280,6 +280,8 @@
       (:kernels (equation-first/compile
                  #'staged-public/checked-long-stage! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'staged-public/floating-result-transform! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -16,6 +16,17 @@
               :operands [{:sym weights :dtype :float :map {:groups [[[j 3] [blk 2] [sub 3]]]}}]}
              {:axis t :extent 4 :dtype :float :init 0.0}]))
 
+(deftm floating-result-transform!
+  [a :- (Array float) b :- (Array float) bias :- (Array float)
+   out :- (Array float) gain :- Float] :- Void
+  (raster.par/contract out [[i 2]] [[blk 2] [t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 8) (* blk 4) t))
+                      (raster.arrays/aget b (+ (* blk 4) t)))
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift inner}
+             {:axis t :extent 4 :dtype :float :init 0.0}]
+    :epilogue {:acc value :expr (+ value (aget bias _) gain) :dtype :float
+               :operands [{:sym bias :dtype :float :map {:groups [[[i 2]]]}}]}))
+
 (deftm checked-long-stage!
   [a :- (Array float) b :- (Array float) out :- (Array float) gain :- Long] :- Void
   (raster.par/contract out [[i 1]] [[blk 2] [t 4]]

--- a/test/raster/compiler/passes/parallel/staged_result_transform_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_result_transform_test.clj
@@ -1,0 +1,100 @@
+(ns raster.compiler.passes.parallel.staged-result-transform-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.fixtures.staged-contracts :as public]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.contraction-closure :as closure]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.passes.parallel.staged-scalar-body :as staged]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.staged-scalar-body-test :as fixture]
+            [raster.gpu.device-probe :as probe]
+            [raster.runtime.hardware :as hardware]
+            [raster.gpu.link :as link]))
+
+(defn source []
+  (facts/from-components
+   (-> (select-keys (fixture/three-stage-facts) [:out :free-axes :contract-axes :body :opts])
+       (assoc :dtype :float)
+       (assoc-in [:opts :epilogue]
+                 {:acc 'value :expr '(+ value (aget bias _)) :dtype :float
+                  :operands [{:sym 'bias :dtype :float :map {:groups '[[[j 3]]]}}]}))))
+
+(deftest result-transforms-share-storage-and-scalar-lowering
+  (let [s (source)
+        scheduled (staged/lower s :scalar-types {'scale :float})]
+    (is (= '[a b bias weights out scale] (:arguments scheduled)))
+    (is (= 3 (get-in scheduled [:legality :storage-elements 'bias])))
+    (doseq [dialect [:opencl-portable :opencl-intel :cuda :hip]]
+      (is (= [:float :float :float :float :float :float]
+             (mapv :dtype (:abi (target/emit-artifact "staged_result_transform" scheduled dialect))))))))
+
+(deftest result-transforms-cannot-read-closed-reduction-indices
+  (doseq [mutate [#(assoc-in % [:epilogue :expr] '(+ value t))
+                  #(assoc-in % [:epilogue :acc] 'scale)
+                  #(assoc-in % [:epilogue :operands 0 :map] {:groups '[[[t 4]]]})]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (staged/lower (mutate (source)) :scalar-types {'scale :float}))))
+  (let [s (source)
+        attrs {:contraction s :array-parameters '[a b bias weights] :capture-parameters '[scale]}]
+    (is (= {'bias 3}
+           (into {} (map (juxt :parameter :elements))
+                 (filter #(= 'bias (:parameter %)) (closure/storage-requirements attrs)))))))
+
+(deftest result-transform-declared-types-cannot-retype-captures-or-storage
+  (doseq [s [(assoc-in (source) [:epilogue :scalars] [{:sym 'scale :dtype :double}])
+             (assoc-in (source) [:epilogue :scalars] [{:sym 'scale :dtype :float}
+                                                    {:sym 'scale :dtype :float}])
+             (-> (source)
+                 (assoc-in [:epilogue :expr] '(+ value (aget a _)))
+                 (assoc-in [:epilogue :operands 0 :sym] 'a)
+                 (assoc-in [:epilogue :operands 0 :dtype] :double))]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (staged/lower s :scalar-types {'scale :float})))))
+
+(deftest destination-reading-result-transforms-decline-before-closure-admission
+  (let [s (-> (source)
+              (assoc-in [:epilogue :expr] '(+ value (aget out _)))
+              (assoc-in [:epilogue :operands 0 :sym] 'out))
+        s (assoc-in s [:opts :epilogue] (:epilogue s))
+        failure (try (staged/analyze! s :scalar-types {'scale :float}) nil
+                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+    (is (= :staged-scalar-body-declined (:reason failure)))
+    (is (= :result-transform-inout (:missing-rule failure)))
+    (is (nil? (frontend/form->program
+               (list 'let* ['effect (facts/surface-form s)] nil)
+               {:dtype :float :array-types {'a :float 'b :float 'weights :float 'out :float}
+                :scalar-types {'scale :float}})))))
+
+(deftest public-result-transforms-have-checked-allocation-free-invocations
+  (doseq [vendor [:cuda :hip]]
+    (let [device (keyword (str (name vendor) ":staged-result-transform-test"))]
+      (hardware/register-target-device!
+       device {:type vendor :capabilities (cond-> {:warp-size 32 :subgroup-sizes [32]
+                                                   :max-workgroup-size 1024}
+                                           (= vendor :cuda) (assoc :compute-capability [8 0])
+                                           (= vendor :hip) (assoc :gfx-arch :gfx1100))})
+      (let [compilation (equation-first/compile #'public/floating-result-transform!
+                                               {:target device :dtype :float})
+            arguments [(float-array 16) (float-array 8) (float-array 2) (float-array 2) (float 1.5)]]
+        (is (= :none (get-in compilation [:stats :fallback])))
+        (is (= 0 (get-in (equation-first/lower compilation arguments) [:attributes :driver-allocations])))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (equation-first/lower compilation (assoc arguments 2 (float-array 1)))))))))
+
+(deftest public-result-transform-executes-after-reduction
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "public staged result transform")
+    (let [output (float-array (repeat 2 -555.0))
+          compilation (equation-first/compile #'public/floating-result-transform! {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compilation
+                                     [(float-array (repeat 16 1.0)) (float-array (repeat 8 2.0))
+                                      (float-array [1.0 3.0]) output (float 1.5)])
+          output-id (some (fn [[id node]] (when (identical? output (:source node)) id)) (:nodes plan))]
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (some? output-id))
+      (let [executable (link/instantiate! plan)]
+        (try
+          (link/run! executable)
+          (is (= [18.5 20.5] (vec (link/download executable output-id))))
+          (finally (link/close! executable)))))))

--- a/test/raster/compiler/passes/parallel/staged_scalar_body_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_scalar_body_test.clj
@@ -104,7 +104,7 @@
   (doseq [[source rule]
           [[(assoc (three-stage-facts) :free-axes '[[i n] [j 3]]) :static-domain]
            [(assoc (three-stage-facts) :free-axes '[[i 0] [j 3]]) :static-domain]
-           [(assoc (three-stage-facts) :epilogue {:acc 'value :expr 'value}) :numerical-contract]
+           [(assoc (three-stage-facts) :combine 'max) :numerical-contract]
            [(update (three-stage-facts) :body
                     #(list 'clojure.core/identity %)) :scalar-expression]]]
     (let [failure (try (staged/analyze! source :scalar-types {'scale :float}) nil


### PR DESCRIPTION
## Summary

Extend the generated floating staged contraction route with post-reduction scalar result transforms, using the existing strict scalar SSA builder and common KernelBody emitters.

The retained closure checks accumulator scope and disallows closed reduction coordinates. Shared storage requirements now include the epilogue's declared maps over free axes. Explicit scalar declarations are checked against authoritative dtypes both during admission and after SSA binding. Duplicate declarations and contradictory storage types reject.

Destination-reading epilogues remain a declared capability miss until inout storage proof is implemented; they decline before frontend admission rather than throwing a closure error. The transform runs only after every reduction stage closes and its result is explicitly cast to the existing output dtype.

## Validation

- Focused result-transform, generic stage, closure and frontend tests: 86 tests, 407 assertions, zero failures/errors.
- Public Arc LinkPlan execution gives [18.5, 20.5], including per-output bias and scalar gain exactly once after reduction.
- Direct source emission exercises portable/Intel OpenCL, CUDA and HIP.
- Public CUDA/HIP compile and allocation-free invocation plans; undersized bias buffers reject.
- Shared public workload added to the actual nvcc/hipcc fixture generator.
- Scope, closed-axis, scalar-declaration, storage-type and destination-read decline regressions.
- Independent bounded review found no remaining concrete blocker.
- Rebased onto merged #463 with identical pre/post trees. Full suites and vendor compilers delegated to CI.

## Remaining scope

No new semantic API, kernel source template or operator registry. This does not retire the entire staged fallback: decoded operands, broader integer stages, destination-reading transforms and dynamic domains remain explicitly separate work. No performance/SOTA claim.
