### PR TITLE
Project canonical SOAC carried effects into shared scheduled loops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,7 @@ commands:
           name: Install Clojure CLI 1.12.0.1488
           command: |
             if ! command -v clojure &> /dev/null; then
-              curl -L -O https://download.clojure.org/install/linux-install-1.12.0.1488.sh
-              chmod +x linux-install-1.12.0.1488.sh
-              sudo ./linux-install-1.12.0.1488.sh
-              rm linux-install-1.12.0.1488.sh
+              sudo bash scripts/ci-install-clojure.sh
             fi
 
 executors:

--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -145,6 +145,6 @@ fusion does not absorb these ordered effect maps.
 Direct canonical program envelopes and scheduled JVM/KernelBody emission are exercised. The
 production source-realization adapter explicitly refuses carried loops until its continuation
 binding is implemented; frontend recognition is still closed. A capture whose physical symbol
-collides with a carry binder/result currently fails scheduled validation rather than being silently
+collides with a map/loop/local/result binder currently fails projection rather than being silently
 captured. General hygienic physical-name projection is a follow-up before claiming unrestricted
 symbol-ID composability. No throughput claim or public quantizer migration follows from this slice.

--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -108,9 +108,8 @@ existing KernelBody LoopArg/ForLoop/Yield contract. Loop locals and parameters d
 zero-trip loops return their initializer, and stores precede recurrence computation. Lexical
 sibling binders are renamed into collision-free KernelBody SSA identities.
 
-This is a **scheduled-region prerequisite**, not new TypedSOAC source admission. Canonical
-dialect projection and frontend recognition remain closed until the next slice. The public Q8_K
-packers therefore still use the measured compatibility route and unchanged two-phase schedule.
+This first landing was a **scheduled-region prerequisite**, not new TypedSOAC source admission.
+The public Q8_K packers still use the measured compatibility route and unchanged two-phase schedule.
 
 Carried regions require retained compound source types and reject unsupported conversions rather
 than inheriting map emission's device-wrap defaults. Checked integer arithmetic retains its width
@@ -124,3 +123,28 @@ substitution, shadowing of cast names, source overflow order, and fail-closed co
 The OpenCL device oracle checks two independent rows and poisoned output tails. The same scheduled
 fixture joins hardware-free CUDA/HIP compiler gates; this does not claim vendor-device execution
 or any packing throughput improvement yet.
+
+## Canonical carried-effect projection
+
+The existing `effect-loop` also has an explicitly result-bearing form:
+
+```clojure
+(effect-loop {:index k :lower 0
+              :carry {:parameter acc :result sum :dtype :float}}
+  extent initial
+  (lambda [k acc]
+    (effect-region [typed-local ...] [ordered-effect ...] update)))
+```
+
+Initializer and update are grammar-visible scalar operands, not expressions hidden in attribute
+maps. The result-bearing region is legal only as a carried-loop body. Common projection preserves
+it into the scheduled region; validation threads result scope through subsequent effects and
+checks destination reads against read-write storage and explicit read effects. Existing pure-map
+fusion does not absorb these ordered effect maps.
+
+Direct canonical program envelopes and scheduled JVM/KernelBody emission are exercised. The
+production source-realization adapter explicitly refuses carried loops until its continuation
+binding is implemented; frontend recognition is still closed. A capture whose physical symbol
+collides with a carry binder/result currently fails scheduled validation rather than being silently
+captured. General hygienic physical-name projection is a follow-up before claiming unrestricted
+symbol-ID composability. No throughput claim or public quantizer migration follows from this slice.

--- a/scripts/ci-install-clojure.sh
+++ b/scripts/ci-install-clojure.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Pinned CLI payload from Clojure's official distribution, without the upstream
+# installer's unchecked GitHub-release download. Run as root for /usr/local, or
+# pass an owned absolute prefix for an isolated smoke test.
+set -euo pipefail
+
+cli_version=1.12.0.1488
+cli_sha256=bc19be0010bef0421c26fd3bec7bc3bca08c192828d59a151845422dc4420742
+cli_prefix=${1:-/usr/local}
+if [[ ! "$cli_prefix" =~ ^/[a-zA-Z0-9/._-]+$ ]]; then
+  echo "unsupported Clojure installation prefix: $cli_prefix" >&2
+  exit 2
+fi
+
+cli_work=$(mktemp -d -t raster-clojure-install.XXXXXX)
+trap 'rm -rf -- "$cli_work"' EXIT
+cli_archive="$cli_work/clojure-tools.tar.gz"
+curl --fail --show-error --location --retry 3 --retry-delay 2 \
+  --connect-timeout 20 --max-time 180 \
+  "https://download.clojure.org/install/clojure-tools-${cli_version}.tar.gz" \
+  --output "$cli_archive"
+printf '%s  %s\n' "$cli_sha256" "$cli_archive" | sha256sum --check --status
+gzip -t "$cli_archive"
+tar xzf "$cli_archive" -C "$cli_work"
+
+cli_source="$cli_work/clojure-tools"
+cli_lib="$cli_prefix/lib/clojure"
+cli_bin="$cli_prefix/bin"
+cli_man="$cli_prefix/share/man/man1"
+install -d "$cli_lib/libexec" "$cli_bin" "$cli_man"
+install -m644 "$cli_source/deps.edn" "$cli_source/example-deps.edn" "$cli_source/tools.edn" "$cli_lib/"
+install -m644 "$cli_source/exec.jar" "$cli_source/clojure-tools-${cli_version}.jar" "$cli_lib/libexec/"
+sed -i "s@PREFIX@$cli_lib@g" "$cli_source/clojure"
+sed -i "s@BINDIR@$cli_bin@g" "$cli_source/clj"
+install -m755 "$cli_source/clojure" "$cli_source/clj" "$cli_bin/"
+install -m644 "$cli_source/clojure.1" "$cli_source/clj.1" "$cli_man/"
+"$cli_bin/clojure" -Sdescribe

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -191,10 +191,16 @@
 
 (defn effect-loop-attributes?
   "The binder of a counted store loop inside an effect region: its index symbol and the integer
-   lower bound. The extent is a scalar operand of the form, so the grammar checks it."
+   lower bound, optionally a typed carry/result binding. Extent, initializer and update stay
+   scalar operands of the grammar, never expressions hidden inside attribute maps."
   [value]
   (and (map? value)
-       (= #{:index :lower} (set (keys value)))
+       (or (= #{:index :lower} (set (keys value)))
+           (and (= #{:index :lower :carry} (set (keys value)))
+                (let [{:keys [parameter result dtype] :as carry} (:carry value)]
+                  (and (= #{:parameter :result :dtype} (set (keys carry)))
+                       (symbol? parameter) (symbol? result)
+                       (contains? #{:int :long :float :double} dtype)))))
        (symbol? (:index value))
        (integer? (:lower value))))
 
@@ -513,7 +519,8 @@
   (Effect [e :enforce]
           (effect ?sym:destination ?ec:conflict
                   ?s:destination-index ?s:predicate ?s:value)
-          (effect-loop ?ela ?s:extent ?el))
+          (effect-loop ?ela ?s:extent ?el)
+          (effect-loop ?ela ?s:extent ?s:init ?rel))
 
   (Local [d :enforce]
          (let-value ?sym:binding ?dt ?s:init))
@@ -529,6 +536,10 @@
 
   (EffectLambda [el :enforce]
                 (lambda [(?:* ?sym:parameter)] ?er))
+
+  (ResultEffectLambda [rel :enforce]
+                      (lambda [(?:* ?sym:parameter)]
+                        (effect-region [(?:* d)] [(?:+ e)] ?s:update)))
 
   (Fold [f :enforce]
         (fold ?fa ?l))
@@ -645,9 +656,9 @@
       {:destination-index destination-index :predicate predicate :value written-value})))
 
 (defn effect-loop-form?
-  "Whether an effect-region item is a counted store loop `(effect-loop attrs extent lambda)`."
+  "Whether an effect-region item is a counted store loop, optionally with an initializer."
   [value]
-  (and (seq? value) (= 'effect-loop (first value)) (= 4 (count value))))
+  (and (seq? value) (= 'effect-loop (first value)) (contains? #{4 5} (count value))))
 
 (defn effect-form?
   "Whether a typed ordered-effect region item has canonical syntax: one store effect or one
@@ -661,13 +672,20 @@
 (defn effect-parts
   "Project one effect-region item. Store effects yield their destination, conflict contract,
    index, predicate and value; loops yield `:loop true` with `:index`, `:lower`, `:extent` and
-   the `:lambda` whose single parameter is the loop index."
+   the `:lambda`. Result-bearing loops additionally expose a typed `:carry` with initializer and
+   update; their parameter vector is [index carry-parameter]."
   [value]
   (cond
     (effect-loop-form? value)
-    (let [[_ attributes extent lambda] value]
-      {:loop true :index (:index attributes) :lower (:lower attributes)
-       :extent extent :lambda lambda})
+    (let [[_ attributes extent] value
+          carried? (= 5 (count value))
+          lambda (last value)]
+      (cond-> {:loop true :index (:index attributes) :lower (:lower attributes)
+               :extent extent :lambda lambda}
+        (or carried? (:carry attributes))
+        (assoc :carry (assoc (:carry attributes)
+                             :init (when carried? (nth value 3))
+                             :update (:effect-result (lambda-parts lambda))))))
 
     (effect-form? value)
     (let [[_ destination conflict destination-index predicate written-value] value]
@@ -739,7 +757,14 @@
                        (closed! update after-effects :update))
                      (conj bound result))
                    ;; Ordinary loops do not export names, including any nested carried result.
-                   (do (walk effects (into (conj bound index) (map :id locals))) bound))
+                   (do
+                     (closed! lower bound :lower)
+                     (closed! extent bound :extent)
+                     (walk effects (reduce (fn [scope {:keys [id init]}]
+                                             (closed! init scope :local)
+                                             (conj scope id))
+                                           (conj bound index) locals))
+                     bound))
                  (do (doseq [field [:destination-index :predicate :value]]
                        (closed! (get effect field) bound field))
                      bound)))
@@ -782,12 +807,25 @@
    Locals are returned as maps so compiler passes do not independently parse their S-expression
    spelling. The TypedSOAC form remains the sole serialized representation."
   [lambda]
-  (let [[_ parameters [_ local-forms body-results]] lambda]
-    {:parameters (vec parameters)
-     :locals (mapv (fn [[_ id dtype init]]
-                     {:id id :dtype dtype :init init})
-                   local-forms)
-     :body-results (vec body-results)}))
+  (let [[_ parameters [_ local-forms body-results effect-result :as region]] lambda]
+    (cond-> {:parameters (vec parameters)
+             :locals (mapv (fn [[_ id dtype init]]
+                             {:id id :dtype dtype :init init})
+                           local-forms)
+             :body-results (vec body-results)}
+      (= 4 (count region)) (assoc :effect-result effect-result))))
+
+(defn scheduled-effect
+  "Project a canonical effect into the shared scheduled shape, without source reconstruction.
+   This projection does not substitute captures, assign destination dtypes or select a target."
+  [effect]
+  (let [{:keys [loop index lower extent lambda carry] :as part} (effect-parts effect)]
+    (if loop
+      (let [{:keys [locals body-results]} (lambda-parts lambda)]
+        {:loop (cond-> {:index index :lower lower :extent extent :locals locals
+                        :effects (mapv scheduled-effect body-results)}
+                 carry (assoc :carry carry))})
+      part)))
 
 (defn scalar-fold-form?
   "True for a typed ordered fold embedded in a scalar region."
@@ -1084,13 +1122,9 @@
       (doseq [body body-results
               expression (cond
                            (= 'scatter kind) (vals (write-parts body))
-                           (= 'effect-map kind)
-                           (let [{:keys [loop extent destination destination-index predicate
-                                         value]}
-                                 (effect-parts body)]
-                             (if loop
-                               [extent]
-                               [destination destination-index predicate value]))
+                           ;; Ordered effects export loop results into their continuation. Their
+                           ;; scope is checked as a spine below, not against one fixed environment.
+                           (= 'effect-map kind) []
                            :else [body])
               :let [unbound (util/free-syms expression final-bound)]
               :when (seq unbound)]
@@ -1125,39 +1159,39 @@
             by-destination (group-by :destination leaves)
             iteration-order (:iteration-order attributes)
             region-bound (into (set parameters) (cons (:index attributes) (map :id locals)))]
-        (doseq [part effects :when (:loop part)]
-          (let [{loop-parameters :parameters loop-locals :locals :keys [body-results]}
-                (lambda-parts (:lambda part))
-                loop-ids (mapv :id loop-locals)
-                ;; loop locals are ordered SSA: each initializer sees the index and the
-                ;; locals before it, never a later one
-                {:keys [bound local-unbound]}
-                (reduce (fn [{:keys [bound local-unbound]} {:keys [id init]}]
-                          {:bound (conj bound id)
-                           :local-unbound (into local-unbound (util/free-syms init bound))})
-                        {:bound (conj region-bound (:index part)) :local-unbound #{}}
-                        loop-locals)
-                inner (map effect-parts body-results)
-                extent-unbound (util/free-syms (:extent part) region-bound)
-                unbound (into local-unbound
-                              (mapcat #(util/free-syms % bound))
-                              (mapcat (fn [{:keys [loop destination-index predicate value]}]
-                                        (when-not loop
-                                          [destination-index predicate value]))
-                                      inner))]
-            (when-not (and (= [(:index part)] loop-parameters)
-                           (= (count loop-ids) (count (distinct loop-ids)))
-                           (not (contains? region-bound (:index part)))
-                           (every? some? inner)
-                           (not (some :loop inner))
-                           (seq inner)
-                           (empty? extent-unbound)
-                           (empty? unbound))
-              (fail! :typed-soac-effect-loop
-                     "effect loops are closed single-level counted regions over their loop index"
-                     {:equation equation-id :loop (:index part) :parameters loop-parameters
-                      :extent-unbound extent-unbound :unbound unbound
-                      :body body-results}))))
+        (reduce
+         (fn [scope part]
+           (if (:loop part)
+             (let [{loop-parameters :parameters loop-locals :locals :keys [body-results] :as region}
+                   (lambda-parts (:lambda part))
+                   carry (:carry part)
+                   expected (cond-> [(:index part)] carry (conj (:parameter carry)))
+                   ids (into expected (map :id loop-locals))
+                   inner (mapv effect-parts body-results)]
+               (when (and carry
+                          (some (fn [expression]
+                                  (or (util/effectful? expression)
+                                      (some descriptor/aset-call? (tree-seq coll? seq expression))))
+                                [(:init carry) (:update carry)]))
+                 (fail! :typed-soac-effect-carry-write
+                        "carried values cannot hide stores outside the ordered effect spine"
+                        {:equation equation-id :carry carry}))
+               (when-not (and (= expected loop-parameters)
+                              (= (boolean carry) (contains? region :effect-result))
+                              (= (count ids) (count (distinct ids)))
+                              (empty? (set/intersection scope (set ids)))
+                              (every? some? inner) (not-any? :loop inner) (seq inner))
+                 (fail! :typed-soac-effect-loop
+                        "effect loops require matching typed binders and one closed effect level"
+                        {:equation equation-id :loop (:index part) :parameters loop-parameters}))
+               (cond-> scope carry (conj (:result carry))))
+             scope))
+         region-bound effects)
+        (try
+          (validate-scheduled-effect-carries! (mapv scheduled-effect body-results) region-bound)
+          (catch clojure.lang.ExceptionInfo e
+            (fail! :typed-soac-effect-loop "effect scope is not closed in source order"
+                   {:equation equation-id :cause (ex-data e)})))
         (when-not (= result-count destination-count (count (:dtypes attributes)))
           (fail! :typed-soac-effect-results
                  "effect-map results, physical destinations, and dtypes must align"
@@ -1658,6 +1692,26 @@
                {:equation equation-id :results results :storage storage}))
       (let [destinations (mapv :destination storage)
             aliases (get-in program-facts [:equations equation-id :aliases])]
+        (when (= 'effect-map kind)
+          (let [lambda (:lambda (operation-parts equation))
+                parts (mapv effect-parts (:body-results (lambda-parts lambda)))]
+            (when (some :carry parts)
+              (let [destination-parameters (:destination-parameters (parameter-layout equation))
+                    accesses (zipmap destination-parameters (map :access storage))
+                    reads (filter descriptor/aget-call? (tree-seq coll? seq lambda))]
+                (doseq [read reads
+                        :let [parameter (descriptor/aget-array-sym read)]
+                        :when (contains? accesses parameter)]
+                  (when-not (= :read-write (get accesses parameter))
+                    (fail! :typed-soac-effect-carry-read-access
+                           "a carried region's destination reads require read-write storage"
+                           {:equation equation-id :destination parameter :read read})))
+                (when (and (seq reads)
+                           (not (contains? (get-in program-facts [:equations equation-id :effects])
+                                           :memory/read)))
+                  (fail! :typed-soac-effect-carry-read-effect
+                         "carried-region reads must be explicit in equation effects"
+                         {:equation equation-id}))))))
         (when (and (= 'effect-map kind)
                    (not= destinations (:destinations (operation-parts equation))))
           (fail! :typed-soac-effect-storage

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -354,27 +354,25 @@
                                 (fn [init] (util/subst-syms substitutions init)))
                        locals)
           lower-effect
-          (fn lower-effect [effect]
-            (let [{:keys [loop destination conflict destination-index predicate value]
-                   :as parts}
-                  (soac-dialect/effect-parts effect)]
+          (fn lower-effect [{:keys [loop destination conflict destination-index predicate value]}]
               (if loop
-                (let [{:keys [locals body-results]} (soac-dialect/lambda-parts (:lambda parts))]
-                  {:loop {:index (:index parts)
-                          :lower (:lower parts)
-                          :extent (util/subst-syms substitutions (:extent parts))
-                          :locals (mapv #(update % :init
-                                                 (fn [init] (util/subst-syms substitutions init)))
-                                        locals)
-                          :effects (mapv lower-effect body-results)}})
+                {:loop (-> loop
+                           (update :extent #(util/subst-syms substitutions %))
+                           (update :locals #(mapv (fn [local]
+                                                   (update local :init (partial util/subst-syms substitutions))) %))
+                           (update :effects #(mapv lower-effect %))
+                           (cond-> (:carry loop)
+                             (update :carry #(-> %
+                                                 (update :init (partial util/subst-syms substitutions))
+                                                 (update :update (partial util/subst-syms substitutions))))))}
                 {:destination (util/subst-syms substitutions destination)
                  :dtype (get destination-dtypes
                              (util/subst-syms substitutions destination))
                  :conflict conflict
                  :destination-index (util/subst-syms substitutions destination-index)
                  :predicate (util/subst-syms substitutions predicate)
-                 :value (util/subst-syms substitutions value)})))
-          effects (mapv lower-effect body-results)
+                 :value (util/subst-syms substitutions value)}))
+          effects (mapv (comp lower-effect soac-dialect/scheduled-effect) body-results)
           effect-leaves (soac-dialect/effect-leaves effects)
           stable (set (get-in attributes [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable captures))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -350,6 +350,25 @@
                         [parameter (list 'clojure.core/aget array (:index attributes))])
                       elements arrays)
                  (map vector destination-parameters physical-results)))
+          ;; Until region-wide hygienic instantiation lands, do not let physical capture names
+          ;; become loop/local references (the map index is a binder too, not just carry slots).
+          _ (when (some (comp :carry soac-dialect/effect-parts) body-results)
+              (let [loop-parts (keep #(let [part (soac-dialect/effect-parts %)]
+                                       (when (:loop part) part)) body-results)
+                    binders (into (set (cons (:index attributes) (map :id locals)))
+                                  (mapcat (fn [part]
+                                            (let [{:keys [parameters locals]}
+                                                  (soac-dialect/lambda-parts (:lambda part))]
+                                              (concat parameters (map :id locals)
+                                                      (when-let [result (get-in part [:carry :result])]
+                                                        [result])))))
+                                  loop-parts)
+                    physical (set (filter symbol? (concat arrays captures physical-results)))
+                    collisions (clojure.set/intersection binders physical)]
+                (when (seq collisions)
+                  (throw (ex-info "physical capture names collide with lexical effect binders"
+                                  {:reason :typed-soac-effect-capture-collision
+                                   :collisions collisions :equation equation-id})))))
           locals (mapv #(update % :init
                                 (fn [init] (util/subst-syms substitutions init)))
                        locals)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -65,7 +65,11 @@
                        :as parts}
                       (dialect/effect-parts body)]
                   (if loop
-                    (let [{:keys [locals body-results]} (dialect/lambda-parts (:lambda parts))]
+                    (let [_ (when (:carry parts)
+                              (throw (ex-info "carried effects require structured scheduled lowering"
+                                              {:reason :typed-soac-production-subset
+                                               :missing-rule :carried-effect-realization})))
+                          {:keys [locals body-results]} (dialect/lambda-parts (:lambda parts))]
                       (list 'effect-loop {:index (:index parts) :lower (:lower parts)}
                             (project-expression (:extent parts))
                             (list 'lambda [(:index parts)]

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -400,6 +400,10 @@
                                     [:nodes 0 :operation]))
            (write-artifact! directory suffix "scheduled-carried-effect-loop"
                             (carried-fixture/artifact (carried-fixture/scheduled-loop 8) dialect))
+           (write-artifact! directory suffix "typed-carried-effect-loop"
+                            (carried-fixture/artifact
+                             (first (soac-lower/lower-typed-effect-map
+                                     (carried-fixture/typed-program 8) :ze:0)) dialect))
            (write-artifact! directory suffix "public-outer-product"
                             (get-in (segop-emit/generate-kernel-graph
                                      (capacity-fixture/inferred-graph) :target-dialect dialect)

--- a/test/raster/compiler/passes/parallel/carried_effect_loop_device_test.clj
+++ b/test/raster/compiler/passes/parallel/carried_effect_loop_device_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.ir.kernel-call :as call]
             [raster.compiler.passes.parallel.carried-effect-loop-fixture :as fixture]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.gpu.device-probe :as probe]))
 
 (deftest carried-store-loops-match-the-sequential-oracle-on-opencl
@@ -14,8 +15,11 @@
           launch! (ns-resolve runtime 'launch-registered-bound!)
           read! (ns-resolve runtime 'buffer->array)
           free! (ns-resolve runtime 'free-buffer!)]
-      (doseq [trips [0 1 8]]
-        (let [compiled (fixture/artifact (fixture/scheduled-loop trips) :opencl-portable)
+      (doseq [kind [:scheduled :typed] trips [0 1 8]]
+        (let [operation (if (= kind :typed)
+                          (first (lower/lower-typed-effect-map (fixture/typed-program trips) :ze:0))
+                          (fixture/scheduled-loop trips))
+              compiled (fixture/artifact operation :opencl-portable)
               values (vec (range 16))
               x (buffer-of-array (float-array values) :float)
               words (buffer-of-array (float-array (repeat 19 -77)) :float)
@@ -23,7 +27,10 @@
           (try
             (register! (:kernel-name compiled) compiled)
             (launch! (bind-call (call/make compiled
-                                          [x totals words {:type :long :value 2} {:type :long :value 2}])))
+                                          (mapv {'x x 'totals totals 'words words
+                                                 'rows {:type :long :value 2}
+                                                 'seed {:type :float :value 0.25}}
+                                                (:arguments compiled)))))
             (is (= (vec (concat (map-indexed (fn [i v] (if (< (mod i 8) trips) (float v) -77.0)) values)
                                 (repeat 3 -77.0)))
                    (vec (read! words))) "only the selected row elements are written")

--- a/test/raster/compiler/passes/parallel/carried_effect_loop_fixture.clj
+++ b/test/raster/compiler/passes/parallel/carried_effect_loop_fixture.clj
@@ -1,6 +1,8 @@
 (ns raster.compiler.passes.parallel.carried-effect-loop-fixture
-  "Scheduled-region fixture: source/dialect admission is intentionally not claimed."
+  "Scheduled and canonical region fixtures; analyzed-source admission is not claimed."
   (:require [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]))
 
 (defn scheduled-loop [trips]
@@ -23,4 +25,40 @@
 (defn artifact [operation target]
   (emit/generate-scheduled-segmap-kernel
    operation :dtype :float :target-dialect target
-   :array-types {'x :float 'words :float 'totals :float} :scalar-types {'rows :long}))
+   :array-types {'x :float 'words :float 'totals :float} :scalar-types {'rows :long 'seed :float}))
+
+(defn typed-program [trips]
+  (let [words-result [:carry 0] totals-result [:carry 1]
+        tensor #(av/tensor {:dtype :float :shape [%]})
+        equation
+        (list '= :carry [words-result totals-result]
+              (list 'effect-map
+                    {:index 'i :extent 'rows :dtypes [:float :float]
+                     :iteration-order :independent :attributes {:stable-array-captures ['x]}}
+                    [] '[x seed rows] '[words totals]
+                    (dialect/effect-lambda-form
+                     '[source initial row-count packed sums]
+                     [(list 'effect-loop {:index 'k :lower 0
+                                          :carry {:parameter 'acc :result 'sum :dtype :float}}
+                            trips 'initial
+                            (list 'lambda '[k acc]
+                                  (list 'effect-region
+                                        [(dialect/local-value 'loaded :float '(aget source (+ (* i 8) k)))]
+                                        [(list 'effect 'packed :unique '(+ (* i 8) k) true 'loaded)]
+                                        (with-meta '(+ acc loaded) {:raster.type/tag 'double}))))
+                      (list 'effect 'sums :unique 'i true 'sum)])))
+        equation-facts (assoc (dialect/default-equation-facts)
+                              :effects #{:memory/read :memory/write}
+                              :aliases {words-result 'words totals-result 'totals}
+                              :attributes {:result-storage
+                                           [{:destination 'words :access :write :host-return :effect}
+                                            {:destination 'totals :access :write :host-return :effect}]})]
+    (dialect/make
+     (dialect/default-program-facts
+      {:values {'x (tensor 16) 'words (tensor 16) 'totals (tensor 2)
+                'rows (av/tensor {:dtype :long :shape []})
+                'seed (av/tensor {:dtype :float :shape []})
+                words-result (tensor 16) totals-result (tensor 2)}
+       :inputs '[x seed rows] :equations {:carry equation-facts}
+       :effects #{:memory/read :memory/write}})
+     [equation] [])))

--- a/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
@@ -1,0 +1,113 @@
+(ns raster.compiler.passes.parallel.typed-effect-carry-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.jvm.segop-simd :as jvm]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.carried-effect-loop-fixture :as fixture]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(defn- rewrite-loop [program f]
+  (walk/postwalk #(if (dialect/effect-loop-form? %) (f %) %) program))
+
+(defn- reason [program]
+  (try (dialect/validate! program) :accepted
+       (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+
+(deftest canonical-carried-effects-project-without-source-reconstruction
+  (doseq [trips [0 1 8]]
+    (let [program (fixture/typed-program trips)
+          equation (first (dialect/equations program))
+          loop (-> equation dialect/operation-parts :lambda dialect/lambda-parts
+                   :body-results first dialect/effect-parts)
+          operation (first (lower/lower-typed-effect-map program :ze:0))
+          carry (get-in operation [:scalar-region :effects 0 :loop :carry])
+          execute (eval (list 'fn '[x words totals rows seed] (jvm/compile-effect-segmap operation)))
+          totals (float-array 2) words (float-array (repeat 16 -77))]
+      (is (= :accepted (reason program)))
+      (is (= 'initial (get-in loop [:carry :init])))
+      (is (= 'seed (:init carry)) "capture appears only in initializer but is still substituted")
+      (is (= :float (:dtype carry)))
+      (is (= 'double (:raster.type/tag (meta (:update carry)))))
+      (is (nil? (:lambda operation)))
+      (execute (float-array (range 16)) words totals 2 (float 0.25))
+      (is (= (mapv (fn [row] (+ 0.25 (reduce + (take trips (drop (* row 8) (range 16)))))) [0 1])
+             (vec totals)))
+      (doseq [target [:opencl-portable :cuda :hip]]
+        (is (= :kernel-body (get-in (fixture/artifact operation target) [:attributes :emission-route])))))))
+
+(deftest carried-regions-survive-remapping-and-remain-an-effect-fusion-boundary
+  (let [program (fixture/typed-program 8)
+        remapped (dialect/remap-values program {'seed 'starting-value})
+        operation (first (lower/lower-typed-effect-map remapped :ze:0))
+        [fused stats] (fusion/fusion-fixpoint program)]
+    (is (= 'starting-value (get-in operation [:scalar-region :effects 0 :loop :carry :init])))
+    (is (= (dialect/equations program) (dialect/equations fused)))
+    (is (zero? (:vertical stats)))
+    (is (zero? (:horizontal stats)))
+    (is (= :explicit-typed-algorithm (get-in (route/program-envelope program) [:attributes :host-control])))
+    (is (= :carried-effect-realization
+           (try ((ns-resolve 'raster.compiler.passes.parallel.typed-soac-route 'scalar-region)
+                 (first (dialect/equations program)))
+                :accepted
+                (catch clojure.lang.ExceptionInfo e (:missing-rule (ex-data e))))))))
+
+(deftest canonical-carries-reject-invalid-shapes-scope-and-hidden-writes
+  (let [program (fixture/typed-program 1)
+        variants
+        [(rewrite-loop program (fn [[op attrs extent init lambda]] (list op (dissoc attrs :carry) extent init lambda)))
+         (rewrite-loop program (fn [[op attrs extent _ lambda]] (list op attrs extent 'sum lambda)))
+         (rewrite-loop program (fn [[op attrs _ init lambda]] (list op attrs 'acc init lambda)))
+         (rewrite-loop program (fn [[op attrs extent init [_ _ region]]]
+                                 (list op attrs extent init (list 'lambda '[k wrong] region))))
+         (rewrite-loop program (fn [[op attrs extent init [lam params [region locals effects _]]]]
+                                 (list op attrs extent init (list lam params (list region locals effects 'unknown)))))
+         (rewrite-loop program (fn [[op attrs extent init [lam params [region locals effects _]]]]
+                                 (list op attrs extent init
+                                       (list lam params (list region locals effects '(aset packed 0 1.0))))))]]
+    (doseq [variant variants] (is (not= :accepted (reason variant))))
+    (is (= :typed-soac-effect-carry-write (reason (last variants))))))
+
+(deftest carry-update-destination-reads-require-read-write-storage
+  (let [program (rewrite-loop
+                 (fixture/typed-program 1)
+                 (fn [[op attrs extent init [lam params [region locals effects _]]]]
+                   (list op attrs extent init
+                         (list lam params (list region locals effects '(aget packed (+ (* i 8) k)))))))
+        facts (assoc-in (dialect/facts program) [:equations :carry :attributes :result-storage 0 :access] :read-write)
+        readable (dialect/make facts (dialect/equations program) [])
+        operation (first (lower/lower-typed-effect-map readable :ze:0))]
+    (is (= :typed-soac-effect-carry-read-access (reason program)))
+    (is (contains? (:inputs operation) 'words))
+    (is (= :kernel-body (get-in (fixture/artifact operation :opencl-portable) [:attributes :emission-route])))))
+
+(deftest capture-collisions-fail-closed-before-execution
+  (doseq [physical ['acc 'sum 'k]]
+    (let [program (dialect/remap-values (fixture/typed-program 1) {'seed physical})
+          operation (first (lower/lower-typed-effect-map program :ze:0))]
+      (is (= :accepted (reason program)))
+      (is (= :scheduled-effect-carry
+             (try (jvm/compile-effect-segmap operation) :accepted
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+
+(deftest canonical-result-scope-follows-the-effect-spine
+  (let [base (fixture/typed-program 1)
+        reverse-effects (walk/postwalk
+                         (fn [form]
+                           (if (and (seq? form) (= 'effect-region (first form)) (= 3 (count form)))
+                             (list 'effect-region (second form) (vec (reverse (nth form 2))))
+                             form)) base)
+        capture-update (rewrite-loop
+                        base
+                        (fn [[op attrs extent init [lam params [region locals effects _]]]]
+                          (list op attrs extent init
+                                (list lam params (list region locals effects
+                                                       (with-meta '(+ acc row-count) {:raster.type/tag 'double}))))))
+        operation (first (lower/lower-typed-effect-map capture-update :ze:0))
+        totals (float-array 2)
+        execute (eval (list 'fn '[x words totals rows seed] (jvm/compile-effect-segmap operation)))]
+    (is (= :typed-soac-effect-loop (reason reverse-effects)))
+    (is (= '(+ acc rows) (get-in operation [:scalar-region :effects 0 :loop :carry :update])))
+    (execute (float-array (range 16)) (float-array 16) totals 2 (float 0.25))
+    (is (= [2.25 2.25] (vec totals)))))

--- a/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
@@ -83,12 +83,11 @@
     (is (= :kernel-body (get-in (fixture/artifact operation :opencl-portable) [:attributes :emission-route])))))
 
 (deftest capture-collisions-fail-closed-before-execution
-  (doseq [physical ['acc 'sum 'k]]
-    (let [program (dialect/remap-values (fixture/typed-program 1) {'seed physical})
-          operation (first (lower/lower-typed-effect-map program :ze:0))]
+  (doseq [physical ['acc 'sum 'k 'i 'loaded]]
+    (let [program (dialect/remap-values (fixture/typed-program 1) {'seed physical})]
       (is (= :accepted (reason program)))
-      (is (= :scheduled-effect-carry
-             (try (jvm/compile-effect-segmap operation) :accepted
+      (is (= :typed-soac-effect-capture-collision
+             (try (lower/lower-typed-effect-map program :ze:0) :accepted
                   (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
 
 (deftest canonical-result-scope-follows-the-effect-spine


### PR DESCRIPTION
## Purpose

Extend the existing canonical SOAC effect-loop to express one typed result and project it into the shared scheduled carry contract landed in #478. This is not a new quantization primitive or analyzed-source admission.

## Changes

- Keep initializer/update grammar-visible, with a dedicated result-bearing effect lambda.
- Share canonical-to-scheduled effect projection between validation and lowering.
- Thread result scope in order, preserve capture substitution and retained source types, and reject hidden stores in carry expressions.
- Require read-write storage for destination reads and explicit read effects in carried regions.
- Preserve the ordered-effect fusion boundary. Explicitly reject carried production source realization before the older adapter can drop the carry.
- Extend existing device/vendor compiler fixtures through canonical SOAC.

## Validation

37 focused tests / 355 assertions, zero failures/errors in the capped REPL. Includes Intel Arc OpenCL numerical execution, zero/one/eight trips and poisoned tails, JVM semantics, three target emitters, scope/shape rejection, capture-only uses, remapping, fusion preservation, and read/write contracts. Existing dialect and ordered-effect suites pass. Full suites, CPU OpenCL and CUDA/HIP source compiler gates run in CI.

Independent review found no concrete blocker; added the suggested collision regression. Physical capture symbols that collide with a loop binder/result currently fail scheduled validation safely. General hygienic projection and production continuation binding remain explicit follow-ups before source admission. The public Q8_K packers still use their previous two-phase compatibility route; no performance improvement is claimed here.
