### PR TITLE
Separate staged accumulator, epilogue and output storage precision

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -801,3 +801,16 @@ the distinction from premature Int arithmetic. Independent Arc references cover 
 Float rounding, and both public decoded workloads enter the CUDA/HIP/OpenCL compile fixtures.
 Possible overflowing folds still decline before schedule admission. This is correctness and
 coverage work, not a throughput claim or proof that all staged source fallbacks can be removed.
+
+### Separate accumulation, result-transform and storage precision
+
+The recursive staged schedule converts its completed result to the declared output storage dtype
+instead of requiring storage to equal the outer accumulator dtype. The shared conversion policy
+rejects unsupported floating-to-integral conversions and unrequested integral narrowing.
+An epilogue first converts to its own declared dtype, including a bare identity expression, then
+converts to storage dtype. Neither conversion changes the preceding accumulator types or rounding.
+
+Independent Arc cases distinguish Float accumulation then Double storage (0 rather than 1) and
+Double accumulation then a Float identity epilogue then Double storage (16777216 rather than
+16777217). Both are public vendor compile fixtures. Single-stage closure admission and the legacy
+quant router's implicit accumulator semantics remain separate retirement work.

--- a/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
@@ -52,8 +52,8 @@
         floating-stages (if integral-inner? (pop stage-list) stage-list)
         axes (vec (concat (:free-axes source) (:contract-axes source)))
         n (reduce *' 1 (map second (:free-axes source)))
-        out-type (dtype/canon (:dtype (first stage-list)))
-        _ (when-not (and (= out-type (dtype/canon (or (:out-dtype source) out-type)))
+        out-type (dtype/canon (or (:out-dtype source) (:dtype (first stage-list))))
+        _ (when-not (and (contains? #{:int :long :float :double} out-type)
                          (every? #(= 1 (count (set (map :dtype %))))
                                  (vals (group-by :parameter requirements))))
             (decline! :storage-types "scalar staged storage requires one declared dtype per buffer"

--- a/src/raster/compiler/passes/parallel/staged_scalar_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_body.clj
@@ -4,6 +4,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.numeric-constant :as constant]
+            [raster.compiler.core.scalar-conversion :as conversion]
             [raster.compiler.ir.contract-stages :as stages]
             [raster.compiler.ir.contraction-closure :as closure]
             [raster.compiler.ir.kernel-body :as body]
@@ -80,6 +81,11 @@
                                         [(body/->Yield [(:result sum)])]))
                            [(body/value result dt)] {})]})))
         computation (build-stage 0)
+        store-cast (fn [lowered expression]
+                     (when-not (conversion/policy (:type lowered) out-type :reject)
+                       (decline! :result-conversion "result storage conversion needs an explicit supported policy"
+                                 {:source (:type lowered) :target out-type}))
+                     ((:cast builder) lowered out-type expression))
         result-transform
         (when-let [epilogue (:epilogue source)]
           (let [legality (body/scalar-region-legal? epilogue)
@@ -94,8 +100,16 @@
                                     (not (or (:tag (meta expression)) (:raster.type/tag (meta expression)))))
                              (vary-meta expression assoc :raster.type/tag (dtype/scalar-tag-for-dtype dt))
                              expression)
-                lowered ((:lower builder) expression dt {(:result computation) (:dtype computation)})]
-            ((:cast builder) lowered out-type expression)))
+                lowered ((:cast builder)
+                         ((:lower builder) expression dt {(:result computation) (:dtype computation)})
+                         dt expression)]
+            (store-cast lowered expression)))
+        ;; Storage conversion follows the complete staged computation (and optional epilogue).
+        ;; Changing the accumulator dtype here would change intermediate rounding.
+        stored-result (or result-transform
+                          (store-cast
+                           {:result (:result computation) :type (:dtype computation) :operations []}
+                           (:body source)))
         arrays (:array-parameters attributes)
         captures (:capture-parameters attributes)
         parameter (fn [id kind dt elements]
@@ -120,9 +134,9 @@
                                       (reduce *' 1 (map second (drop (inc i) (:free-axes source))))) extent)))
                                  (:free-axes source))))
                  :masks [(body/->Mask mask [(body/predicate :lt segment n)])]
-                 :operations (conj (into (:operations computation) (:operations result-transform))
+                 :operations (conj (into (:operations computation) (:operations stored-result))
                                    (body/->ScalarStore (:out source) [segment]
-                                                        (or (:result result-transform) (:result computation)) mask))
+                                                        (:result stored-result) mask))
                  :launch (launch/spec {:workgroup-size [workgroup-size]
                                        :group-count [(quot (+ n (dec workgroup-size)) workgroup-size)]})
                  :schedule {:strategy :staged-scalar :workgroup-size workgroup-size}}]

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -292,6 +292,10 @@
       (:kernels (equation-first/compile
                  #'staged-public/widened-byte-three-wide! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'staged-public/floating-stages-double-output! {:target device-id :dtype :double}))
+      (:kernels (equation-first/compile
+                 #'staged-public/double-stages-float-identity-output! {:target device-id :dtype :double}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -27,6 +27,23 @@
     :epilogue {:acc value :expr (+ value (aget bias _) gain) :dtype :float
                :operands [{:sym bias :dtype :float :map {:groups [[[i 2]]]}}]}))
 
+(deftm floating-stages-double-output!
+  [a :- (Array double) out :- (Array double)] :- Void
+  (raster.par/contract out [[i 1]] [[blk 1] [t 3]]
+    (raster.arrays/aget a (+ (* i 3) (* blk 3) t))
+    :out-dtype :double
+    :stages [{:axis blk :extent 1 :dtype :float :init 0.0 :lift inner}
+             {:axis t :extent 3 :dtype :float :init 0.0}]))
+
+(deftm double-stages-float-identity-output!
+  [a :- (Array double) out :- (Array double)] :- Void
+  (raster.par/contract out [[i 1]] [[blk 1] [t 3]]
+    (raster.arrays/aget a (+ (* i 3) (* blk 3) t))
+    :out-dtype :double
+    :stages [{:axis blk :extent 1 :dtype :double :init 0.0 :lift inner}
+             {:axis t :extent 3 :dtype :double :init 0.0}]
+    :epilogue {:acc value :expr value :dtype :float}))
+
 (defmacro decoded-read [array index]
   `(raster.arrays/aget ~array ~index))
 

--- a/test/raster/compiler/passes/parallel/staged_result_conversion_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_result_conversion_test.clj
@@ -1,0 +1,29 @@
+(ns raster.compiler.passes.parallel.staged-result-conversion-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.gpu.device-probe :as probe]
+            [raster.gpu.link :as link]))
+
+(deftest output-conversion-does-not-widen-the-accumulation
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "staged accumulator/output conversion")
+    (doseq [[function values expected alternative]
+            [[#'fixtures/floating-stages-double-output! [16777216.0 1.0 -16777216.0]
+              0.0 1.0]
+             [#'fixtures/double-stages-float-identity-output! [16777216.0 1.0 0.0]
+              16777216.0 16777217.0]]]
+     (let [a (double-array values)
+          out (double-array [Double/NaN])
+          compiled (equation-first/compile function
+                                           {:target :ocl:0 :dtype :double})
+          plan (equation-first/lower compiled [a out])
+          output-id (some (fn [[id node]] (when (identical? out (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (is (not= expected alternative))
+        (is (= alternative (reduce + a)) "dropping Float rounding would give a different answer")
+        (is (= :none (get-in compiled [:stats :fallback])))
+        (link/run! executable)
+        (is (= [expected] (vec (link/download executable output-id))))
+        (finally (link/close! executable)))))))

--- a/test/raster/compiler/passes/parallel/staged_scalar_body_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_scalar_body_test.clj
@@ -170,8 +170,10 @@
 
 (deftest scalar-captures-require-authoritative-types
   (is (thrown? clojure.lang.ExceptionInfo (staged/lower (three-stage-facts))))
+  (is (some? (staged/lower (assoc (three-stage-facts) :out-dtype :double)
+                            :scalar-types {'scale :float})))
   (is (thrown? clojure.lang.ExceptionInfo
-               (staged/lower (assoc (three-stage-facts) :out-dtype :double)
+               (staged/lower (assoc (three-stage-facts) :out-dtype :int)
                              :scalar-types {'scale :float}))))
 
 (defn production-graph []


### PR DESCRIPTION
## Summary

Stacked on #471. Separate accumulator precision, epilogue precision and destination storage in
the generated recursive staged schedule. An explicit final cast replaces the old requirement
that destination dtype equal the outer accumulator dtype. The shared conversion policy rejects
unsupported float-to-integer casts and unrequested integral narrowing.

Review also found and fixed an identity-epilogue hole: lowering a bare accumulator symbol did not
apply the epilogue's declared dtype. The epilogue now explicitly converts before storage conversion.

No accumulator type is rewritten. Single-stage closure admission, implicit quantization router
semantics and source-emitter retirement remain subsequent work.

## Validation

- 22 focused tests, 100 assertions, zero failures/errors in the existing capped REPL.
- Real Intel Arc: Float accumulation → Double storage returns 0, not widened-accumulator 1.
- Real Intel Arc: Double accumulation → Float identity epilogue → Double storage rounds
  16777217 to 16777216.
- Both public workloads added to vendor compile fixtures.
- Final read-only review found no remaining blocker after the identity-epilogue repair.
- Full suite and seven CI gates required before merge; no full local suite.
