### PR TITLE
Compose verified packed inner folds with recursive typed stages

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -747,3 +747,22 @@ fixtures for CUDA/HIP compilation. The compatibility ledger records the generate
 This does not claim mixed-storage or integer-overflow coverage, whole staged-emitter retirement,
 or competitive kernel throughput. Unnormalized direct typed facts remain explicitly gated;
 remaining precision/storage cases and measured schedule performance are still campaign work.
+
+### Recursive floating stages around a proved packed inner fold
+
+The generated staged schedule composes the existing verified byte-product Int32 fold beneath
+multiple Float/Double stages. Its shared packed fragment is also used by the original two-stage
+schedule; packing remains four byte loads and typed word operations, with no pointer reinterpretation.
+The existing packed admission proves exact-product replacement, contiguous declared maps,
+four-divisible extent, zero identity and every Int32 accumulation prefix. It is not a general
+integer-loop invariant or a new quantization-specific rule.
+
+Every outer stage explicitly converts its lifted term to its declared accumulator dtype, including
+identity lifts. Public three-stage compilation and resident Arc execution use the generated route;
+an independent reference rounds each Float stage with non-power-of-two scales. Hardware-free tests
+retain mixed Float/Double outer dtypes and reject unproved integer, layout and lexical cases.
+The public workload is included in vendor compile fixtures and the compatibility ledger.
+
+Nonpacked integral folds, unproved overflow, decoded byte products and arbitrary mixed storage
+remain separate work. This closes a recursive composition gap, not whole staged source-emitter
+retirement or a throughput claim; vectorized packing and cooperative schedules still need measurement.

--- a/src/raster/compiler/passes/parallel/packed_stage_fragment.clj
+++ b/src/raster/compiler/passes/parallel/packed_stage_fragment.clj
@@ -1,0 +1,39 @@
+(ns raster.compiler.passes.parallel.packed-stage-fragment
+  "Shared typed byte-product stage fragment. Its owner must prove packed-stage admission."
+  (:require [clojure.walk :as walk]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(defn lower
+  "Build the admitted packed inner fold with the owner's scalar builder and index proof.
+   `plan` is the successful inner-dp4a-plan; identities are allocated by the owning schedule.
+   This fragment neither recognizes source arithmetic nor invents an overflow policy."
+  [{:keys [builder lower-index scope operands inner plan packed-index carry result]}]
+  (let [pack (fn [{:keys [sym map]}]
+               (reduce
+                (fn [word offset]
+                  (let [coordinate (walk/postwalk-replace
+                                    {(:axis inner) (list 'clojure.core/+
+                                                        (list 'clojure.core/* packed-index 4) offset)}
+                                    (am/index-expr map))
+                        loaded ((:cast builder)
+                                ((:load builder) sym [(lower-index coordinate scope)]) :int coordinate)
+                        byte-word ((:compute builder) :bit-and :int
+                                   [(:result loaded) (body/literal 255 :int)] {})
+                        shifted ((:compute builder) :shl :int
+                                 [(:result byte-word) (body/literal (* offset 8) :int)] {})
+                        joined ((:compute builder) :bit-or :int [(:result word) (:result shifted)] {})]
+                    {:operations (vec (concat (:operations word) (:operations loaded)
+                                              (:operations byte-word) (:operations shifted)
+                                              (:operations joined)))
+                     :result (:result joined)}))
+                {:operations [] :result (body/literal 0 :int)} (range 4)))
+        [a b] (mapv pack operands)
+        dot ((:compute builder) :dp4a :int [(:result a) (:result b) carry] {})]
+    {:result result :dtype :int
+     :operations [(body/->ForLoop
+                   (body/value packed-index :int) 0 (:packed-extent plan) 1
+                   [(body/->LoopArg (body/value carry :int) (body/literal 0 :int))]
+                   (vec (concat (:operations a) (:operations b) (:operations dot)
+                                [(body/->Yield [(:result dot)])]))
+                   [(body/value result :int)] {})]}))

--- a/src/raster/compiler/passes/parallel/staged_contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_contraction_body.clj
@@ -6,7 +6,6 @@
   (:require [clojure.walk :as walk]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.scalar-conversion :as conversion]
-            [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as stages]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
@@ -14,6 +13,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]
+            [raster.compiler.passes.parallel.packed-stage-fragment :as packed-stage]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
             [raster.compiler.ir.soac-dialect :as soac]
@@ -52,25 +52,10 @@
                     :conversion-policy (fn [from to]
                                          (when (contains? #{[:byte :int] [:int :float]} [from to])
                                            (conversion/policy from to :reject)))})
-          pack (fn [{:keys [sym map]}]
-                 (reduce
-                  (fn [word offset]
-                    (let [coordinate (walk/postwalk-replace
-                                      {(:axis inner) (list 'clojure.core/+ (list 'clojure.core/* packed-index 4) offset)}
-                                      (am/index-expr map))
-                          loaded ((:cast builder)
-                                  ((:load builder) sym [(lower-index coordinate scope)]) :int coordinate)
-                          byte-word ((:compute builder) :bit-and :int
-                                     [(:result loaded) (body/literal 255 :int)] {})
-                          shifted ((:compute builder) :shl :int
-                                   [(:result byte-word) (body/literal (* offset 8) :int)] {})
-                          joined ((:compute builder) :bit-or :int [(:result word) (:result shifted)] {})]
-                      {:operations (vec (concat (:operations word) (:operations loaded)
-                                                (:operations byte-word) (:operations shifted) (:operations joined)))
-                       :result (:result joined)}))
-                  {:operations [] :result (body/literal 0 :int)} (range 4)))
-          [a b] (mapv pack operands)
-          dot ((:compute builder) :dp4a :int [(:result a) (:result b) inner-carry] {})
+          inner-fragment (packed-stage/lower
+                          {:builder builder :lower-index lower-index :scope scope
+                           :operands operands :inner inner :plan plan :packed-index packed-index
+                           :carry inner-carry :result inner-result})
           lift-expr (walk/postwalk-replace
                      {'inner inner-result}
                      (stages/substitute-operand-indices (:lift outer) (stages/stage-index-exprs stage-list)))
@@ -103,12 +88,7 @@
                      (body/value (:axis outer) :int) 0 (:extent outer) 1
                      [(body/->LoopArg (body/value outer-carry :float) (body/literal 0.0 :float))]
                      (vec (concat
-                           [(body/->ForLoop
-                             (body/value packed-index :int) 0 (:packed-extent plan) 1
-                             [(body/->LoopArg (body/value inner-carry :int) (body/literal 0 :int))]
-                             (vec (concat (:operations a) (:operations b) (:operations dot)
-                                          [(body/->Yield [(:result dot)])]))
-                             [(body/value inner-result :int)] {})]
+                           (:operations inner-fragment)
                            (:operations lift) (:operations add) [(body/->Yield [(:result add)])]))
                      [(body/value outer-result :float)] {})
                     (body/->ScalarStore out [segment] outer-result mask)]

--- a/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
@@ -3,7 +3,8 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.contraction-closure :as closure]
-            [raster.compiler.ir.contraction-facts :as facts]))
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.passes.parallel.staged-contraction-schedule :as packed-schedule]))
 
 (defn decline! [rule message data]
   (throw (ex-info message (assoc data :reason :staged-scalar-body-declined :missing-rule rule))))
@@ -36,6 +37,12 @@
         _ (closure/validate-result-scalar-types! source scalar-types)
         requirements (closure/storage-requirements attributes)
         stage-list (:stages source)
+        packed-operands (get-in source [:opts :operands])
+        packed-plan (when (= :int (dtype/canon (:dtype (peek stage-list))))
+                      (let [plan (packed-schedule/inner-dp4a-plan
+                                  (assoc source :operands packed-operands))]
+                        (when (:ok plan) plan)))
+        floating-stages (if packed-plan (pop stage-list) stage-list)
         axes (vec (concat (:free-axes source) (:contract-axes source)))
         n (reduce *' 1 (map second (:free-axes source)))
         out-type (dtype/canon (:dtype (first stage-list)))
@@ -44,8 +51,10 @@
                                  (vals (group-by :parameter requirements))))
             (decline! :storage-types "scalar staged storage requires one declared dtype per buffer"
                       {:requirements requirements :out-dtype (:out-dtype source)}))
-        _ (when-not (and (every? #(contains? #{:float :double} (dtype/canon %))
-                                 (concat [(:dtype source)] (map :dtype stage-list)))
+        _ (when-not (and (or packed-plan
+                            (contains? #{:float :double} (dtype/canon (:dtype source))))
+                         (every? #(contains? #{:float :double} (dtype/canon (:dtype %)))
+                                 floating-stages)
                          (every? #(contains? scalar-types %) scalars)
                          (integer? workgroup-size) (<= 1 workgroup-size 256)
                          (every? #(<= (second %) Integer/MAX_VALUE) axes)
@@ -61,6 +70,8 @@
     {:reads reads
      :attributes attributes
      :stage-list stage-list
+     :packed-plan packed-plan
+     :packed-operands packed-operands
      :axes axes
      :n n
      :out-type out-type

--- a/src/raster/compiler/passes/parallel/staged_scalar_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_body.clj
@@ -11,6 +11,7 @@
             [raster.compiler.ir.scheduled-kernel-body :as scheduled]
             [raster.compiler.passes.parallel.index-expression :as index]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]
+            [raster.compiler.passes.parallel.packed-stage-fragment :as packed-stage]
             [raster.compiler.passes.parallel.staged-scalar-admission :as admission]))
 
 (def decline! admission/decline!)
@@ -19,7 +20,7 @@
   "Construct the typed stage plan using the shared scalar lowerer. No target emission,
    KernelBody construction or driver work occurs during frontend capability checking."
   [source & {:keys [scalar-types workgroup-size] :or {scalar-types {} workgroup-size 64}}]
-  (let [{:keys [reads attributes stage-list axes n out-type sizes array-types]} (admission/analyze! source :scalar-types scalar-types
+  (let [{:keys [reads attributes stage-list axes n out-type sizes array-types packed-plan packed-operands]} (admission/analyze! source :scalar-types scalar-types
                                                     :workgroup-size workgroup-size)
         reserved (atom (set (filter symbol? (tree-seq coll? seq source))))
         fresh (fn [prefix]
@@ -27,8 +28,8 @@
                   (if (contains? @reserved id) (recur (gensym prefix))
                       (do (swap! reserved conj id) id))))
         group (fresh "stage_group") lane (fresh "stage_lane") segment (fresh "stage_segment")
-        mask (fresh "stage_mask")
-        scope (set (concat (map first axes) [group lane segment]))
+        mask (fresh "stage_mask") packed-index (fresh "stage_word")
+        scope (set (concat (map first axes) [group lane segment packed-index]))
         builder (scalar/make-lowerer
                  {:arrays reads :array-types array-types :scalar-types scalar-types
                   :require-source-types? true
@@ -37,7 +38,13 @@
                   :decline! decline!})
         build-stage
         (fn build-stage [depth]
-          (let [{:keys [axis extent lift] :as stage} (nth stage-list depth)
+          (if (and packed-plan (= depth (dec (count stage-list))))
+            (packed-stage/lower
+             {:builder builder :lower-index #(index/lower %1 (into scope %2) decline!)
+              :scope scope :operands packed-operands :inner (nth stage-list depth)
+              :plan packed-plan :packed-index packed-index
+              :carry (fresh "stage_dot") :result (fresh "stage_dot_result")})
+            (let [{:keys [axis extent lift] :as stage} (nth stage-list depth)
                 dt (dtype/canon (:dtype stage))
                 carry (fresh "stage_carry") result (fresh "stage_result")
                 child (when (< depth (dec (count stage-list))) (build-stage (inc depth)))
@@ -65,7 +72,7 @@
                                                           (if (nil? (:init stage)) 0.0 (:init stage))) dt))]
                            (vec (concat (:operations child) (:operations term) (:operations sum)
                                         [(body/->Yield [(:result sum)])]))
-                           [(body/value result dt)] {})]}))
+                           [(body/value result dt)] {})]})))
         computation (build-stage 0)
         result-transform
         (when-let [epilogue (:epilogue source)]

--- a/src/raster/compiler/passes/parallel/staged_scalar_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_body.clj
@@ -62,7 +62,9 @@
                                                   (dtype/scalar-tag-for-dtype
                                                    (if child dt (:dtype source))))))
                              expression)
-                term ((:lower builder) expression dt (if child {(:result child) (:dtype child)} {}))
+                term ((:cast builder)
+                      ((:lower builder) expression dt (if child {(:result child) (:dtype child)} {}))
+                      dt expression)
                 sum ((:compute builder) :+ dt [carry (:result term)] {})]
             {:result result :dtype dt
              :operations [(body/->ForLoop

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -286,6 +286,8 @@
       (:kernels (equation-first/compile
                  #'staged-public/widening-decoded-stages! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'staged-public/packed-three-stage! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -26,6 +26,14 @@
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
 
+  :recursive-packed-contraction-gpu
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true :declines {}}
+   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 1
+              :typed-scalar-equations 0 :backend-reused 0 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
+              :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
+
   :dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -101,6 +101,10 @@
     (pipeline/compile-report #'staged-public/widening-decoded-stages!
                              :target-device target :dtype :float)
 
+    :recursive-packed-contraction-gpu
+    (pipeline/compile-report #'staged-public/packed-three-stage!
+                             :target-device target :dtype :float)
+
     :symbolic-dense-contraction-gpu
     (let [compilation (equation-first/compile
                        #'contract/contract-mm {:target target :dtype :float})
@@ -164,6 +168,7 @@
              :staged-byte-float-contraction-gpu
              :staged-floating-contraction-gpu
              :decoded-staged-contraction-gpu
+             :recursive-packed-contraction-gpu
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -30,6 +30,20 @@
 (defmacro decoded-read [array index]
   `(raster.arrays/aget ~array ~index))
 
+(deftm packed-three-stage!
+  [a :- (Array byte) b :- (Array byte) super-scale :- (Array float)
+   sub-scale :- (Array float) out :- (Array float)] :- Void
+  (raster.par/contract out [[i 2] [j 3]] [[sb 2] [blk 2] [t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 16) (* sb 8) (* blk 4) t))
+                      (raster.arrays/aget b (+ (* j 16) (* sb 8) (* blk 4) t)))
+    :stages [{:axis sb :extent 2 :dtype :float :init 0.0
+              :lift (* inner (aget super-scale _))
+              :operands [{:sym super-scale :dtype :float :map {:groups [[[i 2] [sb 2]]]}}]}
+             {:axis blk :extent 2 :dtype :float :init 0.0
+              :lift (* inner (aget sub-scale _))
+              :operands [{:sym sub-scale :dtype :float :map {:groups [[[j 3] [blk 2]]]}}]}
+             {:axis t :extent 4 :dtype :int :init 0}]))
+
 (deftm floating-decoded-stages!
   [a :- (Array float) b :- (Array float) out :- (Array float)
    shift :- Float scale :- Float] :- Void

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -81,12 +81,17 @@
                    (list 'let* ['effect (raster.compiler.ir.contraction-facts/surface-form facts)] 'out))]
     (doseq [unsupported [(-> source
                             (assoc-in [:stages 1 :dtype] :float)
-                            (assoc-in [:opts :stages 1 :dtype] :float))
-                         (-> source
-                             (assoc-in [:stages 0 :lift] '(* inner scale))
-                             (assoc-in [:opts :stages 0 :lift] '(* inner scale)))]]
+                            (assoc-in [:opts :stages 1 :dtype] :float))]]
       (is (nil? (frontend/form->program (form-for unsupported) options))
-          "unsupported valid staged semantics remain available to the compatibility route"))))
+          "unsupported valid staged semantics remain available to the compatibility route"))
+    (let [with-capture (-> source
+                           (assoc-in [:stages 0 :lift] '(* inner scale))
+                           (assoc-in [:opts :stages 0 :lift] '(* inner scale)))
+          p (frontend/form->program (form-for with-capture) options)
+          operation (soac/operation-parts (first (soac/equations p)))]
+      (is (= p (soac/validate! p)))
+      (is (= '[scale] (:captures operation))
+          "recursive stage lowering now retains scalar lift captures"))))
 
 (deftest typed-contraction-retains-the-canonical-payload-through-ssa
   (let [p (program)

--- a/test/raster/compiler/passes/parallel/recursive_packed_stage_test.clj
+++ b/test/raster/compiler/passes/parallel/recursive_packed_stage_test.clj
@@ -1,0 +1,44 @@
+(ns raster.compiler.passes.parallel.recursive-packed-stage-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.gpu.device-probe :as probe]
+            [raster.gpu.link :as link]))
+
+(defn- reference [a b super-scale sub-scale]
+  (vec
+   (for [i (range 2) j (range 3)]
+     (reduce
+      (fn [outer sb]
+        (let [middle
+              (reduce
+               (fn [mid blk]
+                 (let [dot (reduce + 0
+                                   (for [t (range 4)]
+                                     (* (long (aget ^bytes a (+ (* i 16) (* sb 8) (* blk 4) t)))
+                                        (long (aget ^bytes b (+ (* j 16) (* sb 8) (* blk 4) t))))))]
+                   (float (+ mid (float (* (float dot)
+                                           (aget ^floats sub-scale (+ (* j 2) blk))))))))
+               (float 0) (range 2))]
+          (float (+ outer (float (* middle (aget ^floats super-scale (+ (* i 2) sb))))))))
+      (float 0) (range 2)))))
+
+(deftest public-three-stage-packed-fold-preserves-each-rounding-boundary
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "recursive packed staged contraction")
+    (let [a (byte-array (take 32 (cycle [-128 127 3 -5 0 17])))
+          b (byte-array (take 48 (cycle [127 -128 -11 0 9])))
+          super-scale (float-array [0.13 0.71 0.93 0.27])
+          sub-scale (float-array [0.19 0.37 0.59 0.83 0.41 0.67])
+          out (float-array (repeat 6 Float/NaN))
+          compiled (equation-first/compile #'fixtures/packed-three-stage!
+                                          {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compiled [a b super-scale sub-scale out])
+          output-id (some (fn [[id node]] (when (identical? out (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (is (= :none (get-in compiled [:stats :fallback])))
+        (is (= :staged-scalar (get-in compiled [:kernels 0 :attributes :kernel-body :schedule :strategy])))
+        (link/run! executable)
+        (is (= (reference a b super-scale sub-scale) (vec (link/download executable output-id))))
+        (finally (link/close! executable))))))

--- a/test/raster/compiler/passes/parallel/recursive_packed_stage_test.clj
+++ b/test/raster/compiler/passes/parallel/recursive_packed_stage_test.clj
@@ -2,8 +2,44 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.backend.gpu.kernel-body-target :as target]
+            [raster.compiler.passes.parallel.staged-scalar-body :as staged]
             [raster.gpu.device-probe :as probe]
             [raster.gpu.link :as link]))
+
+(defn- source-components [width]
+  (let [axes [['i 2] ['sb 2] ['blk 2] ['t width]]
+        layout (am/of-axes axes)]
+    {:out 'out :free-axes [['i 2]] :contract-axes (vec (rest axes)) :dtype :byte
+     :body (list 'raster.numeric/* (list 'aget 'a (am/index-expr layout))
+                 (list 'aget 'b (am/index-expr layout)))
+     :opts {:operands [{:sym 'a :map layout} {:sym 'b :map layout}]
+            :stages [{:axis 'sb :extent 2 :dtype :float :init 0.0 :lift 'inner}
+                     {:axis 'blk :extent 2 :dtype :double :init 0.0 :lift 'inner}
+                     {:axis 't :extent width :dtype :int :init 0}]}}))
+
+(deftest recursive-packed-stages-refuse-unproved-contracts
+  (doseq [[case-id components]
+          [[:long-inner (assoc-in (source-components 4) [:opts :stages 2 :dtype] :long)]
+           [:nonzero-init (assoc-in (source-components 4) [:opts :stages 2 :init] 1)]
+           [:unaligned-extent (source-components 3)]
+           [:wrong-map (assoc-in (source-components 4) [:opts :operands 0 :map]
+                                (am/of-axes '[[sb 2] [i 2] [blk 2] [t 4]]))]
+           [:extra-factor (update (source-components 4) :body #(list '* % 2))]
+           [:escaped-axis (assoc-in (source-components 4) [:opts :stages 0 :lift] '(* inner t))]]]
+    (is (thrown? clojure.lang.ExceptionInfo (staged/lower (facts/from-components components)))
+        (name case-id))))
+
+(deftest recursive-packed-stages-preserve-mixed-outer-dtypes
+  (let [scheduled (staged/lower (facts/from-components (source-components 4)))
+        loops (filter #(and (map? %) (contains? % :iter-args))
+                      (tree-seq coll? seq (:body scheduled)))]
+    (doseq [dialect [:opencl-portable :cuda :hip]]
+      (let [artifact (target/emit-artifact "recursive_packed_mixed" scheduled dialect)]
+        (is (string? (:source artifact)))))
+    (is (= [:float :double :int] (mapv #(get-in % [:results 0 :type]) loops)))))
 
 (defn- reference [a b super-scale sub-scale]
   (vec


### PR DESCRIPTION
## Summary

Compose the verified packed byte-product Int32 inner fold beneath recursive Float/Double stages in the generated typed pipeline.

- Extract one shared typed packed-stage fragment, used by both the existing two-stage schedule and the recursive schedule.
- Reuse existing exact-product, contiguous-map, four-divisible extent and whole-prefix Int32 proofs. No format-specific recognition or general integer-loop inference.
- Convert every lifted term explicitly to its receiving accumulator dtype, including identity lifts.
- Add a public three-stage workload to the compiler ledger and CUDA/HIP compile fixtures.

## Validation

- Focused staged, decoded, recursive and ledger suite: 29 tests, 186 assertions; zero failures/errors.
- Actual Arc execution matches an independent reference with per-stage Float rounding, byte extrema and non-power-of-two scales.
- Negative tests cover Long inner stages, nonzero identity, nondivisible extent, altered maps, extra factors and illegal inner-axis capture.
- Mixed Float/Double outer stages are checked through typed loops and OpenCL/CUDA/HIP emission; not yet a mixed-precision device comparison.
- Independent read-only review found no blocker.
- Full suite and vendor compilation run in CI.

Stacked on #467. Nonpacked integral folds, decoded byte products and complete staged fallback retirement remain follow-ups. No competitive-throughput claim.
