### PR TITLE
Share hygienic effect binding and host continuation construction

### DIFF
--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -160,3 +160,8 @@ Focused validation covers scope round trips, alpha-renaming, free variables, mal
 physical buffer/scalar collisions, and OpenCL device execution; CUDA/HIP compile fixtures include
 a colliding physical capture. The production continuation adapter and frontend admission remain
 the next gates before migrating the public Q8_K packers.
+
+Scheduled JVM emission and production host realization now share ordered continuation construction
+through `effect-source/ordered-effects`. Store and loop spelling retain their existing target
+policies, but the `do`/result-binding spine is no longer duplicated. This preparatory extraction
+does not yet open carried source realization or frontend admission.

--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -165,3 +165,8 @@ Scheduled JVM emission and production host realization now share ordered continu
 through `effect-source/ordered-effects`. Store and loop spelling retain their existing target
 policies, but the `do`/result-binding spine is no longer duplicated. This preparatory extraction
 does not yet open carried source realization or frontend admission.
+
+Both projections also use `typed-soac-projection/instantiate-effect-region` for physical-name
+binding. The host adapter no longer reconstructs and substitutes each effect independently.
+Generated host casts are qualified so a physical value named `float` cannot capture them; user
+expressions are unchanged. Canonical-to-host tests cover colliding map, local, and core names.

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -21,6 +21,7 @@
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
+            [raster.compiler.passes.parallel.effect-source :as effect-source]
             [raster.compiler.passes.scalar.dce :as dce]
             [raster.compiler.core.hardware :as hw]
             [clojure.set]
@@ -1036,11 +1037,9 @@
               (if (contains? #{true 1} predicate)
                 store
                 (list 'if predicate store))))
-          effect-spine
-          (fn effect-spine [items]
-            (if-let [effect (first items)]
-              (if-let [{:keys [index lower extent locals effects carry]} (:loop effect)]
-                  (let [{:keys [parameter result dtype init update]} carry
+          loop-statement
+          (fn [{:keys [index lower extent locals carry]} ordered-body]
+                  (let [{:keys [parameter dtype init update]} carry
                         ;; A typed FP carry rounds to its storage precision with IEEE overflow.
                         ;; This generated conversion is not a user-written checked `float` call.
                         tag (when carry (generated-cast (dtype/scalar-tag-for-dtype dtype)))
@@ -1055,21 +1054,18 @@
                                     (list 'if (ix< index limit)
                                           (materialize-locals
                                            locals
-                                           (list 'do (effect-spine effects)
+                                           (list 'do ordered-body
                                                  (list* 'recur
                                                         (cond-> [(list (if carry 'clojure.core/unchecked-inc
                                                                          'clojure.core/unchecked-inc-int) index)]
                                                           carry (conj (list tag (strip-binder-tags update)))))))
                                           parameter)))]
-                    ;; The result's binding encloses only the continuation, never preceding effects.
-                    (if carry
-                      (list 'let* [result loop-form] (effect-spine (next items)))
-                      (list 'do loop-form (effect-spine (next items)))))
-                (list 'do (effect-statement effect) (effect-spine (next items))))
-              nil))
+                    loop-form))
           typed-region-body
           (when (seq effects)
-            (materialize-locals locals (effect-spine effects)))
+            (materialize-locals locals
+                                (effect-source/ordered-effects
+                                 effects {:emit-store effect-statement :emit-loop loop-statement})))
           body (clojure.walk/postwalk
                 (fn [form] (if (= form index) j-sym form))
                 (bc/desugar-invk (or typed-region-body (:lambda segmap))))]

--- a/src/raster/compiler/passes/parallel/effect_source.clj
+++ b/src/raster/compiler/passes/parallel/effect_source.clj
@@ -1,0 +1,21 @@
+(ns raster.compiler.passes.parallel.effect-source
+  "Shared host continuation construction for validated scheduled effect regions.
+
+   Target projections supply store and loop spelling; this function alone owns ordered effect
+   sequencing and the scope of an exported loop result. It neither infers types nor parses source.")
+
+(defn ordered-effects
+  "Spell scheduled effects as a host continuation. `emit-store` receives a store descriptor;
+   `emit-loop` receives a loop descriptor and its already-spelled ordered body. Both return forms.
+   A carried result encloses only subsequent effects, never its initializer or preceding stores."
+  [effects {:keys [emit-store emit-loop] :as emitters}]
+  (if-let [effect (first effects)]
+    (let [loop (:loop effect)
+          form (if loop
+                 (emit-loop loop (ordered-effects (:effects loop) emitters))
+                 (emit-store effect))
+          continuation (ordered-effects (next effects) emitters)]
+      (if-let [result (get-in loop [:carry :result])]
+        (list 'let* [result form] continuation)
+        (list 'do form continuation)))
+    nil))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -327,9 +327,6 @@
     (let [[_ equation-id results _operation] equation
           {:keys [attributes arrays captures destinations lambda]}
           (soac-dialect/operation-parts equation)
-          {:keys [locals body-results]} (soac-dialect/lambda-parts lambda)
-          {:keys [elements capture-parameters destination-parameters]}
-          (soac-dialect/parameter-layout equation)
           facts (soac-dialect/facts program)
           values (:values facts)
           physical-results (soac-dialect/physical-results facts equation)
@@ -343,25 +340,7 @@
               (throw (ex-info "typed effect-map destination storage changed after validation"
                               {:reason :raster/bug :equation equation-id
                                :destinations destinations :physical physical-results})))
-          ;; Reserve the map index against the physical interface before building element reads.
-          ;; Those reads refer to this bound index, not a free capture of the old index spelling.
-          projected
-          (binding [util/*shadowing-locals*
-                    (into util/*shadowing-locals* (filter symbol? (concat arrays captures physical-results)))]
-            (let [interface-substitutions (into (zipmap capture-parameters captures)
-                                                (concat (map vector elements arrays)
-                                                        (map vector destination-parameters physical-results)))
-                  index-scope (util/subst-scoped interface-substitutions [(:index attributes)] [])
-                  map-index (first (:binders index-scope))
-                  region (util/subst-syms {(:index attributes) map-index} (nth lambda 2))
-                  substitutions (into (zipmap capture-parameters captures)
-                                      (concat (map (fn [parameter array]
-                                                     [parameter (list 'clojure.core/aget array map-index)])
-                                                   elements arrays)
-                                              (map vector destination-parameters physical-results)))]
-              ;; The region adapter keeps interleaved effect-result bindings lexical. Physical
-              ;; core names (count/float/long) are locals here, never calls to clojure.core.
-              {:index map-index :region (util/subst-syms substitutions region)}))
+          projected (typed-projection/instantiate-effect-region equation)
           attributes (assoc attributes :index (:index projected))
           {:keys [locals body-results]}
           (soac-dialect/lambda-parts (list 'lambda [] (:region projected)))

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -58,6 +58,35 @@
         (list 'let* (vec (concat reads parameters)) form))
       form)))
 
+(defn instantiate-effect-region
+  "Instantiate a validated effect-map's lexical parameters against its physical interface.
+   Return the hygienic map index and canonical region, without reconstructing host source.
+   Scheduled lowering and host realization must use this same binding operation."
+  [equation]
+  (let [{:keys [kind attributes arrays captures destinations lambda]}
+        (dialect/operation-parts equation)
+        {:keys [elements capture-parameters destination-parameters]}
+        (dialect/parameter-layout equation)]
+    (when-not (= 'effect-map kind)
+      (throw (ex-info "effect-region instantiation requires an effect-map"
+                      {:reason :typed-soac-effect-map-subset :equation equation})))
+    (binding [util/*shadowing-locals*
+              (into util/*shadowing-locals* (filter symbol? (concat arrays captures destinations)))]
+      ;; Reserve the index before synthesizing reads: those reads refer to this bound index,
+      ;; not a free capture of its old spelling. Core-named physical values remain locals.
+      (let [interface-substitutions (into (zipmap capture-parameters captures)
+                                         (concat (map vector elements arrays)
+                                                 (map vector destination-parameters destinations)))
+            index-scope (util/subst-scoped interface-substitutions [(:index attributes)] [])
+            map-index (first (:binders index-scope))
+            region (util/subst-syms {(:index attributes) map-index} (nth lambda 2))
+            substitutions (into (zipmap capture-parameters captures)
+                                (concat (map (fn [parameter array]
+                                               [parameter (list 'clojure.core/aget array map-index)])
+                                             elements arrays)
+                                        (map vector destination-parameters destinations)))]
+        {:index map-index :region (util/subst-syms substitutions region)}))))
+
 (defn scalar-folds->source
   "Project explicit scalar Fold terms to Raster's interpreted host vocabulary."
   [expression]

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -43,8 +43,21 @@
   [equation]
   (let [{:keys [kind attributes arrays captures destinations lambda element-lambda]}
         (dialect/operation-parts equation)]
-    (if (contains? #{'segmented-fold-map 'contract} kind)
+    (cond
+      (contains? #{'segmented-fold-map 'contract} kind)
       {:locals [] :bodies []}
+
+      (= 'effect-map kind)
+      (let [{:keys [index region]} (projection/instantiate-effect-region equation)
+            {:keys [locals body-results]}
+            (dialect/lambda-parts (list 'lambda [] (projection/scalar-folds->source region)))]
+        (when (dialect/scheduled-effect-carries? (mapv dialect/scheduled-effect body-results))
+          (throw (ex-info "carried effects require structured scheduled lowering"
+                          {:reason :typed-soac-production-subset
+                           :missing-rule :carried-effect-realization})))
+        {:index index :locals locals :bodies body-results})
+
+      :else
       (let [{:keys [locals body-results]}
             (dialect/lambda-parts (or lambda element-lambda))
             {:keys [elements capture-parameters destination-parameters]}
@@ -58,37 +71,11 @@
             project-expression
             (fn [expression]
               (projection/scalar-folds->source
-               (util/subst-syms substitutions expression)))
-            project-body
-            (fn project-body [body]
-              (if (= 'effect-map kind)
-                (let [{:keys [loop destination conflict destination-index predicate value]
-                       :as parts}
-                      (dialect/effect-parts body)]
-                  (if loop
-                    (let [_ (when (:carry parts)
-                              (throw (ex-info "carried effects require structured scheduled lowering"
-                                              {:reason :typed-soac-production-subset
-                                               :missing-rule :carried-effect-realization})))
-                          {:keys [locals body-results]} (dialect/lambda-parts (:lambda parts))]
-                      (list 'effect-loop {:index (:index parts) :lower (:lower parts)}
-                            (project-expression (:extent parts))
-                            (list 'lambda [(:index parts)]
-                                  (dialect/effect-lambda-region
-                                   (mapv (fn [{:keys [id dtype init]}]
-                                           (dialect/local-value id dtype
-                                                                (project-expression init)))
-                                         locals)
-                                   (mapv project-body body-results)))))
-                    (list 'effect (get substitutions destination destination) conflict
-                          (project-expression destination-index)
-                          (project-expression predicate)
-                          (project-expression value))))
-                (project-expression body)))]
+               (util/subst-syms substitutions expression)))]
         {:locals (mapv #(update % :init (fn [init]
                                           (project-expression init)))
                        locals)
-         :bodies (mapv project-body body-results)}))))
+         :bodies (mapv project-expression body-results)}))))
 
 (defn- storage-only-dtype?
   "A dtype with device storage but no JVM scalar: its values move bit-exactly between arrays
@@ -98,7 +85,7 @@
 
 (defn- typed-store-value
   [cast value]
-  (if cast (list cast value) value))
+  (if cast (list (symbol "clojure.core" (name cast)) value) value))
 
 (defn- materialize-region
   [locals body]
@@ -108,7 +95,7 @@
            (mapcat (fn [{:keys [id dtype init]}]
                      (let [tag (dtype/scalar-tag-for-dtype dtype)]
                        [(with-meta id {:raster.type/tag tag})
-                        (list tag init)]))
+                        (list (symbol "clojure.core" (name tag)) init)]))
                    locals))
           body)
     body))
@@ -129,7 +116,7 @@
   (let [[_ equation-id results] equation
         {:keys [kind attributes]} (dialect/operation-parts equation)
         values (:values (dialect/facts program))
-        {region-locals :locals bodies :bodies} (scalar-region equation)
+        {region-locals :locals bodies :bodies region-index :index} (scalar-region equation)
         placement-facts (get-in (dialect/facts program) [:equations equation-id])
         constituent-ids (or (some-> placement-facts :attributes :fusion/constituents keys set)
                             #{(or (get-in placement-facts [:provenance :source-binding-id])
@@ -344,7 +331,7 @@
                           effects {:emit-store statement :emit-loop loop-statement})
             effect-source
             (with-meta
-              (list 'raster.par/map-void! (:index attributes) (:extent attributes)
+              (list 'raster.par/map-void! region-index (:extent attributes)
                     (materialize-region region-locals continuation))
               {:raster.type/elem-type (first result-dtypes)})]
         {:equation-id equation-id

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -8,6 +8,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.effect-source :as effect-source]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
@@ -306,7 +307,7 @@
             casts (mapv #(nth (get dtype->allocation %) 2 nil) result-dtypes)
             dtype-by-destination (zipmap physical-results result-dtypes)
             cast-by-destination (zipmap physical-results casts)
-            effects (mapv dialect/effect-parts bodies)
+            effects (mapv dialect/scheduled-effect bodies)
             _ (when-not (and (= (count results) (count physical-results)
                                 (count result-dtypes) (count casts))
                              (every? some? effects)
@@ -317,21 +318,15 @@
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results
                                  :storage storage :effects effects :dtypes result-dtypes})))
+            loop-statement
+            (fn [{:keys [index lower extent locals]} ordered-body]
+              (list 'loop* [index lower]
+                    (list 'if (list 'clojure.core/< index extent)
+                          (list 'do (materialize-region locals ordered-body)
+                                (list 'recur (list 'clojure.core/inc index)))
+                          nil)))
             statement
-            (fn statement [{:keys [loop destination conflict destination-index predicate value]
-                            :as parts}]
-                  (if loop
-                    (let [{:keys [locals body-results]} (dialect/lambda-parts (:lambda parts))
-                          loop-index (:index parts)]
-                      (list 'loop* [loop-index (:lower parts)]
-                            (list 'if (list 'clojure.core/< loop-index (:extent parts))
-                                  (list 'do
-                                        (materialize-region
-                                         locals
-                                         (list* 'do (mapv (comp statement dialect/effect-parts)
-                                                          body-results)))
-                                        (list 'recur (list 'clojure.core/inc loop-index)))
-                                  nil)))
+            (fn [{:keys [destination conflict destination-index predicate value]}]
                     (let [cast (get cast-by-destination destination)
                           result-dtype (get dtype-by-destination destination)
                           destination (with-meta destination
@@ -344,12 +339,13 @@
                                         destination destination-index typed-value)
                                   (list 'clojure.core/aset destination destination-index
                                         typed-value))]
-                      (if (contains? #{true 1} predicate) store (list 'if predicate store)))))
-            statements (mapv statement effects)
+                      (if (contains? #{true 1} predicate) store (list 'if predicate store))))
+            continuation (effect-source/ordered-effects
+                          effects {:emit-store statement :emit-loop loop-statement})
             effect-source
             (with-meta
               (list 'raster.par/map-void! (:index attributes) (:extent attributes)
-                    (materialize-region region-locals (list* 'do statements)))
+                    (materialize-region region-locals continuation))
               {:raster.type/elem-type (first result-dtypes)})]
         {:equation-id equation-id
          :placement placement

--- a/test/raster/compiler/passes/parallel/effect_source_test.clj
+++ b/test/raster/compiler/passes/parallel/effect_source_test.clj
@@ -1,0 +1,31 @@
+(ns raster.compiler.passes.parallel.effect-source-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.passes.parallel.effect-source :as source]))
+
+(deftest result-binding-encloses-only-the-ordered-continuation
+  (let [effects [{:source '(swap! log conj result)}
+                 {:loop {:carry {:result 'result}
+                         :effects [{:source '(swap! log conj :inside)}]}}
+                 {:source '(swap! log conj result)}]
+        form (source/ordered-effects
+              effects {:emit-store :source
+                       :emit-loop (fn [_ body] (list 'do body 11))})
+        execute (eval (list 'fn '[log result] form))
+        log (atom [])]
+    (is (contains? (util/free-syms form) 'result)
+        "the preceding effect reads the outer value, not the exported result")
+    (is (nil? (execute log 7)))
+    (is (= [7 :inside 11] @log))))
+
+(deftest ordinary-loops-and-empty-regions-preserve-effect-order
+  (let [form (source/ordered-effects
+              [{:source '(swap! log conj :before)}
+               {:loop {:effects [{:source '(swap! log conj :inside)}]}}
+               {:source '(swap! log conj :after)}]
+              {:emit-store :source :emit-loop (fn [_ body] body)})
+        execute (eval (list 'fn '[log] form))
+        log (atom [])]
+    (is (nil? (source/ordered-effects [] {})))
+    (is (nil? (execute log)))
+    (is (= [:before :inside :after] @log))))

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -65,6 +65,18 @@
                       :array-types {'i :float 'out :float 'total :float} :scalar-types {'n :long})
                      [:attributes :emission-route]))))))
 
+(deftest host-effect-realization-shares-hygienic-physical-binding
+  (doseq [physical ['i 'shifted 'float 'count 'long]]
+    (let [program (dialect/remap-values (effect-program) {'x physical})
+          equation (first (dialect/equations program))
+          realized ((ns-resolve 'raster.compiler.passes.parallel.typed-soac-route 'realize-equation)
+                    program equation)
+          execute (eval (list 'fn [physical 'out 'total 'n] (:source realized)))
+          out (float-array [-77 -77]) total (float-array 1)]
+      (is (nil? (execute (float-array [-1 2]) out total 2)))
+      (is (= [-77.0 3.0] (vec out)))
+      (is (= [1.0] (vec total))))))
+
 (defn- nested-operations
   [operations]
   (mapcat (fn [operation]

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -339,6 +339,23 @@
       (is (= [2.5 5.0 37.5 50.0] (mapv double out)))
       (is (zero? (get-in jvm [:stats :fallback]))))))
 
+(deftest production-host-store-loops-preserve-the-continuation
+  (let [source '(let* [effect
+                      (raster.par/map-void!
+                       r rows
+                       (loop* [i 0]
+                         (if (< i width)
+                           (do (aset out (+ (* r width) i) (float i))
+                               (recur (inc i))))))]
+                 effect)
+        result (route/attempt source :float {'out :float}
+                              {:scalar-types {'rows :long 'width :long}})
+        execute (eval (list 'fn '[out rows width] (get-in result [:program :source])))
+        out (float-array (repeat 6 -77))]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (nil? (execute out 2 3)))
+    (is (= [0.0 1.0 2.0 0.0 1.0 2.0] (vec out)))))
+
 (deftest effect-loops-must-be-closed-over-the-loop-index
   (let [program (:program (route/attempt row-loop-source :float {'x :float 'out :float}
                                          {:scalar-types {'rows :long 'feat :long}}))


### PR DESCRIPTION
## Summary
- Use one ordered continuation builder in scheduled JVM and production host projections; retain existing loop/store numerical policies.
- Share capture-avoiding effect-region instantiation rather than rebuilding/substituting each effect independently.
- Qualify generated host casts to prevent physical buffers named float from capturing them.
- Keep carried production realization and source frontend admission explicitly closed pending the next slice. No public Q8_K migration or throughput claim.

## Validation
- 29 focused effect/continuation tests, 337 assertions, including OpenCL device execution.
- 62 production-route/scalar-fold tests, 582 assertions.
- Zero failures/errors in one capped REPL; full suites and vendor compilers delegated to CI.
- Read-only review: no blocker. Rebased onto merged PR480 with an identical tested tree.