### PR TITLE
Preserve contraction lexical types through the shared source walker

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -717,3 +717,15 @@ capture decode free variables or inherit a shadowed outer array's transformation
 This correctness prerequisite does not yet admit decoded loads to the generated staged schedule.
 That migration still requires retained types for the raw-load binder, decoded scalar expressions,
 and any integer widening/overflow semantics; no target-side type inference is introduced here.
+
+### Contraction lexical typing (in progress)
+
+The source walker now supplies contraction-local type contexts for axes, decoded raw loads,
+child-stage accumulators and completed-result accumulators. It uses existing inference rather
+than teaching target emitters to reconstruct these types. Explicitly unknown lexical bindings
+mask stale reference metadata; absent bindings still retain metadata-based rewalk evidence.
+
+Compiler-generated scalar casts are qualified so stage linearity can distinguish genuine
+identity conversions from caller-local functions. Flattening only removes a cast when its
+canonical identity and child accumulator dtype prove it redundant. Decoded GPU admission is
+still gated separately; this prerequisite does not retire uncovered staged fallback cases.

--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -23,6 +23,7 @@
             [raster.compiler.backend.cpu.csimd :as csimd]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.parallel-program :as parallel-program]
@@ -263,8 +264,9 @@
     (seq? expr)
     (let [op (first expr)]
       (cond
-        (= 'int op)  (long (resolve-int-expr (second expr) env))
-        (= 'long op) (long (resolve-int-expr (second expr) env))
+        (and (descriptor/cast-op? op)
+             (contains? '#{int long} (descriptor/cast-result-tag op)))
+        (long (resolve-int-expr (second expr) env))
         ;; arithmetic — classify by the SEMANTIC op (:raster.op/original metadata,
         ;; falling back to the head/impl symbol) via the shared intrinsics registry.
         :else
@@ -544,10 +546,8 @@
   "Resolve a buffer size to a compile-time integer, seeing through the walker's
    (long N)/(int N) literal wrappers; nil if not a compile-time constant."
   [size]
-  (cond
-    (integer? size) (long size)
-    (and (seq? size) (#{'long 'int} (first size)) (integer? (second size))) (long (second size))
-    :else nil))
+  (let [value (:value (constant/value size))]
+    (when (and (integer? value) (<= 0 value Long/MAX_VALUE)) (long value))))
 
 (defn- local-scratch-size
   "If a buffer is small compile-time-constant scratch (not a returned result), its

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -522,8 +522,8 @@
        (get type-map (:dtype attributes) *scalar-type*))
 
      (and (seq? expr) (= 2 (count expr))
-          (contains? #{'int 'float 'double 'long} (first expr)))
-     (get tag->ctype (first expr) *scalar-type*)
+          (descriptor/cast-op? (first expr)))
+     (get tag->ctype (descriptor/cast-result-tag (first expr)) *scalar-type*)
 
      (and (seq? expr) (descriptor/aget-op? (first expr))
           (>= (count expr) 3))
@@ -1027,7 +1027,7 @@
 
      ;; Primitive cast
      (and (seq? expr)
-          (contains? #{'double 'float 'long 'int 'byte 'short} (first expr))
+          (or (descriptor/cast-op? (first expr)) (= 'short (first expr)))
           (= 2 (count expr)))
      ;; Vectorizing: a cast the walker inserted around a now-vector expr. An element-type
      ;; cast MATCHING the element type (e.g. `(double x)` where x is a double vload) is a

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -255,7 +255,9 @@
                       (tag-vec (list broadcast species-sym (list cast-fn expr))))
 
                   ;; Primitive cast — transparent
-                  (and (seq? expr) (contains? #{'double 'float} (first expr)) (= 2 (count expr)))
+                  (and (seq? expr)
+                       (contains? '#{double float} (descriptor/cast-result-tag (first expr)))
+                       (= 2 (count expr)))
                   (rewrite-body (second expr))
 
                   ;; Binary op

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -206,10 +206,12 @@
         (and (= a idx-sym) (expr-free-of? b idx-sym))
         b
         ;; (+ base (long j)) / (+ (long j) base)
-        (and (seq? b) (contains? #{'long 'int} (first b)) (= idx-sym (second b))
+        (and (seq? b) (= 2 (count b))
+             (contains? '#{long int} (descriptor/cast-result-tag (first b))) (= idx-sym (second b))
              (expr-free-of? a idx-sym))
         a
-        (and (seq? a) (contains? #{'long 'int} (first a)) (= idx-sym (second a))
+        (and (seq? a) (= 2 (count a))
+             (contains? '#{long int} (descriptor/cast-result-tag (first a))) (= idx-sym (second a))
              (expr-free-of? b idx-sym))
         b
         ;; (+ base (+ ... j ...)) — recurse into nested +
@@ -301,7 +303,7 @@
          (expr-free-of? (nth expr 2) idx-sym))
     true
     (and (seq? expr)
-         (contains? #{'double 'float 'long 'int} (first expr))
+         (contains? '#{double float long int} (descriptor/cast-result-tag (first expr)))
          (= 2 (count expr)))
     (simd-able? (second expr) idx-sym)
     (and (seq? expr) (= 2 (count expr))
@@ -564,7 +566,7 @@
            (expr-free-of? (nth expr 2) idx-sym))
       (list broadcast species-sym (list cast-fn expr))
 
-      (and (seq? expr) (contains? #{'double 'float 'long 'int} (first expr))
+      (and (seq? expr) (contains? '#{double float long int} (descriptor/cast-result-tag (first expr)))
            (= 2 (count expr)))
       (recur-fn (second expr))
 

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -546,8 +546,9 @@
               (vary-meta result assoc :raster.type/tag rt)
               result)
             ;; Primitive cast — (double x), (float x), etc.
-            (contains? types/primitive-info head)
-            (vary-meta result assoc :raster.type/tag head)
+            (and (not (contains? type-env head))
+                 (or (descriptor/cast-op? head) (contains? types/primitive-info head)))
+            (vary-meta result assoc :raster.type/tag (or (descriptor/cast-result-tag head) head))
             ;; if — result type is the (agreeing) type of its value branches.
             ;; A recur branch carries no value, so the result is the OTHER branch;
             ;; this also types loop bodies of the form (if test (recur ...) acc).

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -13,6 +13,7 @@
   - Testable: handlers can be unit-tested with synthetic contexts
   - Extensible: new form types can be added via defmethod"
   (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.dtype :as dtype]
             [clojure.string :as str]
             [raster.compiler.core.types :as types]
             [raster.compiler.core.inference :as inf]
@@ -131,13 +132,15 @@
 
   Reads the ctx type-env first (the per-walk cache), then falls back to a tag
   carried on the symbol itself (`:raster.type/tag` metadata stamped at the
-  reference site by a prior walk). Carrying the type on the AST means a re-walk
+  reference site by a prior walk), only when the symbol is absent from the environment.
+  An explicitly unknown lexical binding masks stale metadata. Carrying the type on the AST means a re-walk
   over restructured code (PE/CSE/inline) keeps a binding's type even when the
   re-derived ctx type-env doesn't reach into a nested scope (e.g. an ftm closure
   capturing an outer var)."
   [ctx sym]
-  (or (get-in (:type-env ctx) [sym :tag])
-      (when (symbol? sym) (:raster.type/tag (meta sym)))))
+  (if (contains? (:type-env ctx) sym)
+    (get-in (:type-env ctx) [sym :tag])
+    (when (symbol? sym) (:raster.type/tag (meta sym)))))
 
 (defn ctx-get-fn-info
   "Get fn-info for a symbol."
@@ -179,6 +182,12 @@
 
     ;; Parallel ops — resolve namespace aliases (par/reduce → raster.par/reduce)
     ;; so user code using aliases gets the typed handlers with proper type-env.
+    (and (seq? form)
+         (symbol? (first form))
+         (= 'raster.par/contract
+            (resolve-aliased-symbol (first form) (:source-ns ctx))))
+    :par-contract
+
     (and (seq? form)
          (let [head (first form)
                resolved (if (and (symbol? head) (namespace head))
@@ -317,7 +326,8 @@
 
     ;; Primitive cast — (double x), (long x), etc. — walk inner, don't re-cast
     (and (seq? form) (= 2 (count form))
-         (contains? types/primitive-info (first form)))
+         (not (contains? (:type-env ctx) (first form)))
+         (descriptor/cast-op? (first form)))
     :cast
 
     ;; try/catch/finally
@@ -390,7 +400,12 @@
   Preserves metadata and auto-hints field access on typed receivers.
   Resolves namespace-aliased symbols to fully qualified names."
   [form ctx]
-  (let [;; Resolve namespace-aliased symbols to fully qualified names
+  (let [;; An explicitly unknown local masks type evidence from an earlier scope.
+        form (if (and (symbol? form) (contains? (:type-env ctx) form)
+                      (nil? (get-in (:type-env ctx) [form :tag])))
+               (vary-meta form dissoc :tag :raster.type/tag :raster.type/element :raster.type/fn-info)
+               form)
+        ;; Resolve namespace-aliased symbols to fully qualified names
         form (if (and (symbol? form) (namespace form) (not (ctx-get-tag ctx form)))
                (resolve-aliased-symbol form (:source-ns ctx))
                form)
@@ -398,6 +413,7 @@
         ;; so downstream code can always resolve them. Only qualifies non-fn vars
         ;; (constants, def values). Skips locals, special forms, macros, and fns.
         form (if (and (symbol? form) (not (namespace form))
+                      (not (contains? (:type-env ctx) form))
                       (not (ctx-get-tag ctx form))
                       (not (special-symbol? form)))
                (if-let [v (try (ns-resolve (:source-ns ctx) form) (catch Exception _ nil))]
@@ -946,6 +962,60 @@
         (with-meta result {:raster.type/elem-type elem-type})
         result))))
 
+(defn- stamp-operand-return
+  [result arguments ctx]
+  (let [index (:return-type-arg (form/form-info result))
+        returned (when (some? index) (nth arguments index nil))
+        tag (or (inf/hint-tag returned)
+                (when (symbol? returned) (ctx-get-tag ctx returned)))]
+    (if tag (vary-meta result assoc :raster.type/tag tag) result)))
+
+(defn- compiler-cast [tag expression]
+  (list (symbol "clojure.core" (name tag)) expression))
+
+(defmethod walk-form :par-contract [source ctx]
+  (let [[head output free-axes contract-axes body & options] source
+        opts (apply hash-map options)
+        axis-context (fn [axes]
+                       (reduce (fn [env [axis _]] (ctx-assoc-type env axis 'long)) ctx axes))
+        body-ctx (axis-context (concat free-axes contract-axes))
+        scalar-tag #(when (dtype/known? %) (dtype/scalar-tag-for-dtype %))
+        stages (:stages opts)
+        walked-options
+        (reduce-kv
+         (fn [result key value]
+           (assoc result key
+                  (case key
+                    :decode
+                    (into (empty value)
+                          (map (fn [[operand expression]]
+                                 (let [raw-type (dtype/dtype-for-array-tag (ctx-get-tag ctx operand))
+                                       env (ctx-assoc-type body-ctx 'x (scalar-tag raw-type))]
+                                   [operand (walk expression env)]))) value)
+                    :stages
+                    (mapv (fn [index stage]
+                            (let [env (axis-context (concat free-axes (take (inc index) contract-axes)))
+                                  env (ctx-assoc-type env 'inner
+                                                      (scalar-tag (:dtype (get stages (inc index)))))]
+                              (into (empty stage)
+                                    (map (fn [[k v]] [k (walk v (if (= k :lift) env ctx))])) stage)))
+                          (range) stages)
+                    :epilogue
+                    (let [acc-tag (or (scalar-tag (:dtype (first stages)))
+                                      (some-> (ctx-get-tag ctx output) dtype/dtype-for-array-tag scalar-tag))
+                          env (ctx-assoc-type (axis-context free-axes) (:acc value) acc-tag)]
+                      (into (empty value)
+                            (map (fn [[k v]] [k (walk v (if (= k :expr) env ctx))])) value))
+                    (walk value ctx))))
+         {} opts)]
+    (let [result (with-meta
+                   (apply list head (walk output ctx)
+                          (mapv (fn [[axis extent]] [axis (walk extent ctx)]) free-axes)
+                          (mapv (fn [[axis extent]] [axis (walk extent ctx)]) contract-axes)
+                          (walk body body-ctx) (mapcat identity walked-options))
+                   (meta source))]
+      (stamp-operand-return result (rest result) ctx))))
+
 (defmethod walk-form :par-reduce [form ctx]
   (let [[_ acc-sym init-expr i-sym bound-expr body-expr] form
         walked-init (walk init-expr ctx)
@@ -1323,7 +1393,7 @@
               ;; wrap the float arg in (double ...)
                 rewritten-args (if promotion-casts
                                  (mapv (fn [arg cast]
-                                         (if cast (list cast arg) arg))
+                                         (if cast (compiler-cast cast arg) arg))
                                        rewritten-args promotion-casts)
                                  rewritten-args)
               ;; Emit .invk when we have a typed-impl AND either:
@@ -1516,7 +1586,7 @@
         ;; Handles both unqualified symbols and namespace-aliased symbols (e.g. rev/value+grad).
         ;; Only qualify non-macro, non-special-form vars (macros like case/cond must stay unqualified
         ;; because the walker walks their raw args and cast-wrapping would corrupt macro semantics)
-        f (if (and (symbol? f) (not (inf/type-env-tag type-env f)))
+        f (if (and (symbol? f) (not (contains? type-env f)))
             (if-let [v (try (ns-resolve source-ns f) (catch Exception _ nil))]
               (if (and (var? v) (not (:macro (meta v))))
                 (symbol (str (.name (.ns ^clojure.lang.Var v)))
@@ -1534,21 +1604,14 @@
                              (if (and tag (contains? types/primitive-info tag)
                                       ;; Don't re-wrap already-cast args
                                       (not (and (seq? walked)
-                                                (contains? types/primitive-info (first walked)))))
-                               (list tag walked)
+                                                (descriptor/cast-op? (first walked)))))
+                               (compiler-cast tag walked)
                                walked)))
                          args walked-args)
                     walked-args)
-        result (apply list (walk f ctx) cast-args)
-        ;; Compiler forms can return an existing operand without being an ordinary
-        ;; dispatched call (e.g. contract returns its destination). Use the shared
-        ;; form contract during the lexical walk, before a following binding is
-        ;; consumed. Late result typing cannot repair an already unresolved call.
-        return-index (:return-type-arg (form/form-info result))
-        returned (when (some? return-index) (nth walked-args return-index nil))
-        return-tag (or (inf/hint-tag returned)
-                       (when (symbol? returned) (ctx-get-tag ctx returned)))]
-    (if return-tag (vary-meta result assoc :raster.type/tag return-tag) result)))
+        result (apply list (walk f ctx) cast-args)]
+    ;; Propagate operand-return contracts before a following binding is consumed.
+    (stamp-operand-return result walked-args ctx)))
 
 ;; ================================================================
 ;; Branch: primitive cast (idempotent)

--- a/src/raster/compiler/ir/contract_stages.clj
+++ b/src/raster/compiler/ir/contract_stages.clj
@@ -61,6 +61,8 @@
 (defn linear-in-inner
   "If `lift` is LINEAR in `inner` — i.e. `inner` itself, or a product one of whose factors is
    `inner` — return the vector of the REMAINING factors (possibly empty). Otherwise nil.
+   With a child dtype, canonical core casts proved identical to that dtype are also accepted.
+   Bare cast names are not proof: a caller may bind a different function with that name.
 
    Linearity is what makes staging a schedule rather than a different computation: it is exactly
    the condition under which the accumulate distributes,
@@ -68,14 +70,23 @@
    so the lift factors can be pushed into the body to obtain the flat equivalent. A non-linear
    lift (say `(sqrt inner)`) has no flat form — it is a genuinely different reduction, and is
    refused rather than silently mis-scheduled."
-  [lift inner]
-  (cond
-    (= lift inner) []
-    (and (seq? lift) (mul-head? (first lift)))
-    (let [args (vec (rest lift))
-          n (count (filter #(= inner %) args))]
-      (when (= 1 n) (vec (remove #(= inner %) args))))
-    :else nil))
+  ([lift inner] (linear-in-inner lift inner nil))
+  ([lift inner inner-dtype]
+   (letfn [(identity-inner? [expression]
+             (or (= expression inner)
+                 (and inner-dtype (seq? expression) (= 2 (count expression))
+                      (= "clojure.core" (some-> (od/semantic-op expression) namespace))
+                      (od/cast-op? (od/semantic-op expression))
+                      (= (dt/canon inner-dtype)
+                         (dt/dtype-for-scalar-tag (od/cast-result-tag (od/semantic-op expression))))
+                      (identity-inner? (second expression)))))]
+     (cond
+       (identity-inner? lift) []
+       (and (seq? lift) (mul-head? (od/semantic-op lift)))
+       (let [args (vec (od/call-args lift))
+             n (count (filter identity-inner? args))]
+         (when (= 1 n) (vec (remove identity-inner? args))))
+       :else nil))))
 
 (declare contract-extent)
 
@@ -130,7 +141,7 @@
        ;; every outer stage: lift present, uses `inner` once, linear, no forbidden ops
        (first
         (keep
-         (fn [{:keys [axis lift]}]
+         (fn [[index {:keys [axis lift]}]]
            (let [nodes (tree-seq coll? seq lift)
                  uses (count (filter #(= inner %) nodes))
                  heads (into #{} (keep #(when (seq? %) (first %))) nodes)]
@@ -142,10 +153,10 @@
                (seq (set/intersection heads forbidden-in-lift))
                {:ok false :reason :layout-changing-op-in-lift :axis axis
                 :ops (set/intersection heads forbidden-in-lift)}
-               (nil? (linear-in-inner lift inner))
+               (nil? (linear-in-inner lift inner (:dtype (nth stages (inc index)))))
                {:ok false :reason :lift-not-linear-in-inner :axis axis :lift lift}
                :else nil)))
-         (butlast stages)))
+         (map-indexed vector (butlast stages))))
        ;; dtypes must not narrow outward (inner → outer)
        ;; The flat equivalent distributes products over sums, not seeded folds. A nonzero
        ;; seed contributes once per enclosing iteration and is absent from that equivalent.
@@ -216,9 +227,9 @@
   (let [stages (vec stages)
         idx-of (stage-index-exprs stages)
         factors (map #(substitute-operand-indices % idx-of)
-                     (mapcat (fn [{:keys [lift]}]
-                               (when lift (linear-in-inner lift inner)))
-                             (butlast stages)))]
+                     (mapcat (fn [[index {:keys [lift]}]]
+                               (when lift (linear-in-inner lift inner (:dtype (nth stages (inc index))))))
+                             (map-indexed vector (butlast stages))))]
     (if (empty? factors)
       body
       (cons 'raster.numeric/* (cons body (vec factors))))))

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -675,7 +675,7 @@
   [expr acc-sym]
   (or (= expr acc-sym)
       (and (seq? expr)
-           (= 'double (first expr))
+           (= 'double (descriptor/cast-result-tag (first expr)))
            (= 2 (count expr))
            (= (second expr) acc-sym))))
 

--- a/src/raster/compiler/passes/parallel/staged_contraction_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_admission.clj
@@ -85,7 +85,7 @@
                                        [sym (extent! map (dissoc domain (:axis inner)))]) lifts)))
           ;; The stage contract gives lift reads their declared maps. Admit scalar factors only;
           ;; arbitrary calls, local binders and casts need their own retained region contract.
-          factors (stages/linear-in-inner (:lift outer) 'inner)
+          factors (stages/linear-in-inner (:lift outer) 'inner (:dtype inner))
           lift-ids (set (map :sym lifts))
           _ (require! (every? #(or (number? %)
                                   (and (descriptor/aget-call? %)
@@ -105,4 +105,3 @@
        :plan plan
        :n n
        :sizes sizes})))
-

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -10,6 +10,7 @@
             [raster.compiler.core.types :as types]
             [raster.compiler.core.op-descriptor :as op]
             [raster.compiler.core.inference :as inf]
+            [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.form :as form]
             [raster.compiler.passes.scalar.cse :as cse]
@@ -18,6 +19,12 @@
 
 (def ^:private call-head util/call-head)
 (def ^:private call-args util/call-args)
+
+(defn- known-vg-element [elements target index-expression]
+  (let [index (:value (constant/value index-expression))
+        values (get elements target)]
+    (when (and (symbol? target) values (integer? index) (<= 0 index) (< index (count values)))
+      (nth values index))))
 
 (defn- value-ctor-call?
   "True if body is a bare (->Type ...) constructor for a registered value type.
@@ -1062,14 +1069,7 @@
        ;; Check for (nth <vg-sym> N) — resolve to element symbol
                    (let [nth-resolved
                          (when (and (seq? init) (= 'clojure.core/nth (first init)) (= 3 (count init)))
-                           (let [target (second init)
-                                 idx-expr (nth init 2)
-                                 idx (cond (integer? idx-expr) idx-expr
-                                           (and (seq? idx-expr) (= 'long (first idx-expr))) (second idx-expr)
-                                           :else nil)]
-                             (when (and (symbol? target) idx (contains? @vg-elements target))
-                               (let [elems (get @vg-elements target)]
-                                 (when (< idx (count elems)) (clojure.core/nth elems idx))))))]
+                           (known-vg-element @vg-elements (second init) (nth init 2)))]
                      (if nth-resolved
                        (do (swap! result-pairs conj [sym nth-resolved])
                            (reset! any-inlined? true))
@@ -1209,15 +1209,7 @@
      (let [resolve-vg-nth (fn resolve-vg-nth [expr]
                             (cond
                               (and (seq? expr) (= 'clojure.core/nth (first expr)) (= 3 (count expr)))
-                              (let [target (second expr)
-                                    idx-expr (clojure.core/nth expr 2)
-                                    idx (cond (integer? idx-expr) idx-expr
-                                              (and (seq? idx-expr) (= 'long (first idx-expr))) (second idx-expr)
-                                              :else nil)]
-                                (if (and (symbol? target) idx (contains? @vg-elements target))
-                                  (let [elems (get @vg-elements target)]
-                                    (if (< idx (count elems)) (clojure.core/nth elems idx) expr))
-                                  expr))
+                              (or (known-vg-element @vg-elements (second expr) (nth expr 2)) expr)
                               (seq? expr) (let [r (apply list (map resolve-vg-nth expr))]
                                             (if-let [m (meta expr)] (with-meta r m) r))
                               (vector? expr) (mapv resolve-vg-nth expr)

--- a/test/raster/compiler/backend/cpu/aot_test.clj
+++ b/test/raster/compiler/backend/cpu/aot_test.clj
@@ -19,6 +19,15 @@
             [raster.compiler.backend.cpu.aot :as aot]
             [raster.compiler.ir.parallel-program :as parallel-program]))
 
+(deftest qualified-integer-size-casts-use-the-shared-descriptor
+  (doseq [cast '[int long clojure.core/int clojure.core/long]]
+    (is (= 7 (aot/resolve-int-expr (list cast 'n) {'n 7})))))
+
+(deftest scratch-sizes-use-checked-constant-evidence
+  (is (= 8 (#'aot/const-int-size '(clojure.core/long (clojure.core/int 8)))))
+  (doseq [expression ['(int 4294967296) -1 'n '(long n)]]
+    (is (nil? (#'aot/const-int-size expression)))))
+
 (defn- clang-available? []
   (try
     (let [cc (or (System/getenv "RASTER_CC") "clang")

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -2,6 +2,11 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.c-emit :as c-emit]))
 
+(deftest qualified-primitive-casts-emit-like-their-bare-spelling
+  (doseq [cast '[double float long int byte]]
+    (is (= (c-emit/emit-expr (list cast 'x) 'i #{} "i")
+           (c-emit/emit-expr (list (symbol "clojure.core" (name cast)) 'x) 'i #{} "i")))))
+
 (deftest portable-identifiers-cover-the-cuda-and-hip-cpp-language
   (is (not (c-emit/c-identifier? "class")))
   (is (not (c-emit/c-identifier? "default")))

--- a/test/raster/compiler/core/contraction_scope_test.clj
+++ b/test/raster/compiler/core/contraction_scope_test.clj
@@ -51,4 +51,6 @@
   (doseq [tag ['float 'long]]
     (let [ctx (walker/make-ctx {:type-env {'x {:tag tag}}})
           expression (list (symbol "clojure.core" (name tag)) 'x)]
-      (is (every? #(= expression %) (take 5 (iterate #(walker/walk % ctx) expression)))))))
+      (let [walks (take 5 (rest (iterate #(walker/walk % ctx) expression)))]
+        (is (every? #(= expression %) walks))
+        (is (every? #(= tag (:raster.type/tag (meta %))) walks))))))

--- a/test/raster/compiler/core/contraction_scope_test.clj
+++ b/test/raster/compiler/core/contraction_scope_test.clj
@@ -1,0 +1,54 @@
+(ns raster.compiler.core.contraction-scope-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.walker :as walker]
+            [raster.par]))
+
+(defn walked [extra-types]
+  (walker/walk
+   '(raster.par/contract out [[i rows]] [[blk 2] [t 4]]
+      (* (aget a (+ (* i 8) (* blk 4) t)) (aget b (+ (* blk 4) t)))
+      :decode {a (- x shift)}
+      :stages [{:axis blk :extent 2 :dtype :double :init 0.0 :lift (* inner gain)}
+               {:axis t :extent 4 :dtype :float :init 0.0}]
+      :epilogue {:acc value :expr (+ value bias) :dtype :double})
+   (walker/make-ctx
+    {:type-env (into {} (map (fn [[id tag]] [id {:tag tag}]))
+                     (merge {'out 'doubles 'a 'floats 'b 'floats 'rows 'long
+                             'shift 'float 'gain 'float 'bias 'double
+                             'x 'long 'inner 'long 'value 'long} extra-types))})))
+
+(deftest contraction-local-binders-have-authoritative-types
+  (let [source (walked {})
+        opts (apply hash-map (drop 5 source))]
+    (is (= 'float (:raster.type/tag (meta (get-in opts [:decode 'a])))))
+    (is (= 'float (:raster.type/tag (meta (get-in opts [:stages 0 :lift])))))
+    (is (= 'double (:raster.type/tag (meta (get-in opts [:epilogue :expr])))))
+    (is (= 'rows (second (first (nth source 2)))) "extent stays in the outer scope")
+    (is (= 'float (:raster.type/tag (meta (nth source 4)))))))
+
+(deftest raw-load-binder-type-is-not-inherited-from-an-outer-x
+  (let [opts (apply hash-map (drop 5 (walked {'a 'bytes 'shift 'long})))
+        decode (get-in opts [:decode 'a])]
+    (is (nil? (:raster.type/tag (meta decode)))
+        "the existing inference leaves unproved narrow arithmetic untagged")
+    (is (some #(= '(clojure.core/byte x) %) (tree-seq coll? seq decode))
+        "the raw-load binder has the Byte storage type, not outer Long x"))
+  (let [opts (apply hash-map (drop 5 (walked {'a 'Object})))
+        decode (get-in opts [:decode 'a])]
+    (is (not-any? #(and (symbol? %) (= 'x %) (= 'long (:raster.type/tag (meta %))))
+                  (tree-seq coll? seq decode)))))
+
+(deftest unknown-lexical-bindings-mask-rewalk-metadata
+  (let [x (with-meta 'x {:raster.type/tag 'long :tag 'long :line 17})
+        unknown (walker/make-ctx {:type-env {'x {:tag nil}}})
+        absent (walker/make-ctx {})]
+    (is (nil? (walker/ctx-get-tag unknown x)))
+    (is (= {:line 17} (meta (walker/walk x unknown))))
+    (is (= 'long (walker/ctx-get-tag absent x)))
+    (is (= 'long (:raster.type/tag (meta (walker/walk x absent)))))))
+
+(deftest generated-casts-are-stable-across-rewalks
+  (doseq [tag ['float 'long]]
+    (let [ctx (walker/make-ctx {:type-env {'x {:tag tag}}})
+          expression (list (symbol "clojure.core" (name tag)) 'x)]
+      (is (every? #(= expression %) (take 5 (iterate #(walker/walk % ctx) expression)))))))

--- a/test/raster/compiler/csimd_test.clj
+++ b/test/raster/compiler/csimd_test.clj
@@ -8,11 +8,20 @@
             [raster.compiler.backend.cpu.csimd :as cs]
             [raster.compiler.backend.cpu.codegen :as cpu]
             [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.backend.jvm.segop-simd :as ss]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.reduction :as reduction]))
 
 (defn- numeric-invk [impl & arguments]
   (util/make-invk impl arguments))
+
+(deftest qualified-index-casts-retain-contiguous-simd-loads
+  (doseq [cast '[long int clojure.core/long clojure.core/int]
+          index [(list 'clojure.core/+ 'base (list cast 'i))
+                 (list 'clojure.core/+ (list cast 'i) 'base)]]
+    (let [read (list 'clojure.core/aget 'a index)]
+      (is (= '[a base] (ss/aget-form? read 'i)))
+      (is (ss/simd-able? (list 'clojure.core/double read) 'i)))))
 
 (defn- clang-avx2? []
   (try

--- a/test/raster/compiler/ir/contract_stages_test.clj
+++ b/test/raster/compiler/ir/contract_stages_test.clj
@@ -86,6 +86,28 @@
                        {:axis t :extent 32 :dtype :int :init 0}]
                      '[[blk 4] [t 32]]))))))
 
+(deftest typed-identity-casts-preserve-stage-linearity
+  (testing "only casts proved identical to the child accumulator can disappear"
+    (doseq [[expression dtype] [['(clojure.core/float inner) :float]
+                                ['(clojure.core/int inner) :int]
+                                ['(clojure.core/float (clojure.core/float inner)) :float]]]
+      (is (= [] (cs/linear-in-inner expression 'inner dtype))))
+    (doseq [[expression dtype] [['(float inner) :float]
+                                ['(clojure.core/float inner) nil]
+                                ['(float inner) :double]
+                                ['(double inner) :float]
+                                ['(float (int inner)) :float]]]
+      (is (nil? (cs/linear-in-inner expression 'inner dtype)))))
+  (testing "typed lift legality and flattening preserve every non-inner factor"
+    (let [stages '[{:axis blk :extent 2 :dtype :double :init 0.0
+                   :lift (raster.numeric/* (clojure.core/float inner) gain)}
+                  {:axis t :extent 4 :dtype :float :init 0.0}]]
+      (is (:ok (cs/stages-legal? stages '[[blk 2] [t 4]])))
+      (is (= '(raster.numeric/* term gain) (cs/flat-equivalent stages 'term)))
+      (is (= :lift-not-linear-in-inner
+             (:reason (cs/stages-legal? (assoc-in stages [0 :lift] '(double inner))
+                                       '[[blk 2] [t 4]])))))))
+
 (deftest rejections
   (testing "stages must cover the contract axes exactly, outer→inner"
     (is (= :stages-do-not-match-contract-axes

--- a/test/raster/compiler/passes/parallel/loop_lift_test.clj
+++ b/test/raster/compiler/passes/parallel/loop_lift_test.clj
@@ -2,7 +2,14 @@
   (:require [clojure.test :refer [deftest testing is]]
             [raster.par :as par]
             [raster.compiler.ir.par :as ir.par]
+            [raster.compiler.passes.parallel.patterns :as patterns]
             [raster.compiler.passes.parallel.loop-lift :as loop-lift]))
+
+(deftest reduction-accumulator-casts-use-canonical-identity
+  (doseq [expression ['s '(double s) '(clojure.core/double s)]]
+    (is (patterns/acc-ref? expression 's)))
+  (doseq [expression ['(float s) '(clojure.core/int s) '(other/double s) '(double t)]]
+    (is (not (patterns/acc-ref? expression 's)))))
 
 ;; ================================================================
 ;; Map pattern detection

--- a/test/raster/compiler/passes/scalar/inline_test.clj
+++ b/test/raster/compiler/passes/scalar/inline_test.clj
@@ -23,7 +23,15 @@
             [raster.par]
             [raster.numeric]
             [raster.arrays]
+            [raster.compiler.passes.scalar.inline :as inline]
             [raster.ad.reverse :as rev]))
+
+(deftest value-gradient-projection-indices-use-checked-constant-evidence
+  (let [elements {'vg ['primal 'gradient]}]
+    (doseq [index [1 '(long 1) '(clojure.core/long 1) '(clojure.core/int (long 1))]]
+      (is (= 'gradient (#'inline/known-vg-element elements 'vg index))))
+    (doseq [index [-1 2 'n '(long n) '(int 4294967296) '(float 1)]]
+      (is (nil? (#'inline/known-vg-element elements 'vg index))))))
 
 ;; Monomorphic callee taking THREE args (mirrors the concrete-float finetune.train/gblock,
 ;; which takes 38 and was called with 37).


### PR DESCRIPTION
## Summary

- Bind contraction axes, raw-load `x`, child-stage `inner`, and epilogue accumulator through the existing source walker/type environment.
- Preserve operand-return contracts and mask stale type metadata for explicitly unknown lexical locals.
- Emit canonical compiler casts; recognize proved identity casts in stage linearity without confusing caller-local cast names or growing casts on rewalk.
- Keep decoded GPU admission gated: this is its source-typing prerequisite, not a new target-side inference registry.

## Validation

- Focused walker/scope/stage/public generated numerical and result-transform tests: 55 tests, 227 assertions, green.
- Packed staged device, host par and load-transform tests plus walker/scope: 82 tests, 292 assertions, green before final cast-classifier idempotence fix (covered in the 55-test rerun).
- Independent read-only review; stale metadata, cast identity and rewalk growth findings fixed and re-reviewed.
- Full suite and CUDA/HIP/OpenCL compile checks delegated to CI; no new JVM or cloud dependency.

No new performance claim. Broader integer/decode/inout staged migration and external benchmarking remain on the campaign.

## CI repair

The first full run exposed qualified-cast spelling assumptions outside the focused contraction tests.
The repair uses the existing operator descriptor and checked numeric-constant evaluator:

- Deduplicate both value+grad tuple projection resolvers; retain checked constant bounds.
- Recognize canonical casts in CPU size evaluation, local scratch sizing, C emission, SIMD affine loads and reduction accumulator matching.
- Carry canonical cast result dtypes through walker rewalks, without typing shadowed local functions as casts.

Targeted reruns pass for nested derivatives, MAML, GSDM/GPT-2 training convergence, x8 SIMD instruction/numerical checks, convolution gradients, exact compatibility-ledger signatures, symbolic derivative compilation, and resident nested/full training AD. No signatures or numerical assertions were relaxed. Full CI must rerun on this repair head.

The exposed carry-scan shape-activity issue and existing CPU size evaluator's int-as-long behavior remain separate correctness debt; this repair does not claim to redesign either contract.
