### PR TITLE
Admit explicit single-stage contractions through the typed closure

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -814,3 +814,14 @@ Independent Arc cases distinguish Float accumulation then Double storage (0 rath
 Double accumulation then a Float identity epilogue then Double storage (16777216 rather than
 16777217). Both are public vendor compile fixtures. Single-stage closure admission and the legacy
 quant router's implicit accumulator semantics remain separate retirement work.
+
+### Explicit single-stage contractions share the same closure
+
+A nonempty stage list now admits its one-stage base case through the same lexical, storage,
+legality and shared KernelBody proofs as deeper nests. No special kernel or quantization rule is
+introduced. Public decoded width-three byte products use a proved Int fold followed by Float
+storage; exact width-four products use the existing packed fragment through that same recursive
+base case. Both have independent Arc references and public vendor compile fixtures. Extent
+mismatch and seeded stages remain errors; unproved Int prefix bounds remain capability declines.
+This admits explicit single-stage source contracts; the legacy router's implicit stage synthesis
+and layout-retargeting still need normalization before the old staged emitter can be removed.

--- a/src/raster/compiler/ir/contraction_closure.clj
+++ b/src/raster/compiler/ir/contraction_closure.clj
@@ -63,7 +63,7 @@
         indices (mapv first axes)
         stage-list (:stages contraction)
         legality (stages/stages-legal? stage-list (:contract-axes contraction))]
-    (when-not (and (seq (:free-axes contraction)) (> (count stage-list) 1)
+    (when-not (and (seq (:free-axes contraction)) (seq stage-list)
                    (= (count indices) (count (set indices)))
                    (every? symbol? indices)
                    (every? #(and (integer? %) (pos? %)) (map second axes)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -296,6 +296,10 @@
       (:kernels (equation-first/compile
                  #'staged-public/double-stages-float-identity-output! {:target device-id :dtype :double}))
       (:kernels (equation-first/compile
+                 #'staged-public/decoded-byte-single-stage! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'staged-public/packed-byte-single-stage! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -44,6 +44,23 @@
              {:axis t :extent 3 :dtype :double :init 0.0}]
     :epilogue {:acc value :expr value :dtype :float}))
 
+(deftm decoded-byte-single-stage!
+  [a :- (Array byte) b :- (Array byte) out :- (Array float)] :- Void
+  (raster.par/contract out [[i 2]] [[t 3]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 3) t))
+                      (raster.arrays/aget b (+ (* i 3) t)))
+    :decode {a (- (long x) 7)}
+    :out-dtype :float
+    :stages [{:axis t :extent 3 :dtype :int :init 0}]))
+
+(deftm packed-byte-single-stage!
+  [a :- (Array byte) b :- (Array byte) out :- (Array float)] :- Void
+  (raster.par/contract out [[i 2]] [[t 4]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 4) t))
+                      (raster.arrays/aget b (+ (* i 4) t)))
+    :out-dtype :float
+    :stages [{:axis t :extent 4 :dtype :int :init 0}]))
+
 (defmacro decoded-read [array index]
   `(raster.arrays/aget ~array ~index))
 

--- a/test/raster/compiler/passes/parallel/single_stage_typed_test.clj
+++ b/test/raster/compiler/passes/parallel/single_stage_typed_test.clj
@@ -1,0 +1,56 @@
+(ns raster.compiler.passes.parallel.single-stage-typed-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.gpu.device-probe :as probe]
+            [raster.gpu.link :as link]))
+
+(defn- single-stage-form [width stages]
+  (list 'let*
+        ['effect (list 'raster.par/contract 'out [['i 2]] [['t width]]
+                       '(raster.numeric/* (raster.arrays/aget a t) (raster.arrays/aget b t))
+                       :out-dtype :float :stages stages)]
+        'out))
+
+(deftest single-stage-admission-retains-shape-and-overflow-proofs
+  (let [stage (fn [width] [{:axis 't :extent width :dtype :int :init 0}])
+        options {:dtype :float :array-types '{a :byte b :byte out :float}}
+        compile #(frontend/form->program % options)
+        program (compile (single-stage-form 3 (stage 3)))]
+    (is (some? (soac/validate! program)))
+    (is (nil? (compile (single-stage-form 131072 (stage 131072))))
+        "an unproved integral prefix is a capability decline, not malformed syntax")
+    (doseq [form [(single-stage-form 3 (stage 2))
+                  (single-stage-form 3 [{:axis 't :extent 3 :dtype :int :init 1}])]]
+      (is (thrown? clojure.lang.ExceptionInfo (compile form))))))
+
+(deftest decoded-single-stage-preserves-integer-accumulation-and-float-storage
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "single-stage typed byte contraction")
+    (doseq [[function width decode]
+            [[#'fixtures/decoded-byte-single-stage! 3 #(- (long %) 7)]
+             [#'fixtures/packed-byte-single-stage! 4 long]]]
+     (let [a (byte-array (take (* 2 width) [-128 127 0 11 -13 5 127 -128]))
+          b (byte-array (take (* 2 width) [127 -128 9 0 11 -4 -128 127]))
+          expected (mapv (fn [i]
+                           (float (reduce + 0
+                                          (for [t (range width) :let [k (+ (* i width) t)]]
+                                            (* (decode (aget a k)) (long (aget b k)))))))
+                         (range 2))
+          out (float-array [Float/NaN Float/NaN])
+          compiled (equation-first/compile function
+                                           {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compiled [a b out])
+          output-id (some (fn [[id node]] (when (identical? out (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (is (= :none (get-in compiled [:stats :fallback])))
+        (is (= {:kernel-body 1} (get-in compiled [:stats :emission :emission-routes])))
+        (is (= (= width 4)
+               (boolean (some #(re-find #"rstr_dp4a" (:source %)) (:kernels compiled))))
+            "only the proved exact-product case uses the packed fragment")
+        (link/run! executable)
+        (is (= expected (vec (link/download executable output-id))))
+        (finally (link/close! executable)))))))


### PR DESCRIPTION
## Summary

Stacked on #472. Admit explicit one-stage contractions as the recursive typed closure's base case.
All existing stage legality, lexical, storage, scalar typing and overflow proofs still apply.

No new emitter or quantization rules: decoded width-three Byte products use a verified Int fold
and Float storage; exact width-four products use the existing shared packed fragment.

## Validation

- 12 focused tests, 83 assertions, zero failures/errors in the existing capped REPL.
- Independent Intel Arc numerical references for decoded scalar and packed single-stage cases.
- Hardware-free extent mismatch/seed rejection and possible-overflow capability decline.
- Both public workloads included in vendor compile fixtures.
- Read-only review found no blocker; requested packed-path coverage was added and passed.
- Full suite and all seven gates delegated to CI.

This does not yet retire the old staged emitter: the quant router's implicit stage synthesis
and optional layout-retargeting still need normalization through retained typed source facts.
