### PR TITLE
Retain scalar type evidence and resident effect-map placement

### DIFF
--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -636,6 +636,14 @@
               (if (and (seq tags) (every? some? tags) (apply = tags))
                 (vary-meta result assoc :raster.type/tag (first tags))
                 result))
+            ;; Java interop overload resolution already lives in central inference.
+            ;; Retain its result on the call itself, not only on a consuming let binder:
+            ;; nested scalar conversions in TypedSOAC must not rediscover the overload.
+            (and (symbol? head) (namespace head))
+            (if-let [rt (binding [*ns* (the-ns (:source-ns ctx))]
+                          (inf/static-method-return-tag head (rest result) type-env))]
+              (vary-meta result assoc :raster.type/tag rt)
+              result)
             :else result))
         result))))
 

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -935,6 +935,9 @@
 (defmethod walk-form :par-map-void [form ctx]
   ;; The bound is outside the induction-variable scope, just as for map!.
   ;; Keep the effect-only SOAC intact; its body does not determine a return type.
+  (when-not (and (= 4 (count form)) (symbol? (second form)))
+    (throw (ex-info "map-void! requires a symbol index, a bound, and a body"
+                    {:reason :invalid-effect-map-form :form form})))
   (let [[_ i-sym bound-expr body-expr] form
         walked-bound (walk bound-expr ctx)
         idx-ctx (ctx-assoc-type ctx i-sym 'long)]

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -198,6 +198,12 @@
     :par-map
 
     (and (seq? form)
+         (symbol? (first form))
+         (= 'raster.par/map-void!
+            (resolve-aliased-symbol (first form) (:source-ns ctx))))
+    :par-map-void
+
+    (and (seq? form)
          (let [head (first form)
                resolved (if (and (symbol? head) (namespace head))
                           (resolve-aliased-symbol head (:source-ns ctx))
@@ -925,6 +931,16 @@
 ;; ================================================================
 ;; Branch: parallel ops (map!, reduce, scan, stencil!)
 ;; ================================================================
+
+(defmethod walk-form :par-map-void [form ctx]
+  ;; The bound is outside the induction-variable scope, just as for map!.
+  ;; Keep the effect-only SOAC intact; its body does not determine a return type.
+  (let [[_ i-sym bound-expr body-expr] form
+        walked-bound (walk bound-expr ctx)
+        idx-ctx (ctx-assoc-type ctx i-sym 'long)]
+    (with-meta (list 'raster.par/map-void! i-sym walked-bound
+                     (walk body-expr idx-ctx))
+      (meta form))))
 
 (defmethod walk-form :par-map [form ctx]
   ;; Handle both standard and offset variants:

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -959,10 +959,13 @@
                        (or (:scalar-types opts) (:array-types opts))
                        (vary-meta assoc :scalar-types (:scalar-types opts)
                                   :array-types (:array-types opts)))
-                result (opencl-pass/opencl-pass form
-                                                :device-id target-device
-                                                :dtype (:dtype opts)
-                                                :schedule (:schedule opts))]
+                result (apply opencl-pass/opencl-pass form
+                              (cond-> [:device-id target-device
+                                       :dtype (:dtype opts)
+                                       :schedule (:schedule opts)]
+                                ;; Resident buffers cannot be consumed by a host fallback merely
+                                ;; because specialization made a small extent a literal.
+                                (:resident-gpu? opts) (into [:min-elements 0])))]
             (register-gpu-kernels! (:kernels result) target-device)
             (register-gpu-dispatches! (:dispatches result) target-device)
             {:form (:form result) :stats (:stats result)
@@ -1828,6 +1831,7 @@
         array-params (filterv #(contains? array-param-set %) all-params)
         scalar-params (filterv #(not (contains? array-param-set %)) all-params)
         post-opts (cond-> {:inline? true :simd? false :target-device device-id
+                           :resident-gpu? true
                            :active-params active-params :dtype effective-dtype
                            :schedule resolved-schedule}
                     param-env (assoc :param-env param-env)

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -119,6 +119,30 @@
     (is (nil? (:raster.op/original (meta mixed)))
         "retaining an inferred type does not pretend that a bare core call was devirtualized")))
 
+(deftest effect-map-index-has-a-lexical-type-scope
+  (let [walked (wb (with-meta
+                    '(raster.par/map-void! i (clojure.core/+ i i)
+                       (clojure.core/quot i width))
+                    {:line 123})
+                   {'i 'double 'width 'long})
+        [_ _ bound body] walked]
+    (is (= 'double (:raster.type/tag (meta bound)))
+        "the bound sees the outer binding, not the induction variable")
+    (is (= 'long (:raster.type/tag (meta body)))
+        "the existing scalar inference now sees both operand types")
+    (is (= 123 (:line (meta walked))))
+    (is (nil? (:raster.type/tag (meta walked)))
+        "an effect map does not inherit the body's scalar result"))
+  (let [walked (wb '(raster.par/map-void! i n (clojure.core/quot i unknown))
+                   {'n 'long})]
+    (is (nil? (:raster.type/tag (meta (last walked))))
+        "index scope does not invent types for unknown operands"))
+  (let [walked (wb '(do (raster.par/map-void! i n (clojure.core/quot i width))
+                        (clojure.core/+ i i))
+                   {'i 'double 'n 'long 'width 'long})]
+    (is (= 'double (:raster.type/tag (meta (last walked))))
+        "the induction variable does not escape the effect map")))
+
 (deftest walk-nested-let-test
   (testing "nested let bindings are walked"
     (let [walked (wb '(let [a (raster.numeric/+ x y)

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -151,6 +151,29 @@
            (try (wb form) nil
                 (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
 
+(deftest java-static-overload-results-survive-nested-conversions
+  (doseq [[input-type result-type] [['float 'int] ['double 'long]]]
+    (let [walked (wb (list 'clojure.core/long
+                           (list 'Math/round (list input-type 'x)))
+                     {'x input-type})]
+      (is (= result-type (:raster.type/tag (meta (second walked)))))
+      (is (= 'long (:raster.type/tag (meta walked))))))
+  (is (= 'double (:raster.type/tag (meta (wb '(Math/sqrt (double x)) {'x 'double})))))
+  (is (nil? (:raster.type/tag (meta (wb '(Math/round unknown))))))
+  (is (nil? (:raster.type/tag (meta (wb '(unknown.namespace/round unknown)))))))
+
+(deftest java-static-result-resolution-uses-the-source-imports
+  (let [source-name (gensym "walker-source-")
+        source-ns (create-ns source-name)]
+    (try
+      (.importClass source-ns 'SourceMath java.lang.Math)
+      (is (= 'long
+             (:raster.type/tag
+              (meta (walker/walk-body '(SourceMath/round (clojure.core/double x))
+                                      {:source-ns source-ns
+                                       :type-env (te {'x 'double})})))))
+      (finally (remove-ns source-name)))))
+
 (deftest walk-nested-let-test
   (testing "nested let bindings are walked"
     (let [walked (wb '(let [a (raster.numeric/+ x y)

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -143,6 +143,14 @@
     (is (= 'double (:raster.type/tag (meta (last walked))))
         "the induction variable does not escape the effect map")))
 
+(deftest malformed-effect-map-does-not-drop-source-operands
+  (doseq [form ['(raster.par/map-void! i n)
+               '(raster.par/map-void! i n nil (throw (Exception.)))
+               '(raster.par/map-void! [i] n nil)]]
+    (is (= :invalid-effect-map-form
+           (try (wb form) nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+
 (deftest walk-nested-let-test
   (testing "nested let bindings are walked"
     (let [walked (wb '(let [a (raster.numeric/+ x y)

--- a/test/raster/compiler/ir/program_stage_test.clj
+++ b/test/raster/compiler/ir/program_stage_test.clj
@@ -22,6 +22,9 @@
   (nn/residual-add! at q output 4))
 
 (defn- descriptor []
+  ;; The literal extent 4 is intentionally below the staging backend's host-fallback
+  ;; threshold. Resident compilation must keep these effects on the device regardless
+  ;; of whether the walker retains `4` or a redundant `(long 4)` cast.
   (pipeline/compile-gpu-program #'staged-attention! :ze:0 :dtype :float))
 
 (defn- projection-bindings


### PR DESCRIPTION
## Combined reviewed change
Includes #483: give map-void! its Long induction scope, preserve outer-bound scope and metadata, and reject malformed forms. Resident compilation disables the staging small-kernel host-fallback threshold; ordinary staged compilation retains it.

Also retain existing central Java static overload results on expressions, resolved against source namespace. No new type/operator registry or emitter inference.

## Validation
Exact combined head 129b65000493fd184d4c8456a06c0328f4bcdb8a passed all seven CircleCI gates: setup/build, emitted fixtures, CUDA, HIP, OpenCL CPU, and full test shard. Focused walker+semantic-stage 25 tests/80 assertions; quantization/projection 4 tests/61 assertions; real-device padded B=3 Q8_K→Q4 projection one test/one numerical assertion. All green. Read-only review completed.

The older #483 OpenCL job passed 161 tests/2738 assertions then terminated with a native segmentation fault. This PR is the tested green superset, consolidating the stack without claiming that native worker crash was repaired.

Public Q8_K carried-loop admission remains separate and unmerged. No throughput or fully unified-emitter claim.