### PR TITLE
Realize canonical carried effects through the shared scheduled host loop

### DIFF
--- a/design/quant-emission-audit-2026-09-09.md
+++ b/design/quant-emission-audit-2026-09-09.md
@@ -142,10 +142,10 @@ it into the scheduled region; validation threads result scope through subsequent
 checks destination reads against read-write storage and explicit read effects. Existing pure-map
 fusion does not absorb these ordered effect maps.
 
-Direct canonical program envelopes and scheduled JVM/KernelBody emission are exercised. The
-production source-realization adapter explicitly refuses carried loops until its continuation
-binding is implemented; frontend recognition is still closed. No throughput claim or public
-quantizer migration follows from this slice.
+Direct canonical program envelopes and scheduled JVM/KernelBody emission are exercised. Production
+host realization now uses the same carried-loop construction as scheduled JVM emission; frontend
+recognition is still closed. No throughput claim or public quantizer migration follows from this
+slice.
 
 ## Hygienic effect-region instantiation
 
@@ -158,15 +158,27 @@ before element reads are synthesized. Physical core-named symbols such as `count
 
 Focused validation covers scope round trips, alpha-renaming, free variables, malformed forms,
 physical buffer/scalar collisions, and OpenCL device execution; CUDA/HIP compile fixtures include
-a colliding physical capture. The production continuation adapter and frontend admission remain
-the next gates before migrating the public Q8_K packers.
+a colliding physical capture. Frontend admission remains the next gate before migrating the public
+Q8_K packers.
 
 Scheduled JVM emission and production host realization now share ordered continuation construction
 through `effect-source/ordered-effects`. Store and loop spelling retain their existing target
-policies, but the `do`/result-binding spine is no longer duplicated. This preparatory extraction
-does not yet open carried source realization or frontend admission.
+policies, but the `do`/result-binding spine is no longer duplicated.
 
 Both projections also use `typed-soac-projection/instantiate-effect-region` for physical-name
 binding. The host adapter no longer reconstructs and substitutes each effect independently.
 Generated host casts are qualified so a physical value named `float` cannot capture them; user
 expressions are unchanged. Canonical-to-host tests cover colliding map, local, and core names.
+
+## Shared carried-loop host realization
+
+The existing scheduled JVM counted-loop builder, local materialization, and generated storage-cast
+policy are shared with production host realization. Both evaluate the bound and initializer once,
+execute stores before the recurrence, and scope the result over only subsequent effects. Generated
+FP32 conversions preserve IEEE overflow; user-written checked arithmetic still throws after any
+preceding stores. Existing ordinary source loops retain their induction policy.
+
+Parity tests exercise zero/one/eight trips, poisoned tails, physical-name collisions, overflowing
+FP32 initialization, and a checked Long recurrence that must fail before publishing its result.
+This admits canonical carried regions to host realization, not analyzed quantizer source. The
+frontend must still recognize a typed single-carry store loop without hoisting it into pure locals.

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -976,45 +976,12 @@
           j-sym (gensym "effect_i__")
           {:keys [locals effects]} (:scalar-region segmap)
           carried-effects? (soac-dialect/scheduled-effect-carries? effects)
-          generated-cast (fn [tag]
-                           (if (and carried-effects? (= 'float tag))
-                             'clojure.core/unchecked-float
-                             (symbol "clojure.core" (name tag))))
+          generated-cast (partial effect-source/storage-cast carried-effects?)
           _ (when (seq effects)
               (soac-dialect/validate-scheduled-effect-carries!
                effects (concat (:inputs segmap) (:outputs segmap) (:scalars segmap)
                                [index] (map :id locals))))
-          ;; Typed locals are materialized as explicit casts; source binder tags inside their
-          ;; initializers (a walker `^double v` over a primitive init) would make the JVM compiler
-          ;; refuse the form, so the tags are dropped here and the casts carry the types.
-          strip-binder-tags
-          (fn [form]
-            (clojure.walk/postwalk
-             (fn [x]
-               (if (and (seq? x) (contains? #{'let* 'loop*} (first x)) (vector? (second x)))
-                 (with-meta
-                   (list* (first x)
-                          (vec (map-indexed (fn [ordinal item]
-                                              (if (and (even? ordinal) (symbol? item)
-                                                       (:tag (meta item)))
-                                                (vary-meta item dissoc :tag)
-                                                item))
-                                            (second x)))
-                          (nnext x))
-                   (meta x))
-                 x))
-             form))
-          materialize-locals
-          (fn [locals body]
-            (if (seq locals)
-              (list 'let*
-                    (vec (mapcat (fn [{:keys [id dtype init]}]
-                                   (let [tag (dtype/scalar-tag-for-dtype dtype)]
-                                     [(with-meta id {:raster.type/tag tag})
-                                      (list (generated-cast tag) (strip-binder-tags init))]))
-                                 locals))
-                    body)
-              body))
+          materialize-locals (partial effect-source/typed-locals generated-cast)
           effect-statement
           (fn effect-statement
             [{:keys [destination dtype conflict destination-index predicate value] :as effect}]
@@ -1037,30 +1004,7 @@
               (if (contains? #{true 1} predicate)
                 store
                 (list 'if predicate store))))
-          loop-statement
-          (fn [{:keys [index lower extent locals carry]} ordered-body]
-                  (let [{:keys [parameter dtype init update]} carry
-                        ;; A typed FP carry rounds to its storage precision with IEEE overflow.
-                        ;; This generated conversion is not a user-written checked `float` call.
-                        tag (when carry (generated-cast (dtype/scalar-tag-for-dtype dtype)))
-                        index-tag (if carry 'clojure.core/long 'clojure.core/int)
-                        limit (gensym "effect_carry_limit__")
-                        initial (gensym "effect_carry_init__")
-                        loop-form
-                        (list 'let* (cond-> [limit (list index-tag extent)]
-                                      carry (conj initial (list tag (strip-binder-tags init))))
-                              (list 'loop* (cond-> [index (list index-tag lower)]
-                                             carry (conj parameter initial))
-                                    (list 'if (ix< index limit)
-                                          (materialize-locals
-                                           locals
-                                           (list 'do ordered-body
-                                                 (list* 'recur
-                                                        (cond-> [(list (if carry 'clojure.core/unchecked-inc
-                                                                         'clojure.core/unchecked-inc-int) index)]
-                                                          carry (conj (list tag (strip-binder-tags update)))))))
-                                          parameter)))]
-                    loop-form))
+          loop-statement (partial effect-source/counted-loop generated-cast)
           typed-region-body
           (when (seq effects)
             (materialize-locals locals

--- a/src/raster/compiler/passes/parallel/effect_source.clj
+++ b/src/raster/compiler/passes/parallel/effect_source.clj
@@ -2,7 +2,73 @@
   "Shared host continuation construction for validated scheduled effect regions.
 
    Target projections supply store and loop spelling; this function alone owns ordered effect
-   sequencing and the scope of an exported loop result. It neither infers types nor parses source.")
+   sequencing and the scope of an exported loop result. It neither infers types nor parses source."
+  (:require [clojure.walk :as walk]
+            [raster.compiler.core.dtype :as dtype]))
+
+(defn storage-cast
+  "Generated storage conversion, not a user-written cast. Carried FP32 regions use IEEE rounding
+   and overflow, matching KernelBody; existing non-carried host regions retain checked casts."
+  [carried? tag]
+  (if (and carried? (= 'float tag))
+    'clojure.core/unchecked-float
+    (symbol "clojure.core" (name tag))))
+
+(defn- strip-binder-tags
+  [form]
+  ;; JVM loop/let initializers already carry their primitive types. Keep Raster's independent
+  ;; type facts, but remove source binder hints that the Clojure compiler would reject.
+  (walk/postwalk
+   (fn [x]
+     (if (and (seq? x) (contains? #{'let* 'loop*} (first x)) (vector? (second x)))
+       (with-meta
+         (list* (first x)
+                (vec (map-indexed (fn [ordinal item]
+                                    (if (and (even? ordinal) (symbol? item) (:tag (meta item)))
+                                      (vary-meta item dissoc :tag)
+                                      item))
+                                  (second x)))
+                (nnext x))
+         (meta x))
+       x))
+   form))
+
+(defn typed-locals
+  "Materialize retained local dtypes through explicit generated casts."
+  [generated-cast locals body]
+  (if (seq locals)
+    (list 'let*
+          (vec (mapcat (fn [{:keys [id dtype init]}]
+                         (let [tag (dtype/scalar-tag-for-dtype dtype)]
+                           [(with-meta id {:raster.type/tag tag})
+                            (list (generated-cast tag) (strip-binder-tags init))]))
+                       locals))
+          body)
+    body))
+
+(defn counted-loop
+  "Spell the validated scheduled counted-loop contract, including its optional typed carry.
+   Bounds/initializer are evaluated once. Stores precede recurrence evaluation. A zero-trip loop
+   returns its initializer. Result scope is supplied separately by `ordered-effects`."
+  [generated-cast {:keys [index lower extent locals carry]} ordered-body]
+  (let [{:keys [parameter dtype init update]} carry
+        tag (when carry (generated-cast (dtype/scalar-tag-for-dtype dtype)))
+        index-tag (if carry 'clojure.core/long 'clojure.core/int)
+        limit (gensym "effect_carry_limit__")
+        initial (gensym "effect_carry_init__")]
+    (list 'let* (cond-> [limit (list index-tag extent)]
+                  carry (conj initial (list tag (strip-binder-tags init))))
+          (list 'loop* (cond-> [index (list index-tag lower)]
+                         carry (conj parameter initial))
+                (list 'if (list 'clojure.core/< index limit)
+                      (typed-locals
+                       generated-cast locals
+                       (list 'do ordered-body
+                             (list* 'recur
+                                    (cond-> [(list (if carry 'clojure.core/unchecked-inc
+                                                     'clojure.core/unchecked-inc-int) index)]
+                                      carry (conj (list tag (strip-binder-tags update)))))))
+                      parameter)))))
 
 (defn ordered-effects
   "Spell scheduled effects as a host continuation. `emit-store` receives a store descriptor;

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -51,10 +51,6 @@
       (let [{:keys [index region]} (projection/instantiate-effect-region equation)
             {:keys [locals body-results]}
             (dialect/lambda-parts (list 'lambda [] (projection/scalar-folds->source region)))]
-        (when (dialect/scheduled-effect-carries? (mapv dialect/scheduled-effect body-results))
-          (throw (ex-info "carried effects require structured scheduled lowering"
-                          {:reason :typed-soac-production-subset
-                           :missing-rule :carried-effect-realization})))
         {:index index :locals locals :bodies body-results})
 
       :else
@@ -295,6 +291,11 @@
             dtype-by-destination (zipmap physical-results result-dtypes)
             cast-by-destination (zipmap physical-results casts)
             effects (mapv dialect/scheduled-effect bodies)
+            carried? (dialect/scheduled-effect-carries? effects)
+            generated-cast (partial effect-source/storage-cast carried?)
+            materialize-locals (if carried?
+                                 (partial effect-source/typed-locals generated-cast)
+                                 materialize-region)
             _ (when-not (and (= (count results) (count physical-results)
                                 (count result-dtypes) (count casts))
                              (every? some? effects)
@@ -306,12 +307,15 @@
                                  :equation equation-id :results results
                                  :storage storage :effects effects :dtypes result-dtypes})))
             loop-statement
-            (fn [{:keys [index lower extent locals]} ordered-body]
-              (list 'loop* [index lower]
-                    (list 'if (list 'clojure.core/< index extent)
-                          (list 'do (materialize-region locals ordered-body)
-                                (list 'recur (list 'clojure.core/inc index)))
-                          nil)))
+            (fn [{:keys [index lower extent locals carry] :as loop} ordered-body]
+              (if carry
+                (effect-source/counted-loop generated-cast loop ordered-body)
+                ;; Preserve the existing source loop's induction policy when no carry is present.
+                (list 'loop* [index lower]
+                      (list 'if (list 'clojure.core/< index extent)
+                            (list 'do (materialize-locals locals ordered-body)
+                                  (list 'recur (list 'clojure.core/inc index)))
+                            nil))))
             statement
             (fn [{:keys [destination conflict destination-index predicate value]}]
                     (let [cast (get cast-by-destination destination)
@@ -320,7 +324,7 @@
                                         {:raster.type/tag
                                          (dtype/array-tag-for-dtype result-dtype)
                                          :tag (dtype/array-tag-for-dtype result-dtype)})
-                          typed-value (typed-store-value cast value)
+                          typed-value (if cast (list (generated-cast cast) value) value)
                           store (if (dialect/reducing-scatter-conflict? conflict)
                                   (list 'raster.par/atomic-add!
                                         destination destination-index typed-value)
@@ -332,7 +336,7 @@
             effect-source
             (with-meta
               (list 'raster.par/map-void! region-index (:extent attributes)
-                    (materialize-region region-locals continuation))
+                    (materialize-locals region-locals continuation))
               {:raster.type/elem-type (first result-dtypes)})]
         {:equation-id equation-id
          :placement placement

--- a/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_effect_carry_test.clj
@@ -48,11 +48,50 @@
     (is (zero? (:vertical stats)))
     (is (zero? (:horizontal stats)))
     (is (= :explicit-typed-algorithm (get-in (route/program-envelope program) [:attributes :host-control])))
-    (is (= :carried-effect-realization
-           (try ((ns-resolve 'raster.compiler.passes.parallel.typed-soac-route 'scalar-region)
-                 (first (dialect/equations program)))
-                :accepted
-                (catch clojure.lang.ExceptionInfo e (:missing-rule (ex-data e))))))))
+    (is (some? (-> ((ns-resolve 'raster.compiler.passes.parallel.typed-soac-route 'scalar-region)
+                   (first (dialect/equations program)))
+                  :bodies first dialect/effect-parts :carry)))))
+
+(defn- host-source [program]
+  (:source ((ns-resolve 'raster.compiler.passes.parallel.typed-soac-route 'realize-equation)
+            (dialect/validate! program) (first (dialect/equations program)))))
+
+(deftest production-carries-share-scheduled-execution-and-hygiene
+  (doseq [trips [0 1 8] physical ['seed 'i 'acc 'sum 'loaded 'float]]
+    (let [program (dialect/remap-values (fixture/typed-program trips) {'seed physical})
+          operation (first (lower/lower-typed-effect-map program :ze:0))
+          arguments ['x 'words 'totals 'rows physical]
+          host (eval (list 'fn arguments (host-source program)))
+          scheduled (eval (list 'fn arguments (jvm/compile-effect-segmap operation)))
+          x (float-array (range 16))
+          host-words (float-array (repeat 16 -77)) host-totals (float-array 2)
+          words (float-array (repeat 16 -77)) totals (float-array 2)]
+      (scheduled x words totals 2 (float 0.25))
+      (is (nil? (host x host-words host-totals 2 (float 0.25))))
+      (is (= (vec words) (vec host-words)))
+      (is (= (vec totals) (vec host-totals))))))
+
+(deftest production-carry-preserves-generated-fp32-conversion-and-checked-source-arithmetic
+  (let [overflow-init (rewrite-loop (fixture/typed-program 0)
+                                    (fn [[op attrs extent _ lambda]]
+                                      (list op attrs extent 1.0e100 lambda)))
+        host (eval (list 'fn '[x words totals rows seed] (host-source overflow-init)))
+        totals (float-array 1)]
+    (host (float-array 16) (float-array 16) totals 1 (float 0.25))
+    (is (= Float/POSITIVE_INFINITY (aget totals 0))))
+  (let [checked (rewrite-loop
+                 (fixture/typed-program 1)
+                 (fn [[op attrs extent init [lam params [region locals effects _]]]]
+                   (list op attrs extent init
+                         (list lam params
+                               (list region locals effects
+                                     (with-meta '(clojure.core/+ 9223372036854775807 1)
+                                                {:raster.type/tag 'long}))))))
+        host (eval (list 'fn '[x words totals rows seed] (host-source checked)))
+        words (float-array (repeat 16 -77)) totals (float-array [-77])]
+    (is (thrown? ArithmeticException (host (float-array (range 16)) words totals 1 (float 0.25))))
+    (is (= 0.0 (aget words 0)) "the store precedes the failing recurrence")
+    (is (= -77.0 (aget totals 0)) "a failed recurrence never publishes its continuation result")))
 
 (deftest canonical-carries-reject-invalid-shapes-scope-and-hidden-writes
   (let [program (fixture/typed-program 1)


### PR DESCRIPTION
## Summary
- Reuse the existing scheduled JVM counted-loop, typed-local and generated-storage conversion implementation for canonical carried-effect host realization.
- Preserve zero-trip initialization, store-before-recurrence ordering, continuation result scope, IEEE FP32 generated conversions, and checked source arithmetic.
- Remove the production realization refusal; analyzed-source frontend admission remains closed pending its separate dependency/conflict checks.
- Keep existing ordinary source-loop induction policies unchanged. No public Q8_K migration or throughput claim.

## Validation
- 19 carried-effect/helper tests, 269 assertions.
- 74 production-route/scalar-fold/ordered-effect/device tests, 708 assertions.
- Zero failures/errors in one capped REPL; review found no blocker.
- Rebased onto merged PR481 with identical tested tree. Full suites and vendor gates delegated to CI.