### PR TITLE
Explicit integer wrapping and typed rounding semantics

### DIFF
--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -266,7 +266,10 @@
       (cond
         (and (descriptor/cast-op? op)
              (contains? '#{int long} (descriptor/cast-result-tag op)))
-        (long (resolve-int-expr (second expr) env))
+        (let [value (resolve-int-expr (second expr) env)]
+          (if (= :wrap (descriptor/cast-integral-narrowing op))
+            (unchecked-int value)
+            (long value)))
         ;; arithmetic — classify by the SEMANTIC op (:raster.op/original metadata,
         ;; falling back to the head/impl symbol) via the shared intrinsics registry.
         :else

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -1034,14 +1034,27 @@
      ;; no-op → drop it (`(double)(double4)` is illegal C). A cast to a DIFFERENT element
      ;; type over a vector is a genuine per-lane precision change (a `^double` helper in a
      ;; float kernel) with no clean vector lowering → bail this kernel to the scalar loop.
+     (let [target-tag (or (descriptor/cast-result-tag (first expr)) 'short)
+           argument (second expr)
+           _ (when (= :wrap (descriptor/cast-integral-narrowing (first expr)))
+               (let [source-type (or (some-> (or (types/sym-type-tag argument)
+                                                (types/literal-tag argument))
+                                             dtype/dtype-for-scalar-tag)
+                                     (when (symbol? argument)
+                                       (some (fn [[type c-type]]
+                                               (when (= c-type (get *scalar-var-types* argument)) type))
+                                             (concat type-map (dtype/backend-types :opencl)))))]
+                 (when-not (and source-type (dtype/integral? source-type))
+                   (throw (ex-info "unchecked C narrowing requires a retained integral source type"
+                                   {:reason :unchecked-cast-source-type :expression expr})))))]
      (if (and *vec-width* (contains-vload? (second expr)))
-       (if (= (name (first expr)) *scalar-type*)
+       (if (= (name target-tag) *scalar-type*)
          (emit-expr (second expr) idx-sym array-syms opencl-idx)
          (throw (ex-info "vector precision cast" {:raster.compiler.backend.gpu.c-emit/bail true})))
-       (emit-cast (let [tag (name (first expr))]
+       (emit-cast (let [tag (name target-tag)]
                     ;; Narrow integer casts name JVM scalar tags; C spells them by width.
                     (get {"byte" "int8_t" "short" "int16_t"} tag (remap-type tag)))
-                  (emit-expr (second expr) idx-sym array-syms opencl-idx)))
+                  (emit-expr (second expr) idx-sym array-syms opencl-idx))))
 
      ;; TypedSOAC scalar Fold. It remains a semantic term through scheduling;
      ;; the C-family leaf chooses the portable one-work-item sequential schedule.

--- a/src/raster/compiler/core/numeric_constant.clj
+++ b/src/raster/compiler/core/numeric_constant.clj
@@ -36,7 +36,9 @@
         (try
           {:value (case tag
                     byte (byte (:value operand))
-                    int (int (:value operand))
+                    int (if (= :wrap (descriptor/cast-integral-narrowing (first expression)))
+                          (unchecked-int (:value operand))
+                          (int (:value operand)))
                     long (long (:value operand))
                     float (float (:value operand))
                     double (double (:value operand)))}

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -425,10 +425,15 @@
 ;; --- Primitive casts ---
 
 (def cast-ops
-  "Primitive cast symbols and their result types."
-  {'long 'long, 'int 'int, 'byte 'byte, 'double 'double, 'float 'float
-   'clojure.core/long 'long, 'clojure.core/int 'int
-   'clojure.core/byte 'byte, 'clojure.core/double 'double, 'clojure.core/float 'float})
+  "Primitive source conversion contracts. Width and narrowing policy have one owner."
+  (assoc (into {} (map (fn [[op tag]] [op {:result-tag tag :integral-narrowing :reject}]))
+               {'long 'long, 'int 'int, 'byte 'byte, 'double 'double, 'float 'float
+                'clojure.core/long 'long, 'clojure.core/int 'int
+                'clojure.core/byte 'byte, 'clojure.core/double 'double,
+                'clojure.core/float 'float})
+         ;; Only the resolved core spelling is admitted: a lexical function named
+         ;; unchecked-int is not a source conversion contract.
+         'clojure.core/unchecked-int {:result-tag 'int :integral-narrowing :wrap}))
 
 (defn cast-op?
   "True if sym is a primitive cast operation."
@@ -438,7 +443,12 @@
 (defn cast-result-tag
   "Return the result type tag for a cast op, or nil."
   [sym]
-  (get cast-ops sym))
+  (get-in cast-ops [sym :result-tag]))
+
+(defn cast-integral-narrowing
+  "Explicit source narrowing policy, or nil for a non-cast."
+  [sym]
+  (get-in cast-ops [sym :integral-narrowing]))
 
 ;; --- Scalar ops (type-preserving, pure) ---
 

--- a/src/raster/compiler/ir/invocation_plan.clj
+++ b/src/raster/compiler/ir/invocation_plan.clj
@@ -269,6 +269,7 @@
   (loop [expression expression]
     (if (and (seq? expression)
              (descriptor/cast-op? (descriptor/semantic-op expression))
+             (not= :wrap (descriptor/cast-integral-narrowing (descriptor/semantic-op expression)))
              (= 1 (count (descriptor/call-args expression))))
       (recur (first (descriptor/call-args expression)))
       expression)))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -162,7 +162,7 @@
                                (body/scalar-expression operator result-type arguments options))]
                  :result result :type result-type :range range}))
 
-            (cast-lowered [lowered target expression]
+            (cast-lowered [lowered target expression & [explicit-narrowing]]
               (let [target (dtype/canon target)]
                 (if (= target (:type lowered))
                   lowered
@@ -170,9 +170,11 @@
                         [rounding overflow]
                         ;; Map/fold retain their existing device-wrap default. A stricter owner
                         ;; supplies its conversion contract rather than inheriting that policy.
-                        (or (if conversion-policy
-                              (conversion-policy source target)
-                              (scalar-conversion/policy source target :wrap))
+                        (or (if (= :wrap explicit-narrowing)
+                              (scalar-conversion/policy source target :wrap)
+                              (if conversion-policy
+                                (conversion-policy source target)
+                                (scalar-conversion/policy source target :wrap)))
                             (decline! :cast-policy
                                       "scalar cast has no portable rounding and overflow policy"
                                       {:expression expression :source source :target target}))
@@ -265,7 +267,8 @@
                                 (descriptor/cast-result-tag (first expression)))
                         source-expected (dtype/canon (source-type (second expression) target env))
                         lowered (lower (second expression) source-expected env)]
-                    (cast-lowered lowered target expression))
+                    (cast-lowered lowered target expression
+                                  (descriptor/cast-integral-narrowing (first expression))))
 
                   (and (seq? expression)
                        (= 'raster.numeric/oftype (descriptor/semantic-op expression))

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -150,6 +150,7 @@
   (loop [expression expression]
     (if (and (seq? expression)
              (descriptor/cast-op? (descriptor/semantic-op expression))
+             (not= :wrap (descriptor/cast-integral-narrowing (descriptor/semantic-op expression)))
              (= 1 (count (descriptor/call-args expression))))
       (recur (first (descriptor/call-args expression)))
       (when (and (seq? expression)

--- a/src/raster/math.clj
+++ b/src/raster/math.clj
@@ -117,9 +117,12 @@
   [x :- Double] :- Double (Math/floor x))
 (deftm floor [x :- Float] :- Float (float (Math/floor (double x))))
 
-(deftm round "Round x to the nearest integer (half-up)."
+(deftm round
+  "Round to the nearest integer, with ties toward positive infinity (including negative ties).
+   Float returns Integer; Double returns Long. NaN yields zero; overflow and infinities
+   saturate to the result width. This is not ties-to-even or a wrapping integer conversion."
   [x :- Double] :- Long (Math/round x))
-(deftm round [x :- Float] :- Integer (Math/round (float x)))
+(deftm round [x :- Float] :- Integer (Math/round x))
 
 (deftm trunc
   "Truncate towards zero (round towards zero)."

--- a/test/raster/compiler/backend/cpu/aot_test.clj
+++ b/test/raster/compiler/backend/cpu/aot_test.clj
@@ -24,6 +24,7 @@
     (is (= 7 (aot/resolve-int-expr (list cast 'n) {'n 7})))))
 
 (deftest scratch-sizes-use-checked-constant-evidence
+  (is (= 1 (aot/resolve-int-expr '(clojure.core/unchecked-int n) {'n 4294967297})))
   (is (= 8 (#'aot/const-int-size '(clojure.core/long (clojure.core/int 8)))))
   (doseq [expression ['(int 4294967296) -1 'n '(long n)]]
     (is (nil? (#'aot/const-int-size expression)))))

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -7,6 +7,18 @@
     (is (= (c-emit/emit-expr (list cast 'x) 'i #{} "i")
            (c-emit/emit-expr (list (symbol "clojure.core" (name cast)) 'x) 'i #{} "i")))))
 
+(deftest explicit-unchecked-integer-casts-require-integral-evidence
+  (doseq [value [4294967295 (with-meta 'word {:raster.type/tag 'long})]]
+    (is (.startsWith (c-emit/emit-expr (list 'clojure.core/unchecked-int value) nil #{} "idx")
+                     "(int)(")))
+  (is (= "(int)(word)"
+         (binding [c-emit/*scalar-var-types* {'word "long"}]
+           (c-emit/emit-expr '(clojure.core/unchecked-int word) nil #{} "idx"))))
+  (doseq [value [1.5 'unknown (with-meta 'floating {:raster.type/tag 'double})]]
+    (is (= :unchecked-cast-source-type
+           (try (c-emit/emit-expr (list 'clojure.core/unchecked-int value) nil #{} "idx")
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+
 (deftest portable-identifiers-cover-the-cuda-and-hip-cpp-language
   (is (not (c-emit/c-identifier? "class")))
   (is (not (c-emit/c-identifier? "default")))

--- a/test/raster/compiler/backend/gpu/java_round_test.clj
+++ b/test/raster/compiler/backend/gpu/java_round_test.clj
@@ -41,34 +41,47 @@
                                        (Float/intBitsToFloat (.nextInt random))
                                        (Double/longBitsToDouble (.nextLong random))))))))
 
+(defn- check-unary-on-opencl! [input output values expected body name]
+  (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+        register! (ns-resolve ocl 'register-kernel!)
+        buffer-of-array (ns-resolve ocl 'buffer-of-array)
+        make-buffer (ns-resolve ocl 'make-buffer)
+        bind-call (ns-resolve ocl 'bind-kernel-call)
+        launch! (ns-resolve ocl 'launch-registered-bound!)
+        read! (ns-resolve ocl 'buffer->array)
+        free! (ns-resolve ocl 'free-buffer!)
+        compiled (artifact/make
+                  {:kernel-name name :target :opencl-c
+                   :source (emit/emit-scalar-kernel name body {:target-dialect :opencl-portable})
+                   :abi (body-abi/project-contracts
+                         [(abi/slot 'x :input input :c-name "rstr_x" :role :input)
+                          (abi/slot 'y :output output :c-name "rstr_y" :role :result)] body)
+                   :arguments '[x y] :launch (:launch body) :effects {:kind :map}
+                   :provenance {:kernel-body (:id body)}})
+        x (buffer-of-array ((case input :float float-array :double double-array :long long-array) values) input)
+        y (make-buffer (count values) output)]
+    (try
+      (register! name compiled)
+      (launch! (bind-call (call/make compiled [x y])))
+      (is (= expected (vec (read! y))) (str name " JVM boundary oracle"))
+      (finally (free! y) (free! x)))))
+
+(deftest unchecked-int-matches-jvm-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "explicit wrapping integer conversion")
+    (let [rng (java.util.Random. 282)
+          values (vec (concat [Long/MIN_VALUE Long/MAX_VALUE Integer/MIN_VALUE Integer/MAX_VALUE
+                               -2147483649 2147483648 4294967295 4294967296 -1 0 1]
+                              (repeatedly 64 #(.nextLong rng))))]
+      (check-unary-on-opencl! :long :int values (mapv unchecked-int values)
+                             (fixtures/unchecked-int-body (count values)) "unchecked_int_test"))))
+
 (deftest java-round-matches-jvm-on-opencl
   (if-not @probe/opencl-available?
     (probe/opencl-skip! "typed Java round overloads and numerical edge cases")
-    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
-          register! (ns-resolve ocl 'register-kernel!)
-          buffer-of-array (ns-resolve ocl 'buffer-of-array)
-          make-buffer (ns-resolve ocl 'make-buffer)
-          bind-call (ns-resolve ocl 'bind-kernel-call)
-          launch! (ns-resolve ocl 'launch-registered-bound!)
-          read! (ns-resolve ocl 'buffer->array)
-          free! (ns-resolve ocl 'free-buffer!)]
-      (doseq [[input output] [[:float :int] [:double :long]]]
-        (let [values (samples input)
-              expected (mapv (if (= input :float) #(Math/round (unchecked-float %)) #(Math/round (double %))) values)
-              body (fixtures/java-round-body input output (count values))
-              name (str "java_round_" (name input))
-              compiled (artifact/make
-                        {:kernel-name name :target :opencl-c
-                         :source (emit/emit-scalar-kernel name body {:target-dialect :opencl-portable})
-                         :abi (body-abi/project-contracts
-                               [(abi/slot 'x :input input :c-name "rstr_x" :role :input)
-                                (abi/slot 'y :output output :c-name "rstr_y" :role :result)] body)
-                         :arguments '[x y] :launch (:launch body) :effects {:kind :map}
-                         :provenance {:kernel-body (:id body)}})
-              x (buffer-of-array ((if (= input :float) float-array double-array) values) input)
-              y (make-buffer (count values) output)]
-          (try
-            (register! name compiled)
-            (launch! (bind-call (call/make compiled [x y])))
-            (is (= expected (vec (read! y))) (str input " Java round boundary oracle"))
-            (finally (free! y) (free! x))))))))
+    (doseq [[input output] [[:float :int] [:double :long]]]
+      (let [values (samples input)
+            expected (mapv (if (= input :float) #(Math/round (unchecked-float %)) #(Math/round (double %))) values)]
+        (check-unary-on-opencl! input output values expected
+                               (fixtures/java-round-body input output (count values))
+                               (str "java_round_" (name input)))))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -470,6 +470,10 @@
                           (body-emit/emit-scalar-kernel
                            "java_round_f64" (body-fixtures/java-round-body :double :long 1)
                            {:target-dialect dialect}))
+           (write-source! directory suffix "unchecked-int"
+                          (body-emit/emit-scalar-kernel
+                           "unchecked_int" (body-fixtures/unchecked-int-body 1)
+                           {:target-dialect dialect}))
            (write-source! directory suffix "word-shifts-i32"
                           (body-emit/emit-scalar-kernel
                            "word_shifts_i32" (body-fixtures/word-shifts-body :int 1)

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -2,17 +2,19 @@
   "Shared verifier, source-compile, and device fixtures for scheduled KernelBody operations."
   (:require [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.core.scalar-conversion :as conversion]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar]))
 
-(defn java-round-body [input-type output-type width]
+(defn- unary-scalar-body [id expression input-type output-type width]
   (let [builder (scalar/make-lowerer
                  {:array-types {'x input-type} :arrays #{'x} :scalar-types {'lane :int}
                   :lower-index (fn [value _] value)
+                  :conversion-policy conversion/policy
                   :decline! (fn [rule message data] (throw (ex-info message (assoc data :rule rule))))})
-        lowered ((:lower builder) '(Math/round (aget x lane)) output-type {'lane :int})]
+        lowered ((:lower builder) expression output-type {'lane :int})]
     (body/make
-     {:id [:java-round input-type width]
+     {:id [id input-type width]
       :parameters [(body/->KernelParameter 'x :input input-type [width] :global
                                           (layout/row-major [width] input-type) :input)
                    (body/->KernelParameter 'y :output output-type [width] :global
@@ -21,6 +23,13 @@
       :indices [(body/->IndexBinding 'lane :local 0)]
       :operations (conj (:operations lowered) (body/->ScalarStore 'y ['lane] (:result lowered) nil))
       :launch (launch/spec {:workgroup-size [width] :group-count [1]})})))
+
+(defn java-round-body [input-type output-type width]
+  (unary-scalar-body :java-round '(Math/round (aget x lane)) input-type output-type width))
+
+(defn unchecked-int-body [width]
+  (unary-scalar-body :unchecked-int '(clojure.core/unchecked-int (aget x lane))
+                    :long :int width))
 
 (defn word-shifts-body
   "Typed word shifts share an input row and store left/arithmetic-right/logical-right results."

--- a/test/raster/compiler/core/numeric_constant_test.clj
+++ b/test/raster/compiler/core/numeric_constant_test.clj
@@ -19,6 +19,14 @@
     (is (= form (constant/literal-or-original form)))
     (is (not (constant/equivalent? form form)))))
 
+(deftest explicit-wrapping-cast-is-not-a-checked-cast
+  (doseq [n [0 2147483647 2147483648 4294967295 Long/MIN_VALUE Long/MAX_VALUE]]
+    (is (= {:value (unchecked-int n)}
+           (constant/value (list 'clojure.core/unchecked-int n)))))
+  (is (nil? (constant/value '(int 2147483648))))
+  (is (nil? (constant/value '(unchecked-int 2147483648)))
+      "an unresolved bare call could be shadowed"))
+
 (deftest infinities-and-nan
   (is (constant/equivalent? 'Float/POSITIVE_INFINITY Double/POSITIVE_INFINITY))
   (is (not (constant/equivalent? 'Float/POSITIVE_INFINITY 'Double/NEGATIVE_INFINITY)))

--- a/test/raster/compiler/ir/invocation_plan_test.clj
+++ b/test/raster/compiler/ir/invocation_plan_test.clj
@@ -6,6 +6,10 @@
 (defn- scalar [dtype]
   (av/tensor {:dtype dtype :shape []}))
 
+(deftest wrapping-casts-are-not-shape-identities
+  (is (= 'xs (#'invocation/shape-source '(clojure.core/long (alength xs)))))
+  (is (nil? (#'invocation/shape-source '(clojure.core/unchecked-int (alength xs))))))
+
 (defn- array-value [dtype extent]
   (av/tensor {:dtype dtype :shape [extent] :representation {:kind :plain}}))
 

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -33,6 +33,22 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires one argument"
                          (lower '(Math/round (aget x i) (aget x i)) :long {'i :int})))))
 
+(deftest explicit-integer-wrapping-does-not-relax-the-owner-policy
+  (let [lower (:lower (scalar/make-lowerer
+                      {:array-types {} :arrays #{} :scalar-types {'x :long 'f :double}
+                       :lower-index (fn [expression _] expression)
+                       :conversion-policy conversion/policy
+                       :decline! (fn [rule message data]
+                                   (throw (ex-info message (assoc data :rule rule))))}))
+        result (lower '(clojure.core/unchecked-int x) :int {'x :long})]
+    (is (= :int (:type result)))
+    (is (= {:rounding :exact :overflow :wrap}
+           (get-in (last (:operations result)) [:expression :options])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conversion policy|overflow policy"
+                         (lower '(clojure.core/int x) :int {'x :long})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conversion policy|overflow policy"
+                         (lower '(clojure.core/unchecked-int f) :int {'f :double})))))
+
 (defn- mixed-region [lowerer]
   ((:lower-region lowerer)
    '{:bindings [candidate (aget x i) better (> candidate old-value)]

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -33,6 +33,10 @@
             [raster.nn :as nn]
             [raster.ode.pde :as pde]))
 
+(deftest wrapping-casts-do-not-prove-shape-projections
+  (is (= 'xs (#'route/shape-projection-source '(clojure.core/long (alength xs)))))
+  (is (nil? (#'route/shape-projection-source '(clojure.core/unchecked-int (alength xs))))))
+
 (defn- evaluate-test-scalar-expression [expression operands]
   (cond
     (number? expression) expression

--- a/test/raster/math_test.clj
+++ b/test/raster/math_test.clj
@@ -11,6 +11,18 @@
                                  sincos signum]]))
 
 (def ^:private tol 1e-12)
+(deftest rounding-has-explicit-width-and-boundary-semantics
+  (doseq [[cast expected-class reference]
+          [[double Long #(Math/round (double %))]
+           [unchecked-float Integer #(Math/round (unchecked-float %))]]
+          input [Double/NaN Double/POSITIVE_INFINITY Double/NEGATIVE_INFINITY
+                 -2.5 -1.5 -0.5 -0.0 0.0 0.5 1.5 2.5
+                 2147483648.0 9223372036854775808.0]]
+    (let [input (cast input)
+          result (round input)]
+      (is (= (reference input) result))
+      (is (= expected-class (class result))))))
+
 (def ^:private float-tol 1e-5)
 
 (defn- approx=


### PR DESCRIPTION
## Summary
- Keep resolved unchecked-int wrapping explicit in the shared source conversion descriptor and KernelBody lowering; strict owners still reject implicit narrowing and unsupported floating conversion.
- Preserve wrapping in AOT size evaluation; never erase it as a shape identity. C emission requires retained integral type evidence.
- Use the existing raster.math/round owner: document tie direction, result widths, NaN and saturation; remove the redundant checked Float cast.
- Add OpenCL numerical boundary coverage and CUDA/HIP/OpenCL compile fixtures. No new rounding registry or handwritten kernel.

## Validation
- Independent read-only review: no remaining blocker.
- Isolated PR tree: 90 tests / 764 assertions plus 2 focused tests / 8 assertions, zero failures/errors.
- Real OpenCL wrapping and Java rounding boundary oracles executed, not skipped.
- Full suite and vendor compiler gates delegated to CircleCI.

The Q8_K source-admission migration remains a separate follow-up; this PR does not claim full emitter unification or performance gains.