### PR TITLE
Verify nonpacked integral stages through shared typed kernel lowering

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -785,3 +785,19 @@ post-loop facts, unsafe index-derived terms and safe fallback after speculative 
 This is a verifier prerequisite, not yet broader integer-stage admission or general index-arithmetic
 safety. Nonpacked/decoded byte reductions still need their source-to-schedule validation and device
 comparisons before a migrated source emitter can be retired.
+
+### Nonpacked integral stages through the shared verifier
+
+Static Int/Long inner folds now use the recursive staged scalar schedule when the shared
+KernelBody verifier proves every accumulation prefix fits. Four-byte packing is an optional
+schedule, not the semantic admission boundary: widths 1, 3 and 5 and normalized byte decodes
+are covered. Admission validates a normalized body specification through the same checks used
+when materializing KernelBody, without allocating a record or invoking a target emitter.
+
+Strict typed scalar lowering preserves retained integral operation widths before stage casts.
+Checked or wrapping arithmetic retains a mathematical range only when the entire range fits its
+machine dtype; this does not rewrite overflow policy. A public Long multiply/divide decode tests
+the distinction from premature Int arithmetic. Independent Arc references cover byte extrema and
+Float rounding, and both public decoded workloads enter the CUDA/HIP/OpenCL compile fixtures.
+Possible overflowing folds still decline before schedule admission. This is correctness and
+coverage work, not a throughput claim or proof that all staged source fallbacks can be removed.

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1282,12 +1282,12 @@
              (and (contains? #{:byte :int :long} result-type)
                   (contains? #{:+ :- :*} canonical-op))]
          (if integral-arithmetic?
-           ;; A checked operation may trap and a wrapping operation may narrow modulo its
-           ;; representation.  Neither permits downstream arithmetic to borrow an unbounded
-           ;; mathematical interval; only an independently proved operation retains it.
-           (if (= :no-overflow (:overflow options))
-             (scalar-result-range canonical-op result-type infos)
-             (scalar-range/for-dtype result-type))
+           ;; Preserve a bounded mathematical result even when the instruction still carries
+           ;; its checked/wrapping policy. No policy is rewritten: if overflow is possible,
+           ;; the downstream fact remains the entire machine dtype.
+           (let [derived (scalar-result-range canonical-op result-type infos)]
+             (if (scalar-range/contained-in-dtype? derived result-type)
+               derived (scalar-range/for-dtype result-type)))
            (scalar-result-range canonical-op result-type infos))))}))
 
 (defn- expression-info!
@@ -2129,12 +2129,9 @@
         (clean-state! :kernel final-state))
       (set/difference @claimed reserved))))
 
-(defn validate!
-  "Verify a scheduled KernelBody and return it unchanged."
+(defn- validate-contents!
+  "Shared checks for a normalized schedule specification and a materialized KernelBody."
   [body]
-  (when-not (kernel-body? body)
-    (throw (ex-info "kernel body must be a KernelBody value"
-                    {:body body :actual (type body)})))
   (let [{:keys [id parameters views stable-reads allocations indices masks fragments operations
                 schedule launch provenance attributes]} body]
     (when (nil? id)
@@ -2403,6 +2400,27 @@
         (validate-dataflow-operations! operations initial-values context))))
   body)
 
+(defn validate!
+  "Verify a scheduled KernelBody and return it unchanged."
+  [body]
+  (when-not (kernel-body? body)
+    (throw (ex-info "kernel body must be a KernelBody value"
+                    {:body body :actual (type body)})))
+  (validate-contents! body))
+
+(defn- normalize-spec [spec]
+  (merge {:parameters [] :views [] :stable-reads [] :allocations [] :indices [] :masks []
+          :fragments [] :operations [] :schedule {} :launch {} :provenance {} :attributes {}}
+         spec))
+
+(defn validate-spec!
+  "Run the same semantic checks before materializing a KernelBody. No target or driver work.
+   Returns the normalized specification; this does not bypass validation at materialization."
+  [spec]
+  (when-not (map? spec)
+    (throw (ex-info "kernel specification must be a map" {:spec spec})))
+  (validate-contents! (normalize-spec spec)))
+
 (defn required-async-source-alignments
   "Return external input alignment preconditions implied by overlap-required async copies.
 
@@ -2428,12 +2446,11 @@
 
 (defn make
   "Construct and verify a target-neutral scheduled kernel body."
-  [{:keys [id parameters views stable-reads allocations indices masks fragments operations schedule
-           launch provenance attributes]
-    :or {parameters [] views [] stable-reads [] allocations [] indices [] masks [] fragments []
-         operations [] schedule {} launch {} provenance {} attributes {}}}]
-  (validate! (->KernelBody id parameters views stable-reads allocations indices masks fragments
-                           operations schedule launch provenance attributes)))
+  [spec]
+  (let [{:keys [id parameters views stable-reads allocations indices masks fragments operations
+                schedule launch provenance attributes]} (normalize-spec spec)]
+    (validate! (->KernelBody id parameters views stable-reads allocations indices masks fragments
+                             operations schedule launch provenance attributes))))
 
 (defn validate-launch-index-ranges!
   "Check the physical ranges of a verified body's hardware bindings at concrete launch time.

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -188,16 +188,16 @@
 
             (lower [expression expected env]
               (let [expression (inline-lets expression)
-                    ;; Preserve floating rounding before consumer promotion. Integral contexts
-                    ;; retain their existing owner policy: quantized loops still carry widened
-                    ;; integers around narrower intrinsic results and need separate reconciliation.
+                    ;; Strict typed owners preserve operation width before any consumer cast.
+                    ;; Older packed owners retain their explicit widened-integer policy.
                     expected (canon-type expected)
                     _ (when (and require-source-types? (seq? expression))
                         (source-type expression expected env))
                     retained (when (seq? expression) (retained-type expression))
-                    operation-type (if (and (dtype/fp-dtype? expected)
-                                            retained (or require-source-types?
-                                                         (dtype/fp-dtype? retained)))
+                    operation-type (if (and retained
+                                            (or require-source-types?
+                                                (and (dtype/fp-dtype? expected)
+                                                     (dtype/fp-dtype? retained))))
                                      retained expected)
                     lowered (lower-value expression operation-type env)]
                 (if (not= operation-type expected)
@@ -445,9 +445,13 @@
                                             "scalar intrinsic operands require one dtype"
                                             {:expression expression :operand-type operand-type
                                              :actual (mapv :type lowered)}))
+                              result-range (if (= :quot operator)
+                                             (scalar-range/quotient operand-ranges)
+                                             proven-range)
                               computed (compute-ssa operator result-type (mapv :result lowered)
-                                                    options (when (= :no-overflow overflow)
-                                                              proven-range))]
+                                                    options (when (scalar-range/contained-in-dtype?
+                                                                    result-range result-type)
+                                                              result-range))]
                           (update computed :operations #(into (vec (mapcat :operations lowered)) %))))))
 
                   :else

--- a/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
@@ -4,6 +4,7 @@
             [raster.compiler.core.numeric-constant :as constant]
             [raster.compiler.ir.contraction-closure :as closure]
             [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.axis-map :as am]
             [raster.compiler.passes.parallel.staged-contraction-schedule :as packed-schedule]))
 
 (defn decline! [rule message data]
@@ -27,6 +28,11 @@
     (decline! :numerical-contract "scalar staged schedule does not implement these numerical extensions"
               {:source source}))
   (let [{:keys [reads scalars]} (facts/dependencies source)
+        _ (doseq [{:keys [sym map]} (get-in source [:opts :operands]) :when map]
+            (let [operand (some #(when (= sym (:sym %)) %) (:operands source))]
+              (when-not (and operand (am/index-matches? map (:idx operand)))
+                (decline! :operand-map "declared operand map disagrees with the actual load index"
+                          {:operand sym :map map :index (:idx operand)}))))
         _ (when (some #(= (:out source) (:sym %)) (get-in source [:epilogue :operands]))
             (decline! :result-transform-inout
                       "destination-reading result transforms require an inout storage proof"
@@ -42,7 +48,8 @@
                       (let [plan (packed-schedule/inner-dp4a-plan
                                   (assoc source :operands packed-operands))]
                         (when (:ok plan) plan)))
-        floating-stages (if packed-plan (pop stage-list) stage-list)
+        integral-inner? (contains? #{:int :long} (dtype/canon (:dtype (peek stage-list))))
+        floating-stages (if integral-inner? (pop stage-list) stage-list)
         axes (vec (concat (:free-axes source) (:contract-axes source)))
         n (reduce *' 1 (map second (:free-axes source)))
         out-type (dtype/canon (:dtype (first stage-list)))
@@ -51,7 +58,8 @@
                                  (vals (group-by :parameter requirements))))
             (decline! :storage-types "scalar staged storage requires one declared dtype per buffer"
                       {:requirements requirements :out-dtype (:out-dtype source)}))
-        _ (when-not (and (or packed-plan
+        _ (when-not (and (or (and integral-inner? (contains? #{:byte :int :long}
+                                                           (dtype/canon (:dtype source))))
                             (contains? #{:float :double} (dtype/canon (:dtype source))))
                          (every? #(contains? #{:float :double} (dtype/canon (:dtype %)))
                                  floating-stages)

--- a/src/raster/compiler/passes/parallel/staged_scalar_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_body.clj
@@ -60,18 +60,22 @@
                                         #(if (or (:raster.type/tag %) (:tag %)) %
                                            (assoc % :raster.type/tag
                                                   (dtype/scalar-tag-for-dtype
-                                                   (if child dt (:dtype source))))))
+                                                   (if (or child (contains? #{:int :long} dt))
+                                                     dt (:dtype source))))))
                              expression)
                 term ((:cast builder)
                       ((:lower builder) expression dt (if child {(:result child) (:dtype child)} {}))
                       dt expression)
-                sum ((:compute builder) :+ dt [carry (:result term)] {})]
+                sum ((:compute builder) :+ dt [carry (:result term)]
+                     (if (contains? #{:int :long} dt) {:overflow :no-overflow} {}))]
             {:result result :dtype dt
              :operations [(body/->ForLoop
                            (body/value axis :int) 0 extent 1
                            [(body/->LoopArg (body/value carry dt)
                                            (body/literal (constant/literal-or-original
-                                                          (if (nil? (:init stage)) 0.0 (:init stage))) dt))]
+                                                          (if (nil? (:init stage))
+                                                            (if (contains? #{:int :long} dt) 0 0.0)
+                                                            (:init stage))) dt))]
                            (vec (concat (:operations child) (:operations term) (:operations sum)
                                         [(body/->Yield [(:result sum)])]))
                            [(body/value result dt)] {})]})))
@@ -122,6 +126,10 @@
                  :launch (launch/spec {:workgroup-size [workgroup-size]
                                        :group-count [(quot (+ n (dec workgroup-size)) workgroup-size)]})
                  :schedule {:strategy :staged-scalar :workgroup-size workgroup-size}}]
+    (try (body/validate-spec! body-spec)
+         (catch clojure.lang.ExceptionInfo e
+           (decline! :kernel-body-proof "staged body does not satisfy the shared verifier"
+                     {:cause (ex-data e) :message (.getMessage e)})))
     {:source source :body-spec body-spec :arguments arguments
      :sizes sizes :output-elements n :out-type out-type}))
 

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -288,6 +288,10 @@
       (:kernels (equation-first/compile
                  #'staged-public/packed-three-stage! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'staged-public/decoded-byte-three-wide! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'staged-public/widened-byte-three-wide! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -34,6 +34,14 @@
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
 
+  :nonpacked-decoded-contraction-gpu
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true :declines {}}
+   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0 :typed-reused 1
+              :typed-scalar-equations 0 :backend-reused 0 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
+              :fallback-reasons [] :declines {} :routes {:kernel-body 1}}}
+
   :dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -105,6 +105,10 @@
     (pipeline/compile-report #'staged-public/packed-three-stage!
                              :target-device target :dtype :float)
 
+    :nonpacked-decoded-contraction-gpu
+    (pipeline/compile-report #'staged-public/widened-byte-three-wide!
+                             :target-device target :dtype :float)
+
     :symbolic-dense-contraction-gpu
     (let [compilation (equation-first/compile
                        #'contract/contract-mm {:target target :dtype :float})
@@ -169,6 +173,7 @@
              :staged-floating-contraction-gpu
              :decoded-staged-contraction-gpu
              :recursive-packed-contraction-gpu
+             :nonpacked-decoded-contraction-gpu
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -30,6 +30,24 @@
 (defmacro decoded-read [array index]
   `(raster.arrays/aget ~array ~index))
 
+(deftm decoded-byte-three-wide!
+  [a :- (Array byte) b :- (Array byte) out :- (Array float) scale :- Float] :- Void
+  (raster.par/contract out [[i 2]] [[blk 2] [t 3]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 6) (* blk 3) t))
+                      (raster.arrays/aget b (+ (* i 6) (* blk 3) t)))
+    :decode {a (- (long x) 7)}
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift (* inner scale)}
+             {:axis t :extent 3 :dtype :int :init 0}]))
+
+(deftm widened-byte-three-wide!
+  [a :- (Array byte) b :- (Array byte) out :- (Array float) scale :- Float] :- Void
+  (raster.par/contract out [[i 2]] [[blk 2] [t 3]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 6) (* blk 3) t))
+                      (raster.arrays/aget b (+ (* i 6) (* blk 3) t)))
+    :decode {a (quot (* (long x) 33554432) 33554432)}
+    :stages [{:axis blk :extent 2 :dtype :float :init 0.0 :lift (* inner scale)}
+             {:axis t :extent 3 :dtype :int :init 0}]))
+
 (deftm packed-three-stage!
   [a :- (Array byte) b :- (Array byte) super-scale :- (Array float)
    sub-scale :- (Array float) out :- (Array float)] :- Void

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -875,6 +875,17 @@
            (body/->Yield ['next-carry])]
           [(body/value 'loop-result :int)] {})]))))
 
+(deftest specification-and-materialized-kernel-share-validation
+  (let [kernel (scalar-body [])
+        spec (into {} kernel)]
+    (is (= spec (with-redefs [body/->KernelBody (fn [& _] (throw (Exception. "materialized")))]
+                  (body/validate-spec! spec))))
+    (is (= kernel (body/make spec)))
+    (doseq [invalid [(assoc spec :operations [:unknown])
+                     (assoc spec :parameters nil)]]
+      (is (thrown? clojure.lang.ExceptionInfo (body/validate-spec! invalid)))
+      (is (thrown? clojure.lang.ExceptionInfo (body/make invalid))))))
+
 (deftest scalar-and-collective-operators-have-semantic-dtype-domains
   (testing "floating intrinsics do not accept integers"
     (is (thrown-with-msg?

--- a/test/raster/compiler/ir/scalar_range_test.clj
+++ b/test/raster/compiler/ir/scalar_range_test.clj
@@ -48,6 +48,16 @@
   (is (= (bigint "18446744073709551615")
          (ranges/counted-loop-trips Long/MIN_VALUE Long/MAX_VALUE 1))))
 
+(deftest quotient-proof-requires-a-positive-constant-divisor
+  (doseq [lo (range -9 10) hi (range lo 10) divisor [1 2 7]]
+    (let [proof (ranges/quotient [{:lower lo :upper hi}
+                                 {:lower divisor :upper divisor}])]
+      (is (every? #(<= (:lower proof) (quot % divisor) (:upper proof))
+                  (range lo (inc hi))))))
+  (doseq [divisor [nil {:lower 0 :upper 0} {:lower -1 :upper -1}
+                   {:lower -1 :upper 1} {:lower 1 :upper 2}]]
+    (is (nil? (ranges/quotient [(ranges/for-dtype :long) divisor])))))
+
 (deftest typed-index-ranges-cover-every-small-domain-value
   (doseq [width [1 2 7 12] divisor [1 2 3 5]
           op [:floor-div :mod]]

--- a/test/raster/compiler/passes/parallel/nonpacked_integral_stage_test.clj
+++ b/test/raster/compiler/passes/parallel/nonpacked_integral_stage_test.clj
@@ -1,0 +1,44 @@
+(ns raster.compiler.passes.parallel.nonpacked-integral-stage-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as packed]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.compiler.passes.parallel.staged-scalar-body :as staged]
+            [raster.gpu.device-probe :as probe]
+            [raster.gpu.link :as link]))
+
+(deftest nonpacked-inner-folds-require-verified-prefix-bounds
+  (doseq [width [1 3 5]]
+    (is (some? (staged/analyze! (packed/packed-facts 2 3 2 width)))))
+  (let [failure (try (staged/analyze! (packed/packed-facts 1 1 1 131072)) nil
+                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+    (is (= :kernel-body-proof (:missing-rule failure)))))
+
+(deftest public-decoded-byte-fold-matches-integer-reference
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "nonpacked decoded byte staged reduction")
+    (doseq [[function decode] [[#'fixtures/decoded-byte-three-wide! #(- (long %) 7)]
+                              [#'fixtures/widened-byte-three-wide! long]]]
+     (let [a (byte-array [-128 127 0 11 -13 5 17 -128 3 127 -1 7])
+          b (byte-array [127 -128 9 0 11 -4 -17 127 1 -128 7 3])
+          scale (float 0.13)
+          expected (vec (for [i (range 2)]
+                          (reduce (fn [sum blk]
+                                    (let [dot (reduce + 0
+                                                      (for [t (range 3)
+                                                            :let [k (+ (* i 6) (* blk 3) t)]]
+                                                        (* (decode (aget a k))
+                                                           (long (aget b k)))))]
+                                      (float (+ sum (float (* (float dot) scale))))))
+                                  (float 0) (range 2))))
+          out (float-array (repeat 2 Float/NaN))
+          compiled (equation-first/compile function
+                                          {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compiled [a b out scale])
+          output-id (some (fn [[id node]] (when (identical? out (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (is (= :none (get-in compiled [:stats :fallback])))
+        (link/run! executable)
+        (is (= expected (vec (link/download executable output-id))))
+        (finally (link/close! executable)))))))

--- a/test/raster/compiler/passes/parallel/recursive_packed_stage_test.clj
+++ b/test/raster/compiler/passes/parallel/recursive_packed_stage_test.clj
@@ -22,15 +22,18 @@
 
 (deftest recursive-packed-stages-refuse-unproved-contracts
   (doseq [[case-id components]
-          [[:long-inner (assoc-in (source-components 4) [:opts :stages 2 :dtype] :long)]
-           [:nonzero-init (assoc-in (source-components 4) [:opts :stages 2 :init] 1)]
-           [:unaligned-extent (source-components 3)]
+          [[:nonzero-init (assoc-in (source-components 4) [:opts :stages 2 :init] 1)]
            [:wrong-map (assoc-in (source-components 4) [:opts :operands 0 :map]
                                 (am/of-axes '[[sb 2] [i 2] [blk 2] [t 4]]))]
            [:extra-factor (update (source-components 4) :body #(list '* % 2))]
            [:escaped-axis (assoc-in (source-components 4) [:opts :stages 0 :lift] '(* inner t))]]]
     (is (thrown? clojure.lang.ExceptionInfo (staged/lower (facts/from-components components)))
         (name case-id))))
+
+(deftest nonpacked-integer-stages-use-the-same-recursive-schedule
+  (doseq [components [(assoc-in (source-components 4) [:opts :stages 2 :dtype] :long)
+                      (source-components 3)]]
+    (is (some? (staged/lower (facts/from-components components))))))
 
 (deftest recursive-packed-stages-preserve-mixed-outer-dtypes
   (let [scheduled (staged/lower (facts/from-components (source-components 4)))


### PR DESCRIPTION
## Summary

Stacked on #470. Make verified Int/Long inner reductions independent of four-byte packing,
including normalized Byte decode expressions, through the recursive typed scalar schedule.

- Share semantic validation between a pre-materialization KernelBody specification and `make`.
- Preserve retained integral expression widths before consumer/stage casts in strict typed lowering.
- Retain arithmetic intervals only when all results fit the machine dtype, without changing overflow policy.
- Admit scalar inner folds only when the shared verifier proves accumulation prefixes safe.
- Add public decoded/widened fixtures to vendor compile gates and a measured compatibility-ledger signature.

No new quantization registry, source emitter, target intrinsic, or handwritten kernel. Unsafe or
unproved folds remain declines. This does not claim throughput parity or complete source-emitter retirement.

## Validation

- Focused tests in the existing capped REPL: 62 tests, 800 assertions, zero failures/errors.
- Includes independent real Intel Arc results for both public Byte decodes with extrema and Float rounding.
- Additional quotient range properties: scalar-range suite 6 tests, 1105 assertions, zero failures/errors.
- New compatibility-ledger workload measured and checked on its synthetic target.
- Read-only final review: no correctness blockers.
- Full suite and CUDA/HIP/OpenCL compiler gates delegated to CI; all seven must pass before merge.
