### PR TITLE
Fix host contraction decode semantics with shared hygienic load transforms

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -705,3 +705,15 @@ frontend admission. Decoded operands and broader integer stage schedules remain 
 Public validation includes post-reduction placement on Arc, all common source dialects, short
 epilogue-buffer rejection before allocation, and CUDA/HIP vendor fixtures using the same public
 workload. Whole staged-emitter retirement remains contingent on the uncovered numerical contracts.
+
+### Shared load-transform semantics
+
+The host contraction macro and retained staged emitter now share the same capture-avoiding
+per-operand load-transform substitution. The host previously ignored `:decode`, so it was not a
+valid numerical oracle for decoded kernels. Decode applies to the core summand before stage lifts
+and the final result transform. Summand locals are alpha-renamed before substitution so they cannot
+capture decode free variables or inherit a shadowed outer array's transformation.
+
+This correctness prerequisite does not yet admit decoded loads to the generated staged schedule.
+That migration still requires retained types for the raw-load binder, decoded scalar expressions,
+and any integer widening/overflow semantics; no target-side type inference is introduced here.

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1726,13 +1726,7 @@
         ;; read is matched via the registry — the literal `(= 'aget (first f))` here meant a decode
         ;; was SILENTLY DROPPED for every walker-spelled operand, emitting `a[l]*b[l]` where the
         ;; semantics are `(a[l]-zp)*b[l]`. A wrong answer, not a slow one.
-        body (if (empty? decodes)
-               body
-               (descriptor/rewrite-aget-reads
-                body
-                (fn [f] (let [arr (descriptor/aget-array-sym f)]
-                          (when (contains? decodes arr)
-                            (util/subst-syms {'x f} (get decodes arr)))))))
+        body (cf/apply-load-transforms body decodes)
         ;; EPILOGUE — the store splice. An epilogue is a lift on a virtual outermost level of
         ;; extent 1, which is why it needs no linearity (nothing to distribute over one iteration)
         ;; while a real stage lift does. Gives this emitter the dequant scale that the two quant

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -124,6 +124,22 @@
                        :sym sym :declared (am/index-expr declared) :actual idx})))
     declared))
 
+(defn apply-load-transforms
+  "Apply per-operand scalar load transforms to the core summand only.
+   The raw-load binder x is substituted capture-avoidingly; stage lifts and result
+   transforms are separate regions and must not receive these transformations."
+  [expression decodes]
+  (if (empty? decodes)
+    expression
+    (od/rewrite-aget-reads
+     ;; Decode declarations close over the surrounding scope, not locals in the summand.
+     ;; Freshen the summand first: its binders cannot capture decode captures, and a locally
+     ;; shadowed array must not acquire the outer array's load transform.
+     (util/alpha-convert expression)
+     (fn [read]
+       (when-let [decode (get decodes (od/aget-array-sym read))]
+         (util/subst-syms {'x read} decode))))))
+
 (defn surface-form
   "Spell contraction components in the temporary `raster.par/contract` target vocabulary."
   [{:keys [out free-axes contract-axes body opts metadata]}]

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -297,10 +297,14 @@
   fallback; it is fully compositional because it enters a segmented TypedSOAC reduction, so its
   output fuses with downstream SOACs (epilogue) like any reduction.
 
+  Optional :decode maps operand symbols to scalar expressions in x, the raw load.
+  These transforms apply to core summand loads before stage lifts and the final epilogue;
+  their free variables belong to the contraction scope, not summand-local bindings.
+
   Example (C[m,n] = A[m,k]·B[k,n], row-major):
     (raster.par/contract C [[i m] [j n]] [[l k]]
       (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))"
-  [out free-axes contract-axes body & {:keys [init combine stages epilogue]
+  [out free-axes contract-axes body & {:keys [init combine stages epilogue decode]
                                        :or {init 0.0 combine '+}}]
   (assert (vector? free-axes) "par/contract: free-axes must be a vector of [idx bound]")
   (assert (vector? contract-axes)
@@ -315,6 +319,10 @@
             (let [legal ((requiring-resolve 'raster.compiler.ir.contract-stages/stages-legal?)
                          stages contract-axes)]
               (assert (:ok legal) (str "par/contract: illegal :stages (" (:reason legal) ")"))))
+        body (if (seq decode)
+               ((requiring-resolve 'raster.compiler.ir.contraction-facts/apply-load-transforms)
+                body decode)
+               body)
         body (if (seq stages)
                ((requiring-resolve 'raster.compiler.ir.contract-stages/flat-equivalent) stages body)
                body)

--- a/test/raster/compiler/contract_load_transform_test.clj
+++ b/test/raster/compiler/contract_load_transform_test.clj
@@ -1,0 +1,51 @@
+(ns raster.compiler.contract-load-transform-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.par]
+            [raster.compiler.ir.contraction-facts :as facts]))
+
+(deftest host-contract-applies-decode-before-accumulation
+  (let [a (double-array [3.0]) out (double-array 1) shift 1.0]
+    (raster.par/contract out [[i 1]] [[k 1]] (aget a k)
+                         :decode {a (- x shift)})
+    (is (= [2.0] (vec out)))))
+
+(deftest host-stages-and-result-transform-compose-with-decoded-loads
+  (let [a (double-array [3.0 4.0 5.0 6.0]) b (double-array [2.0 3.0 4.0 5.0])
+        out (double-array 1) scale 0.5 bias 3.0]
+    (raster.par/contract out [[i 1]] [[blk 2] [t 2]]
+                         (* (aget a (+ (* blk 2) t)) (aget b (+ (* blk 2) t)))
+                         :decode {a (- x 1.0) b (+ x 2.0)}
+                         :stages [{:axis blk :extent 2 :dtype :double :init 0.0 :lift (* inner scale)}
+                                  {:axis t :extent 2 :dtype :double :init 0.0}]
+                         :epilogue {:acc value :expr (+ value bias) :dtype :double})
+    (is (= [44.0] (vec out)))))
+
+(deftest load-transform-substitution-preserves-lexical-scope
+  (let [a (double-array [3.0 100.0]) out (double-array 1)]
+    (raster.par/contract out [[i 1]] [[k 1]] (aget a k)
+                         :decode {a (let [k 1] (+ x k))})
+    (is (= [4.0] (vec out)) "decode-local k cannot capture the raw load's index"))
+  (let [a (double-array [3.0]) out (double-array 1)]
+    (raster.par/contract out [[i 1]] [[k 1]] (aget a k)
+                         :decode {a (let [x 7.0] x)})
+    (is (= [7.0] (vec out)) "a local x shadows the raw-load binder")))
+
+(deftest summand-locals-cannot-capture-decode-captures-or-array-identity
+  (let [a (double-array [3.0]) out (double-array 1) shift 1.0]
+    (raster.par/contract out [[i 1]] [[k 1]]
+                         (let [shift 100.0] (aget a k))
+                         :decode {a (- x shift)})
+    (is (= [2.0] (vec out)) "decode shift belongs to its declaration scope"))
+  (let [a (double-array [3.0]) out (double-array 1)]
+    (raster.par/contract out [[i 1]] [[k 1]]
+                         (let [a (double-array [100.0])] (aget a k))
+                         :decode {a (- x 1.0)})
+    (is (= [100.0] (vec out)) "a shadowing local array does not inherit the outer decode")))
+
+(deftest load-transform-rewriting-preserves-metadata-and-quoted-data
+  (let [tagged (with-meta '(+ (aget a k) 1.0) {:raster.type/tag 'double})
+        result (facts/apply-load-transforms tagged {'a '(- x shift)})]
+    (is (= 'double (:raster.type/tag (meta result))))
+    (is (= '(+ (- (aget a k) shift) 1.0) result))
+    (is (= '(quote (aget a k))
+           (facts/apply-load-transforms '(quote (aget a k)) {'a '(- x shift)})))))


### PR DESCRIPTION
## Summary

Fix a discovered host/compiler semantics mismatch: `par/contract` ignored `:decode` in its host macro expansion. A one-element input 3.0 with decode x−1.0 returned 3.0 instead of 2.0.

Introduce one shared per-operand load-transform substitution in ContractionFacts, consumed by both the host macro and retained staged source emitter. Apply it only to the core summand, before stage lifts and the final epilogue. No decode means no new macro-time helper loading.

The shared lexical utilities protect both directions of capture: summand binders are alpha-renamed before rewriting; raw-read substitution inside each decode is capture-avoiding. A locally shadowed array does not inherit its outer array's decode. Existing read matching preserves qualified forms, metadata and quoted data.

## Validation

- 60 focused tests, 177 assertions, zero failures/errors: new load-transform regressions, existing par tests and staged GPU device suite.
- Tests cover the original one-element failure, two decoded operands with nested stages and an epilogue, capture in both directions, locally shadowed arrays, metadata and quoted data.
- Independent bounded review found and then verified the reverse-capture fix; no remaining blocker.
- Full suites and vendor compilation delegated to CI.

This is the numerical-reference prerequisite for generated decoded kernels. Typed GPU decode admission remains unchanged; no new operator registry or target-side inference is introduced.
