### PR TITLE
Parallel KernelBody emission for Q8_K row quantizers

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1409,6 +1409,14 @@ The immediate continuation after the verified double-buffered weighted-reduction
    from source. Additional atomic monoids, privatized histogram schedules, nested
    structured C/SIMD sites, the remaining parallel forms, calibrated whole-graph placement costs,
    and deletion of the remaining graph/backend fallbacks remain.
+   Source result-valued store loops now enter the existing ordered effect-loop representation
+   with one typed carry, preserving stores-before-update and the exported result's lexical scope.
+   Guarded store independence uses a generic fixed-digit domain proof: an equality can fix an
+   omitted terminal mixed-radix digit, but differing guarded domains cannot share an injectivity
+   certificate. Q8_K dense/padded row quantizers use the existing typed math/bit primitives and
+   explicit wrapping conversions, exposing their whole-superblock layout to that algebra. Both
+   phases emit parallel KernelBody kernels without a compatibility leaf; regression tests check
+   launch shape as well as numerical parity. This is emission coverage, not a performance claim.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/ir/index_algebra.clj
+++ b/src/raster/compiler/ir/index_algebra.clj
@@ -397,6 +397,26 @@
                        (when-let [parent (get parents digit)] (covered? parent))))]
     (every? covered? leaves)))
 
+(defn restrict-fixed-leaves
+  "Restrict an index form to a domain fixing dropped leaf digits to integer constants.
+
+   The caller must prove the store guard implies these equalities. Only dropped terminal
+   digits may be restricted: a digit contributing to an address (directly or through an
+   ancestor) requires substitution and offset reasoning, which this rule deliberately refuses.
+   Keep the domain witness so multi-store callers cannot combine proofs from different domains."
+  [form fixed]
+  (when form
+    (let [{:keys [terms leaves parents]} form
+          covered? (fn covered? [digit]
+                     (or (contains? terms digit)
+                         (when-let [parent (get parents digit)] (covered? parent))))]
+      (when (and (not (contains? form :fixed-leaves))
+                 (map? fixed)
+                 (every? integer? (vals fixed))
+                 (every? #(and (contains? leaves %) (not (covered? %))) (keys fixed)))
+        (assoc form :leaves (set/difference leaves (set (keys fixed)))
+                    :fixed-leaves fixed)))))
+
 (defn- supported-factor?
   "A symbolic factor of a coefficient is admissible only when some lower digit's radix vouches
    for it: it is a factor of that radix, or a quot fact bounds such a factor by it. Then a zero

--- a/src/raster/compiler/passes/parallel/effect_source.clj
+++ b/src/raster/compiler/passes/parallel/effect_source.clj
@@ -58,8 +58,8 @@
         initial (gensym "effect_carry_init__")]
     (list 'let* (cond-> [limit (list index-tag extent)]
                   carry (conj initial (list tag (strip-binder-tags init))))
-          (list 'loop* (cond-> [index (list index-tag lower)]
-                         carry (conj parameter initial))
+          (list 'loop* (cond-> [(vary-meta index dissoc :tag) (list index-tag lower)]
+                         carry (conj (vary-meta parameter dissoc :tag) initial))
                 (list 'if (list 'clojure.core/< index limit)
                       (typed-locals
                        generated-cast locals
@@ -82,6 +82,6 @@
                  (emit-store effect))
           continuation (ordered-effects (next effects) emitters)]
       (if-let [result (get-in loop [:carry :result])]
-        (list 'let* [result form] continuation)
+        (list 'let* [(vary-meta result dissoc :tag) form] continuation)
         (list 'do form continuation)))
     nil))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -24,6 +24,7 @@
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
+            [raster.compiler.passes.parallel.patterns :as patterns]
             [raster.compiler.passes.scalar.effects :as effects]))
 
 (defn- fail!
@@ -184,17 +185,37 @@
             (update store field #(util/subst-syms substitutions %)))
           store [:index :predicate :value]))
 
-(defn- substitute-loop
-  "Apply `substitutions` inside a counted store loop: its extent, its body locals' inits and its
-   stores. The loop index itself is bound by the loop and is never substituted."
-  [substitutions {:keys [index] :as loop}]
-  (let [substitutions (dissoc substitutions index)]
-    (-> loop
-        (update :extent #(util/subst-syms substitutions %))
-        (update :locals (fn [locals]
-                          (mapv #(update % :init (fn [init] (util/subst-syms substitutions init)))
-                                locals)))
-        (update :stores (fn [stores] (mapv #(substitute-store substitutions %) stores))))))
+(defn- instantiate-store-loop
+  "Apply the shared lexical scope engine to a source loop descriptor. A closed-core let scope
+   carries the local initializers and operand payloads; no separate carry/local scope walker is
+   maintained here. The bound and carry initializer remain outside the body parameter scope."
+  [substitutions {:keys [index locals stores carry] :as loop} & [fresh-index]]
+  (binding [util/*shadowing-locals*
+            (into util/*shadowing-locals* (filter symbol? (vals substitutions)))]
+    (let [fields [:index :predicate :value]
+          payload (cond-> (mapv #(mapv % fields) stores) carry (conj (:update carry)))
+          body (list 'let* (vec (mapcat (juxt :id :init) locals)) payload)
+          scope (util/subst-scoped substitutions
+                                   (cond-> [index] carry (conj (:parameter carry))) [body])
+          [bound-index parameter] (:binders scope)
+          body (if fresh-index
+                 (util/subst-syms {bound-index fresh-index} (first (:body scope)))
+                 (first (:body scope)))
+          [_ bindings payload] body
+          local-pairs (partition 2 bindings)]
+      (cond-> (assoc loop
+                     :index (or fresh-index bound-index)
+                     :extent (util/subst-syms substitutions (:extent loop))
+                     :locals (mapv (fn [local [id init]] (assoc local :id id :init init))
+                                   locals local-pairs)
+                     :stores (mapv (fn [store values] (merge store (zipmap fields values)))
+                                   stores payload))
+        carry (assoc :carry (assoc carry :parameter parameter
+                                   :init (util/subst-syms substitutions (:init carry))
+                                   :update (peek payload)))))))
+
+(defn- substitute-loop [substitutions loop]
+  (instantiate-store-loop substitutions loop))
 
 (defn- region-order
   "The source order of a region's effects as `[:store i]` / `[:loop j]` entries into its
@@ -209,14 +230,8 @@
   "Give a counted store loop the index name `fresh`, renaming its body locals' inits and its
    stores. Sibling loops that reuse one source index name (`i`) would otherwise share a
    KernelBody SSA value."
-  [{:keys [index] :as loop} fresh]
-  (let [renames {index fresh}]
-    (-> loop
-        (assoc :index fresh)
-        (update :locals (fn [locals]
-                          (mapv #(update % :init (fn [init] (util/subst-syms renames init)))
-                                locals)))
-        (update :stores (fn [stores] (mapv #(substitute-store renames %) stores))))))
+  [loop fresh]
+  (instantiate-store-loop {} loop fresh))
 
 (defn- rebase-region-locals
   "Move a recursively recognized region behind `offset` lexical SSA values.
@@ -230,33 +245,40 @@
                        (fn [ordinal {:keys [id]}]
                          [id (symbol (str "rstr_local_" (+ offset ordinal)))])
                        locals))]
-    {:locals (mapv (fn [{:keys [id] :as local}]
+    (cond-> {:locals (mapv (fn [{:keys [id] :as local}]
                      (-> local
                          (assoc :id (get renames id))
                          (update :init #(util/subst-syms renames %))))
                    locals)
      :stores (mapv #(substitute-store renames %) stores)
      :loops (mapv #(substitute-loop renames %) (or loops []))
-     :order (region-order region)}))
+     :order (region-order region)}
+      (contains? region :result) (assoc :result (util/subst-syms renames (:result region))))))
 
-(defn- strip-trailing-recur
-  "Remove a counted loop's `(recur (inc i))` from the tail of its body, returning the remaining
-   statements form, or nil when the tail is not that exact step."
-  [form index]
+(defn- split-trailing-recur
+  "Split a counted loop's tail recurrence from its ordered stores. Carried loops require the
+   shared exact long induction-step contract, without erasing narrowing conversions."
+  [form index carried?]
   (let [step? (fn [x]
-                (and (seq? x) (= 'recur (first x)) (= 2 (count x))
-                     (let [update (strip-index-cast (second x))]
+                (and (seq? x) (= 'recur (first x)) (= (if carried? 3 2) (count x))
+                     (if carried?
+                       (and (empty? (set/intersection
+                                     (disj (util/free-syms (second x)) index)
+                                     util/*shadowing-locals*))
+                            (patterns/ordered-unit-step? (second x) index))
+                       (let [update (strip-index-cast (second x))]
                        (or (and (seq? update) (= 2 (count update))
                                 (contains? '#{inc clojure.core/inc} (first update))
                                 (= index (strip-index-cast (second update))))
                            (and (seq? update) (= 3 (count update))
                                 (contains? '#{+ clojure.core/+} (first update))
                                 (= index (strip-index-cast (second update)))
-                                (= 1 (strip-index-cast (nth update 2))))))))]
+                                (= 1 (strip-index-cast (nth update 2)))))))))]
     (cond
-      (step? form) '(do)
+      (step? form) {:body '(do) :update (when carried? (nth form 2))}
       (and (seq? form) (= 'do (first form)) (step? (last form)))
-      (list* 'do (butlast (rest form)))
+      {:body (list* 'do (butlast (rest form)))
+       :update (when carried? (nth (last form) 2))}
       ;; (let* [...] stmt… (recur …)) — the closed-core spelling puts the statements directly
       ;; in the let body; normalize them into one `do` before the recursive recognition.
       (and (seq? form) (symbol? (first form)) (form/let-head? (first form)) (<= 3 (count form)))
@@ -264,8 +286,8 @@
             inner (if (= 1 (count statements))
                     (first statements)
                     (list* 'do statements))]
-        (when-let [stripped (strip-trailing-recur inner index)]
-          (list head bindings stripped)))
+        (when-let [split (split-trailing-recur inner index carried?)]
+          (update split :body #(list head bindings %))))
       :else nil)))
 
 (declare store-region pointwise-input?)
@@ -300,10 +322,10 @@
                         (when (and (seq? test) (= 3 (count test))
                                    (contains? '#{< clojure.core/<} (first test))
                                    (= loop-index (strip-index-cast (second test))))
-                          (when-let [statements (strip-trailing-recur then loop-index)]
+                          (when-let [split (split-trailing-recur then loop-index false)]
                             {:index loop-index :lower lower
                              :extent (strip-index-cast (nth test 2))
-                             :body statements}))))))]
+                             :body (:body split)}))))))]
     (when (and counted
                (not= (:index counted) index)
                (not (contains? (util/free-syms (:extent counted)) (:index counted))))
@@ -329,6 +351,60 @@
                       :stores (mapv #(substitute-store renames %) (:stores region))}]
              :order [[:loop 0]]}))))))
 
+(defn- carried-store-binding
+  "Recognize exactly one typed result-valued store loop followed by stores using its result.
+   Alpha-normalize the source lexical scope first; the result never enters pre-effect locals."
+  [body index]
+  (let [[head bindings & _] body
+        [result initializer] bindings]
+    (when (and (form/let-head? head) (vector? bindings) (= 2 (count bindings))
+               (symbol? result) (seq? initializer) (form/loop-head? (first initializer))
+               (vector? (second initializer)) (= 4 (count (second initializer))))
+      (let [[_ [result initializer] & tail] (util/alpha-convert body)
+            [_ [loop-index lower parameter init] conditional] initializer
+            normalized (patterns/normalize-ordered-loop initializer)
+            raw-extent (:bound normalized)
+            ;; Only a widening Long spelling is stripped. The descriptor boundary below requires
+            ;; an integral scalar fact (or an in-range literal), so this cannot erase a check.
+            extent (if (and (seq? raw-extent) (= 2 (count raw-extent))
+                            (= 'clojure.core/long (first raw-extent)))
+                     (second raw-extent) raw-extent)
+            [_ test then exit] (when (seq? conditional) conditional)
+            dtype (retained-local-dtype parameter init)
+            result-dtype (retained-local-dtype result initializer)]
+        (when (and (= 3 (count initializer)) (symbol? loop-index) (symbol? parameter)
+                   (integer? lower) (<= 0 lower) (= parameter exit)
+                   (= :long (retained-local-dtype loop-index lower))
+                   (contains? #{:float :double :long :int} dtype) (= dtype result-dtype)
+                   (seq? conditional) (= 'if (first conditional)) (= 4 (count conditional))
+                   (seq? test) (= 3 (count test))
+                   (contains? '#{< clojure.core/<} (first test))
+                   (not (contains? util/*shadowing-locals* (first test)))
+                   (or (= loop-index (second test))
+                       (= (list 'clojure.core/long loop-index) (second test)))
+                   (= loop-index (:index-sym normalized))
+                   ;; Source tests re-evaluate their bound, whereas the scheduled contract caches
+                   ;; it. Only an immutable scalar reference or literal is admitted here.
+                   (or (symbol? extent)
+                       (and (integer? extent) (<= 0 extent Long/MAX_VALUE)))
+                   (empty? (set/intersection #{loop-index parameter}
+                                            (util/free-syms (nth test 2))))
+                   (empty? (set/intersection #{loop-index parameter} (util/free-syms init)))
+                   (not (util/effectful? init)))
+          (when-let [{:keys [body update]} (split-trailing-recur then loop-index true)]
+            (when-not (util/effectful? update)
+              (let [region (store-region body index update)
+                    continuation (store-region (list* 'do tail) index)]
+                (when (and region continuation (seq (:stores region)) (empty? (:loops region))
+                           (seq (:stores continuation)) (empty? (:locals continuation))
+                           (empty? (:loops continuation)))
+                  {:locals [] :stores (:stores continuation)
+                   :loops [{:index loop-index :lower lower :extent extent
+                            :locals (:locals region) :stores (:stores region)
+                            :carry {:parameter parameter :result result :dtype dtype
+                                    :init init :update (:result region)}}]
+                   :order (into [[:loop 0]] (region-order continuation))})))))))))
+
 (defn- store-region
   "Recognize an ordered, pure local-SSA spine ending exclusively in certified effects.
 
@@ -337,14 +413,16 @@
    this source recognizer or a C emitter would make the region only nominally typed. Direct stores
    and atomic additions become data here; cross-work-item legality is checked separately after
    local dependencies are expanded for analysis."
-  [body index]
+  [body index & [result-expression]]
+  (let [region
   (cond
     (and (seq? body) (form/let-head? (first body)))
+    (or (when-not (some? result-expression) (carried-store-binding body index))
     (let [[_ bindings & nested-body] body]
       (when (and (even? (count bindings))
                  (seq nested-body)
                  (not-any? util/effectful? (take-nth 2 (rest bindings))))
-        (when-let [nested-region (store-region (list* 'do nested-body) index)]
+        (when-let [nested-region (store-region (list* 'do nested-body) index result-expression)]
           (let [pairs (vec (partition 2 bindings))
                 typed (mapv (fn [[binding init]]
                               [binding init (retained-local-dtype binding init)])
@@ -359,7 +437,7 @@
                                  :substitutions (assoc substitutions binding id)}))
                             {:locals [] :substitutions {}} typed)
                     nested (rebase-region-locals nested-region (count locals))]
-                {:locals (into locals
+                (cond-> {:locals (into locals
                                (map #(update % :init
                                              (fn [init]
                                                (util/subst-syms substitutions init))))
@@ -367,12 +445,14 @@
                  :stores (mapv #(substitute-store substitutions %)
                                (:stores nested))
                  :loops (mapv #(substitute-loop substitutions %) (:loops nested))
-                 :order (region-order nested)}))))))
+                 :order (region-order nested)}
+                  (contains? nested :result)
+                  (assoc :result (util/subst-syms substitutions (:result nested)))))))))))
 
     (and (seq? body) (= 'do (first body)))
     (let [expressions (vec (rest body))]
       (if (= 1 (count expressions))
-        (store-region (first expressions) index)
+        (store-region (first expressions) index result-expression)
         (let [groups (mapv #(store-region % index) expressions)]
           (when (and (seq groups) (every? some? groups)
                      (every? (comp empty? :locals) groups))
@@ -520,7 +600,10 @@
                  :value (if cast? (second raw-value) raw-value)
                  :cast (when cast? (first raw-value))}]})
 
-    :else nil))
+    :else nil)]
+    (cond-> region
+      (and region (some? result-expression) (not (contains? region :result)))
+      (assoc :result result-expression))))
 
 (defn- independent-stores?
   [_locals stores]
@@ -703,15 +786,43 @@
    uniform array reads become invariant atoms (`destinations` are the region's written arrays)."
   [store index extent locals loops destinations]
   (let [loop (when (:loop store) (nth loops (:loop store)))
+        carry-bindings (set (mapcat #(when-let [carry (:carry %)]
+                                      [(:parameter carry) (:result carry)]) loops))
+        index-expanded (reduce (fn [expression {:keys [id init]}]
+                                 (util/subst-syms {id init} expression))
+                               (:index store) (reverse (concat locals (:locals loop))))
         varying (into #{index}
                       (concat (map :id locals) (map :id (:locals loop))
-                              (map :index loops)))
+                              (map :index loops) carry-bindings))
         atoms (atom {})
         expand (fn [form]
                  (invariant-read-atoms (expand-scalar-definitions form) destinations varying atoms))]
+    ;; Evolving carries and exported per-item results are not invariant extent factors. A carry
+    ;; in the transitive index slice must not accidentally prove unique cross-item addressing.
+    (when (empty? (set/intersection carry-bindings (util/free-syms index-expanded)))
     (index-algebra/index-form (expand (:index store)) index (expand extent)
                               (mapv #(update % :init expand) (concat locals (:locals loop)))
-                              (if loop {(:index loop) (expand (:extent loop))} {}))))
+                              (if loop {(:index loop) (expand (:extent loop))} {})))))
+
+(defn- fixed-guard-domain
+  "A guard equality fixes one integral digit. Consume only retained integral operands and
+   identity/widening Long casts; never infer a constraint from a shadowed comparison or cast."
+  [predicate locals]
+  (let [types (into {} (map (juxt :id :dtype)) locals)
+        integral? (fn [x] (or (integer? x) (contains? #{:byte :short :int :long} (get types x))))
+        operand (fn [x]
+                  (if (and (seq? x) (= 2 (count x))
+                           (= 'clojure.core/long (first x)) (integral? (second x)))
+                    (second x)
+                    x))
+        op (descriptor/semantic-op predicate)
+        args (mapv operand (descriptor/call-args predicate))]
+    (when (and (= :eq (descriptor/comparison-kind op))
+               (not (contains? util/*shadowing-locals* op)) (= 2 (count args)))
+      (let [[a b] args]
+        (cond
+          (and (symbol? a) (integral? a) (integer? b)) {a b}
+          (and (symbol? b) (integral? b) (integer? a)) {b a})))))
 
 (defn- proven-unique-stores
   "The stores whose destination writes are provably injective across work items: each store's
@@ -719,7 +830,13 @@
    provably disjoint offsets. Returns the set of store ordinals."
   [stores index extent locals loops]
   (let [destinations (set (map :out stores))
-        forms (mapv #(store-index-form % index extent locals loops destinations) stores)
+        forms (mapv (fn [store]
+                      (let [form (store-index-form store index extent locals loops destinations)
+                            fixed (fixed-guard-domain (:predicate store) locals)]
+                        (if (and fixed (not (index-algebra/injective? form)))
+                          (or (index-algebra/restrict-fixed-leaves form fixed) form)
+                          form)))
+                    stores)
         by-destination (group-by (fn [ordinal] (:out (nth stores ordinal)))
                                  (range (count stores)))]
     (into #{}
@@ -728,6 +845,9 @@
                       (when (and (every? some? group-forms)
                                  (every? index-algebra/injective? group-forms)
                                  (apply = (map :terms group-forms))
+                                 ;; Different guarded domains can alias across work items even
+                                 ;; when each store is separately injective on its own domain.
+                                 (apply = (map :fixed-leaves group-forms))
                                  ;; stores at one address (the arms of a conditional) are the
                                  ;; same element of one work item; distinct offsets must be
                                  ;; disjoint across work items
@@ -745,15 +865,27 @@
                    [effect]))
                effects)))
 
+(defn- source-loop-expressions [{:keys [lower extent locals carry]}]
+  (concat [lower extent] (map :init locals)
+          (when carry [(:init carry) (:update carry)])))
+
 (defn- write-region-description
   [id symbol index extent {:keys [locals stores loops] :as region} elem-type
-   & {:keys [host-return array-types] :or {host-return :effect array-types {}}}]
+   & {:keys [host-return array-types scalar-types]
+      :or {host-return :effect array-types {} scalar-types {}}}]
   (let [order (region-order region)
+        local-types (into scalar-types (map (juxt :id :dtype)) locals)
         loops (vec (map-indexed (fn [ordinal loop]
                                   (rename-loop-index
                                    loop (clojure.core/symbol (str "rstr_loop_index_" ordinal))))
                                 (or loops [])))]
     (when (and (or (seq stores) (seq loops))
+               (every? (fn [{:keys [extent carry]}]
+                         (or (nil? carry) (integer? extent)
+                             (contains? #{:int :long}
+                                        (or (get local-types extent)
+                                            (retained-local-dtype extent nil)))))
+                       loops)
                (or (= :effect host-return) (and (empty? loops) (= 1 (count stores))))
                ;; A destination written both directly and inside a store loop would lose the work
                ;; item's source order between the two kinds of write; such regions stay unsupported.
@@ -872,12 +1004,14 @@
                                     (= 1 (count (set (map :effect-conflict grouped)))))
                                   (group-by :out all-stores)))
             all-locals (vec (concat locals (mapcat :locals loops)))
+            loop-expressions (mapcat source-loop-expressions loops)
+            carry-bindings (set (mapcat #(when-let [carry (:carry %)]
+                                          [(:parameter carry) (:result carry)]) loops))
             iteration-order (when ordered?
                               (if (or (some #(= :ordered (:effect-conflict %)) all-stores)
                                       (not (ordered-effects-safe?
                                             locals all-stores
-                                            (concat (map :extent loops)
-                                                    (map :init (mapcat :locals loops))))))
+                                            loop-expressions)))
                                 :sequential
                                 :independent))
             destinations (if ordered?
@@ -886,11 +1020,11 @@
             values (mapv :value all-stores)
             write-indices (mapv :index all-stores)
             predicates (mapv :predicate all-stores)
-            analysis-values (concat (map :init all-locals) (map :extent loops)
+            analysis-values (concat (map :init locals) loop-expressions
                                     write-indices predicates values)
             io (update (extract-io (list* 'do analysis-values) index destinations)
                        :scalars set/difference (set (map :id all-locals))
-                       (set (map :index loops)))
+                       (set (map :index loops)) carry-bindings)
             results (if (= :buffer host-return)
                       [symbol]
                       (mapv #(effect-result-id id %) (range (count destinations))))
@@ -900,12 +1034,13 @@
                            (select-keys store [:out :index :predicate :value :cast
                                                :effect-conflict]))
             loop-effects (mapv (fn [ordinal {loop-index :index loop-locals :locals
-                                             :keys [lower extent]}]
-                                 {:loop {:index loop-index :lower lower :extent extent
+                                             :keys [lower extent carry]}]
+                                 {:loop (cond-> {:index loop-index :lower lower :extent extent
                                          :locals loop-locals
                                          :effects (mapv store-effect
                                                         (filter #(= ordinal (:loop %))
-                                                                all-stores))}})
+                                                                all-stores))}
+                                          carry (assoc :carry carry))})
                                (range) loops)
             ;; Effects keep the region's source order across direct stores and loops.
             ordered-effects (mapv (fn [[kind ordinal]]
@@ -1432,7 +1567,7 @@
         (write-region-description id symbol idx bound region
                                 (dtype/canon (or elem-type default-dtype))
                                 :host-return (or (::host-return (meta expression)) :effect)
-                                :array-types array-types)))
+                                :array-types array-types :scalar-types scalar-types)))
 
     :else nil))
 
@@ -2244,8 +2379,8 @@
 (defn- effect-expressions
   "Every expression an effect evaluates, descending into store loops."
   [effect]
-  (if-let [{:keys [extent locals effects]} (:loop effect)]
-    (concat [extent] (map :init locals) (mapcat effect-expressions effects))
+  (if-let [{:keys [effects] :as loop} (:loop effect)]
+    (concat (source-loop-expressions loop) (mapcat effect-expressions effects))
     [(:index effect) (:predicate effect) (:value effect)]))
 
 (defn- effect-map-equation
@@ -2277,14 +2412,18 @@
         effect-form
         (fn effect-form [{:keys [out index predicate value cast effect-conflict] :as effect}]
           (if-let [{loop-index :index loop-locals :locals loop-effects :effects
-                    :keys [lower extent]} (:loop effect)]
-            (list 'effect-loop {:index loop-index :lower lower} (transform extent)
-                  (list 'lambda [loop-index]
-                        (dialect/effect-lambda-region
-                         (mapv (fn [{:keys [id dtype init]}]
+                    :keys [lower extent carry]} (:loop effect)]
+            (let [local-forms (mapv (fn [{:keys [id dtype init]}]
                                  (dialect/local-value id dtype (transform init)))
                                loop-locals)
-                         (mapv effect-form loop-effects))))
+                  body (cond-> (list 'effect-region local-forms (mapv effect-form loop-effects))
+                         carry (concat [(transform (:update carry))]))
+                  attributes (cond-> {:index loop-index :lower lower}
+                               carry (assoc :carry (select-keys carry [:parameter :result :dtype])))
+                  lambda (list 'lambda (cond-> [loop-index] carry (conj (:parameter carry))) body)]
+              (if carry
+                (list 'effect-loop attributes (transform extent) (transform (:init carry)) lambda)
+                (list 'effect-loop attributes (transform extent) lambda)))
             (list 'effect (get destination-substitutions out)
                   effect-conflict (transform index) (transform predicate)
                   (transform (if cast (list cast value) value)))))
@@ -2966,7 +3105,9 @@
                                 (contains? graph-shape-scalar-ids (:sym description))
                                 (update :attributes assoc :graph-shape-definition true)
                                 storage
-                                (-> (assoc :effects (if (= :contract (:kind description))
+                                (-> (assoc :effects (if (or (= :contract (:kind description))
+                                                           (and (= :effect-map (:kind description))
+                                                                (seq (:inputs description))))
                                                      #{:memory/read :memory/write}
                                                      #{:memory/write})
                                            :aliases (into {}

--- a/src/raster/quant/kernels_k.clj
+++ b/src/raster/quant/kernels_k.clj
@@ -9,6 +9,8 @@
   256 each row spans whole super-blocks, so the flat per-row arrays index as (row, block)."
   (:require [raster.core :refer [deftm]]
             [raster.arrays :as ra]
+            [raster.numeric :as rn]
+            [raster.math :as math]
             [raster.par :as par]
             [raster.quant.kernels :as qc]))
 
@@ -94,7 +96,8 @@
 (deftm quant-act-q8k-rows-gpu!
   "Q8_K activation quantization over a row-major [nrows,in] tensor. The physical result is
   the ordered `(xp,xs,bsums)` representation with row-major leaves; `submax` is transient
-  reduction scratch. Batch is an ordinary outer shape axis and does not affect the format."
+  reduction scratch. `in` must be a multiple of 256. Batch is an ordinary outer shape axis
+  and does not affect the format."
   [x :- (Array float), xp :- (Array int), xs :- (Array float), bsums :- (Array int),
    submax :- (Array float), in :- Long, nrows :- Long] :- Void
   (do
@@ -106,9 +109,11 @@
                                  (recur (inc k) (max m (max v (- v)))))
                                m))]
                      (ra/aset submax si (float m))))
-    (par/map-void! sj (* (long nrows) (quot (long in) 32))
+    ;; The public layout is whole 256-element super-blocks. Express its eight sub-blocks
+    ;; directly so the generic index proof sees the exact mixed-radix domain.
+    (par/map-void! sj (* (long nrows) (* 8 (quot (long in) 256)))
                    (let [nsb (quot (long in) 256)
-                         nsub (quot (long in) 32)
+                         nsub (* 8 nsb)
                          row (quot sj nsub)
                          row-sub (rem sj nsub)
                          sb (quot row-sub 8)
@@ -120,30 +125,30 @@
                          d (/ (double mx) 127.0)
                          id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)
                          sidx (+ (* row nsub) (* sb 8) j)
-                         wbase (+ (* row (quot (long in) 4)) (* sb 64) (* j 8))
-                         ebase (+ (* row (long in)) (* sb 256) (* j 32))]
+                         wbase (* sidx 8)
+                         ebase (* sidx 32)]
                      (when (== j 0)
                        (ra/aset xs (+ (* row nsb) sb) (float d)))
                      (let [bs (loop [w 0 s 0]
                                 (if (< w 8)
                      ;; |x·id| ≤ 127 by construction (id = 127/max|x|), so round lands in
-                     ;; int8 range without an explicit clamp; the (long ...) cast types q.
+                     ;; int8 range without an explicit clamp; math/round retains its Long result.
                                   (let [e (+ ebase (* w 4))
-                                        q0 (long (Math/round (* (double (ra/aget x e)) id)))
-                                        q1 (long (Math/round (* (double (ra/aget x (+ e 1))) id)))
-                                        q2 (long (Math/round (* (double (ra/aget x (+ e 2))) id)))
-                                        q3 (long (Math/round (* (double (ra/aget x (+ e 3))) id)))
+                                        q0 (math/round (* (double (ra/aget x e)) id))
+                                        q1 (math/round (* (double (ra/aget x (+ e 1))) id))
+                                        q2 (math/round (* (double (ra/aget x (+ e 2))) id))
+                                        q3 (math/round (* (double (ra/aget x (+ e 3))) id))
                            ;; Keep bit-or binary in the shared IR. The JVM bytecode backend's
                            ;; primitive bit op is binary; passing four operands used to discard
                            ;; the high two lanes while OpenCL happened to accept the variadic form.
-                                        word (bit-or (bit-or (bit-and q0 0xFF)
-                                                             (bit-shift-left (bit-and q1 0xFF) 8))
-                                                     (bit-or (bit-shift-left (bit-and q2 0xFF) 16)
-                                                             (bit-shift-left (bit-and q3 0xFF) 24)))]
-                                    (ra/aset xp (+ wbase w) (int word))
+                                        word (rn/bit-or (rn/bit-or (rn/bit-and q0 0xFF)
+                                                                  (rn/bit-shift-left (rn/bit-and q1 0xFF) 8))
+                                                        (rn/bit-or (rn/bit-shift-left (rn/bit-and q2 0xFF) 16)
+                                                                   (rn/bit-shift-left (rn/bit-and q3 0xFF) 24)))]
+                                    (ra/aset xp (+ wbase w) (unchecked-int word))
                                     (recur (inc w) (+ s q0 q1 q2 q3)))
                                   s))]
-                       (ra/aset bsums sidx (int bs)))))))
+                       (ra/aset bsums sidx (unchecked-int bs)))))))
 
 (deftm quant-act-q8k-padded-rows-gpu!
   "Quantize dense row-major `[nrows,width]` activations into Q8_K leaves laid out at
@@ -162,15 +167,16 @@
                          m (loop [k 0 m 0.0]
                              (if (< k 32)
                                (let [col (+ col-base k)]
-                                 (if (< col (long width))
-                                   (let [v (ra/aget x (+ xbase col))]
-                                     (recur (inc k) (max m (max v (- v)))))
-                                   (recur (inc k) m)))
+                                 (recur (inc k)
+                                        (if (< col (long width))
+                                          (let [v (ra/aget x (+ xbase col))]
+                                            (max m (max v (- v))))
+                                          m)))
                                m))]
                      (ra/aset submax si (float m))))
-    (par/map-void! sj (* (long nrows) (quot (long padded-in) 32))
+    (par/map-void! sj (* (long nrows) (* 8 (quot (long padded-in) 256)))
                    (let [nsb (quot (long padded-in) 256)
-                         nsub (quot (long padded-in) 32)
+                         nsub (* 8 nsb)
                          row (quot sj nsub)
                          row-sub (rem sj nsub)
                          sb (quot row-sub 8)
@@ -182,7 +188,7 @@
                          d (/ (double mx) 127.0)
                          id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)
                          sidx (+ (* row nsub) (* sb 8) j)
-                         wbase (+ (* row (quot (long padded-in) 4)) (* sb 64) (* j 8))
+                         wbase (* sidx 8)
                          col-base (+ (* sb 256) (* j 32))
                          xbase (* row (long width))]
                      (when (== j 0)
@@ -191,25 +197,25 @@
                                 (if (< w 8)
                                   (let [col (+ col-base (* w 4))
                                         q0 (if (< col (long width))
-                                             (long (Math/round (* (double (ra/aget x (+ xbase col))) id)))
+                                             (math/round (* (double (ra/aget x (+ xbase col))) id))
                                              0)
                                         q1 (if (< (+ col 1) (long width))
-                                             (long (Math/round (* (double (ra/aget x (+ xbase col 1))) id)))
+                                             (math/round (* (double (ra/aget x (+ xbase col 1))) id))
                                              0)
                                         q2 (if (< (+ col 2) (long width))
-                                             (long (Math/round (* (double (ra/aget x (+ xbase col 2))) id)))
+                                             (math/round (* (double (ra/aget x (+ xbase col 2))) id))
                                              0)
                                         q3 (if (< (+ col 3) (long width))
-                                             (long (Math/round (* (double (ra/aget x (+ xbase col 3))) id)))
+                                             (math/round (* (double (ra/aget x (+ xbase col 3))) id))
                                              0)
-                                        word (bit-or (bit-or (bit-and q0 0xFF)
-                                                             (bit-shift-left (bit-and q1 0xFF) 8))
-                                                     (bit-or (bit-shift-left (bit-and q2 0xFF) 16)
-                                                             (bit-shift-left (bit-and q3 0xFF) 24)))]
-                                    (ra/aset xp (+ wbase w) (int word))
+                                        word (rn/bit-or (rn/bit-or (rn/bit-and q0 0xFF)
+                                                                  (rn/bit-shift-left (rn/bit-and q1 0xFF) 8))
+                                                        (rn/bit-or (rn/bit-shift-left (rn/bit-and q2 0xFF) 16)
+                                                                   (rn/bit-shift-left (rn/bit-and q3 0xFF) 24)))]
+                                    (ra/aset xp (+ wbase w) (unchecked-int word))
                                     (recur (inc w) (+ s q0 q1 q2 q3)))
                                   s))]
-                       (ra/aset bsums sidx (int bs)))))))
+                       (ra/aset bsums sidx (unchecked-int bs)))))))
 
 ;; ---- dp4a int8-GEMV core (the format-agnostic hardware-accelerated path) ----
 ;; int8×int8 GEMV over int32-packed lanes: y[o] = Σ_w dp4a(wp[o*kw+w], xp[w]). par/dp4a

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -340,6 +340,10 @@
       (:kernels (equation-first/compile
                  #'qk/quant-act-i8-rows-gpu! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'qk/quant-act-q8k-rows-gpu! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'qk/quant-act-q8k-padded-rows-gpu! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!

--- a/test/raster/compiler/ir/index_algebra_test.clj
+++ b/test/raster/compiler/ir/index_algebra_test.clj
@@ -35,6 +35,22 @@
     (is (not (ia/injective? dropped)) "dropping the head digit makes heads collide")
     (is (nil? whole) "a decomposed index may not also appear whole")))
 
+(deftest dropped-digit-is-injective-only-on-a-proven-fixed-domain
+  (let [locals '[{:id q :init (quot idx 4)} {:id r :init (rem idx 4)}]
+        form (ia/index-form 'q 'idx 20 locals {})]
+    (is (not (ia/injective? form)))
+    (doseq [r (range 4)]
+      (let [restricted (ia/restrict-fixed-leaves form {'r r})
+            indices (filter #(= r (rem % 4)) (range 20))
+            addresses (map #(quot % 4) indices)]
+        (is (ia/injective? restricted))
+        (is (= {'r r} (:fixed-leaves restricted)))
+        (is (nil? (ia/restrict-fixed-leaves restricted {})) "cannot erase an existing domain witness")
+        (is (= (count addresses) (count (distinct addresses))))))
+    (doseq [fixed [{'q 0} {'idx 0} {'unknown 0} {'r 0.5}]]
+      (is (nil? (ia/restrict-fixed-leaves form fixed))))
+    (is (not (ia/injective? (ia/restrict-fixed-leaves form {}))))))
+
 (deftest constant-offsets-are-one-more-digit
   (let [rope (ia/index-form '(+ (+ (* t (* heads head-dim)) (* h head-dim)) i)
                             'idx '(* (* batch seq-len) (* heads hdim2)) rope-locals {})

--- a/test/raster/compiler/passes/parallel/guarded_store_proof_test.clj
+++ b/test/raster/compiler/passes/parallel/guarded_store_proof_test.clj
@@ -1,0 +1,33 @@
+(ns raster.compiler.passes.parallel.guarded-store-proof-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]))
+
+(def locals
+  '[{:id q :dtype :long :init (clojure.core/quot idx 4)}
+    {:id r :dtype :long :init (clojure.core/rem idx 4)}])
+
+(defn store [predicate]
+  {:out 'out :index 'q :predicate predicate})
+
+(defn proven [stores]
+  (#'frontend/proven-unique-stores stores 'idx 20 locals []))
+
+(deftest fixed-guard-restores-only-proven-cross-item-independence
+  (doseq [guard ['(clojure.core/== r 0)
+                '(clojure.core/== 0 r)
+                '(clojure.core/== (clojure.core/long r) (clojure.core/long 0))]]
+    (is (= #{0} (proven [(store guard)]))))
+  (doseq [guard [true '(clojure.core/< r 2) '(clojure.core/== q 0)
+                '(clojure.core/== (clojure.core/unchecked-int r) 0)
+                '(clojure.core/== (clojure.core/int r) 0)
+                '(clojure.core/== r (aget values idx))]]
+    (is (empty? (proven [(store guard)]))))
+  (binding [util/*shadowing-locals* #{'==}]
+    (is (empty? (proven [(store '(== r 0))])))))
+
+(deftest separately-injective-guards-cannot-certify-their-overlapping-union
+  (is (= #{0 1} (proven [(store '(clojure.core/== r 0))
+                         (store '(clojure.core/== r 0))])))
+  (is (empty? (proven [(store '(clojure.core/== r 0))
+                       (store '(clojure.core/== r 1))]))))

--- a/test/raster/compiler/passes/parallel/typed_carried_effect_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_carried_effect_frontend_test.clj
@@ -1,0 +1,124 @@
+(ns raster.compiler.passes.parallel.typed-carried-effect-frontend-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(def source
+  '(let* [effect
+          (raster.par/map-void!
+           row rows
+           (do (aset scales row (float seed))
+               (let* [^double sum
+                      (loop* [^long k 0 ^double acc 0.25]
+                        (if (< k width)
+                          (let* [^float v (aget x (+ (* row width) k))]
+                            (aset packed (+ (* row width) k) v)
+                            (recur (inc k) (+ acc (double v))))
+                          acc))]
+                 (aset sums row (float sum)))))]
+     effect))
+
+(defn attempt [form]
+  (route/attempt form :float {'x :float 'packed :float 'scales :float 'sums :float}
+                 {:scalar-types {'rows :long 'width :long 'seed :float}}))
+
+(deftest typed-result-valued-store-loop-is-an-ordered-effect-not-a-pure-local
+  (let [result (attempt source)
+        program (:program result)
+        algorithm (-> program :equations first :algorithm)
+        equation (first (dialect/equations algorithm))
+        parts (-> equation dialect/operation-parts :lambda dialect/lambda-parts)
+        effects (mapv dialect/effect-parts (:body-results parts))
+        scheduled (:form (segop-lower/segop-lower-pass program {:target-device :ze:0 :dtype :float}))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[x packed scales sums rows width seed] (:form jvm)))
+        packed (float-array (repeat 6 -77)) scales (float-array 2) sums (float-array 2)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= 'effect-map (dialect/operation-kind equation)))
+    (is (empty? (:locals parts)))
+    (is (= [false true false] (mapv #(boolean (:loop %)) effects)))
+    (is (some? (:carry (second effects))))
+    (is (= :independent (-> equation dialect/operation-parts :attributes :iteration-order)))
+    (is (nil? (execute (float-array [1 2 3 4 5 6]) packed scales sums 2 3 (float 2.5))))
+    (is (= [1.0 2.0 3.0 4.0 5.0 6.0] (vec packed)))
+    (is (= [2.5 2.5] (vec scales)))
+    (is (= [6.25 15.25] (vec sums)))))
+
+(defn- replace-form [form before after]
+  (walk/postwalk #(if (= before %) after %) form))
+
+(deftest unsupported-recurrences-decline-before-typed-admission
+  (doseq [variant [(replace-form source '(inc k) '(int (inc k)))
+                   (replace-form source '(< k width) '(< (int k) width))
+                   (replace-form source '(< k width) '(< k (+ width (long acc))))
+                   (replace-form source '(< k width) '(< k (aget scales row)))
+                   (replace-form source '(< k width) '(< k (do (aset scales row 0.0) width)))
+                   (replace-form source 0.25 '(double k))
+                   (replace-form source 0.25 '(do (aset sums row 1.0) 0.25))
+                   (replace-form source '(+ acc (double v))
+                                 '(do (aset scales row 1.0) (+ acc (double v))))
+                   (walk/postwalk #(if (and (symbol? %) (= 'acc %)) (with-meta % nil) %) source)
+                   (walk/postwalk #(if (and (symbol? %) (= 'sum %)) (with-meta % nil) %) source)]]
+    (is (not= :typed-soac (get-in (attempt variant) [:stats :route])))))
+
+(deftest shadowed-comparison-casts-are-not-erased
+  (doseq [test-form ['(< (long k) width) '(< k (long width))]]
+    (is (not= :typed-soac
+              (get-in (route/attempt (replace-form source '(< k width) test-form)
+                                    :float {'x :float 'packed :float 'scales :float 'sums :float}
+                                    {:scalar-types {'rows :long 'width :long 'seed :float
+                                                    'long :object}})
+                      [:stats :route])))))
+
+(deftest shadowed-recurrence-operators-are-not-fixed-unit-steps
+  (doseq [[step shadow] [['(inc k) 'inc] ['(+ k 1) '+] ['(inc (long k)) 'long]]]
+    (is (not= :typed-soac
+              (get-in (route/attempt (replace-form source '(inc k) step)
+                                    :float {'x :float 'packed :float 'scales :float 'sums :float}
+                                    {:scalar-types (assoc {'rows :long 'width :long 'seed :float}
+                                                         shadow :object)})
+                      [:stats :route])))))
+
+(deftest carry-only-destination-reads-constrain-storage-and-iteration
+  (doseq [variant [(replace-form source 0.25 '(double (aget sums row)))
+                   (replace-form source '(+ acc (double v)) '(+ acc (double (aget scales row))))]]
+    (let [result (attempt variant)
+          algorithm (-> result :program :equations first :algorithm)
+          equation (first (dialect/equations algorithm))
+          facts (dialect/facts algorithm)
+          storage (dialect/result-storage facts (second equation))
+          read-write (set (map :destination (filter #(= :read-write (:access %)) storage)))]
+      (is (= :typed-soac (get-in result [:stats :route])))
+      (is (contains? (get-in facts [:equations (second equation) :effects]) :memory/read))
+      (is (= :sequential (-> equation dialect/operation-parts :attributes :iteration-order)))
+      (is (seq read-write)))))
+
+(deftest floating-or-unknown-symbolic-bounds-are-not-integral-iteration-contracts
+  (doseq [scalar-types [{'rows :long 'width :float 'seed :float}
+                       {'rows :long 'seed :float}]]
+    (is (not= :typed-soac
+              (get-in (route/attempt source :float
+                                    {'x :float 'packed :float 'scales :float 'sums :float}
+                                    {:scalar-types scalar-types})
+                      [:stats :route])))))
+
+(deftest carry-dependent-indices-cannot-be-invariant-injectivity-factors
+  (let [direct (replace-form source '(aset packed (+ (* row width) k) v)
+                             '(aset packed (+ (* row width) (long acc)) v))
+        indirect (walk/postwalk
+                  (fn [form]
+                    (if (and (seq? form) (= 'let* (first form)) (= 'v (first (second form))))
+                      (let [[head bindings & body] form]
+                        (list* head (into [(with-meta 'slot {:tag 'long}) '(long acc)] bindings)
+                               (map #(replace-form % '(aset packed (+ (* row width) k) v)
+                                                    '(aset packed (+ (* row width) slot) v)) body)))
+                      form))
+                  source)]
+    (doseq [variant [direct indirect]]
+      (let [result (attempt variant)
+            equation (-> result :program :equations first :algorithm dialect/equations first)]
+        (is (= :typed-soac (get-in result [:stats :route])))
+        (is (= :sequential (-> equation dialect/operation-parts :attributes :iteration-order)))))))

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -223,21 +223,36 @@
         projection-kernels (:kernels projection-pipeline)
         projection-report (report/from-pipeline projection-pipeline)]
     (is (= 2 (count quant-kernels)) "Q8_K remains an ordered two-phase reduction")
+    (is (= 2 (count padded-kernels)))
+    (doseq [kernel (concat quant-kernels padded-kernels)]
+      (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+      (is (nil? (get-in kernel [:attributes :kernel-body-decline])))
+      (is (= :one-work-item-per-element (get-in kernel [:attributes :kernel-body :schedule :strategy])))
+      (is (= [256] (get-in kernel [:launch :workgroup-size]))))
     (doseq [packing [(second quant-kernels) (second padded-kernels)]]
-      (is (re-find #"if \(\(\(long\)\(j\) == \(long\)\(0\)\)\) \{ xs\["
-                   (:source packing))
-          "exactly sub-block zero publishes the shared super-block scale"))
-    (is (= '[[[submax :float] [x :float] [_n_bound :int]]
-             [[bsums :int] [submax :float] [x :float] [xp :int]
-              [xs :float] [in :long] [_n_bound :int]]]
+      (let [body (get-in packing [:attributes :kernel-body])
+            ops (:operations body)
+            branch (first (filter #(some (fn [op] (= 'xs (:buffer op))) (:then-operations %)) ops))
+            condition (first (filter #(= (:condition branch) (get-in % [:result :id])) ops))]
+        (is (= :independent (get-in body [:attributes :effect-iteration-order])))
+        (is (= :eq (get-in condition [:expression :op])))
+        (is (= 0 (get-in condition [:expression :arguments 1 :value]))
+            "only the zero digit publishes the super-block scale")
+        (is (not-any? #(= 'xs (:buffer %))
+                      (tree-seq coll? seq (:else-operations branch))))))
+    (is (= '[[[x :float] [submax :float] [_n_bound :long]]
+             [[submax :float] [x :float] [bsums :int] [xp :int]
+              [xs :float] [in :long] [_n_bound :long]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) quant-kernels)))
-    (is (= '[[[submax :float] [x :float] [padded-in :long] [width :long] [_n_bound :int]]
-             [[bsums :int] [submax :float] [x :float] [xp :int] [xs :float]
-              [padded-in :long] [width :long] [_n_bound :int]]]
+    (is (= '[[[x :float] [submax :float] [padded-in :long] [width :long] [_n_bound :long]]
+             [[submax :float] [x :float] [bsums :int] [xp :int] [xs :float]
+              [padded-in :long] [width :long] [_n_bound :long]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) padded-kernels))
         "the adapter changes layout indexing without changing the two-phase Q8_K representation")
-    (is (every? #(re-find #"col\).*<.*width" (:source %)) padded-kernels)
-        "both phases guard dense-row reads and synthesize the padding region")
+    (doseq [kernel padded-kernels]
+      (is (boolean (some #(and (= :lt (:op %)) (some #{'width} (:arguments %)))
+                         (tree-seq coll? seq (get-in kernel [:attributes :kernel-body :operations]))))
+          "both phases retain the width comparison guarding dense-row reads"))
     (is (= 1 (count projection-kernels)))
     (is (= {:backend :opencl
             :source-dialect :typed-soac


### PR DESCRIPTION
## Summary
- Admit source result-valued store loops into the existing typed effect-loop: preserve one carry, ordered stores/update, lexical result scope and retained types.
- Prove guarded write independence generically by fixing omitted terminal mixed-radix digits. Reject differing guarded domains, witness erasure, shadowed recurrence operations, and carry-dependent index proofs.
- Migrate dense/padded Q8_K packers to existing typed rounding/bit primitives and explicit wrapping. Express the documented whole-superblock layout directly; preserve guarded padding loads and reduction order.
- Both phases now emit parallel KernelBody kernels, zero compatibility fallback. Tests check typed ABI, per-element launch, zero-digit scale publication and padding guards.
- Add both public quantizers to CUDA/HIP/OpenCL compile fixtures; update north-star ledger.

## Validation
- Independent read-only review: no remaining blocker.
- 29 focused tests / 260 assertions plus 4 integration tests / 53 assertions, zero failures/errors.
- Real OpenCL carried-loop execution and ZE B=3 padded Q8_K-to-Q4 graph executed, not skipped; host packed words/scales/sums parity passed.
- Rebased onto PR485 squash with identical tested tree.
- Full suites and vendor compilers delegated to CI. No throughput or SOTA claim.