### PR TITLE
Preserve canonical accumulation across differing input and output storage

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -839,3 +839,19 @@ decoded Byte/Int accumulation and a Double accumulator with Float storage and a 
 epilogue. Both enter vendor compile fixtures. Rank-zero, multiple reduced axes, non-additive folds
 and undeclared accumulator precision retain their existing paths. Implicit legacy Byte policy still
 requires a numeric equivalence proof; this is not a blanket Byte-to-Int rewrite or emitter retirement.
+
+### Input storage does not choose accumulation precision
+
+Single-axis sums with input storage differing from the output can use the same canonical-stage
+projection without changing accumulator dtype. The frontend selects it for mixed storage or
+explicit accumulator policy; homogeneous contractions keep their existing schedule selection.
+This still requires one common declared dtype among core input arrays, not arbitrary heterogeneous
+operand storage. Existing rank/domain, layout, capture and numerical legality gates remain.
+
+For an innermost floating stage over integral storage, untyped compound roots now decline rather
+than borrowing arithmetic width from the buffer dtype. Retained source types govern operations;
+typed loads/casts use their existing scalar contracts. Tests inspect Long byte-product arithmetic
+separately from Float scale arithmetic. Public Arc execution of 1024 products of -128 by -128,
+then two products of 1 by 1, gives ordered Float result16777216 rather than Int-then-Float16777218.
+The public workload enters vendor compile fixtures. This is correctness/generalization work;
+packed replacement of a floating fold still requires an independent equivalence proof.

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -276,13 +276,12 @@
      :dtype (first (reduction/dtypes (:reduction facts)))}))
 
 ;; ── body shape: what a leaf that DISCARDS the body must first account for ────────────
-(defn explicit-accumulator-stage
-  "Expose an explicitly declared single-axis accumulator as the stage schedule's base case.
+(defn single-axis-accumulator-stage
+  "Expose the canonical single-axis accumulator as the stage schedule's base case.
    Precision, combine and identity come from the canonical reduction, never operand storage.
    Other reductions remain unchanged and retain their existing admission paths."
   [source]
-  (if (and (contains? (:opts source) :acc-dtype)
-           (seq (:free-axes source))
+  (if (and (seq (:free-axes source))
            (empty? (:stages source)) (= 1 (count (:contract-axes source))))
     (let [{:keys [dtype combine neutral]} (scalar-reduction-view source)
           [axis extent] (first (:contract-axes source))

--- a/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_admission.clj
@@ -58,9 +58,8 @@
                                  (vals (group-by :parameter requirements))))
             (decline! :storage-types "scalar staged storage requires one declared dtype per buffer"
                       {:requirements requirements :out-dtype (:out-dtype source)}))
-        _ (when-not (and (or (and integral-inner? (contains? #{:byte :int :long}
-                                                           (dtype/canon (:dtype source))))
-                            (contains? #{:float :double} (dtype/canon (:dtype source))))
+        _ (when-not (and (contains? #{:byte :int :long :float :double}
+                                    (dtype/canon (:dtype source)))
                          (every? #(contains? #{:float :double} (dtype/canon (:dtype %)))
                                  floating-stages)
                          (every? #(contains? scalar-types %) scalars)

--- a/src/raster/compiler/passes/parallel/staged_scalar_body.clj
+++ b/src/raster/compiler/passes/parallel/staged_scalar_body.clj
@@ -56,7 +56,12 @@
                              (:body source))
                 ;; The stage contract declares its root result type; nested expressions must
                 ;; retain their own checked types, never inherit a consumer's conversion.
-                expression (if (seq? expression)
+                ;; Integral storage is not an arithmetic-width declaration for a floating
+                ;; fold. Leave untyped roots to strict scalar admission in that case; typed
+                ;; loads/casts remain understood, but compound arithmetic must retain its type.
+                expression (if (and (seq? expression)
+                                    (not (and (nil? child) (dtype/fp-dtype? dt)
+                                              (not (dtype/fp-dtype? (:dtype source))))))
                              (vary-meta expression
                                         #(if (or (:raster.type/tag %) (:tag %)) %
                                            (assoc % :raster.type/tag

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1282,8 +1282,7 @@
              (update io :scalars set/union identity-scalars)))
 
     (and (seq? expression) (= 'raster.par/contract (first expression)))
-    (let [facts (contraction-facts/explicit-accumulator-stage
-                (contraction-facts/contraction-facts
+    (let [facts (contraction-facts/contraction-facts
                  expression
                  ;; A contraction's element dtype is the declared dtype of the array it writes.
                  ;; The form's elem-type stamp is the compile's dtype policy, which a hard-typed
@@ -1291,7 +1290,16 @@
                  ;; dtype is only the last resort when nothing declares it.
                  :dtype (or (some-> (get array-types (second expression)) dtype/canon)
                             (:raster.type/elem-type (meta expression))
-                            default-dtype :double)))
+                            default-dtype :double))
+          ;; Select this schedule for explicit precision or mixed storage, without diverting
+          ;; homogeneous matrix contractions from their existing optimized schedule families.
+          mixed-storage? (some (fn [{:keys [sym]}]
+                                 (when-let [declared (get array-types sym)]
+                                   (not= (dtype/canon declared) (dtype/canon (:dtype facts)))))
+                               (:operands facts))
+          facts (if (or (contains? (:opts facts) :acc-dtype) mixed-storage?)
+                  (contraction-facts/single-axis-accumulator-stage facts)
+                  facts)
           {:keys [free-axes contract-axes out opts]} facts
           contraction-dtype (dtype/canon (:dtype facts))
           ;; A result transform that reads the destination reads the storage the contraction

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -304,6 +304,8 @@
       (:kernels (equation-first/compile
                  #'staged-public/explicit-double-accumulator-epilogue! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'staged-public/byte-products-float-accumulation! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-long-state {:target device-id :dtype :float}))

--- a/test/raster/compiler/fixtures/staged_contracts.clj
+++ b/test/raster/compiler/fixtures/staged_contracts.clj
@@ -76,6 +76,12 @@
     :acc-dtype :double :out-dtype :float
     :epilogue {:acc value :expr (- value 16777216.0) :dtype :double}))
 
+(deftm byte-products-float-accumulation!
+  [a :- (Array byte) b :- (Array byte) out :- (Array float)] :- Void
+  (raster.par/contract out [[i 1]] [[t 1026]]
+    (raster.numeric/* (raster.arrays/aget a (+ (* i 1026) t))
+                      (raster.arrays/aget b t))))
+
 (defmacro decoded-read [array index]
   `(raster.arrays/aget ~array ~index))
 

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -82,6 +82,9 @@
     (let [mixed (-> source
                     (assoc-in [:stages 1 :dtype] :float)
                     (assoc-in [:opts :stages 1 :dtype] :float))
+          _ (is (nil? (frontend/form->program (form-for mixed) options))
+                "raw compound arithmetic cannot borrow its width from Byte storage")
+          mixed (update mixed :body vary-meta assoc :raster.type/tag 'long)
           p (frontend/form->program (form-for mixed) options)
           retained (get-in (soac/operation-parts (first (soac/equations p)))
                            [:attributes :contraction])]

--- a/test/raster/compiler/ir/contraction_closure_test.clj
+++ b/test/raster/compiler/ir/contraction_closure_test.clj
@@ -73,17 +73,21 @@
     (is (= ['out] (:captures map-op)))
     (is (= p (soac/validate! p)))))
 
-(deftest unsupported-staged-schedules-do-not-become-authoritative-typed-islands
+(deftest staged-storage-precision-and-captures-remain-distinct
   (let [source (fixtures/packed-facts 3 5 3 32)
         options {:dtype :float :array-types '{a :byte b :byte da :float db :float out :float}
                  :scalar-types {'scale :float}}
         form-for (fn [facts]
                    (list 'let* ['effect (raster.compiler.ir.contraction-facts/surface-form facts)] 'out))]
-    (doseq [unsupported [(-> source
-                            (assoc-in [:stages 1 :dtype] :float)
-                            (assoc-in [:opts :stages 1 :dtype] :float))]]
-      (is (nil? (frontend/form->program (form-for unsupported) options))
-          "unsupported valid staged semantics remain available to the compatibility route"))
+    (let [mixed (-> source
+                    (assoc-in [:stages 1 :dtype] :float)
+                    (assoc-in [:opts :stages 1 :dtype] :float))
+          p (frontend/form->program (form-for mixed) options)
+          retained (get-in (soac/operation-parts (first (soac/equations p)))
+                           [:attributes :contraction])]
+      (is (= p (soac/validate! p)))
+      (is (= :byte (:dtype retained)))
+      (is (= :float (get-in retained [:stages 1 :dtype]))))
     (let [with-capture (-> source
                            (assoc-in [:stages 0 :lift] '(* inner scale))
                            (assoc-in [:opts :stages 0 :lift] '(* inner scale)))

--- a/test/raster/compiler/ir/explicit_accumulator_stage_test.clj
+++ b/test/raster/compiler/ir/explicit_accumulator_stage_test.clj
@@ -14,26 +14,25 @@
 
 (deftest explicit-precision-comes-from-the-canonical-reduction
   (let [original (source {:acc-dtype :int})
-        normalized (facts/explicit-accumulator-stage original)]
+        normalized (facts/single-axis-accumulator-stage original)]
     (is (= [{:axis 't :extent 3 :dtype :int :init 0}] (:stages normalized)))
     (is (= :float (:out-dtype normalized)))
     (is (= (select-keys (facts/scalar-reduction-view original) [:dtype :combine :neutral])
            (select-keys (facts/scalar-reduction-view normalized) [:dtype :combine :neutral])))
-    (is (identical? normalized (facts/explicit-accumulator-stage normalized)))))
+    (is (identical? normalized (facts/single-axis-accumulator-stage normalized)))))
 
 (deftest unrelated-reduction-policies-are-not-replaced
-  (doseq [original [(source {})
-                    (source {:acc-dtype :int :combine '* :init 1})
+  (doseq [original [(source {:acc-dtype :int :combine '* :init 1})
                     (source {:stages [{:axis 't :extent 3 :dtype :float :init 0.0}]})
                     (facts/from-components
                      {:out 'out :free-axes [] :contract-axes '[[t 3]]
                       :body '(raster.arrays/aget a t) :dtype :float :opts {:acc-dtype :double}})
                     (assoc (source {:acc-dtype :int}) :contract-axes '[[x 2] [t 3]])]]
-    (is (identical? original (facts/explicit-accumulator-stage original))))
+    (is (identical? original (facts/single-axis-accumulator-stage original))))
   (is (thrown? clojure.lang.ExceptionInfo (source {:acc-dtype :int :init 2})))
   (let [byte-storage (assoc (source {}) :dtype :byte)]
-    (is (identical? byte-storage (facts/explicit-accumulator-stage byte-storage))
-        "byte storage without an accumulator declaration does not synthesize an Int stage")))
+    (is (= :float (get-in (facts/single-axis-accumulator-stage byte-storage) [:stages 0 :dtype]))
+        "storage does not override the canonical accumulator precision")))
 
 (deftest explicit-accumulator-types-the-epilogue-before-output-conversion
   (if-not @probe/opencl-available?

--- a/test/raster/compiler/passes/parallel/mixed_storage_stage_test.clj
+++ b/test/raster/compiler/passes/parallel/mixed_storage_stage_test.clj
@@ -2,10 +2,25 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.compiler.backend.gpu.staged-contraction-fixtures :as packed]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.staged-scalar-body :as staged]
             [raster.gpu.device-probe :as probe]
             [raster.gpu.link :as link]))
+
+(deftest raw-mixed-storage-arithmetic-needs-retained-width
+  (let [source (-> (packed/packed-facts 1 1 1 4)
+                   (assoc-in [:stages 1 :dtype] :float)
+                   (assoc-in [:opts :stages 1 :dtype] :float))
+        failure (try (staged/analyze! source) nil
+                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+    (is (= :scalar-source-type (:missing-rule failure)))
+    (let [typed (update source :body vary-meta assoc :raster.type/tag 'long)
+          operations (tree-seq coll? seq (:operations (:body (staged/lower typed))))
+          products (filter #(and (map? %) (= :* (:op %))) operations)]
+      (is (= {:long 1 :float 2} (frequencies (map :result-type products)))
+          "one Long byte product precedes the two Float scale products"))))
 
 (deftest homogeneous-contractions-keep-existing-schedule-selection
   (with-redefs [facts/single-axis-accumulator-stage

--- a/test/raster/compiler/passes/parallel/mixed_storage_stage_test.clj
+++ b/test/raster/compiler/passes/parallel/mixed_storage_stage_test.clj
@@ -1,0 +1,42 @@
+(ns raster.compiler.passes.parallel.mixed-storage-stage-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.fixtures.staged-contracts :as fixtures]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.gpu.device-probe :as probe]
+            [raster.gpu.link :as link]))
+
+(deftest homogeneous-contractions-keep-existing-schedule-selection
+  (with-redefs [facts/single-axis-accumulator-stage
+                (fn [& _] (throw (ex-info "homogeneous contraction diverted to scalar stage" {})))]
+    (is (some? (frontend/form->program
+                '(let* [effect (raster.par/contract out [[i 2] [j 3]] [[k 4]]
+                                 (raster.numeric/* (raster.arrays/aget a (+ (* i 4) k))
+                                                   (raster.arrays/aget b (+ (* k 3) j))))]
+                   out)
+                {:dtype :float :array-types '{a :float b :float out :float}})))))
+
+(deftest byte-storage-does-not-change-float-accumulation
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "mixed-storage canonical accumulator")
+    (let [a (byte-array (concat (repeat 1024 -128) [1 1]))
+          b (aclone a)
+          terms (map #(clojure.core/* (long %1) (long %2)) a b)
+          expected (reduce #(float (+ %1 (float %2))) (float 0) terms)
+          widened (float (reduce + 0 terms))
+          out (float-array [Float/NaN])
+          compiled (equation-first/compile #'fixtures/byte-products-float-accumulation!
+                                           {:target :ocl:0 :dtype :float})
+          plan (equation-first/lower compiled [a b out])
+          output-id (some (fn [[id node]] (when (identical? out (:source node)) id)) (:nodes plan))
+          executable (link/instantiate! plan)]
+      (try
+        (is (= 16777216.0 expected))
+        (is (= 16777218.0 widened))
+        (is (= :none (get-in compiled [:stats :fallback])))
+        (is (= {:kernel-body 1} (get-in compiled [:stats :emission :emission-routes])))
+        (is (not-any? #(re-find #"rstr_dp4a" (:source %)) (:kernels compiled)))
+        (link/run! executable)
+        (is (= [expected] (vec (link/download executable output-id))))
+        (finally (link/close! executable))))))


### PR DESCRIPTION
## Summary

Stacked on #474. Select the shared canonical single-stage projection for differing input/output
storage, retaining the canonical accumulator dtype. Homogeneous matrix contractions keep their
existing schedule families. Core input arrays still require a common declared dtype.

This does not infer Int accumulation from Byte storage. Ordered Float accumulation can differ
from exact integer accumulation followed by one Float cast, even when all integer prefixes fit.

Review found an untyped raw-facts arithmetic-width hazard. Innermost floating stages over integral
storage now decline untyped compound roots instead of assigning the storage dtype as arithmetic
width. Retained source types and existing typed load/cast semantics remain authoritative.

## Validation

- Final focused batch: 33 tests, 176 assertions, zero failures/errors in the existing capped REPL.
- Independent Intel Arc reference: Byte products return ordered Float16777216, not Int-cast16777218.
- Generated-operation regression: one retained Long byte product, followed by two Float scales.
- Untyped raw mixed-storage compound arithmetic declines; homogeneous frontend does not invoke
  the scalar-stage projection. Existing explicit-accumulator and staged tests remain green.
- Public mixed-storage workload added to vendor compile fixtures.
- Final read-only repair review found no remaining blocker.
- Full suite and all seven gates required before merge. No performance claim or complete legacy
  emitter retirement follows from this slice.
