### PR TITLE
Instantiate typed effect regions through shared lexical scope adapters

### DIFF
--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -144,7 +144,19 @@ fusion does not absorb these ordered effect maps.
 
 Direct canonical program envelopes and scheduled JVM/KernelBody emission are exercised. The
 production source-realization adapter explicitly refuses carried loops until its continuation
-binding is implemented; frontend recognition is still closed. A capture whose physical symbol
-collides with a map/loop/local/result binder currently fails projection rather than being silently
-captured. General hygienic physical-name projection is a follow-up before claiming unrestricted
-symbol-ID composability. No throughput claim or public quantizer migration follows from this slice.
+binding is implemented; frontend recognition is still closed. No throughput claim or public
+quantizer migration follows from this slice.
+
+## Hygienic effect-region instantiation
+
+Canonical effect regions and loops now describe their lexical scopes through the existing shared
+form adapter. Ordered stores occupy sequential initializer slots; a carried result enters scope
+only after its loop. Physical-name substitution therefore reuses the compiler's capture-avoiding
+substitution rather than a separate effect walker or a collision refusal. The map index is reserved
+before element reads are synthesized. Physical core-named symbols such as `count`, `float`, and
+`long` are explicitly authoritative locals during instantiation.
+
+Focused validation covers scope round trips, alpha-renaming, free variables, malformed forms,
+physical buffer/scalar collisions, and OpenCL device execution; CUDA/HIP compile fixtures include
+a colliding physical capture. The production continuation adapter and frontend admission remain
+the next gates before migrating the public Q8_K packers.

--- a/src/raster/compiler/core/util.clj
+++ b/src/raster/compiler/core/util.clj
@@ -159,6 +159,13 @@
        ;; with the body so the raw AD payload never desyncs from the walked code.
        :aux  (some->> aux (mapv #(subst-syms inner % leaf-fn)))})))
 
+(defn subst-scoped
+  "Capture-avoiding substitution for an IR owner's separately stored binders and ordered body.
+   Returns the common scope-info shape; uses the same scope engine as subst-syms."
+  [smap binders body]
+  (subst-scope smap {:binders binders :inits [] :body body}
+               false false (fn [sm expression] (get sm expression expression))))
+
 (defn subst-syms
   "Capture-avoiding substitution of free symbol occurrences per
    smap {old-sym → replacement-expr}, over a closed-core S-expression.

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -78,6 +78,15 @@
         (= 'fold head)
         {:kind :fold :introduces-scope? true :liftable? false :head head}
 
+        (= 'effect-region head)
+        {:kind :effect-region :introduces-scope? true :liftable? false :head head}
+
+        (= 'effect-loop head)
+        {:kind :effect-loop :introduces-scope? true :liftable? false :head head}
+
+        (= 'effect head)
+        {:kind :effect :introduces-scope? false :liftable? false :head head}
+
         ;; Special forms — NOT liftable
         (contains? #{'try 'catch 'finally 'recur 'throw 'new} head)
         {:kind :special :introduces-scope? false :liftable? false :head head}
@@ -190,7 +199,7 @@
    Returns nil for non-binding forms (the caller recurses generically into all
    children). Otherwise returns:
 
-     {:scopes [{:binders [sym ...]   ;; symbols this scope introduces
+     {:scopes [{:binders [sym ...]   ;; symbols this scope introduces; nil for ordered effect-only slots
                 :inits   [expr ...]  ;; init exprs paired w/ binders (empty for
                                      ;;   fn*/dotimes/catch/par-idx — no init)
                 :body    [expr ...]  ;; exprs in which :binders are visible
@@ -300,6 +309,54 @@
                  (rl form 'fold attributes'
                      (list 'lambda (vec binders) (list 'region [] (vec body))))))}))
 
+        ;; An effect-region's result binders enter scope only after their loop initializer.
+        ;; Nil binder slots retain intervening stores in the same sequential spine.
+        :effect-region
+        (let [[_ locals effects result] form]
+          (when (and (contains? #{3 4} (count form)) (vector? locals) (vector? effects)
+                     (every? #(and (seq? %) (= 4 (count %)) (= 'let-value (first %))) locals))
+            (let [result? (= 4 (count form))
+              local-count (count locals)
+              carry? (fn [effect] (when (and (seq? effect) (= 'effect-loop (first effect)))
+                                    (get-in (second effect) [:carry :result])))
+              result-binders (mapv carry? effects)]
+            {:sequential? true
+             :scopes [{:binders (into (mapv second locals) result-binders)
+                       :inits (into (mapv #(nth % 3) locals) effects)
+                       :body (if result? [result] [])}]
+             :outer []
+             :rebuild
+             (fn [[{:keys [binders inits body]}] _]
+               (let [locals' (mapv (fn [local id init] (rl local (first local) id (nth local 2) init))
+                                   locals (take local-count binders) (take local-count inits))
+                     effects' (mapv (fn [effect original-result result]
+                                      (if original-result
+                                        (apply rl effect (first effect)
+                                               (assoc-in (second effect) [:carry :result] result)
+                                               (nnext effect))
+                                        effect))
+                                    (drop local-count inits) result-binders (drop local-count binders))]
+                 (apply rl form 'effect-region locals' effects' (when result? body))))})))
+
+        :effect-loop
+        (let [[_ attributes extent] form
+              carried? (= 5 (count form))
+              lambda (last form)]
+          (when (and (contains? #{4 5} (count form)) (map? attributes)
+                     (seq? lambda) (= 'lambda (first lambda)) (vector? (second lambda)))
+            (let [[_ parameters region] lambda]
+            {:sequential? false
+             :scopes [{:binders parameters :inits [] :body [region]}]
+             :outer (cond-> [(:lower attributes) extent] carried? (conj (nth form 3)))
+             :rebuild
+             (fn [[{:keys [binders body]}] [lower extent initial]]
+               (let [attributes' (cond-> (assoc attributes :index (first binders) :lower lower)
+                                   carried? (assoc-in [:carry :parameter] (second binders)))
+                     lambda (list 'lambda (vec binders) (first body))]
+                 (if carried?
+                   (rl form 'effect-loop attributes' extent initial lambda)
+                   (rl form 'effect-loop attributes' extent lambda))))})))
+
         ;; letfn* — mutual recursion: binders visible to their own inits
         ;; (matched as :call by form-info, so dispatch on head here)
         :call
@@ -396,7 +453,7 @@
 (defn scope-form?
   "True if the form introduces a new scope (dotimes, loop, fn, par)."
   [form]
-  (contains? #{:scope :lambda :par :fold} (:kind (form-info form))))
+  (contains? #{:scope :lambda :par :fold :effect-region :effect-loop} (:kind (form-info form))))
 
 (defn call-form?
   "True if the form is a function call (.invk or regular)."

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -343,54 +343,38 @@
               (throw (ex-info "typed effect-map destination storage changed after validation"
                               {:reason :raster/bug :equation equation-id
                                :destinations destinations :physical physical-results})))
-          substitutions
-          (into (zipmap capture-parameters captures)
-                (concat
-                 (map (fn [parameter array]
-                        [parameter (list 'clojure.core/aget array (:index attributes))])
-                      elements arrays)
-                 (map vector destination-parameters physical-results)))
-          ;; Until region-wide hygienic instantiation lands, do not let physical capture names
-          ;; become loop/local references (the map index is a binder too, not just carry slots).
-          _ (when (some (comp :carry soac-dialect/effect-parts) body-results)
-              (let [loop-parts (keep #(let [part (soac-dialect/effect-parts %)]
-                                       (when (:loop part) part)) body-results)
-                    binders (into (set (cons (:index attributes) (map :id locals)))
-                                  (mapcat (fn [part]
-                                            (let [{:keys [parameters locals]}
-                                                  (soac-dialect/lambda-parts (:lambda part))]
-                                              (concat parameters (map :id locals)
-                                                      (when-let [result (get-in part [:carry :result])]
-                                                        [result])))))
-                                  loop-parts)
-                    physical (set (filter symbol? (concat arrays captures physical-results)))
-                    collisions (clojure.set/intersection binders physical)]
-                (when (seq collisions)
-                  (throw (ex-info "physical capture names collide with lexical effect binders"
-                                  {:reason :typed-soac-effect-capture-collision
-                                   :collisions collisions :equation equation-id})))))
-          locals (mapv #(update % :init
-                                (fn [init] (util/subst-syms substitutions init)))
-                       locals)
+          ;; Reserve the map index against the physical interface before building element reads.
+          ;; Those reads refer to this bound index, not a free capture of the old index spelling.
+          projected
+          (binding [util/*shadowing-locals*
+                    (into util/*shadowing-locals* (filter symbol? (concat arrays captures physical-results)))]
+            (let [interface-substitutions (into (zipmap capture-parameters captures)
+                                                (concat (map vector elements arrays)
+                                                        (map vector destination-parameters physical-results)))
+                  index-scope (util/subst-scoped interface-substitutions [(:index attributes)] [])
+                  map-index (first (:binders index-scope))
+                  region (util/subst-syms {(:index attributes) map-index} (nth lambda 2))
+                  substitutions (into (zipmap capture-parameters captures)
+                                      (concat (map (fn [parameter array]
+                                                     [parameter (list 'clojure.core/aget array map-index)])
+                                                   elements arrays)
+                                              (map vector destination-parameters physical-results)))]
+              ;; The region adapter keeps interleaved effect-result bindings lexical. Physical
+              ;; core names (count/float/long) are locals here, never calls to clojure.core.
+              {:index map-index :region (util/subst-syms substitutions region)}))
+          attributes (assoc attributes :index (:index projected))
+          {:keys [locals body-results]}
+          (soac-dialect/lambda-parts (list 'lambda [] (:region projected)))
           lower-effect
           (fn lower-effect [{:keys [loop destination conflict destination-index predicate value]}]
               (if loop
-                {:loop (-> loop
-                           (update :extent #(util/subst-syms substitutions %))
-                           (update :locals #(mapv (fn [local]
-                                                   (update local :init (partial util/subst-syms substitutions))) %))
-                           (update :effects #(mapv lower-effect %))
-                           (cond-> (:carry loop)
-                             (update :carry #(-> %
-                                                 (update :init (partial util/subst-syms substitutions))
-                                                 (update :update (partial util/subst-syms substitutions))))))}
-                {:destination (util/subst-syms substitutions destination)
-                 :dtype (get destination-dtypes
-                             (util/subst-syms substitutions destination))
+                {:loop (update loop :effects #(mapv lower-effect %))}
+                {:destination destination
+                 :dtype (get destination-dtypes destination)
                  :conflict conflict
-                 :destination-index (util/subst-syms substitutions destination-index)
-                 :predicate (util/subst-syms substitutions predicate)
-                 :value (util/subst-syms substitutions value)}))
+                 :destination-index destination-index
+                 :predicate predicate
+                 :value value}))
           effects (mapv (comp lower-effect soac-dialect/scheduled-effect) body-results)
           effect-leaves (soac-dialect/effect-leaves effects)
           stable (set (get-in attributes [:attributes :stable-array-captures]))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -18,6 +18,7 @@
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.attention-route :as attention-route]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contract-route :as contract-route]
@@ -404,6 +405,11 @@
                             (carried-fixture/artifact
                              (first (soac-lower/lower-typed-effect-map
                                      (carried-fixture/typed-program 8) :ze:0)) dialect))
+           (write-artifact! directory suffix "typed-carried-effect-capture-collision"
+                            (carried-fixture/artifact
+                             (first (soac-lower/lower-typed-effect-map
+                                     (soac-dialect/remap-values (carried-fixture/typed-program 8) {'seed 'i}) :ze:0))
+                             dialect :scalar-types {'rows :long 'i :float}))
            (write-artifact! directory suffix "public-outer-product"
                             (get-in (segop-emit/generate-kernel-graph
                                      (capacity-fixture/inferred-graph) :target-dialect dialect)

--- a/test/raster/compiler/ir/effect_region_scope_test.clj
+++ b/test/raster/compiler/ir/effect_region_scope_test.clj
@@ -1,0 +1,58 @@
+(ns raster.compiler.ir.effect-region-scope-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.form :as form]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(defn- region []
+  (list 'effect-region
+        [(list 'let-value 'local :long 'seed)]
+        [(list 'effect 'out :unique 0 true 'local)
+         (list 'effect-loop {:index 'k :lower 0 :carry {:parameter 'acc :result 'sum :dtype :long}}
+               'n 'local
+               (list 'lambda '[k acc]
+                     (list 'effect-region
+                           [(list 'let-value 'term :long '(aget source k))]
+                           [(list 'effect 'out :unique 'k true 'term)]
+                           (with-meta '(+ acc term) {:raster.type/tag 'long}))))
+         (list 'effect 'out :unique 1 true 'sum)]))
+
+(deftest scope-authority-models-interleaved-results-as-sequential-bindings
+  (let [r (region) scope (form/scope-info r)]
+    (is (:sequential? scope))
+    (is (= ['local nil 'sum nil] (get-in scope [:scopes 0 :binders])))
+    (is (= #{'seed 'out 'source 'n} (util/free-syms r)))
+    (is (= r ((:rebuild scope) (:scopes scope) (:outer scope))))
+    (let [before (list 'effect-region (second r)
+                       (assoc (nth r 2) 0 (list 'effect 'out :unique 0 true 'sum)))]
+      (is (contains? (util/free-syms before) 'sum) "result is not in scope before its loop"))))
+
+(deftest malformed-scope-shapes-are-not-destructured-as-binding-regions
+  (doseq [r ['(effect-region 1 2) '(effect-region [17] []) '(effect-loop {} 3 1)]]
+    (is (nil? (form/scope-info r)))))
+
+(deftest substitution-avoids-capturing-external-values-in-the-continuation
+  (let [r (util/subst-syms {'seed 'sum} (region))
+        effects (nth r 2)
+        carry (:carry (dialect/effect-parts (second effects)))
+        result (:result carry)]
+    (is (not= 'sum result))
+    (is (= 'sum (nth (first (second r)) 3)))
+    (is (= result (last (last effects))))
+    (is (= #{'sum 'out 'source 'n} (util/free-syms r)))
+    (is (= 'long (:raster.type/tag (meta (:update carry)))))
+    (is (= ['effect 'effect-loop 'effect] (mapv first effects)))))
+
+(deftest alpha-conversion-preserves-lexical-scope-and-recurrence-links
+  (let [r (util/alpha-convert (region))
+        effects (nth r 2)
+        loop (dialect/effect-parts (second effects))
+        {:keys [locals]} (dialect/lambda-parts (:lambda loop))
+        carry (:carry loop)]
+    (is (= (util/free-syms (region)) (util/free-syms r)))
+    (is (not= 'k (:index loop)))
+    (is (not= 'acc (:parameter carry)))
+    (is (not= 'sum (:result carry)))
+    (is (= (:result carry) (last (last effects))))
+    (is (= (list '+ (:parameter carry) (:id (first locals))) (:update carry)))
+    (is (= (:index loop) (last (:init (first locals)))))))

--- a/test/raster/compiler/passes/parallel/carried_effect_loop_device_test.clj
+++ b/test/raster/compiler/passes/parallel/carried_effect_loop_device_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.carried-effect-loop-device-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.carried-effect-loop-fixture :as fixture]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.gpu.device-probe :as probe]))
@@ -15,11 +16,15 @@
           launch! (ns-resolve runtime 'launch-registered-bound!)
           read! (ns-resolve runtime 'buffer->array)
           free! (ns-resolve runtime 'free-buffer!)]
-      (doseq [kind [:scheduled :typed] trips [0 1 8]]
-        (let [operation (if (= kind :typed)
-                          (first (lower/lower-typed-effect-map (fixture/typed-program trips) :ze:0))
-                          (fixture/scheduled-loop trips))
-              compiled (fixture/artifact operation :opencl-portable)
+      (doseq [[kind trips] (concat (for [kind [:scheduled :typed] trips [0 1 8]] [kind trips])
+                                   [[:typed-index-collision 8]])]
+        (let [operation (if (= kind :scheduled)
+                          (fixture/scheduled-loop trips)
+                          (first (lower/lower-typed-effect-map
+                                  (cond-> (fixture/typed-program trips)
+                                    (= kind :typed-index-collision) (dialect/remap-values {'seed 'i})) :ze:0)))
+              compiled (fixture/artifact operation :opencl-portable
+                                         :scalar-types {'rows :long 'seed :float 'i :float})
               values (vec (range 16))
               x (buffer-of-array (float-array values) :float)
               words (buffer-of-array (float-array (repeat 19 -77)) :float)
@@ -29,7 +34,8 @@
             (launch! (bind-call (call/make compiled
                                           (mapv {'x x 'totals totals 'words words
                                                  'rows {:type :long :value 2}
-                                                 'seed {:type :float :value 0.25}}
+                                                 'seed {:type :float :value 0.25}
+                                                 'i {:type :float :value 0.25}}
                                                 (:arguments compiled)))))
             (is (= (vec (concat (map-indexed (fn [i v] (if (< (mod i 8) trips) (float v) -77.0)) values)
                                 (repeat 3 -77.0)))

--- a/test/raster/compiler/passes/parallel/carried_effect_loop_fixture.clj
+++ b/test/raster/compiler/passes/parallel/carried_effect_loop_fixture.clj
@@ -22,10 +22,10 @@
                {:destination 'totals :dtype :float :conflict :unique
                 :destination-index 'i :predicate true :value 'sum}]}}))
 
-(defn artifact [operation target]
+(defn artifact [operation target & {:keys [scalar-types] :or {scalar-types {'rows :long 'seed :float}}}]
   (emit/generate-scheduled-segmap-kernel
    operation :dtype :float :target-dialect target
-   :array-types {'x :float 'words :float 'totals :float} :scalar-types {'rows :long 'seed :float}))
+   :array-types {'x :float 'words :float 'totals :float} :scalar-types scalar-types))
 
 (defn typed-program [trips]
   (let [words-result [:carry 0] totals-result [:carry 1]

--- a/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [clojure.walk :as walk]
             [raster.compiler.backend.jvm.segop-simd :as jvm]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.carried-effect-loop-fixture :as fixture]
             [raster.compiler.passes.parallel.soac-lower :as lower]
@@ -82,13 +83,38 @@
     (is (contains? (:inputs operation) 'words))
     (is (= :kernel-body (get-in (fixture/artifact operation :opencl-portable) [:attributes :emission-route])))))
 
-(deftest capture-collisions-fail-closed-before-execution
+(deftest physical-capture-collisions-are-hygienically-instantiated
   (doseq [physical ['acc 'sum 'k 'i 'loaded]]
-    (let [program (dialect/remap-values (fixture/typed-program 1) {'seed physical})]
+    (let [program (dialect/remap-values (fixture/typed-program 1) {'seed physical})
+          operation (first (lower/lower-typed-effect-map program :ze:0))
+          execute (eval (list 'fn ['x 'words 'totals 'rows physical] (jvm/compile-effect-segmap operation)))
+          totals (float-array 2)]
       (is (= :accepted (reason program)))
-      (is (= :typed-soac-effect-capture-collision
-             (try (lower/lower-typed-effect-map program :ze:0) :accepted
-                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+      (execute (float-array (range 16)) (float-array 16) totals 2 (float 0.25))
+      (is (= [0.25 8.25] (vec totals)))
+      (doseq [target [:opencl-portable :cuda :hip]]
+        (is (= :kernel-body
+               (get-in (emit/generate-scheduled-segmap-kernel
+                        operation :dtype :float :target-dialect target
+                        :array-types {'x :float 'words :float 'totals :float}
+                        :scalar-types {'rows :long physical :float})
+                       [:attributes :emission-route])))))))
+
+(deftest physical-core-names-are-authoritative-locals-during-instantiation
+  (doseq [physical ['count 'float 'long]]
+    (let [program (-> (walk/postwalk #(if (= 'i %) physical %) (fixture/typed-program 1))
+                      (dialect/remap-values {'seed physical}))
+          operation (first (lower/lower-typed-effect-map program :ze:0))
+          execute (eval (list 'fn ['x 'words 'totals 'rows physical] (jvm/compile-effect-segmap operation)))
+          totals (float-array 2)]
+      (execute (float-array (range 16)) (float-array 16) totals 2 (float 0.25))
+      (is (= [0.25 8.25] (vec totals)))
+      (is (= :kernel-body
+             (get-in (emit/generate-scheduled-segmap-kernel
+                      operation :dtype :float :target-dialect :opencl-portable
+                      :array-types {'x :float 'words :float 'totals :float}
+                      :scalar-types {'rows :long physical :float})
+                     [:attributes :emission-route]))))))
 
 (deftest canonical-result-scope-follows-the-effect-spine
   (let [base (fixture/typed-program 1)

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -48,6 +48,23 @@
        :effects #{:memory/write}})
      [equation] [])))
 
+(deftest element-array-name-does-not-capture-the-logical-map-index
+  (let [program (dialect/remap-values (effect-program) {'x 'i})
+        operation (first (soac-lower/lower-typed-effect-map program :ze:0))
+        execute (eval (list 'fn '[i out total n]
+                            ((requiring-resolve 'raster.compiler.backend.jvm.segop-simd/compile-effect-segmap)
+                             operation)))
+        out (float-array [-77 -77]) total (float-array 1)]
+    (execute (float-array [-1 2]) out total 2)
+    (is (= [-77.0 3.0] (vec out)))
+    (is (= [1.0] (vec total)))
+    (doseq [target [:opencl-portable :cuda :hip]]
+      (is (= :kernel-body
+             (get-in (segop-opencl/generate-scheduled-segmap-kernel
+                      operation :dtype :float :target-dialect target
+                      :array-types {'i :float 'out :float 'total :float} :scalar-types {'n :long})
+                     [:attributes :emission-route]))))))
+
 (defn- nested-operations
   [operations]
   (mapcat (fn [operation]


### PR DESCRIPTION
## Summary
- Describe canonical effect-region and effect-loop scopes in the existing form adapter, preserving sequential result binding and ordered stores.
- Replace physical-name collision refusals with shared capture-avoiding substitution, including physical core-named locals.
- Add lexical, JVM, device, and vendor compile regressions; public Q8_K frontend admission remains closed until continuation realization lands.

## Validation
- 62 focused tests, 459 assertions, zero failures/errors in the existing capped REPL, including OpenCL device execution.
- Read-only review: no remaining blocker.
- Rebased onto the PR479 squash with an identical tested tree.
- Full suites and vendor compiler gates delegated to CI.