### PR TITLE
Retain effect-map induction scope through central scalar inference

### DIFF
--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -935,6 +935,9 @@
 (defmethod walk-form :par-map-void [form ctx]
   ;; The bound is outside the induction-variable scope, just as for map!.
   ;; Keep the effect-only SOAC intact; its body does not determine a return type.
+  (when-not (and (= 4 (count form)) (symbol? (second form)))
+    (throw (ex-info "map-void! requires a symbol index, a bound, and a body"
+                    {:reason :invalid-effect-map-form :form form})))
   (let [[_ i-sym bound-expr body-expr] form
         walked-bound (walk bound-expr ctx)
         idx-ctx (ctx-assoc-type ctx i-sym 'long)]

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -198,6 +198,12 @@
     :par-map
 
     (and (seq? form)
+         (symbol? (first form))
+         (= 'raster.par/map-void!
+            (resolve-aliased-symbol (first form) (:source-ns ctx))))
+    :par-map-void
+
+    (and (seq? form)
          (let [head (first form)
                resolved (if (and (symbol? head) (namespace head))
                           (resolve-aliased-symbol head (:source-ns ctx))
@@ -925,6 +931,16 @@
 ;; ================================================================
 ;; Branch: parallel ops (map!, reduce, scan, stencil!)
 ;; ================================================================
+
+(defmethod walk-form :par-map-void [form ctx]
+  ;; The bound is outside the induction-variable scope, just as for map!.
+  ;; Keep the effect-only SOAC intact; its body does not determine a return type.
+  (let [[_ i-sym bound-expr body-expr] form
+        walked-bound (walk bound-expr ctx)
+        idx-ctx (ctx-assoc-type ctx i-sym 'long)]
+    (with-meta (list 'raster.par/map-void! i-sym walked-bound
+                     (walk body-expr idx-ctx))
+      (meta form))))
 
 (defmethod walk-form :par-map [form ctx]
   ;; Handle both standard and offset variants:

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -959,10 +959,13 @@
                        (or (:scalar-types opts) (:array-types opts))
                        (vary-meta assoc :scalar-types (:scalar-types opts)
                                   :array-types (:array-types opts)))
-                result (opencl-pass/opencl-pass form
-                                                :device-id target-device
-                                                :dtype (:dtype opts)
-                                                :schedule (:schedule opts))]
+                result (apply opencl-pass/opencl-pass form
+                              (cond-> [:device-id target-device
+                                       :dtype (:dtype opts)
+                                       :schedule (:schedule opts)]
+                                ;; Resident buffers cannot be consumed by a host fallback merely
+                                ;; because specialization made a small extent a literal.
+                                (:resident-gpu? opts) (into [:min-elements 0])))]
             (register-gpu-kernels! (:kernels result) target-device)
             (register-gpu-dispatches! (:dispatches result) target-device)
             {:form (:form result) :stats (:stats result)
@@ -1828,6 +1831,7 @@
         array-params (filterv #(contains? array-param-set %) all-params)
         scalar-params (filterv #(not (contains? array-param-set %)) all-params)
         post-opts (cond-> {:inline? true :simd? false :target-device device-id
+                           :resident-gpu? true
                            :active-params active-params :dtype effective-dtype
                            :schedule resolved-schedule}
                     param-env (assoc :param-env param-env)

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -119,6 +119,30 @@
     (is (nil? (:raster.op/original (meta mixed)))
         "retaining an inferred type does not pretend that a bare core call was devirtualized")))
 
+(deftest effect-map-index-has-a-lexical-type-scope
+  (let [walked (wb (with-meta
+                    '(raster.par/map-void! i (clojure.core/+ i i)
+                       (clojure.core/quot i width))
+                    {:line 123})
+                   {'i 'double 'width 'long})
+        [_ _ bound body] walked]
+    (is (= 'double (:raster.type/tag (meta bound)))
+        "the bound sees the outer binding, not the induction variable")
+    (is (= 'long (:raster.type/tag (meta body)))
+        "the existing scalar inference now sees both operand types")
+    (is (= 123 (:line (meta walked))))
+    (is (nil? (:raster.type/tag (meta walked)))
+        "an effect map does not inherit the body's scalar result"))
+  (let [walked (wb '(raster.par/map-void! i n (clojure.core/quot i unknown))
+                   {'n 'long})]
+    (is (nil? (:raster.type/tag (meta (last walked))))
+        "index scope does not invent types for unknown operands"))
+  (let [walked (wb '(do (raster.par/map-void! i n (clojure.core/quot i width))
+                        (clojure.core/+ i i))
+                   {'i 'double 'n 'long 'width 'long})]
+    (is (= 'double (:raster.type/tag (meta (last walked))))
+        "the induction variable does not escape the effect map")))
+
 (deftest walk-nested-let-test
   (testing "nested let bindings are walked"
     (let [walked (wb '(let [a (raster.numeric/+ x y)

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -143,6 +143,14 @@
     (is (= 'double (:raster.type/tag (meta (last walked))))
         "the induction variable does not escape the effect map")))
 
+(deftest malformed-effect-map-does-not-drop-source-operands
+  (doseq [form ['(raster.par/map-void! i n)
+               '(raster.par/map-void! i n nil (throw (Exception.)))
+               '(raster.par/map-void! [i] n nil)]]
+    (is (= :invalid-effect-map-form
+           (try (wb form) nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+
 (deftest walk-nested-let-test
   (testing "nested let bindings are walked"
     (let [walked (wb '(let [a (raster.numeric/+ x y)

--- a/test/raster/compiler/ir/program_stage_test.clj
+++ b/test/raster/compiler/ir/program_stage_test.clj
@@ -22,6 +22,9 @@
   (nn/residual-add! at q output 4))
 
 (defn- descriptor []
+  ;; The literal extent 4 is intentionally below the staging backend's host-fallback
+  ;; threshold. Resident compilation must keep these effects on the device regardless
+  ;; of whether the walker retains `4` or a redundant `(long 4)` cast.
   (pipeline/compile-gpu-program #'staged-attention! :ze:0 :dtype :float))
 
 (defn- projection-bindings


### PR DESCRIPTION
## Change
Give map-void! the same lexical Long induction-variable scope as map!. Walk its bound in the enclosing scope, preserve metadata/effect-only semantics, reject malformed arity/binders. No emitter inference or new type table.

## CI repair
Retaining literal extent 4 instead of redundant (long 4) exposed the staging backend small-kernel host-fallback threshold during resident compilation. Resident post-pipeline now passes min-elements 0; ordinary staged compilation retains the existing threshold. Semantic-stage tests cover literal four-element effects composed with attention.

## Validation
Focused walker and semantic-stage suites: 23 tests, 72 assertions, zero failures/errors in the existing capped REPL. Initial CI found the resident threshold regression (two errors); the corrected head reruns all seven gates. Public Q8_K carried-loop admission remains separate; no completed-migration or throughput claim.