### PR TITLE
Give Q8_K scale slots a single writer

### DIFF
--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -85,3 +85,17 @@ matches JVM packed words and scales across three rows, including half-ties and a
 Both overloads and the public packer join the CUDA/HIP compile fixtures. This is correctness and
 emission evidence, **not a throughput measurement**. The original 33-entry table remains the
 pre-repair baseline; Q8_K compatibility emission and the packed helper's lost type remain open.
+
+## Q8_K scale ownership
+
+Both row quantizers now publish each super-block scale only from sub-block `j=0`. Previously
+eight work-items performed non-atomic writes to the same slot; equal values do not establish
+race freedom. The valid-input contract remains complete launches over rows whose physical width
+is a multiple of 256. Packed-word and block-sum ownership, scratch size, two-phase scheduling,
+and the public ABI are unchanged. CPU row/padding checks, emitted store-guard checks, and real
+device quantization-to-Q4_K projection chains pass (five focused tests, 30 assertions).
+
+The second phase still declines TypedSOAC admission. Its store loop also carries a running sum;
+the frontend currently admits index-only store loops. The next generalization must preserve
+result-carrying effects and their order through the existing effect-region and KernelBody loop
+contracts. Do not conceal this with a quantization-specific emitter or a claimed typed route.

--- a/src/raster/quant/kernels_k.clj
+++ b/src/raster/quant/kernels_k.clj
@@ -89,7 +89,8 @@
 ;; phase 1 computes per-32-sub-block |max| (nsb*8 items, 32-deep), phase 2 folds the 8
 ;; sibling submaxes (float max is EXACT under reassociation → d is bit-identical to the
 ;; serial scan) and quantizes its 32 elements (nsb*8 items, ~40-deep). `submax` is an
-;; nrows*nsb*8 float scratch. The 8 same-value xs writes per super-block are benign.
+;; nrows*nsb*8 float scratch. Only sub-block zero publishes each super-block's scale;
+;; identical values do not make concurrent non-atomic writes a valid ownership contract.
 (deftm quant-act-q8k-rows-gpu!
   "Q8_K activation quantization over a row-major [nrows,in] tensor. The physical result is
   the ordered `(xp,xs,bsums)` representation with row-major leaves; `submax` is transient
@@ -121,7 +122,8 @@
                          sidx (+ (* row nsub) (* sb 8) j)
                          wbase (+ (* row (quot (long in) 4)) (* sb 64) (* j 8))
                          ebase (+ (* row (long in)) (* sb 256) (* j 32))]
-                     (ra/aset xs (+ (* row nsb) sb) (float d))
+                     (when (== j 0)
+                       (ra/aset xs (+ (* row nsb) sb) (float d)))
                      (let [bs (loop [w 0 s 0]
                                 (if (< w 8)
                      ;; |x·id| ≤ 127 by construction (id = 127/max|x|), so round lands in
@@ -183,7 +185,8 @@
                          wbase (+ (* row (quot (long padded-in) 4)) (* sb 64) (* j 8))
                          col-base (+ (* sb 256) (* j 32))
                          xbase (* row (long width))]
-                     (ra/aset xs (+ (* row nsb) sb) (float d))
+                     (when (== j 0)
+                       (ra/aset xs (+ (* row nsb) sb) (float d)))
                      (let [bs (loop [w 0 s 0]
                                 (if (< w 8)
                                   (let [col (+ col-base (* w 4))

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -223,6 +223,10 @@
         projection-kernels (:kernels projection-pipeline)
         projection-report (report/from-pipeline projection-pipeline)]
     (is (= 2 (count quant-kernels)) "Q8_K remains an ordered two-phase reduction")
+    (doseq [packing [(second quant-kernels) (second padded-kernels)]]
+      (is (re-find #"if \(\(\(long\)\(j\) == \(long\)\(0\)\)\) \{ xs\["
+                   (:source packing))
+          "exactly sub-block zero publishes the shared super-block scale"))
     (is (= '[[[submax :float] [x :float] [_n_bound :int]]
              [[bsums :int] [submax :float] [x :float] [xp :int]
               [xs :float] [in :long] [_n_bound :int]]]


### PR DESCRIPTION
## Summary
- Both dense and padded Q8_K quantizers publish each superblock scale only from subblock zero.
- Removes eight racing identical non-atomic stores; packed-word and block-sum ownership are unchanged.
- No new emitter, IR node, ABI or scratch change. The existing complete-launch / multiple-of-256 physical-width contract is unchanged.

## Validation
Five focused tests / 30 assertions green: JVM row and padding oracles, emitted store guards, and real device dense and padded batched quantization-to-Q4_K projection chains. Read-only review found no blocker.

Stacked on #476. Merge after the dependency and all seven checks pass on the reviewed head. The result-carrying effect loop remains the next TypedSOAC admission gap; this PR does not claim to fix it.