### PR TITLE
Preserve nested typed effect regions through host and KernelBody lowering

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1429,6 +1429,13 @@ The immediate continuation after the verified double-buffered weighted-reduction
    each loop separately is insufficient: cross-loop accesses may race across rows. Unsupported
    indirect or neighboring-row accesses must remain sequential. No attention-specific exception,
    scalar hoisting, synthetic one-trip loop, or performance claim is needed for this IR extension.
+   A real Arc normalization probe exposes an unresolved precision boundary: Double SSA division
+   followed by nearest-even Float conversion produces an adjacent Float for `1/8.25`. Adding the
+   FP64 pragma alone does not change the result. Device integration currently bounds normalized
+   values by two FP32 ULPs while checking untouched storage exactly; it does not certify FP64
+   division accuracy. Audit target arithmetic guarantees separately, and extend OpenCL feature
+   discovery beyond storage declarations to intermediate scalar types (the current FP64 preamble
+   scan misses those). Explicit cast/rounding and checked-integer contracts remain unchanged.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1420,11 +1420,15 @@ The immediate continuation after the verified double-buffered weighted-reduction
    Result-valued store loops may also precede other store loops in the same ordered effect spine;
    the result scopes over those later loops, without moving their reads before earlier writes.
    The next source-admission gap is a scalar binding *between* such loops (prefill softmax is a
-   concrete workload). Reuse a nested `effect-region` for this lexical continuation, rather than
-   hoisting its locals, duplicating their evaluation per iteration, or adding a semantic attention
-   exception. Canonical validation, capture/conflict analysis, and both host and KernelBody
-   projections must support that nesting before the frontend admits it. Until then, this workload
-   still has a compatibility leaf; sequential correctness is not a parallel-performance claim.
+   concrete workload). The canonical dialect now admits a nested `effect-region` for this lexical
+   continuation: validation, host realization, and KernelBody lowering retain its evaluation point
+   and do not export its locals. This does not yet admit that source shape. Frontend capture/conflict
+   analysis and source projection must preserve the same boundary before prefill softmax can leave
+   its compatibility path. Parallel scheduling additionally needs a shared ownership proof for
+   reads and repeated writes by the same work item across distinct loop-local coordinates. Proving
+   each loop separately is insufficient: cross-loop accesses may race across rows. Unsupported
+   indirect or neighboring-row accesses must remain sequential. No attention-specific exception,
+   scalar hoisting, synthetic one-trip loop, or performance claim is needed for this IR extension.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -975,8 +975,8 @@
           n-sym (gensym "effect_n__")
           j-sym (gensym "effect_i__")
           {:keys [locals effects]} (:scalar-region segmap)
-          carried-effects? (soac-dialect/scheduled-effect-carries? effects)
-          generated-cast (partial effect-source/storage-cast carried-effects?)
+          strict-effects? (soac-dialect/strict-effect-scalar-policy? effects)
+          generated-cast (partial effect-source/storage-cast strict-effects?)
           _ (when (seq effects)
               (soac-dialect/validate-scheduled-effect-carries!
                effects (concat (:inputs segmap) (:outputs segmap) (:scalars segmap)
@@ -1009,7 +1009,8 @@
           (when (seq effects)
             (materialize-locals locals
                                 (effect-source/ordered-effects
-                                 effects {:emit-store effect-statement :emit-loop loop-statement})))
+                                 effects {:emit-store effect-statement :emit-loop loop-statement
+                                          :emit-region materialize-locals})))
           body (clojure.walk/postwalk
                 (fn [form] (if (= form index) j-sym form))
                 (bc/desugar-invk (or typed-region-body (:lambda segmap))))]

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -517,6 +517,7 @@
           (& (?sym:f (?:* s:args)) (? _ seq?)))
 
   (Effect [e :enforce]
+          (effect-region [(?:* d)] [(?:+ e)])
           (effect ?sym:destination ?ec:conflict
                   ?s:destination-index ?s:predicate ?s:value)
           (effect-loop ?ela ?s:extent ?el)
@@ -665,7 +666,9 @@
    counted loop of them."
   [value]
   (or (and (seq? value) (= 'effect (first value)) (= 6 (count value)))
-      (effect-loop-form? value)))
+      (effect-loop-form? value)
+      (and (seq? value) (= 'effect-region (first value)) (= 3 (count value))
+           (vector? (second value)) (vector? (nth value 2)))))
 
 (declare lambda-parts)
 
@@ -676,6 +679,9 @@
    update; their parameter vector is [index carry-parameter]."
   [value]
   (cond
+    (and (effect-form? value) (= 'effect-region (first value)))
+    {:region (lambda-parts (list 'lambda [] value))}
+
     (effect-loop-form? value)
     (let [[_ attributes extent] value
           carried? (= 5 (count value))
@@ -696,10 +702,13 @@
   "The store effects of projected effect parts, descending into store loops."
   [parts]
   (vec (mapcat (fn [part]
-                 (if (:loop part)
+                 (cond
+                   (:region part)
+                   (effect-part-leaves (map effect-parts (:body-results (:region part))))
+                   (:loop part)
                    (effect-part-leaves
                     (map effect-parts (:body-results (lambda-parts (:lambda part)))))
-                   [part]))
+                   :else [part]))
                parts)))
 
 (defn effect-leaves
@@ -707,8 +716,8 @@
    store loops."
   [effects]
   (vec (mapcat (fn [effect]
-                 (if-let [loop (:loop effect)]
-                   (effect-leaves (:effects loop))
+                 (if-let [scope (or (:loop effect) (:region effect))]
+                   (effect-leaves (:effects scope))
                    [effect]))
                effects)))
 
@@ -716,8 +725,30 @@
   "Whether scheduled effects contain a result-carrying loop, including nested effect scopes."
   [effects]
   (boolean (some (fn [effect]
-                   (when-let [loop (:loop effect)]
+                   (when-let [loop (or (:loop effect) (:region effect))]
                      (or (:carry loop) (scheduled-effect-carries? (:effects loop))))) effects)))
+
+(defn- effect-parts-contain?
+  "Search lexical effect scopes without confusing a region with a store leaf."
+  [predicate parts]
+  (boolean
+   (some (fn [part]
+           (or (predicate part)
+               (when-let [region (or (:region part)
+                                     (when (:loop part) (lambda-parts (:lambda part))))]
+                 (effect-parts-contain? predicate (map effect-parts (:body-results region))))))
+         parts)))
+
+(defn strict-effect-scalar-policy?
+  "Carried values and nested lexical regions require retained arithmetic types and explicit
+   storage conversion. Legacy flat, uncarried effects keep their existing policy."
+  [effects]
+  (boolean
+   (some (fn [effect]
+           (or (:region effect)
+               (when-let [loop (:loop effect)]
+                 (or (:carry loop) (strict-effect-scalar-policy? (:effects loop))))))
+         effects)))
 
 (defn validate-scheduled-effect-carries!
   "Check the lexical contract of optional single-result carries in scheduled effect loops.
@@ -733,9 +764,23 @@
             (when-let [unbound (seq (util/free-syms expression bound))]
               (fail "effect carry expression is outside its lexical scope"
                     {:field field :unbound (set unbound) :expression expression})))
+          (locals! [locals bound]
+            (reduce (fn [scope {:keys [id dtype init] :as local}]
+                      (when-not (and (symbol? id) (not (contains? scope id))
+                                     (dtype/known? dtype) (= dtype (dtype/canon dtype))
+                                     (:scalar-tag (dtype/info dtype))
+                                     (not (util/effectful? init))
+                                     (not-any? descriptor/aset-call? (tree-seq coll? seq init)))
+                        (fail "effect locals require fresh typed pure scalar bindings" {:local local}))
+                      (closed! init scope :local)
+                      (conj scope id)) bound locals))
+          (contains-loop? [effects]
+            (some #(or (:loop %) (when (:region %) (contains-loop? (get-in % [:region :effects])))) effects))
           (walk [effects bound]
             (reduce
              (fn [bound effect]
+               (if-let [region (:region effect)]
+                 (do (walk (:effects region) (locals! (:locals region) bound)) bound)
                (if-let [{:keys [index lower extent locals effects carry]} (:loop effect)]
                  (if carry
                    (let [{:keys [parameter result dtype init update]} carry
@@ -744,15 +789,12 @@
                                     (every? symbol? ids)
                                     (= (count ids) (count (distinct ids)))
                                     (empty? (set/intersection bound (set ids)))
-                                    (not-any? :loop effects)
+                                    (not (contains-loop? effects))
                                     (contains? #{:int :long :float :double} dtype))
                        (fail "effect carry requires distinct typed lexical binders" {:carry carry}))
                      (doseq [[field expression] [[:lower lower] [:extent extent] [:init init]]]
                        (closed! expression bound field))
-                     (let [inner (reduce (fn [scope {:keys [id init]}]
-                                           (closed! init scope :local)
-                                           (conj scope id))
-                                         (conj bound index parameter) locals)
+                     (let [inner (locals! locals (conj bound index parameter))
                            after-effects (walk effects inner)]
                        (closed! update after-effects :update))
                      (conj bound result))
@@ -760,14 +802,11 @@
                    (do
                      (closed! lower bound :lower)
                      (closed! extent bound :extent)
-                     (walk effects (reduce (fn [scope {:keys [id init]}]
-                                             (closed! init scope :local)
-                                             (conj scope id))
-                                           (conj bound index) locals))
+                     (walk effects (locals! locals (conj bound index)))
                      bound))
                  (do (doseq [field [:destination-index :predicate :value]]
                        (closed! (get effect field) bound field))
-                     bound)))
+                     bound))))
              bound effects))]
     (walk effects (set scope))
     effects))
@@ -820,12 +859,16 @@
    This projection does not substitute captures, assign destination dtypes or select a target."
   [effect]
   (let [{:keys [loop index lower extent lambda carry] :as part} (effect-parts effect)]
-    (if loop
+    (cond
+      (:region part)
+      {:region {:locals (:locals (:region part))
+                :effects (mapv scheduled-effect (:body-results (:region part)))}}
+      loop
       (let [{:keys [locals body-results]} (lambda-parts lambda)]
         {:loop (cond-> {:index index :lower lower :extent extent :locals locals
                         :effects (mapv scheduled-effect body-results)}
                  carry (assoc :carry carry))})
-      part)))
+      :else part)))
 
 (defn scalar-fold-form?
   "True for a typed ordered fold embedded in a scalar region."
@@ -1159,9 +1202,15 @@
             by-destination (group-by :destination leaves)
             iteration-order (:iteration-order attributes)
             region-bound (into (set parameters) (cons (:index attributes) (map :id locals)))]
-        (reduce
+        (letfn [(validate-parts [parts scope]
+                  (reduce
          (fn [scope part]
-           (if (:loop part)
+           (cond
+             (:region part)
+             (let [{:keys [locals body-results]} (:region part)]
+               (validate-parts (mapv effect-parts body-results) (into scope (map :id locals)))
+               scope)
+             (:loop part)
              (let [{loop-parameters :parameters loop-locals :locals :keys [body-results] :as region}
                    (lambda-parts (:lambda part))
                    carry (:carry part)
@@ -1180,13 +1229,16 @@
                               (= (boolean carry) (contains? region :effect-result))
                               (= (count ids) (count (distinct ids)))
                               (empty? (set/intersection scope (set ids)))
-                              (every? some? inner) (not-any? :loop inner) (seq inner))
+                              (every? some? inner)
+                              (not (effect-parts-contain? :loop inner)) (seq inner))
                  (fail! :typed-soac-effect-loop
                         "effect loops require matching typed binders and one closed effect level"
                         {:equation equation-id :loop (:index part) :parameters loop-parameters}))
+               (validate-parts inner (into scope ids))
                (cond-> scope carry (conj (:result carry))))
-             scope))
-         region-bound effects)
+             :else scope))
+         scope parts))]
+          (validate-parts effects region-bound))
         (try
           (validate-scheduled-effect-carries! (mapv scheduled-effect body-results) region-bound)
           (catch clojure.lang.ExceptionInfo e
@@ -1695,7 +1747,9 @@
         (when (= 'effect-map kind)
           (let [lambda (:lambda (operation-parts equation))
                 parts (mapv effect-parts (:body-results (lambda-parts lambda)))]
-            (when (some :carry parts)
+            (when (or (effect-parts-contain? :region parts)
+                      (scheduled-effect-carries?
+                       (mapv scheduled-effect (:body-results (lambda-parts lambda)))))
               (let [destination-parameters (:destination-parameters (parameter-layout equation))
                     accesses (zipmap destination-parameters (map :access storage))
                     reads (filter descriptor/aget-call? (tree-seq coll? seq lambda))]

--- a/src/raster/compiler/passes/parallel/effect_source.clj
+++ b/src/raster/compiler/passes/parallel/effect_source.clj
@@ -7,10 +7,10 @@
             [raster.compiler.core.dtype :as dtype]))
 
 (defn storage-cast
-  "Generated storage conversion, not a user-written cast. Carried FP32 regions use IEEE rounding
-   and overflow, matching KernelBody; existing non-carried host regions retain checked casts."
-  [carried? tag]
-  (if (and carried? (= 'float tag))
+  "Generated storage conversion, not a user-written cast. Strict FP32 regions use IEEE rounding
+   and overflow, matching KernelBody; legacy flat host regions retain checked casts."
+  [strict? tag]
+  (if (and strict? (= 'float tag))
     'clojure.core/unchecked-float
     (symbol "clojure.core" (name tag))))
 
@@ -72,14 +72,18 @@
 
 (defn ordered-effects
   "Spell scheduled effects as a host continuation. `emit-store` receives a store descriptor;
-   `emit-loop` receives a loop descriptor and its already-spelled ordered body. Both return forms.
+   `emit-loop` receives a loop descriptor and its already-spelled ordered body. `emit-region`
+   receives retained locals and their ordered body. All callbacks return forms.
    A carried result encloses only subsequent effects, never its initializer or preceding stores."
-  [effects {:keys [emit-store emit-loop] :as emitters}]
+  [effects {:keys [emit-store emit-loop emit-region] :as emitters}]
   (if-let [effect (first effects)]
     (let [loop (:loop effect)
-          form (if loop
-                 (emit-loop loop (ordered-effects (:effects loop) emitters))
-                 (emit-store effect))
+          form (cond
+                 (:region effect)
+                 (let [{:keys [locals effects]} (:region effect)]
+                   (emit-region locals (ordered-effects effects emitters)))
+                 loop (emit-loop loop (ordered-effects (:effects loop) emitters))
+                 :else (emit-store effect))
           continuation (ordered-effects (next effects) emitters)]
       (if-let [result (get-in loop [:carry :result])]
         (list 'let* [(vary-meta result dissoc :tag) form] continuation)

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -200,14 +200,14 @@
                         (index-expression/lower
                          expression (set/union index-scope extra-scope) decline!)
                         (merge index-types extra-types))))
-        carried-effects? (soac-dialect/scheduled-effect-carries? effects)
+        strict-effects? (soac-dialect/strict-effect-scalar-policy? effects)
         lowerer (scalar-expression/make-lowerer
                  (cond-> {:array-types array-types :scalar-types scalar-types
                           :arrays (set inputs) :index-scope index-scope
                           :lower-index lower-index :predicate :map-active
                           :source-region [locals result effects]
                           :id-prefix "map" :decline! decline!}
-                   carried-effects? (assoc :require-source-types? true
+                   strict-effects? (assoc :require-source-types? true
                                            :conversion-policy scalar-conversion/policy)))
         base-environment (assoc scalar-types index :long)
         _ (when (seq effects)
@@ -226,7 +226,7 @@
                                 :scalar-region (:scalar-region segmap)}))
                  init (util/subst-syms substitutions init)
                  lowered ((:lower lowerer) init local-type environment)
-                 lowered (if carried-effects? ((:cast lowerer) lowered local-type init) lowered)]
+                 lowered (if strict-effects? ((:cast lowerer) lowered local-type init) lowered)]
              {:substitutions (assoc substitutions id (:result lowered))
               :operations (into operations (:operations lowered))
               :environment (assoc environment (:result lowered) (:type lowered))}))
@@ -285,7 +285,15 @@
         substitute-effect
         (fn substitute-effect [substitutions effect]
           (let [substitute #(util/subst-syms substitutions %)]
-            (if-let [loop (:loop effect)]
+            (cond
+              (:region effect)
+              (update effect :region
+                      (fn [region]
+                        (-> region
+                            (update :locals #(mapv (fn [local] (update local :init substitute)) %))
+                            (update :effects #(mapv (partial substitute-effect substitutions) %)))))
+              (:loop effect)
+              (let [loop (:loop effect)]
               (assoc effect :loop
                      (-> loop
                          (update :lower substitute)
@@ -294,12 +302,24 @@
                            (update :carry #(-> % (update :init substitute) (update :update substitute))))
                          (update :locals (fn [locals] (mapv #(update % :init substitute) locals)))
                          (update :effects (fn [effects]
-                                            (mapv #(substitute-effect substitutions %) effects)))))
-              (reduce (fn [effect field] (update effect field substitute))
+                                            (mapv #(substitute-effect substitutions %) effects))))))
+              :else (reduce (fn [effect field] (update effect field substitute))
                       effect [:destination :destination-index :predicate :value]))))
         lower-effect
         (fn lower-effect
           [environment {:keys [destination conflict destination-index predicate value] :as effect}]
+          (if-let [{:keys [locals effects]} (:region effect)]
+            (let [state (lower-locals locals environment)
+                  inner (reduce (fn [{:keys [environment operations]} effect]
+                                  (let [next (lower-effect
+                                              environment
+                                              (substitute-effect (:substitutions state) effect))]
+                                    (update next :operations #(into operations %))))
+                                {:environment (:environment state) :operations (:operations state)}
+                                effects)]
+              ;; Nested locals/results remain lexical. Their operations still occur here, not
+              ;; in the enclosing region's prefix or inside each later loop iteration.
+              {:environment environment :operations (:operations inner)})
           (if-let [{loop-index :index loop-locals :locals loop-effects :effects
                     :keys [lower extent carry]} (:loop effect)]
             ;; A counted store loop lowers to an ordered ForLoop nested in the work item: its
@@ -375,7 +395,7 @@
                              [(body/->IfRegion (:result lowered-predicate)
                                                (conj effect-operations (body/->Yield []))
                                                [(body/->Yield [])] [])]))))))]
-            {:operations operations :environment environment})))
+            {:operations operations :environment environment}))))
         effect-operations
         (:operations
          (reduce (fn [{:keys [environment operations]} effect]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -345,10 +345,11 @@
           {:keys [locals body-results]}
           (soac-dialect/lambda-parts (list 'lambda [] (:region projected)))
           lower-effect
-          (fn lower-effect [{:keys [loop destination conflict destination-index predicate value]}]
-              (if loop
-                {:loop (update loop :effects #(mapv lower-effect %))}
-                {:destination destination
+          (fn lower-effect [{:keys [loop region destination conflict destination-index predicate value]}]
+              (cond
+                region {:region (update region :effects #(mapv lower-effect %))}
+                loop {:loop (update loop :effects #(mapv lower-effect %))}
+                :else {:destination destination
                  :dtype (get destination-dtypes destination)
                  :conflict conflict
                  :destination-index destination-index

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -291,9 +291,9 @@
             dtype-by-destination (zipmap physical-results result-dtypes)
             cast-by-destination (zipmap physical-results casts)
             effects (mapv dialect/scheduled-effect bodies)
-            carried? (dialect/scheduled-effect-carries? effects)
-            generated-cast (partial effect-source/storage-cast carried?)
-            materialize-locals (if carried?
+            strict-effects? (dialect/strict-effect-scalar-policy? effects)
+            generated-cast (partial effect-source/storage-cast strict-effects?)
+            materialize-locals (if strict-effects?
                                  (partial effect-source/typed-locals generated-cast)
                                  materialize-region)
             _ (when-not (and (= (count results) (count physical-results)
@@ -332,7 +332,8 @@
                                         typed-value))]
                       (if (contains? #{true 1} predicate) store (list 'if predicate store))))
             continuation (effect-source/ordered-effects
-                          effects {:emit-store statement :emit-loop loop-statement})
+                          effects {:emit-store statement :emit-loop loop-statement
+                                   :emit-region materialize-locals})
             effect-source
             (with-meta
               (list 'raster.par/map-void! region-index (:extent attributes)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -405,6 +405,8 @@
                                     [:nodes 0 :operation]))
            (write-artifact! directory suffix "scheduled-carried-effect-loop"
                             (carried-fixture/artifact (carried-fixture/scheduled-loop 8) dialect))
+           (write-artifact! directory suffix "scheduled-nested-effect-region"
+                            (carried-fixture/artifact (carried-fixture/scheduled-normalization 3) dialect))
            (write-artifact! directory suffix "typed-carried-effect-loop"
                             (carried-fixture/artifact
                              (first (soac-lower/lower-typed-effect-map

--- a/test/raster/compiler/ir/nested_effect_region_test.clj
+++ b/test/raster/compiler/ir/nested_effect_region_test.clj
@@ -1,0 +1,96 @@
+(ns raster.compiler.ir.nested-effect-region-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.core.util :as util]))
+
+(defn- program [region access effects]
+  (let [tensor (av/tensor {:dtype :float :shape '[n]})
+        facts (dialect/default-program-facts
+               {:values {'out tensor 'result tensor
+                         'n (av/tensor {:dtype :long :shape []})}
+                :inputs '[n]
+                :effects effects
+                :equations {'e (assoc (dialect/default-equation-facts)
+                                      :effects effects :aliases {'result 'out}
+                                      :attributes {:result-storage
+                                                   [{:destination 'out :access access
+                                                     :host-return :effect}]})}})]
+    (dialect/make
+     facts
+     [(list '= 'e '[result]
+            (list 'effect-map {:index 'i :extent 'n :dtypes [:float]
+                               :iteration-order :independent}
+                  [] [] '[out] (dialect/effect-lambda-form '[dst] [region])))]
+     [])))
+
+(deftest canonical-nested-regions-validate-storage-and-local-contracts
+  (let [region '(effect-region [(let-value v :float (clojure.core/aget dst i))]
+                              [(effect dst :unique i 1 v)])
+        p (program region :read-write #{:memory/read :memory/write})]
+    (is (= p (dialect/validate! p)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (program region :write #{:memory/read :memory/write})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (program region :read-write #{:memory/write})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (program
+                  (list 'effect-loop {:index 'k :lower 0} 2
+                        (dialect/effect-lambda-form '[k] [region]))
+                  :write #{:memory/read :memory/write})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (program '(effect-region [(let-value v :unknown 1)]
+                                          [(effect dst :unique i 1 v)])
+                          :write #{:memory/write})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (program
+                  '(effect-loop {:index k :lower 0} 2
+                     (lambda [k]
+                       (effect-region []
+                         [(effect-region []
+                            [(effect-loop {:index j :lower 0} 2
+                               (lambda [j]
+                                 (effect-region [] [(effect dst :unique i 1 0.0)])))])])))
+                  :write #{:memory/write})))))
+
+(def nested
+  '(effect-region [(let-value inv :double (/ 1.0 sum))]
+                  [(effect out :unique i 1 inv)]))
+
+(deftest nested-regions-project-and-retain-lexical-scope
+  (let [scheduled (dialect/scheduled-effect nested)]
+    (is (= {:region {:locals [{:id 'inv :dtype :double :init '(/ 1.0 sum)}]
+                       :effects [{:destination 'out :conflict :unique
+                                  :destination-index 'i :predicate 1 :value 'inv}]}}
+           scheduled))
+    (is (= [scheduled]
+           (dialect/validate-scheduled-effect-carries! [scheduled] '#{sum out i})))
+    (is (= '[out] (mapv :destination (dialect/effect-leaves [scheduled]))))
+    (is (= '[out] (mapv :destination
+                       (dialect/effect-part-leaves [(dialect/effect-parts nested)]))))
+    (is (= '#{sum out i} (util/free-syms nested)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (dialect/validate-scheduled-effect-carries!
+                  [scheduled {:destination 'out :destination-index 'i :predicate 1 :value 'inv}]
+                  '#{sum out i}))))
+  (doseq [locals [[{:id 'v :dtype :double :init 'later}
+                   {:id 'later :dtype :double :init 1.0}]
+                  [{:id 'sum :dtype :double :init 1.0}]
+                  [{:id 'v :dtype :unknown :init 1.0}]
+                  [{:id 'v :dtype :double :init '(clojure.core/aset out i 1.0)}]]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (dialect/validate-scheduled-effect-carries!
+                  [{:region {:locals locals :effects []}}] '#{sum out i})))))
+
+(deftest regions-cannot-hide-loops-inside-carried-bodies
+  (let [inner {:loop {:index 'j :lower 0 :extent 2 :locals []
+                      :effects [{:destination 'out :destination-index 'j
+                                 :predicate 1 :value 0.0}]}}
+        carried {:loop {:index 'k :lower 0 :extent 2 :locals []
+                        :carry {:parameter 'acc :result 'sum :dtype :double
+                                :init 0.0 :update 'acc}
+                        :effects [{:region {:locals [] :effects [inner]}}]}}]
+    (is (dialect/scheduled-effect-carries?
+         [{:region {:locals [] :effects [carried]}}]))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (dialect/validate-scheduled-effect-carries! [carried] '#{out})))))

--- a/test/raster/compiler/passes/parallel/carried_effect_loop_device_test.clj
+++ b/test/raster/compiler/passes/parallel/carried_effect_loop_device_test.clj
@@ -6,6 +6,20 @@
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.gpu.device-probe :as probe]))
 
+(defn- same-values?
+  [kind expected actual]
+  (and (= (count expected) (count actual))
+       (every? true?
+               (map (fn [expected actual]
+                      ;; This integration oracle bounds division numerics, not FP64 accuracy.
+                      ;; Arc currently differs by one FP32 ULP at reciprocal(8.25), even with
+                      ;; explicit Double SSA and FP64 pragma. Keep inactive sentinels exact.
+                      (if (and (= :nested kind) (not= -77.0 expected))
+                        (<= (Math/abs (- (double actual) (double expected)))
+                            (* 2.0 (double (Math/ulp (float expected)))))
+                        (= expected actual)))
+                    expected actual))))
+
 (deftest carried-store-loops-match-the-sequential-oracle-on-opencl
   (if-not @probe/opencl-available?
     (probe/opencl-skip! "scheduled carried store loops")
@@ -16,16 +30,20 @@
           launch! (ns-resolve runtime 'launch-registered-bound!)
           read! (ns-resolve runtime 'buffer->array)
           free! (ns-resolve runtime 'free-buffer!)]
-      (doseq [[kind trips] (concat (for [kind [:scheduled :typed] trips [0 1 8]] [kind trips])
+      (doseq [[kind trips] (concat (for [kind [:scheduled :typed :nested] trips [0 1 8]] [kind trips])
                                    [[:typed-index-collision 8]])]
-        (let [operation (if (= kind :scheduled)
-                          (fixture/scheduled-loop trips)
+        (let [operation (case kind
+                          :scheduled (fixture/scheduled-loop trips)
+                          :nested (fixture/scheduled-normalization trips)
                           (first (lower/lower-typed-effect-map
                                   (cond-> (fixture/typed-program trips)
                                     (= kind :typed-index-collision) (dialect/remap-values {'seed 'i})) :ze:0)))
               compiled (fixture/artifact operation :opencl-portable
                                          :scalar-types {'rows :long 'seed :float 'i :float})
               values (vec (range 16))
+              sums (mapv (fn [row] (+ 0.25 (reduce + (take trips (drop (* row 8) values)))))
+                         (range 2))
+              inverses (mapv #(float (/ 1.0 %)) sums)
               x (buffer-of-array (float-array values) :float)
               words (buffer-of-array (float-array (repeat 19 -77)) :float)
               totals (buffer-of-array (float-array (repeat 5 -77)) :float)]
@@ -37,11 +55,14 @@
                                                  'seed {:type :float :value 0.25}
                                                  'i {:type :float :value 0.25}}
                                                 (:arguments compiled)))))
-            (is (= (vec (concat (map-indexed (fn [i v] (if (< (mod i 8) trips) (float v) -77.0)) values)
+            (is (same-values? kind (vec (concat (map-indexed (fn [i v]
+                                              (if (< (mod i 8) trips)
+                                                (float (if (= :nested kind)
+                                                         (* v (nth inverses (quot i 8))) v))
+                                                -77.0)) values)
                                 (repeat 3 -77.0)))
                    (vec (read! words))) "only the selected row elements are written")
-            (is (= (vec (concat (for [row (range 2)]
-                                  (+ 0.25 (reduce + (take trips (drop (* row 8) values)))))
+            (is (same-values? kind (vec (concat (if (= :nested kind) inverses sums)
                                 (repeat 3 -77.0)))
                    (vec (read! totals))) "zero-trip carry and inactive output tail are preserved")
             (finally (free! totals) (free! words) (free! x))))))))

--- a/test/raster/compiler/passes/parallel/carried_effect_loop_fixture.clj
+++ b/test/raster/compiler/passes/parallel/carried_effect_loop_fixture.clj
@@ -22,6 +22,21 @@
                {:destination 'totals :dtype :float :conflict :unique
                 :destination-index 'i :predicate true :value 'sum}]}}))
 
+(defn scheduled-normalization [trips]
+  (let [base (update (scheduled-loop trips) :inputs conj 'words)
+        total (get-in base [:scalar-region :effects 1])]
+    (assoc-in base [:scalar-region :effects 1]
+              {:region
+               {:locals [{:id 'inverse :dtype :float
+                          :init (with-meta '(/ 1.0 sum) {:raster.type/tag 'double})}]
+                :effects [{:loop
+                           {:index 'j :lower 0 :extent trips :locals []
+                            :effects [{:destination 'words :dtype :float :conflict :unique
+                                       :destination-index '(+ (* i 8) j) :predicate true
+                                       :value (with-meta '(* (aget words (+ (* i 8) j)) inverse)
+                                                {:raster.type/tag 'double})}]}}
+                          (assoc total :value 'inverse)]}})))
+
 (defn artifact [operation target & {:keys [scalar-types] :or {scalar-types {'rows :long 'seed :float}}}]
   (emit/generate-scheduled-segmap-kernel
    operation :dtype :float :target-dialect target

--- a/test/raster/compiler/passes/parallel/nested_effect_region_test.clj
+++ b/test/raster/compiler/passes/parallel/nested_effect_region_test.clj
@@ -1,0 +1,125 @@
+(ns raster.compiler.passes.parallel.nested-effect-region-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.jvm.segop-simd :as jvm]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.passes.parallel.typed-soac-route]
+            [raster.compiler.passes.parallel.carried-effect-loop-fixture
+             :refer [scheduled-normalization artifact typed-program]
+             :rename {scheduled-normalization normalization}]))
+
+(deftest nested-locals-execute-after-the-carry-before-the-next-loop
+  (doseq [trips [0 1 3]]
+    (let [operation (normalization trips)
+          execute (eval (list 'fn '[x words totals rows] (jvm/compile-effect-segmap operation)))
+          x (float-array (range 16)) words (float-array (repeat 16 -77)) totals (float-array 2)
+          inverses (mapv (fn [row] (float (/ 1.0 (+ 0.25 (reduce + (take trips (drop (* row 8) x)))))))
+                         (range 2))]
+      (execute x words totals 2)
+      (is (= inverses (vec totals)))
+      (is (= (mapv (fn [i]
+                    (if (< (mod i 8) trips)
+                      (float (* (aget x i) (nth inverses (quot i 8))))
+                      (float -77)))
+                  (range 16))
+             (vec words)))
+      (doseq [target [:opencl-portable :cuda :hip]]
+        (let [compiled (artifact operation target)
+              operations (get-in compiled [:attributes :kernel-body :operations])
+              divisions (keep-indexed #(when (= :div (get-in %2 [:expression :op])) %1) operations)
+              loops (keep-indexed #(when (:iter-args %2) %1) operations)]
+          (is (= :kernel-body (get-in compiled [:attributes :emission-route])))
+          (is (= 1 (count divisions)))
+          (is (= 2 (count loops)))
+          (is (< (first loops) (first divisions) (second loops))))))))
+
+(deftest canonical-nested-continuations-share-host-and-scheduled-realization
+  (let [program (walk/postwalk
+                 #(if (= % '(effect sums :unique i true sum))
+                    '(effect-region [(let-value inverse :double
+                                               ^{:raster.type/tag double} (/ 1.0 sum))]
+                                    [(effect sums :unique i true inverse)]) %)
+                 (typed-program 3))
+        program (dialect/validate! program)
+        equation (first (dialect/equations program))
+        realized ((ns-resolve 'raster.compiler.passes.parallel.typed-soac-route 'realize-equation)
+                  program equation)
+        scheduled (first (lower/lower-typed-effect-map program :ze:0))]
+    (doseq [form [(:source realized) (jvm/compile-effect-segmap scheduled)]]
+      (let [execute (eval (list 'fn '[x words totals seed rows] form))
+            words (float-array (repeat 16 -77)) totals (float-array 2)]
+        (execute (float-array (range 16)) words totals (float 0.25) 2)
+        (is (= [(float (/ 1.0 3.25)) (float (/ 1.0 27.25))] (vec totals)))
+        (is (= [0.0 1.0 2.0 -77.0] (subvec (vec words) 0 4)))))))
+
+(deftest nested-local-reads-observe-preceding-stores
+  (let [operation (assoc-in (normalization 1) [:scalar-region :effects 1 :region :locals 0 :init]
+                           '(double (aget words (* i 8))))
+        execute (eval (list 'fn '[x words totals rows] (jvm/compile-effect-segmap operation)))
+        words (float-array (repeat 16 -77)) totals (float-array 2)]
+    (execute (float-array (range 16)) words totals 2)
+    (is (= [0.0 8.0] (vec totals)))))
+
+(deftest nested-initializer-failure-does-not-move-before-preceding-stores
+  (let [operation (-> (normalization 1)
+                      (update :scalars conj 'limit)
+                      (assoc-in [:scalar-region :effects 1 :region :locals]
+                                [{:id 'inverse :dtype :long
+                                  :init (with-meta '(clojure.core/+ limit 1) {:raster.type/tag 'long})}]))
+        execute (eval (list 'fn '[x words totals rows limit] (jvm/compile-effect-segmap operation)))
+        words (float-array [-77]) totals (float-array [-77])]
+    (is (thrown? ArithmeticException
+                 (execute (float-array [9]) words totals 1 Long/MAX_VALUE)))
+    (is (= [9.0] (vec words)))
+    (is (= [-77.0] (vec totals)))))
+
+(deftest nested-locals-do-not-escape-their-continuation
+  (let [operation (update-in (normalization 1) [:scalar-region :effects]
+                              conj {:destination 'totals :dtype :float :conflict :unique
+                                    :destination-index 'i :predicate true :value 'inverse})]
+    (doseq [lower [jvm/compile-effect-segmap #(artifact % :opencl-portable)]]
+      (is (= :scheduled-effect-carry
+             (try (lower operation) :accepted
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+
+(deftest uncarried-nested-regions-retain-checked-source-arithmetic
+  (let [operation (-> (normalization 0)
+                      (update :scalars conj 'limit)
+                      (update-in [:scalar-region :effects] #(vec (rest %)))
+                      (assoc-in [:scalar-region :effects 0 :region :locals 0 :init]
+                                (with-meta '(clojure.core/+ limit 1) {:raster.type/tag 'long})))
+        execute (eval (list 'fn '[x words totals rows limit] (jvm/compile-effect-segmap operation)))
+        totals (float-array [-77])]
+    (is (not (dialect/scheduled-effect-carries? (get-in operation [:scalar-region :effects]))))
+    (is (thrown? ArithmeticException
+                 (execute (float-array 1) (float-array 1) totals 1 Long/MAX_VALUE)))
+    (is (= [-77.0] (vec totals)))
+    (is (= :kernel-body-c-trap-unsupported
+           (try (artifact operation :opencl-portable :scalar-types {'rows :long 'limit :long})
+                :accepted
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (doseq [target [:opencl-intel :cuda :hip]]
+      (let [compiled (artifact operation target :scalar-types {'rows :long 'limit :long})
+            checked (filter #(= :+ (get-in % [:expression :op]))
+                            (get-in compiled [:attributes :kernel-body :operations]))]
+        (is (= 1 (count checked)))
+        (is (= :long (get-in (first checked) [:result :type])))
+        (is (= :trap (get-in (first checked) [:expression :options :overflow])))))))
+
+(deftest uncarried-nested-symbol-initializers-use-explicit-ieee-storage-conversion
+  (let [operation (-> (normalization 0)
+                      (assoc-in [:scalar-region :locals]
+                                [{:id 'seed :dtype :double :init Double/MAX_VALUE}])
+                      (update-in [:scalar-region :effects] #(vec (rest %)))
+                      (assoc-in [:scalar-region :effects 0 :region :locals 0 :init] 'seed))
+        execute (eval (list 'fn '[x words totals rows] (jvm/compile-effect-segmap operation)))
+        totals (float-array 1)]
+    (execute (float-array 1) (float-array 1) totals 1)
+    (is (= Float/POSITIVE_INFINITY (aget totals 0)))
+    (doseq [target [:opencl-portable :cuda :hip]]
+      (let [operations (get-in (artifact operation target) [:attributes :kernel-body :operations])]
+        (is (some #(and (= :cast (get-in % [:expression :op]))
+                        (= :float (get-in % [:result :type]))
+                        (= {:rounding :nearest-even :overflow :ieee}
+                           (get-in % [:expression :options]))) operations))))))


### PR DESCRIPTION
## Summary

Reuse existing `effect-region` syntax as a lexical item in an ordered effect spine. Bind locals at that point, after earlier stores/carries and before later loops. No new attention semantic operation or source-specific lowering.

- Canonical grammar, projection, recursive scope/local/storage validation and effect leaves share the same representation.
- JVM/production host and KernelBody lowering preserve order and do not export nested locals.
- Nested wrappers cannot bypass the existing no-nested-loop contract.
- A shared strict scalar policy applies to carried or nested regions, including carry-free regions. Retained Long arithmetic remains checked before conversion to FP; explicit Float storage conversion preserves IEEE overflow. Legacy flat/no-carry policy is unchanged.
- Shared normalization fixture joins CUDA/HIP/OpenCL compilation gates.

## Validation

53 focused tests, 459 assertions, zero failures/errors in the existing capped REPL. New tests cover canonical storage contracts, scope escape, hidden loops, zero/short/tail normalization, both host realizations, post-store reads/exception ordering, reciprocal placement between loops, and three-target KernelBody emission. Portable OpenCL trapping arithmetic is explicitly rejected; Intel OpenCL/CUDA/HIP retain the trap contract. Vendor hardware execution/performance is not claimed. Full suites/vendor compilation run in CI.

Independent review identified missing strict numerical policy for carry-free regions; fixed with shared policy and regression tests, then re-reviewed without a remaining source blocker.

Real Intel Arc OpenCL follow-up: 1 test/20 assertions passed, including nested normalization at zero/one/eight trips and exact inactive tails (no skip). Normalized values use a two-FP32-ULP integration bound. An exact oracle exposed an unresolved one-ULP discrepancy for Float(1.0/Double(8.25)); explicitly enabling FP64 did not change it. The emitted SSA remains Double with nearest-even Float conversion. This test does not certify FP64 division accuracy; the north-star records that precision investigation and the separate incomplete intermediate-type FP64 preamble scan. Explicit integer/rounding tests remain unchanged.

## Remaining boundary

Frontend admission of post-carry local bindings is deliberately not enabled in this PR. Capture/conflict/read analysis must first preserve nested source regions. Parallelizing repeated row-local reads/writes additionally requires shared ownership across loop coordinates. Prefill softmax therefore still uses its compatibility path; this prerequisite is not a performance claim.

Merge only after all seven checks pass on the reviewed head.
