### PR TITLE
Lower Java round through typed KernelBody; unblock I8 activation packing

### DIFF
--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -63,3 +63,23 @@ The nine scalar routes are the composable Q4/Q6 helpers and packed CPU dot varia
 The default CI corpus currently excludes both quant namespaces. Keep this focused inventory in
 the cold lane until an explicit workload/policy matrix can ratchet intended GPU entry points
 without treating CPU-only helpers or inappropriate dtype specializations as regressions.
+
+## First repair: shared typed Java rounding
+
+The typed scalar lowerer now consumes the existing intrinsic table's Float→Int and Double→Long
+source signatures. It expands rounding into ordinary floor, subtraction, comparison, selection,
+and saturating conversion operations; no quantization-specific kernel or new IR node is involved.
+The overload's result dtype is preserved before conversion to its consumer dtype. Unknown source
+overloads decline instead of being guessed from the output type.
+
+OpenCL uses its explicit saturating conversion. CUDA/HIP guard NaN and signed range boundaries
+before a truncating C++ cast; the upper guard compares against the exact power-of-two boundary,
+not a rounded integer maximum. Other unsupported rounding policies still decline.
+
+The targeted I8 packer rerun now reports validated TypedSOAC, one KernelBody kernel, independent
+effect iteration, and no emission decline. On Intel Arc, both rounding overloads match Java for
+164 inputs each (edge cases plus deterministic random bit patterns). The public packer also
+matches JVM packed words and scales across three rows, including half-ties and a zero row.
+Both overloads and the public packer join the CUDA/HIP compile fixtures. This is correctness and
+emission evidence, **not a throughput measurement**. The original 33-entry table remains the
+pre-repair baseline; Q8_K compatibility emission and the packed helper's lost type remain open.

--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -1,0 +1,65 @@
+# Quantization emission inventory
+
+Measured against main `fb4677aa695cca1be33a1f2133a6fcf8e5a9c27b`, whose tree equals the
+tested mixed-storage PR475 tree. This is compile coverage, not throughput or numerical validation.
+
+## Scope and method
+
+Enumerated source `deftm` vars with `coverage/corpus-vars` in `raster.quant.kernels-k`,
+`raster.quant.kernels`, and `raster.compiler.fixtures.staged-contracts` (33 entry points).
+Called `coverage/report-var` in one capped existing REPL, target `:ocl:0` (Intel Arc).
+Used Float policy except the two Double-output staged fixtures, which require Double policy.
+The initial uniform Float run correctly rejected those two result/storage mismatches; their
+correct-policy reruns are included below.
+
+Wrapped `segop-opencl/generate-staged-contraction-kernel` with a recording delegate while
+compiling, preserving its behavior and counting calls even if a compile subsequently failed.
+The two Double-policy fixtures were also rerun with this instrumentation.
+
+| Route | Entry points | Emission evidence |
+| --- | ---: | --- |
+| TypedSOAC | 20 | One KernelBody artifact per entry point |
+| Scalar | 9 | No GPU artifact; not a GPU success |
+| Compatibility | 2 | Two compatibility-effect-opencl kernels each |
+| Compile error | 2 | See failures below |
+
+There were zero legacy staged-emitter calls in this inventory. This does **not** prove the
+emitter dead: general/scientific callers, direct compatibility APIs, other compile policies and
+shape specializations are outside this measurement. No production emitter is deleted by this audit.
+
+## Actual remaining hot-path debt
+
+`quant-act-q8k-rows-gpu!` and `quant-act-q8k-padded-rows-gpu!` still use compatibility effect
+emission. Their public projections (`qmatmul-q4k-dp4a-rows!`, `qmatmul-q6k-dp4a!`,
+`qmatmul-q6k-gpu!`, `qmatmul-i8-gemm!`, `i8gemv-dp4a!`) use KernelBody. Improving the activation
+packing vertical is therefore more immediately useful than adding more staged projection fixtures.
+
+`quant-act-i8-rows-gpu!` fails with `:segmap-emission-refused`. Its typed scalar lowering attempts
+to convert a Double argument of `Math/round` to Long before the operation and declines
+`:cast-policy`. The generic intrinsic lowerer currently coerces ordinary function arguments to
+the result's expected dtype; Java round has different input and output dtypes. The shared
+intrinsic registry also documents a C-backend negative-half-tie deviation. Fix this as a shared
+typed numeric operation, not a quantization special case or unchecked Float-to-Long cast.
+Validation must include signed ties, adjacent representable values, NaN/infinity and saturation;
+native C round and a naive floor(x+0.5) are not assumed interchangeable with Java semantics.
+
+`wi8-dot-q4-x8` fails the typed fixpoint boundary on an untagged conditional binding `nib`.
+It needs a separate retained-source-type investigation; do not repair it with an emitter-local
+function/type guess.
+
+The nine scalar routes are the composable Q4/Q6 helpers and packed CPU dot variants:
+`qmatmul-q4k-composable!`, `qmatmul-q6k-composable!`, `qmatmul-q4-composable`,
+`qmatmul-q4-composable!`, `qmatmul-q4-x8!`, `qmatmul-q8-x8!`, `wi8-dot`, `wi8-dot-q4`,
+`wi8-dot-q8-x8`. Their intended CPU/C use must be distinguished from missing GPU coverage.
+
+## Next work
+
+1. Correct the shared typed rounding signature/semantics and validate the public I8 quantizer.
+2. Trace Q8_K activation packing's effect/control admission; retain row-local writes and ownership.
+3. Fix the packed CPU helper's lost conditional type through existing inference.
+4. Extend this inventory to remaining scientific/compatibility callers before staged-emitter removal.
+5. Measure packing plus projection end to end, separately from resident projection-only timing.
+
+The default CI corpus currently excludes both quant namespaces. Keep this focused inventory in
+the cold lane until an explicit workload/policy matrix can ratchet intended GPU entry points
+without treating CPU-only helpers or inappropriate dtype specializations as regressions.

--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -72,7 +72,9 @@ and saturating conversion operations; no quantization-specific kernel or new IR 
 The overload's result dtype is preserved before conversion to its consumer dtype. Unknown source
 overloads decline instead of being guessed from the output type.
 
-OpenCL uses its explicit saturating conversion. CUDA/HIP guard NaN and signed range boundaries
+OpenCL sanitizes NaN to floating zero before its explicit saturating conversion: the first CI
+PoCL run otherwise returned signed MIN_VALUE for NaN despite the Arc oracle passing. The same
+edge-case tests remain required on both devices. CUDA/HIP guard NaN and signed range boundaries
 before a truncating C++ cast; the upper guard compares against the exact power-of-two boundary,
 not a rounded integer maximum. Other unsupported rounding policies still decline.
 

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -473,8 +473,13 @@
       ;; The upper comparison uses the exact power-of-two boundary, not rounded MAX_VALUE.
       (and source-fp? (not result-fp?) (= :saturate overflow))
       (if (c-dialect/opencl? *scalar-dialect*)
+        ;; Some CPU OpenCL implementations lower NaN saturation to signed MIN_VALUE.
+        ;; Sanitize the input explicitly, keeping NaN out of the conversion itself even
+        ;; when a vectorizer evaluates both arms of an enclosing result selection.
         (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
-             "(" argument-source ")")
+             "((isnan(" argument-source ") ? "
+             (emit-scalar-value (body/literal 0.0 source-type) context)
+             " : " argument-source "))")
         (if (and (= :toward-zero rounding)
                  (contains? #{:float :double} source-type)
                  (scalar-range/for-dtype result-type))

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -464,16 +464,29 @@
              "(" argument-source ")")
         (str "(" (target-type result-type) ")(" argument-source ")"))
 
-      ;; Saturating FP->integer conversion has a direct OpenCL spelling only.
+      ;; Guard the C cast: out-of-range/NaN FP-to-integer conversion is undefined in C++.
+      ;; The upper comparison uses the exact power-of-two boundary, not rounded MAX_VALUE.
       (and source-fp? (not result-fp?) (= :saturate overflow))
       (if (c-dialect/opencl? *scalar-dialect*)
         (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
              "(" argument-source ")")
-        (throw (ex-info "CUDA/HIP cannot preserve this saturating cast policy"
+        (if (and (= :toward-zero rounding)
+                 (contains? #{:float :double} source-type)
+                 (scalar-range/for-dtype result-type))
+          (let [{:keys [lower upper]} (scalar-range/for-dtype result-type)
+                literal #(emit-scalar-value (body/literal %1 %2) context)
+                x (str "(" argument-source ")")]
+            (str "(isnan(" x ") ? " (literal 0 result-type)
+                 " : " x " >= " (literal (double (inc' upper)) source-type)
+                 " ? " (literal upper result-type)
+                 " : " x " <= " (literal (double lower) source-type)
+                 " ? " (literal lower result-type)
+                 " : (" (target-type result-type) ")" x ")"))
+          (throw (ex-info "CUDA/HIP cannot preserve this saturating cast policy"
                         {:reason :kernel-body-c-cast-policy
                          :dialect (:id *scalar-dialect*)
                          :source-type source-type :result-type result-type
-                         :rounding rounding :overflow overflow})))
+                         :rounding rounding :overflow overflow}))))
 
       ;; Integral widening is exact. Narrowing/exact and trapping conversions need a proof or
       ;; runtime check that this target layer does not currently carry.

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -382,7 +382,12 @@
   (case (dtype/canon type)
     :byte (str "(" (target-type :byte) ")" value)
     :int (str value)
-    :long (str value (if (c-dialect/opencl? *scalar-dialect*) "L" "LL"))
+    :long (let [suffix (if (c-dialect/opencl? *scalar-dialect*) "L" "LL")]
+            ;; The positive magnitude of MIN_VALUE is not a signed C literal. Keeping
+            ;; both operands signed also prevents ternaries from promoting to unsigned.
+            (if (= value Long/MIN_VALUE)
+              (str "(-" Long/MAX_VALUE suffix " - 1" suffix ")")
+              (str value suffix)))
     :half (if (c-dialect/opencl? *scalar-dialect*)
             (str "(half)(" (emit-floating-literal value "f") ")")
             (str "__float2half_rn(" (emit-floating-literal value "f") ")"))

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -36,13 +36,12 @@
 ;; Where backends could diverge on the same op, the CHOICE is recorded here —
 ;; an emitter deviating from this table is a bug, not a preference.
 ;;
-;; :round  Java semantics — floor(x+0.5) — everywhere possible. wasm lowers as
-;;         the floor(x+0.5) polynomial (NOT f64.nearest: round-half-EVEN).
-;;         KNOWN DEVIATION: the C backends emit native round() =
-;;         round-half-AWAY-from-zero, which differs from Java at NEGATIVE .5
-;;         ties (C round(-2.5) = -3, Java = -2). Exact half-ties are
-;;         measure-zero on real data; accepted for GPU speed. Fixing = emit
-;;         floor(x+0.5) in C too.
+;; :round  Typed source lowering expands Java's floating->integer overloads into
+;;         floor/fraction/select and saturating conversion. Ties go toward +infinity;
+;;         NaN becomes zero. Naive floor(x+0.5) is NOT exact at adjacent half-ties.
+;;         LEGACY DEBT: raw C :round still names native round (ties away from zero),
+;;         and wasm's polynomial still adds 0.5 before floor. Neither is the typed
+;;         source expansion; do not claim their numerical semantics are equivalent.
 ;; :mod    floored (Julia/Clojure mod). C/WGSL lower via the :floored-mod
 ;;         strategy; wasm computes a-floor(a/b)*b; JVM uses clojure.core/mod.
 ;; :rem    truncated (C %, JVM rem, wasm i32.rem_s) — all agree natively.
@@ -86,7 +85,10 @@
    :floor (math1 :f64.floor :f32.floor "floor")
    :ceil  {:arity 1 :kind :fn :wasm :poly :c {:fn "ceil"} :wgsl {:fn "ceil"}}   ; -floor(-x)
    :trunc {:arity 1 :kind :fn :wasm (vt3 :f64.trunc :f32.trunc nil) :c {:fn "trunc"} :wgsl {:fn "trunc"}}
-   :round {:arity 1 :kind :fn :c {:fn "round"} :wgsl {:fn "round"} :wasm :poly} ; wasm: floor(x+0.5) poly (Java semantics)
+   :round {:arity 1 :kind :fn :c {:fn "round"} :wgsl {:fn "round"} :wasm :poly
+           ;; Source overloads are not homogeneous FP intrinsics. Typed lowering expands
+           ;; these into ordinary SSA before target emission; raw legacy :round is separate.
+           :typed-expansion :java-round :source-signatures {:float :int :double :long}}
    :neg   {:arity 1 :kind :fn :wasm (vt3 :f64.neg :f32.neg nil) :c {:prefix "-"} :wgsl {:prefix "-"}}
    ;; math — binary
    :min {:arity 2 :kind :fn :wasm (vt3 :f64.min :f32.min nil) :c {:fn "fmin" :glsl "min"} :wgsl {:fn "min"}}

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -385,6 +385,36 @@
                                  (first (descriptor/call-args expression)))) expected expression)
                          expected env)
 
+                  (and (seq? expression)
+                       (= :java-round (:typed-expansion
+                                       (intrinsics/descriptor
+                                        (intrinsics/canonical (descriptor/semantic-op expression))))))
+                  (let [arguments (vec (descriptor/call-args expression))
+                        intrinsic (intrinsics/descriptor
+                                   (intrinsics/canonical (descriptor/semantic-op expression)))
+                        _ (when-not (= 1 (count arguments))
+                            (decline! :scalar-expression "Java round requires one argument"
+                                      {:expression expression}))
+                        input-type (source-type (first arguments) nil env)
+                        result-type (get (:source-signatures intrinsic) input-type)
+                        _ (when-not result-type
+                            (decline! :scalar-source-type "Java round requires a retained floating overload"
+                                      {:expression expression :source input-type}))
+                        input (lower (first arguments) input-type env)
+                        base (compute-ssa :floor input-type [(:result input)] {} nil)
+                        fraction (compute-ssa :- input-type [(:result input) (:result base)] {} nil)
+                        up (compute-ssa :ge :predicate [(:result fraction) (body/literal 0.5 input-type)] {} nil)
+                        next (compute-ssa :+ input-type [(:result base) (body/literal 1.0 input-type)] {} nil)
+                        rounded (compute-ssa :select input-type [(:result up) (:result next) (:result base)] {} nil)
+                        converted (compute-ssa :cast result-type [(:result rounded)]
+                                               {:rounding :toward-zero :overflow :saturate} nil)]
+                    ;; Adding 0.5 before floor would double-round the predecessor of 0.5.
+                    ;; Saturation supplies Java's NaN=0 and signed endpoint semantics.
+                    (cast-lowered (assoc converted :operations
+                                         (vec (mapcat :operations
+                                                      [input base fraction up next rounded converted])))
+                                  expected expression))
+
                   (seq? expression)
                   (let [semantic-operation (descriptor/semantic-op expression)
                         operator (intrinsics/canonical semantic-operation)

--- a/test/raster/compiler/backend/gpu/java_round_test.clj
+++ b/test/raster/compiler/backend/gpu/java_round_test.clj
@@ -20,6 +20,8 @@
       (doseq [target [:opencl-portable :cuda :hip]]
         (let [source (emit/emit-scalar-kernel "java_round_test" body {:target-dialect target})]
           (is (not (str/includes? source "= round(")))
+          (when (and (= output :long) (not= target :opencl-portable))
+            (is (str/includes? source "(-9223372036854775807LL - 1LL)")))
           (is (str/includes? source (if (= target :opencl-portable) "_sat_rtz(" "isnan("))))))))
 
 (defn- samples [type]

--- a/test/raster/compiler/backend/gpu/java_round_test.clj
+++ b/test/raster/compiler/backend/gpu/java_round_test.clj
@@ -1,0 +1,71 @@
+(ns raster.compiler.backend.gpu.java-round-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as fixtures]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emit]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.gpu.device-probe :as probe]))
+
+(deftest java-round-expands-before-target-emission
+  (doseq [[input output] [[:float :int] [:double :long]]]
+    (let [body (fixtures/java-round-body input output 1)
+          computes (filter :expression (:operations body))]
+      (is (= [:floor :- :ge :+ :select :cast] (mapv #(get-in % [:expression :op]) computes)))
+      (is (= {:rounding :toward-zero :overflow :saturate}
+             (get-in (last computes) [:expression :options])))
+      (is (= output (get-in (last computes) [:result :type])))
+      (doseq [target [:opencl-portable :cuda :hip]]
+        (let [source (emit/emit-scalar-kernel "java_round_test" body {:target-dialect target})]
+          (is (not (str/includes? source "= round(")))
+          (is (str/includes? source (if (= target :opencl-portable) "_sat_rtz(" "isnan("))))))))
+
+(defn- samples [type]
+  (let [fp (if (= type :float) unchecked-float double)
+        down (if (= type :float) #(Math/nextDown (float %)) #(Math/nextDown (double %)))
+        up (if (= type :float) #(Math/nextUp (float %)) #(Math/nextUp (double %)))
+        limit (if (= type :float) 2147483648.0 9223372036854775808.0)
+        random (java.util.Random. 9281)]
+    (mapv fp (concat [Double/NaN Double/NEGATIVE_INFINITY Double/POSITIVE_INFINITY
+                      -0.0 0.0 Double/MIN_VALUE (- Double/MIN_VALUE)
+                      Float/MIN_VALUE (- Float/MIN_VALUE)]
+                    (mapcat (fn [x] [(down x) x (up x)])
+                            [-2.5 -1.5 -0.5 0.5 1.5 2.5 (- limit) limit
+                             (if (= type :float) 8388608.0 4503599627370496.0)])
+                    (repeatedly 128 #(if (= type :float)
+                                       (Float/intBitsToFloat (.nextInt random))
+                                       (Double/longBitsToDouble (.nextLong random))))))))
+
+(deftest java-round-matches-jvm-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "typed Java round overloads and numerical edge cases")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve ocl 'register-kernel!)
+          buffer-of-array (ns-resolve ocl 'buffer-of-array)
+          make-buffer (ns-resolve ocl 'make-buffer)
+          bind-call (ns-resolve ocl 'bind-kernel-call)
+          launch! (ns-resolve ocl 'launch-registered-bound!)
+          read! (ns-resolve ocl 'buffer->array)
+          free! (ns-resolve ocl 'free-buffer!)]
+      (doseq [[input output] [[:float :int] [:double :long]]]
+        (let [values (samples input)
+              expected (mapv (if (= input :float) #(Math/round (unchecked-float %)) #(Math/round (double %))) values)
+              body (fixtures/java-round-body input output (count values))
+              name (str "java_round_" (name input))
+              compiled (artifact/make
+                        {:kernel-name name :target :opencl-c
+                         :source (emit/emit-scalar-kernel name body {:target-dialect :opencl-portable})
+                         :abi (body-abi/project-contracts
+                               [(abi/slot 'x :input input :c-name "rstr_x" :role :input)
+                                (abi/slot 'y :output output :c-name "rstr_y" :role :result)] body)
+                         :arguments '[x y] :launch (:launch body) :effects {:kind :map}
+                         :provenance {:kernel-body (:id body)}})
+              x (buffer-of-array ((if (= input :float) float-array double-array) values) input)
+              y (make-buffer (count values) output)]
+          (try
+            (register! name compiled)
+            (launch! (bind-call (call/make compiled [x y])))
+            (is (= expected (vec (read! y))) (str input " Java round boundary oracle"))
+            (finally (free! y) (free! x))))))))

--- a/test/raster/compiler/backend/gpu/java_round_test.clj
+++ b/test/raster/compiler/backend/gpu/java_round_test.clj
@@ -20,6 +20,7 @@
       (doseq [target [:opencl-portable :cuda :hip]]
         (let [source (emit/emit-scalar-kernel "java_round_test" body {:target-dialect target})]
           (is (not (str/includes? source "= round(")))
+          (is (str/includes? source "isnan("))
           (when (and (= output :long) (not= target :opencl-portable))
             (is (str/includes? source "(-9223372036854775807LL - 1LL)")))
           (is (str/includes? source (if (= target :opencl-portable) "_sat_rtz(" "isnan("))))))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -336,6 +336,8 @@
       (:kernels (equation-first/compile
                  #'qk/qmatmul-q4k-dp4a-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'qk/quant-act-i8-rows-gpu! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!
@@ -446,6 +448,14 @@
            (write-source! directory suffix "trapping-arithmetic"
                           (body-emit/emit-scalar-kernel
                            "trapping_arithmetic" (body-fixtures/trapping-arithmetic-body)
+                           {:target-dialect dialect}))
+           (write-source! directory suffix "java-round-f32"
+                          (body-emit/emit-scalar-kernel
+                           "java_round_f32" (body-fixtures/java-round-body :float :int 1)
+                           {:target-dialect dialect}))
+           (write-source! directory suffix "java-round-f64"
+                          (body-emit/emit-scalar-kernel
+                           "java_round_f64" (body-fixtures/java-round-body :double :long 1)
                            {:target-dialect dialect}))
            (write-source! directory suffix "word-shifts-i32"
                           (body-emit/emit-scalar-kernel

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -2,7 +2,25 @@
   "Shared verifier, source-compile, and device fixtures for scheduled KernelBody operations."
   (:require [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
-            [raster.compiler.ir.kernel-launch :as launch]))
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
+
+(defn java-round-body [input-type output-type width]
+  (let [builder (scalar/make-lowerer
+                 {:array-types {'x input-type} :arrays #{'x} :scalar-types {'lane :int}
+                  :lower-index (fn [value _] value)
+                  :decline! (fn [rule message data] (throw (ex-info message (assoc data :rule rule))))})
+        lowered ((:lower builder) '(Math/round (aget x lane)) output-type {'lane :int})]
+    (body/make
+     {:id [:java-round input-type width]
+      :parameters [(body/->KernelParameter 'x :input input-type [width] :global
+                                          (layout/row-major [width] input-type) :input)
+                   (body/->KernelParameter 'y :output output-type [width] :global
+                                          (layout/row-major [width] output-type) :result)]
+      :stable-reads [(body/stable-read 'x)]
+      :indices [(body/->IndexBinding 'lane :local 0)]
+      :operations (conj (:operations lowered) (body/->ScalarStore 'y ['lane] (:result lowered) nil))
+      :launch (launch/spec {:workgroup-size [width] :group-count [1]})})))
 
 (defn word-shifts-body
   "Typed word shifts share an input row and store left/arithmetic-right/logical-right results."

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -19,6 +19,20 @@
       :lower-index (fn [expression scope] (index/lower expression (conj scope 'i) decline!))
       :decline! decline!})))
 
+(deftest java-round-keeps-overload-separate-from-consumer-type
+  (let [lower (:lower (lowerer))
+        widened (lower '(Math/round (aget x i)) :long {'i :int})
+        operations (:operations widened)]
+    (is (= :int (get-in (nth operations 6) [:result :type]))
+        "Float round returns Int even when its consumer requests Long")
+    (is (= :long (:type widened)))
+    (is (= {:rounding :exact :overflow :exact}
+           (get-in (last operations) [:expression :options])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"retained floating overload"
+                         (lower '(Math/round missing) :long {})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires one argument"
+                         (lower '(Math/round (aget x i) (aget x i)) :long {'i :int})))))
+
 (defn- mixed-region [lowerer]
   ((:lower-region lowerer)
    '{:bindings [candidate (aget x i) better (> candidate old-value)]

--- a/test/raster/quant/i8_activation_device_test.clj
+++ b/test/raster/quant/i8_activation_device_test.clj
@@ -1,0 +1,37 @@
+(ns raster.quant.i8-activation-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.quant.kernels-k :as qk]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.gpu.device-probe :as probe]))
+
+(deftest typed-i8-activation-packing-is-row-local-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "typed I8 activation packing")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve ocl 'register-kernel!)
+          buffer-of-array (ns-resolve ocl 'buffer-of-array)
+          make-buffer (ns-resolve ocl 'make-buffer)
+          bind-call (ns-resolve ocl 'bind-kernel-call)
+          launch! (ns-resolve ocl 'launch-registered-bound!)
+          read! (ns-resolve ocl 'buffer->array)
+          free! (ns-resolve ocl 'free-buffer!)
+          width 64 rows 3 blocks (* rows (quot width 32))
+          input (float-array (mapcat (fn [scale]
+                                       (take width (cycle (map #(* scale %) [-127 127 -2.5 -1.5 -0.5 0.5 1.5 2.5]))))
+                                     [1.0 2.0 0.0]))
+          expected-words (int-array (* rows (quot width 4)))
+          expected-scales (float-array blocks)
+          _ (qk/quant-act-i8-rows-gpu! input expected-words expected-scales width rows)
+          compiled (first (:kernels (pipeline/show-pipeline #'qk/quant-act-i8-rows-gpu!
+                                                            :target-device :ocl:0 :dtype :float)))
+          x (buffer-of-array input :float)
+          xp (make-buffer (alength expected-words) :int)
+          xs (make-buffer blocks :float)]
+      (try
+        (register! (:kernel-name compiled) compiled)
+        (launch! (bind-call (kcall/make compiled [x xp xs {:type :long :value width}
+                                                {:type :long :value blocks}])))
+        (is (= (vec expected-words) (vec (read! xp))))
+        (is (= (vec expected-scales) (vec (read! xs))))
+        (finally (free! xs) (free! xp) (free! x))))))

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -204,6 +204,15 @@
           (is (< (Math/abs (- (aget actual (+ (* row out) o)) (aget expected o))) 1e-3)
               (str "Q4_K row " row ", output " o)))))))
 
+(deftest i8-activation-packing-uses-typed-kernel-body
+  (let [compiled (pipeline/show-pipeline #'qk/quant-act-i8-rows-gpu!
+                                         :target-device :ocl:0 :dtype :float)
+        report (report/from-pipeline compiled)]
+    (is (= :typed-soac (get-in report [:route :source-dialect])))
+    (is (true? (get-in report [:route :typed-validated])))
+    (is (= {:kernel-body 1} (get-in report [:emission :routes])))
+    (is (empty? (get-in report [:emission :declines])))))
+
 (deftest row-capable-q4k-path-lowers-through-the-shared-gpu-pipeline
   (let [quant-kernels (:kernels (pipeline/show-pipeline #'qk/quant-act-q8k-rows-gpu!
                                                         :target-device :ze:0 :dtype :float))


### PR DESCRIPTION
## Summary
- Measured 33-entry quantization inventory identifies actual remaining compatibility debt.
- Java Float-to-Int and Double-to-Long signatures live in the existing intrinsic table. Shared lowering expands into ordinary scalar SSA, preserving ties, NaN, saturation and consumer conversions.
- CUDA/HIP use guarded saturating casts; signed minimum literals remain signed.
- I8 activation packing now emits one validated KernelBody kernel. No quantization-specific emitter or IR node added.

## Validation
- Focused shared-lowering/emitter and numerical device tests pass in one capped REPL; no full local suite.
- Intel Arc: 164 inputs per rounding overload match Java, including adjacent half-ties, NaN, infinities, signed endpoints and random bit patterns.
- Public packer matches JVM words/scales across three rows including zero and signed half-ties; compiler route assertions pass.
- Synthetic CUDA/HIP targets each emit one public packer artifact. Both overloads and packer added to vendor CI compile fixtures.
- Independent review: no remaining blockers, including signed-min portability follow-up.

Full suite and vendor compiler checks run in CI. Merge only after all seven gates pass on this reviewed head. CUDA/HIP hardware execution and throughput are not claimed. Q8_K compatibility packing and the packed CPU helper type-retention issue remain follow-ups.