### PR TITLE
Normalize decoded contractions into the generated typed scalar vertical

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -729,3 +729,21 @@ Compiler-generated scalar casts are qualified so stage linearity can distinguish
 identity conversions from caller-local functions. Flattening only removes a cast when its
 canonical identity and child accumulator dtype prove it redundant. Decoded GPU admission is
 still gated separately; this prerequisite does not retire uncovered staged fallback cases.
+
+### Decoded loads enter the ordinary typed scalar region
+
+The source walker now normalizes load transforms before inferring contraction arithmetic.
+Source aliases and macros are resolved before the shared capture-avoiding substitution; the
+result is ordinary scalar arithmetic with explicit casts, not a second decoded KernelBody path.
+Typing the transformed expression from the start is essential: substituting a Double decode
+into an already Float-typed product would preserve an incorrect early rounding point.
+
+Qualified primitive casts use the existing operator descriptor for their result types in shared
+inference. The public decoded staged workloads use the generated staged-scalar schedule, with
+zero fallback and zero driver allocations during compilation/lowering. Validation includes
+alias/macro reads, an actual-device widening-rounding differential, and the same public-source
+fixtures for CUDA/HIP compilation. The compatibility ledger records the generated route.
+
+This does not claim mixed-storage or integer-overflow coverage, whole staged-emitter retirement,
+or competitive kernel throughput. Unnormalized direct typed facts remain explicitly gated;
+remaining precision/storage cases and measured schedule performance are still campaign work.

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1131,8 +1131,10 @@
        (or
         (cond
            ;; Primitive cast — (double x), (long x), etc.
-          (contains? types/primitive-info head)
-          head
+          (and (not (contains? type-env head))
+               (or (descriptor/cast-result-tag head)
+                   (contains? types/primitive-info head)))
+          (or (descriptor/cast-result-tag head) head)
 
            ;; if/when expression — result type = numeric unification of the
            ;; branch types (widen mismatched numeric branches to the larger).

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -14,6 +14,7 @@
   - Extensible: new form types can be added via defmethod"
   (:require [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.util :as util]
             [clojure.string :as str]
             [raster.compiler.core.types :as types]
             [raster.compiler.core.inference :as inf]
@@ -974,19 +975,42 @@
 (defn- compiler-cast [tag expression]
   (list (symbol "clojure.core" (name tag)) expression))
 
+(defn- load-transform-source
+  "Resolve macros and free var names before load-lambda expansion, without assigning types.
+   The shared lexical substitution protects locals and quoted data from var qualification."
+  [body ctx]
+  (binding [*ns* (the-ns (:source-ns ctx))]
+    (let [expanded (mex/macroexpand-core body)
+          names (into {}
+                      (keep (fn [sym]
+                              (when (and (symbol? sym) (not (contains? (:type-env ctx) sym)))
+                                (let [v (try (ns-resolve *ns* sym) (catch Exception _ nil))]
+                                  (when (and (var? v) (not (:macro (meta v))))
+                                    [sym (symbol (str (ns-name (:ns (meta v))))
+                                                 (str (:name (meta v))))])))))
+                      (tree-seq coll? seq expanded))]
+      (util/subst-syms names expanded
+                       (fn [mapping sym]
+                         (if-let [resolved (get mapping sym)]
+                           (with-meta resolved (meta sym)) sym))))))
+
 (defmethod walk-form :par-contract [source ctx]
   (let [[head output free-axes contract-axes body & options] source
         opts (apply hash-map options)
-        ;; Expand load lambdas BEFORE typing their consumers. Substitution after typing
-        ;; preserves stale arithmetic tags when a decode changes the load's precision.
-        body (if (seq (:decode opts))
-               ((requiring-resolve 'raster.compiler.ir.contraction-facts/apply-load-transforms)
-                body (:decode opts))
-               body)
-        opts (dissoc opts :decode)
         axis-context (fn [axes]
                        (reduce (fn [env [axis _]] (ctx-assoc-type env axis 'long)) ctx axes))
         body-ctx (axis-context (concat free-axes contract-axes))
+        ;; Resolve names, then expand load lambdas BEFORE typing their consumers.
+        ;; Substitution after typing retains stale tags when a decode widens precision.
+        body (if (seq (:decode opts))
+               ((requiring-resolve 'raster.compiler.ir.contraction-facts/apply-load-transforms)
+                (load-transform-source body body-ctx)
+                (into {} (map (fn [[operand expression]]
+                                [operand (load-transform-source expression
+                                                                (ctx-assoc-type body-ctx 'x nil))]))
+                      (:decode opts)))
+               body)
+        opts (dissoc opts :decode)
         scalar-tag #(when (dtype/known? %) (dtype/scalar-tag-for-dtype %))
         stages (:stages opts)
         walked-options

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -977,6 +977,13 @@
 (defmethod walk-form :par-contract [source ctx]
   (let [[head output free-axes contract-axes body & options] source
         opts (apply hash-map options)
+        ;; Expand load lambdas BEFORE typing their consumers. Substitution after typing
+        ;; preserves stale arithmetic tags when a decode changes the load's precision.
+        body (if (seq (:decode opts))
+               ((requiring-resolve 'raster.compiler.ir.contraction-facts/apply-load-transforms)
+                body (:decode opts))
+               body)
+        opts (dissoc opts :decode)
         axis-context (fn [axes]
                        (reduce (fn [env [axis _]] (ctx-assoc-type env axis 'long)) ctx axes))
         body-ctx (axis-context (concat free-axes contract-axes))
@@ -987,12 +994,6 @@
          (fn [result key value]
            (assoc result key
                   (case key
-                    :decode
-                    (into (empty value)
-                          (map (fn [[operand expression]]
-                                 (let [raw-type (dtype/dtype-for-array-tag (ctx-get-tag ctx operand))
-                                       env (ctx-assoc-type body-ctx 'x (scalar-tag raw-type))]
-                                   [operand (walk expression env)]))) value)
                     :stages
                     (mapv (fn [index stage]
                             (let [env (axis-context (concat free-axes (take (inc index) contract-axes)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -282,6 +282,10 @@
       (:kernels (equation-first/compile
                  #'staged-public/floating-result-transform! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'staged-public/floating-decoded-stages! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'staged-public/widening-decoded-stages! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -18,6 +18,14 @@
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
 
+  :decoded-staged-contraction-gpu
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true :declines {}}
+   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 1
+              :typed-scalar-equations 0 :backend-reused 0 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
+              :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
+
   :dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -97,6 +97,10 @@
     (pipeline/compile-report #'staged-public/floating-three-stage!
                              :target-device target :dtype :float)
 
+    :decoded-staged-contraction-gpu
+    (pipeline/compile-report #'staged-public/widening-decoded-stages!
+                             :target-device target :dtype :float)
+
     :symbolic-dense-contraction-gpu
     (let [compilation (equation-first/compile
                        #'contract/contract-mm {:target target :dtype :float})
@@ -159,6 +163,7 @@
     (is (= #{:dense-relu-jvm
              :staged-byte-float-contraction-gpu
              :staged-floating-contraction-gpu
+             :decoded-staged-contraction-gpu
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu

--- a/test/raster/compiler/core/contraction_scope_test.clj
+++ b/test/raster/compiler/core/contraction_scope_test.clj
@@ -20,23 +20,17 @@
 (deftest contraction-local-binders-have-authoritative-types
   (let [source (walked {})
         opts (apply hash-map (drop 5 source))]
-    (is (= 'float (:raster.type/tag (meta (get-in opts [:decode 'a])))))
+    (is (not (contains? opts :decode)) "load transforms expand before their consumers are typed")
     (is (= 'float (:raster.type/tag (meta (get-in opts [:stages 0 :lift])))))
     (is (= 'double (:raster.type/tag (meta (get-in opts [:epilogue :expr])))))
     (is (= 'rows (second (first (nth source 2)))) "extent stays in the outer scope")
     (is (= 'float (:raster.type/tag (meta (nth source 4)))))))
 
 (deftest raw-load-binder-type-is-not-inherited-from-an-outer-x
-  (let [opts (apply hash-map (drop 5 (walked {'a 'bytes 'shift 'long})))
-        decode (get-in opts [:decode 'a])]
-    (is (nil? (:raster.type/tag (meta decode)))
-        "the existing inference leaves unproved narrow arithmetic untagged")
-    (is (some #(= '(clojure.core/byte x) %) (tree-seq coll? seq decode))
-        "the raw-load binder has the Byte storage type, not outer Long x"))
-  (let [opts (apply hash-map (drop 5 (walked {'a 'Object})))
-        decode (get-in opts [:decode 'a])]
-    (is (not-any? #(and (symbol? %) (= 'x %) (= 'long (:raster.type/tag (meta %))))
-                  (tree-seq coll? seq decode)))))
+  (doseq [types [{} {'a 'bytes 'shift 'long} {'a 'Object}]]
+    (let [source (walked types)]
+      (is (not-any? #{'x} (tree-seq coll? seq (nth source 4)))
+          "the placeholder is replaced hygienically before ordinary type inference"))))
 
 (deftest unknown-lexical-bindings-mask-rewalk-metadata
   (let [x (with-meta 'x {:raster.type/tag 'long :tag 'long :line 17})

--- a/test/raster/compiler/core/contraction_scope_test.clj
+++ b/test/raster/compiler/core/contraction_scope_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.core.contraction-scope-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.core.walker :as walker]
+            [raster.compiler.ir.contraction-facts :as facts]
             [raster.par]))
 
 (defn walked [extra-types]
@@ -48,3 +49,18 @@
       (let [walks (take 5 (rest (iterate #(walker/walk % ctx) expression)))]
         (is (every? #(= expression %) walks))
         (is (every? #(= tag (:raster.type/tag (meta %))) walks))))))
+
+(deftest decoded-normalization-preserves-lexical-bindings-and-quoted-data
+  (let [ctx (walker/make-ctx {:source-ns 'raster.compiler.core.contraction-scope-test
+                            :type-env {'a {:tag 'doubles} 'shift {:tag 'double}}})
+        source '(let [count (fn [v] (+ v 2))]
+                  [(aget a 0)
+                   (count 3)
+                   (let [a (double-array [7])] (aget a 0))
+                   '(count a)])
+        normalized (#'walker/load-transform-source source ctx)
+        decode (#'walker/load-transform-source '(+ x shift)
+                (assoc-in ctx [:type-env 'x] {:tag nil}))
+        transformed (facts/apply-load-transforms normalized {'a decode})
+        run (eval (list 'fn '[a shift] transformed))]
+    (is (= [11.0 5 7.0 '(count a)] (run (double-array [1]) 10.0)))))

--- a/test/raster/compiler/core/inference_test.clj
+++ b/test/raster/compiler/core/inference_test.clj
@@ -89,6 +89,13 @@
 ;; try-resolve-call
 ;; ================================================================
 
+(deftest qualified-cast-preserves-widening-test
+  (let [env {'x {:tag 'float} 'epsilon {:tag 'float}}]
+    (is (= 'double (inf/infer-rewritten-tag
+                    '(clojure.core/double x) nil env)))
+    (is (= 'double (inf/infer-rewritten-tag
+                    '(clojure.core/+ (clojure.core/double x) epsilon) nil env)))))
+
 (deftest try-resolve-call-arithmetic-test
   (testing "resolves raster.numeric/+ for doubles"
     (let [result (inf/try-resolve-call 'raster.numeric/+ '(x y) (type-env {'x 'double 'y 'double}))]

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -27,6 +27,25 @@
     :epilogue {:acc value :expr (+ value (aget bias _) gain) :dtype :float
                :operands [{:sym bias :dtype :float :map {:groups [[[i 2]]]}}]}))
 
+(deftm floating-decoded-stages!
+  [a :- (Array float) b :- (Array float) out :- (Array float)
+   shift :- Float scale :- Float] :- Void
+  (raster.par/contract out [[i 2]] [[blk 2] [t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 8) (* blk 4) t))
+                      (raster.arrays/aget b (+ (* blk 4) t)))
+    :decode {a (- x shift) b (* x scale)}
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift inner}
+             {:axis t :extent 4 :dtype :float :init 0.0}]))
+
+(deftm widening-decoded-stages!
+  [a :- (Array float) b :- (Array float) out :- (Array float) epsilon :- Double] :- Void
+  (raster.par/contract out [[i 1]] [[blk 1] [t 1]]
+    (raster.numeric/* (raster.arrays/aget a (+ i blk t))
+                      (raster.arrays/aget b (+ blk t)))
+    :decode {a (+ (double x) epsilon)}
+    :stages [{:axis blk :extent 1 :dtype :float :init 0.0 :lift inner}
+             {:axis t :extent 1 :dtype :float :init 0.0}]))
+
 (deftm checked-long-stage!
   [a :- (Array float) b :- (Array float) out :- (Array float) gain :- Long] :- Void
   (raster.par/contract out [[i 1]] [[blk 2] [t 4]]

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -1,7 +1,7 @@
 (ns raster.compiler.fixtures.staged-contracts
   "Public staged workloads shared by numerical tests, the debt ledger and vendor compile gates."
   (:require [raster.core :refer [deftm]]
-            [raster.arrays]
+            [raster.arrays :as arrays]
             [raster.numeric]
             [raster.par]))
 
@@ -27,12 +27,15 @@
     :epilogue {:acc value :expr (+ value (aget bias _) gain) :dtype :float
                :operands [{:sym bias :dtype :float :map {:groups [[[i 2]]]}}]}))
 
+(defmacro decoded-read [array index]
+  `(raster.arrays/aget ~array ~index))
+
 (deftm floating-decoded-stages!
   [a :- (Array float) b :- (Array float) out :- (Array float)
    shift :- Float scale :- Float] :- Void
   (raster.par/contract out [[i 2]] [[blk 2] [t 4]]
-    (raster.numeric/* (raster.arrays/aget a (+ (* i 8) (* blk 4) t))
-                      (raster.arrays/aget b (+ (* blk 4) t)))
+    (raster.numeric/* (arrays/aget a (+ (* i 8) (* blk 4) t))
+                      (decoded-read b (+ (* blk 4) t)))
     :decode {a (- x shift) b (* x scale)}
     :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift inner}
              {:axis t :extent 4 :dtype :float :init 0.0}]))

--- a/test/raster/compiler/passes/parallel/staged_load_transform_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_load_transform_test.clj
@@ -1,0 +1,55 @@
+(ns raster.compiler.passes.parallel.staged-load-transform-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.gpu.device-probe :as probe]
+            [raster.gpu.link :as link]
+            [raster.runtime.hardware :as hardware]))
+
+(deftest public-decoded-stages-use-the-checked-generated-vertical
+  (doseq [[device kind] [[:cuda:decoded-stage-test :cuda] [:hip:decoded-stage-test :hip]]]
+    (hardware/register-target-device! device
+                                     {:type kind :capabilities {:compute-capability [8 0]
+                                                                :warp-size 32 :subgroup-sizes [32]
+                                                                :max-workgroup-size 1024}})
+    (let [compilation (equation-first/compile #'fixtures/floating-decoded-stages!
+                                              {:target device :dtype :float})
+          plan (equation-first/lower compilation [(float-array 16) (float-array 8)
+                                                  (float-array 2) (float 1) (float 0.5)])]
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= :staged-scalar (get-in compilation [:kernels 0 :attributes :kernel-body :schedule :strategy])))
+      (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
+
+(deftest public-decoded-stages-match-host-through-resident-link-plan
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "public decoded staged contraction")
+    (let [a (float-array (range 16)) b (float-array (repeat 8 2.0))
+          expected (float-array 2) output (float-array (repeat 2 -555.0))
+          _ (fixtures/floating-decoded-stages! a b expected (float 1) (float 0.5))
+          compilation (equation-first/compile #'fixtures/floating-decoded-stages! {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compilation [a b output (float 1) (float 0.5)])
+          output-id (some (fn [[id node]] (when (identical? output (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (link/run! executable)
+        (is (= [20.0 84.0] (vec expected)))
+        (is (= (vec expected) (vec (link/download executable output-id))))
+        (finally (link/close! executable))))))
+
+(deftest widening-decode-retypes-the-enclosing-product
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "widening decoded staged contraction")
+    (let [a (float-array [1.0]) b (float-array [1.5]) expected (float-array 1)
+          output (float-array [-555.0]) epsilon (double 6.0e-8)
+          _ (fixtures/widening-decoded-stages! a b expected epsilon)
+          compilation (equation-first/compile #'fixtures/widening-decoded-stages! {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compilation [a b output epsilon])
+          output-id (some (fn [[id node]] (when (identical? output (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (link/run! executable)
+        (is (= :none (get-in compilation [:stats :fallback])))
+        (is (= [(float (* (+ 1.0 epsilon) 1.5))] (vec expected)))
+        (is (not= [(float (* (float (+ 1.0 epsilon)) 1.5))] (vec expected)))
+        (is (= (vec expected) (vec (link/download executable output-id))))
+        (finally (link/close! executable))))))


### PR DESCRIPTION
## Summary

Normalize contraction load transforms before source typing, then lower decoded arithmetic through the ordinary typed scalar region and generated staged schedule. No new decoded target emitter or type registry.

- Expand source macros and canonicalize free aliases before capture-avoiding load substitution.
- Preserve lexical bindings, shadowed arrays and quoted data.
- Honor qualified primitive cast result types in shared inference; retain existing primitive handling.
- Exercise alias/macro loads and a widening-rounding counterexample through public compilation and real Arc execution.
- Add both public decoded workloads to CUDA/HIP compile fixtures and record the generated route in the compatibility ledger.

## Validation

- 52 tests / 166 assertions: JVM SIMD, PDE, shared inference and decoded public/GPU workloads; all pass.
- Updated compatibility ledger: 1 test / 14 assertions; all pass.
- Contraction lexical scopes and normalization hygiene: 5 tests / 17 assertions; all pass.
- Read-only independent review: no blocker.
- Full suite and vendor compile gates delegated to CI.

Stacked on #466; retarget/rebase after its green squash. Mixed-storage/integer-overflow coverage, complete staged fallback retirement and competitive performance remain follow-up work. This PR makes no throughput claim.
