### PR TITLE
Derive native C writable parameters from scheduled outputs

### DIFF
--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -458,9 +458,12 @@
         ;; clang elides it when the array is fully written before read.
         local-decls (apply str (for [[s size elem] local-buffers]
                                  (str (elem->ctype elem "double") " " (ce/c-symbol s) "[" size "] = {0};\n  ")))
-        ;; array params that the body writes (aset target) are in-place OUTPUT params —
-        ;; emit them non-const; read-only input arrays stay const.
-        written (written-array-syms stripped)
+        ;; Scheduled stores are authoritative even when the host projection retains par/map!
+        ;; rather than an aset spelling. Explicit host writes still count outside those regions.
+        ;; Use the same physical-output projection as graph consumers, not a C-only op registry.
+        written (into (written-array-syms stripped)
+                      (mapcat segop/operation-outputs)
+                      (mapcat :operations (:equations *scheduled-program*)))
         ;; param order: input arrays, output buffers, scalar params, array lengths —
         ;; each array gets ITS OWN element type (e.g. float in, int8_t out for quant).
         param-strs (concat

--- a/test/raster/compiler/backend/cpu/aot_test.clj
+++ b/test/raster/compiler/backend/cpu/aot_test.clj
@@ -189,6 +189,22 @@
     (is (contains? (:outputs operation) (:out-sym operation))
         "the scheduled store owns its physical destination before C emission")))
 
+(deftm axpy-inplace-map
+  [x :- (Array float) a :- (Array float) n :- Long] :- (Array float)
+  (raster.par/map! x i n float (rn/+ (ra/aget x i) (ra/aget a i))))
+
+(deftest scheduled-inplace-c-map-retains-writable-parameter-contract
+  (when (clang-available?)
+    (let [compiled (aot/compile-aot-c #'axpy-inplace-map :float :simd? true)
+          source (:c-source (meta compiled))]
+      (is (boolean (re-find #"(?m)^void .*\(float\* restrict x, const float\* restrict a," source))
+          "the scheduled destination is writable while its distinct input remains const")
+      (doseq [n [0 3 8 19]]
+        (let [x (float-array (range n)) a (float-array (repeat n 2))]
+          (compiled x a n)
+          (is (= (mapv #(+ 2.0 %) (range n)) (vec x)))
+          (is (= (vec (repeat n 2.0)) (vec a))))))))
+
 (deftest cpu-c-simd-map
   (when (clang-available?)
     (testing ":simd? true emits __m256 store loop for par/map!, matches scalar + interpreter"


### PR DESCRIPTION
## Summary
The native C signature builder scanned only source aset calls. Preserved scheduled in-place maps therefore declared their output pointer const and failed C compilation. Union existing SegOp physical outputs with explicit host writes; keep read-only inputs const. No new operation registry, alias policy, or emitter.

## Validation
- Reproduced native compilation failure before the fix.
- Full affected CPU-C namespace: 10 tests, 47 assertions, zero failures/errors.
- Native in-place execution covers empty, short, vector and tail sizes; signature assertion distinguishes output from read-only input.
- Independent read-only review: no blocker.
- Full repository suites delegated to CI.

This repairs the existing scheduled C boundary; it does not yet migrate scalar CPU-C or Q8_K to KernelBody.