### PR TITLE
Admit source effect continuations through nested typed regions

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1419,12 +1419,13 @@ The immediate continuation after the verified double-buffered weighted-reduction
    launch shape as well as numerical parity. This is emission coverage, not a performance claim.
    Result-valued store loops may also precede other store loops in the same ordered effect spine;
    the result scopes over those later loops, without moving their reads before earlier writes.
-   The next source-admission gap is a scalar binding *between* such loops (prefill softmax is a
-   concrete workload). The canonical dialect now admits a nested `effect-region` for this lexical
+   Scalar bindings *between* such loops now enter a nested `effect-region` (prefill softmax is a
+   concrete workload). The canonical dialect represents this lexical
    continuation: validation, host realization, and KernelBody lowering retain its evaluation point
-   and do not export its locals. This does not yet admit that source shape. Frontend capture/conflict
-   analysis and source projection must preserve the same boundary before prefill softmax can leave
-   its compatibility path. Parallel scheduling additionally needs a shared ownership proof for
+   and do not export its locals. Source admission preserves sequential multi-binding lets and
+   includes continuation initializers in capture/read/conflict analysis without hoisting them.
+   Prefill softmax now emits one KernelBody kernel without a compatibility leaf; it is still
+   sequential. Parallel scheduling additionally needs a shared ownership proof for
    reads and repeated writes by the same work item across distinct loop-local coordinates. Proving
    each loop separately is insufficient: cross-loop accesses may race across rows. Unsupported
    indirect or neighboring-row accesses must remain sequential. No attention-specific exception,

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1424,8 +1424,11 @@ The immediate continuation after the verified double-buffered weighted-reduction
    continuation: validation, host realization, and KernelBody lowering retain its evaluation point
    and do not export its locals. Source admission preserves sequential multi-binding lets and
    includes continuation initializers in capture/read/conflict analysis without hoisting them.
-   Prefill softmax now emits one KernelBody kernel without a compatibility leaf; it is still
-   sequential. Parallel scheduling additionally needs a shared ownership proof for
+   Production admission temporarily declines sequential nested continuations with the explicit
+   `:sequential-effect-continuation` diagnostic. Prefill softmax retains its existing parallel
+   compatibility launch: replacing it with a single-work-item KernelBody would be a performance
+   regression, not convergence. Direct frontend/host/KernelBody tests exercise the new capability
+   independently of this gate. Removing the gate needs a shared ownership proof for
    reads and repeated writes by the same work item across distinct loop-local coordinates. Proving
    each loop separately is insufficient: cross-loop accesses may race across rows. Unsupported
    indirect or neighboring-row accesses must remain sequential. No attention-specific exception,

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -218,8 +218,8 @@
   (instantiate-store-loop substitutions loop))
 
 (defn- region-order
-  "The source order of a region's effects as `[:store i]` / `[:loop j]` entries into its
-   `:stores` and `:loops` vectors. Regions without loops are their stores in order."
+  "The source order of effects: store/loop ordinals index their inventories; a :region item
+   holds lexical locals and its own ordered continuation. Flat regions default to store order."
   [{:keys [stores loops order]}]
   (when (and (nil? order) (seq loops))
     (throw (ex-info "a region with store loops must carry its source order"
@@ -233,6 +233,25 @@
   [loop fresh]
   (instantiate-store-loop {} loop fresh))
 
+(defn- order-locals [order]
+  (mapcat (fn [[kind region]]
+            (when (= :region kind)
+              (concat (:locals region) (order-locals (:order region))))) order))
+
+(defn- map-region-order
+  "Transform the source effect spine without flattening lexical continuation scopes."
+  [order local-fn store-offset loop-offset]
+  (mapv (fn [[kind value]]
+          [kind (case kind
+                  :region (-> value
+                              (update :locals #(mapv local-fn %))
+                              (update :order #(map-region-order % local-fn store-offset loop-offset)))
+                  :store (+ store-offset value)
+                  :loop (+ loop-offset value))]) order))
+
+(defn- substitute-order [order substitutions]
+  (map-region-order order #(update % :init (partial util/subst-syms substitutions)) 0 0))
+
 (defn- rebase-region-locals
   "Move a recursively recognized region behind `offset` lexical SSA values.
 
@@ -244,15 +263,14 @@
                       (map-indexed
                        (fn [ordinal {:keys [id]}]
                          [id (symbol (str "rstr_local_" (+ offset ordinal)))])
-                       locals))]
-    (cond-> {:locals (mapv (fn [{:keys [id] :as local}]
-                     (-> local
-                         (assoc :id (get renames id))
-                         (update :init #(util/subst-syms renames %))))
-                   locals)
+                       (concat locals (order-locals (region-order region)))))
+        rename-local (fn [{:keys [id] :as local}]
+                       (-> local (assoc :id (get renames id))
+                           (update :init #(util/subst-syms renames %))))]
+    (cond-> {:locals (mapv rename-local locals)
      :stores (mapv #(substitute-store renames %) stores)
      :loops (mapv #(substitute-loop renames %) (or loops []))
-     :order (region-order region)}
+     :order (map-region-order (region-order region) rename-local 0 0)}
       (contains? region :result) (assoc :result (util/subst-syms renames (:result region))))))
 
 (defn- split-trailing-recur
@@ -396,18 +414,18 @@
               (let [region (store-region body index update)
                     continuation (store-region (list* 'do tail) index)]
                 (when (and region continuation (seq (:stores region)) (empty? (:loops region))
-                           (or (seq (:stores continuation)) (seq (:loops continuation)))
-                           (empty? (:locals continuation)))
+                           (or (seq (:stores continuation)) (seq (:loops continuation))))
                   {:locals [] :stores (:stores continuation)
                    :loops (into [{:index loop-index :lower lower :extent extent
                             :locals (:locals region) :stores (:stores region)
                             :carry {:parameter parameter :result result :dtype dtype
                                     :init init :update (:result region)}}]
                                 (:loops continuation))
-                   :order (into [[:loop 0]]
-                                (map (fn [[kind ordinal]]
-                                       [kind (if (= :loop kind) (inc ordinal) ordinal)]))
-                                (region-order continuation))})))))))))
+                   :order (let [order (map-region-order (region-order continuation) identity 0 1)]
+                            (into [[:loop 0]]
+                                  (if (seq (:locals continuation))
+                                    [[:region {:locals (:locals continuation) :order order}]]
+                                    order)))})))))))))
 
 (defn- store-region
   "Recognize an ordered, pure local-SSA spine ending exclusively in certified effects.
@@ -421,7 +439,16 @@
   (let [region
   (cond
     (and (seq? body) (form/let-head? (first body)))
-    (or (when-not (some? result-expression) (carried-store-binding body index))
+    (or (let [[head bindings & tail] body]
+          (when (and (vector? bindings) (> (count bindings) 2) (even? (count bindings))
+                     (some util/effectful? (take-nth 2 (rest bindings))))
+            ;; Source let bindings are sequential. Expose their lexical boundaries without
+            ;; moving a pure prefix/suffix across a result-valued store-loop initializer.
+            (store-region
+             (reduce (fn [tail pair] (list head (vec pair) tail))
+                     (list* 'do tail) (reverse (partition 2 bindings)))
+             index result-expression)))
+        (when-not (some? result-expression) (carried-store-binding body index))
     (let [[_ bindings & nested-body] body]
       (when (and (even? (count bindings))
                  (seq nested-body)
@@ -449,7 +476,7 @@
                  :stores (mapv #(substitute-store substitutions %)
                                (:stores nested))
                  :loops (mapv #(substitute-loop substitutions %) (:loops nested))
-                 :order (region-order nested)}
+                 :order (substitute-order (region-order nested) substitutions)}
                   (contains? nested :result)
                   (assoc :result (util/subst-syms substitutions (:result nested)))))))))))
 
@@ -462,16 +489,13 @@
                      (every? (comp empty? :locals) groups))
             (reduce (fn [{:keys [stores loops order]} group]
                       (let [store-offset (count stores)
-                            loop-offset (count loops)]
+                            loop-offset (count loops)
+                            group (rebase-region-locals group (count (order-locals order)))]
                         {:locals []
                          :stores (into stores (:stores group))
                          :loops (into loops (:loops group))
-                         :order (into order
-                                      (map (fn [[kind ordinal]]
-                                             [kind (+ ordinal (if (= :store kind)
-                                                                store-offset
-                                                                loop-offset))]))
-                                      (region-order group))}))
+                         :order (into order (map-region-order (region-order group) identity
+                                                              store-offset loop-offset))}))
                     {:locals [] :stores [] :loops [] :order []}
                     groups)))))
 
@@ -864,8 +888,8 @@
   "The store effects of a description, descending into store loops."
   [effects]
   (vec (mapcat (fn [effect]
-                 (if-let [loop (:loop effect)]
-                   (effect-leaves (:effects loop))
+                 (if-let [scope (or (:loop effect) (:region effect))]
+                   (effect-leaves (:effects scope))
                    [effect]))
                effects)))
 
@@ -878,7 +902,8 @@
    & {:keys [host-return array-types scalar-types]
       :or {host-return :effect array-types {} scalar-types {}}}]
   (let [order (region-order region)
-        local-types (into scalar-types (map (juxt :id :dtype)) locals)
+        analysis-locals (vec (concat locals (order-locals order)))
+        local-types (into scalar-types (map (juxt :id :dtype)) analysis-locals)
         loops (vec (map-indexed (fn [ordinal loop]
                                   (rename-loop-index
                                    loop (clojure.core/symbol (str "rstr_loop_index_" ordinal))))
@@ -926,14 +951,14 @@
             ;; index through another array, established at runtime by validate-block-indices!),
             ;; and it is an error when the index is in the algebra's reach and the proof fails.
             proven (proven-unique-stores (vec (remove :reduction-op candidate-stores))
-                                         index extent locals loops)
+                                         index extent analysis-locals loops)
             proven? (let [indices (vec (remove :reduction-op candidate-stores))]
                       (fn [store] (contains? proven (.indexOf ^java.util.List indices store))))
             ;; A marker is honoured only for an index outside the algebra's reach: the index
             ;; expression or a local it depends on (transitively) reads an array. Unrelated
             ;; locals may not authorize a claim, so only the index's dependency slice counts.
             data-dependent? (fn [{:keys [index] :as store}]
-                              (let [scope (concat locals
+                               (let [scope (concat analysis-locals
                                                   (:locals (when (:loop store)
                                                              (nth loops (:loop store)))))
                                     inits (into {} (map (juxt :id :init)) scope)
@@ -1007,14 +1032,14 @@
                           (every? (fn [[_ grouped]]
                                     (= 1 (count (set (map :effect-conflict grouped)))))
                                   (group-by :out all-stores)))
-            all-locals (vec (concat locals (mapcat :locals loops)))
+            all-locals (vec (concat analysis-locals (mapcat :locals loops)))
             loop-expressions (mapcat source-loop-expressions loops)
             carry-bindings (set (mapcat #(when-let [carry (:carry %)]
                                           [(:parameter carry) (:result carry)]) loops))
             iteration-order (when ordered?
                               (if (or (some #(= :ordered (:effect-conflict %)) all-stores)
                                       (not (ordered-effects-safe?
-                                            locals all-stores
+                                            analysis-locals all-stores
                                             loop-expressions)))
                                 :sequential
                                 :independent))
@@ -1024,7 +1049,7 @@
             values (mapv :value all-stores)
             write-indices (mapv :index all-stores)
             predicates (mapv :predicate all-stores)
-            analysis-values (concat (map :init locals) loop-expressions
+            analysis-values (concat (map :init analysis-locals) loop-expressions
                                     write-indices predicates values)
             io (update (extract-io (list* 'do analysis-values) index destinations)
                        :scalars set/difference (set (map :id all-locals))
@@ -1047,11 +1072,13 @@
                                           carry (assoc :carry carry))})
                                (range) loops)
             ;; Effects keep the region's source order across direct stores and loops.
-            ordered-effects (mapv (fn [[kind ordinal]]
-                                    (if (= :store kind)
-                                      (store-effect (nth stores ordinal))
-                                      (nth loop-effects ordinal)))
-                                  order)]
+            ordered-effects ((fn project [order]
+                               (mapv (fn [[kind value]]
+                                       (case kind
+                                         :region {:region {:locals (:locals value)
+                                                           :effects (project (:order value))}}
+                                         :store (store-effect (nth stores value))
+                                         :loop (nth loop-effects value))) order)) order)]
         (when (or pointwise? scatter? (and ordered? (every? some? result-dtypes)))
           (merge {:kind (cond pointwise? :map scatter? :scatter :else :effect-map)
                   :id id :sym symbol :index index :extent extent
@@ -2383,9 +2410,11 @@
 (defn- effect-expressions
   "Every expression an effect evaluates, descending into store loops."
   [effect]
+  (if-let [region (:region effect)]
+    (concat (map :init (:locals region)) (mapcat effect-expressions (:effects region)))
   (if-let [{:keys [effects] :as loop} (:loop effect)]
     (concat (source-loop-expressions loop) (mapcat effect-expressions effects))
-    [(:index effect) (:predicate effect) (:value effect)]))
+    [(:index effect) (:predicate effect) (:value effect)])))
 
 (defn- effect-map-equation
   [{:keys [id index extent iteration-order locals inputs scalars results result-storage effects
@@ -2415,6 +2444,11 @@
                           locals)
         effect-form
         (fn effect-form [{:keys [out index predicate value cast effect-conflict] :as effect}]
+          (if-let [region (:region effect)]
+            (dialect/effect-lambda-region
+             (mapv (fn [{:keys [id dtype init]}]
+                     (dialect/local-value id dtype (transform init))) (:locals region))
+             (mapv effect-form (:effects region)))
           (if-let [{loop-index :index loop-locals :locals loop-effects :effects
                     :keys [lower extent carry]} (:loop effect)]
             (let [local-forms (mapv (fn [{:keys [id dtype init]}]
@@ -2430,7 +2464,7 @@
                 (list 'effect-loop attributes (transform extent) lambda)))
             (list 'effect (get destination-substitutions out)
                   effect-conflict (transform index) (transform predicate)
-                  (transform (if cast (list cast value) value)))))
+                  (transform (if cast (list cast value) value))))))
         effect-forms (mapv effect-form effects)]
     (list '= id results
           (list 'effect-map

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -593,6 +593,27 @@
                 (= (:operands equation) (:inputs (dialect/facts algorithm)))
                 (= (:results equation) (dialect/outputs algorithm))))))))
 
+(defn- sequential-continuation-decline
+  "Temporary production admission boundary, not a dialect restriction. Do not replace parallel
+   source rows with a single-work-item continuation until shared read/write ownership is proved."
+  [program]
+  (letfn [(nested-region? [effects]
+            (some (fn [effect]
+                    (let [{:keys [region loop lambda]} (dialect/effect-parts effect)]
+                      (or region
+                          (and loop (nested-region?
+                                     (:body-results (dialect/lambda-parts lambda)))))))
+                  effects))]
+    (some (fn [equation]
+            (let [{:keys [kind attributes lambda]} (dialect/operation-parts equation)]
+              (when (and (= 'effect-map kind)
+                         (= :sequential (:iteration-order attributes))
+                         (nested-region? (:body-results (dialect/lambda-parts lambda))))
+                {:reason :sequential-effect-continuation
+                 :equation (second equation)
+                 :message "nested continuation requires shared read/write ownership before production admission"})))
+          (dialect/equations program))))
+
 (defn attempt
   "Return a typed production ParallelProgram result, an explicit `:declined` result, or nil when
    no parallel binding is in this closed subset."
@@ -625,11 +646,13 @@
                              (dialect/equations typed-result))
                  {:declined {:reason :no-certified-parallel-equation
                              :stats (merge typed-stats resident-stats)}}
-                 (let [{:keys [source realized]} (realize-source form typed-result)]
-                   {:program (envelope typed-result source realized)
-                    :stats (merge typed-stats resident-stats
-                                  {:route :typed-soac :typed-validated true
-                                   :front-end :analyzed-source})})))))
+                 (if-let [decline (sequential-continuation-decline typed-result)]
+                   {:declined decline}
+                   (let [{:keys [source realized]} (realize-source form typed-result)]
+                     {:program (envelope typed-result source realized)
+                      :stats (merge typed-stats resident-stats
+                                    {:route :typed-soac :typed-validated true
+                                     :front-end :analyzed-source})}))))))
          (catch clojure.lang.ExceptionInfo exception
            (if (frontend/source-decline? exception)
              {:declined {:reason (:reason (ex-data exception))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -344,8 +344,6 @@
       (:kernels (equation-first/compile
                  #'qk/quant-act-q8k-padded-rows-gpu! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
-                 #'dl-attention/attn-prefill-softmax! {:target device-id :dtype :float}))
-      (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -344,6 +344,8 @@
       (:kernels (equation-first/compile
                  #'qk/quant-act-q8k-padded-rows-gpu! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'dl-attention/attn-prefill-softmax! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!

--- a/test/raster/compiler/ir/nested_effect_region_test.clj
+++ b/test/raster/compiler/ir/nested_effect_region_test.clj
@@ -1,8 +1,10 @@
 (ns raster.compiler.ir.nested-effect-region-test
   (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.soac-dialect :as dialect]
-            [raster.compiler.core.util :as util]))
+            [raster.compiler.core.util :as util]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
 
 (defn- program [region access effects]
   (let [tensor (av/tensor {:dtype :float :shape '[n]})
@@ -56,6 +58,18 @@
 (def nested
   '(effect-region [(let-value inv :double (/ 1.0 sum))]
                   [(effect out :unique i 1 inv)]))
+
+(deftest production-continuation-gate-descends-through-ordinary-loops
+  (let [region '(effect-region [] [(effect dst :unique i 1 1.0)])
+        p (program (list 'effect-loop {:index 'k :lower 0} 2
+                         (dialect/effect-lambda-form '[k] [region]))
+                   :write #{:memory/write})
+        sequential (walk/postwalk #(if (and (map? %) (contains? % :iteration-order))
+                                     (assoc % :iteration-order :sequential) %) p)]
+    (is (= sequential (dialect/validate! sequential)))
+    (is (nil? (#'route/sequential-continuation-decline p)))
+    (is (= :sequential-effect-continuation
+           (:reason (#'route/sequential-continuation-decline sequential))))))
 
 (deftest nested-regions-project-and-retain-lexical-scope
   (let [scheduled (dialect/scheduled-effect nested)]

--- a/test/raster/compiler/passes/parallel/prefill_softmax_route_test.clj
+++ b/test/raster/compiler/passes/parallel/prefill_softmax_route_test.clj
@@ -1,0 +1,60 @@
+(ns raster.compiler.passes.parallel.prefill-softmax-route-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.dl.attention :as attention]
+            [raster.gpu.device-probe :as probe]))
+
+(def ^:private compiled
+  (delay (pipeline/show-pipeline #'attention/attn-prefill-softmax!
+                                 :target-device :ocl:0 :dtype :float)))
+
+(deftest prefill-softmax-enters-the-typed-ordered-region-vertical
+  (let [p @compiled
+        kernel (first (:kernels p))
+        equations (mapcat #(dialect/equations (:algorithm %))
+                          (get-in p [:soac-fused :equations]))]
+    (is (= :typed-soac (get-in p [:soac-fused :dialect])))
+    (is (= 1 (count (:kernels p))))
+    (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+    (is (= '[sc nrows _n_bound] (mapv :name (:abi kernel))))
+    (is (= [:float :long :long] (mapv :dtype (:abi kernel))))
+    (is (= [:sequential]
+           (mapv #(get-in (dialect/operation-parts %) [:attributes :iteration-order])
+                 (filter #(= 'effect-map (dialect/operation-kind %)) equations))))
+    (is (= [1] (get-in kernel [:launch :workgroup-size]))
+        "source admission must not silently assert the stronger cross-loop ownership proof")))
+
+(deftest prefill-softmax-keeps-row-values-and-output-tails-on-opencl
+  (if-not @probe/opencl-available?
+    (probe/opencl-skip! "typed prefill softmax")
+    (let [runtime (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve runtime 'register-kernel!)
+          buffer-of-array (ns-resolve runtime 'buffer-of-array)
+          bind-call (ns-resolve runtime 'bind-kernel-call)
+          launch! (ns-resolve runtime 'launch-registered-bound!)
+          read! (ns-resolve runtime 'buffer->array)
+          free! (ns-resolve runtime 'free-buffer!)
+          kernel (first (:kernels @compiled))]
+      (register! (:kernel-name kernel) kernel)
+      (doseq [width [0 1 3 8]]
+        (let [heads 2 rows (* width heads) n (* rows width)
+              input (vec (mapcat (fn [row]
+                                  (map #(float (+ (* (- row 3) 1000) (* 0.5 %))) (range width)))
+                                (range rows)))
+              expected (vec (mapcat (fn [row]
+                                     (let [m (apply max row)
+                                           values (map #(Math/exp (- (double %) m)) row)
+                                           total (reduce + values)]
+                                       (map #(/ % total) values)))
+                                   (if (pos? width) (partition width input) [])))
+              scores (buffer-of-array (float-array (concat input [-77 -77])) :float)]
+          (try
+            (launch! (bind-call (call/make kernel [scores {:type :long :value width}
+                                                   {:type :long :value rows}])))
+            (let [actual (vec (read! scores))]
+              (is (every? true? (map #(<= (Math/abs (- (double %1) (double %2))) 1.0e-6)
+                                     expected (take n actual))))
+              (is (= [-77.0 -77.0] (subvec actual n))))
+            (finally (free! scores))))))))

--- a/test/raster/compiler/passes/parallel/prefill_softmax_route_test.clj
+++ b/test/raster/compiler/passes/parallel/prefill_softmax_route_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.ir.kernel-call :as call]
-            [raster.compiler.ir.soac-dialect :as dialect]
             [raster.dl.attention :as attention]
             [raster.gpu.device-probe :as probe]))
 
@@ -10,25 +9,24 @@
   (delay (pipeline/show-pipeline #'attention/attn-prefill-softmax!
                                  :target-device :ocl:0 :dtype :float)))
 
-(deftest prefill-softmax-enters-the-typed-ordered-region-vertical
+(deftest prefill-softmax-keeps-parallel-launch-until-ownership-is-proved
   (let [p @compiled
-        kernel (first (:kernels p))
-        equations (mapcat #(dialect/equations (:algorithm %))
-                          (get-in p [:soac-fused :equations]))]
-    (is (= :typed-soac (get-in p [:soac-fused :dialect])))
+        kernel (first (:kernels p))]
     (is (= 1 (count (:kernels p))))
-    (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+    (is (= :compatibility-effect-opencl (get-in kernel [:attributes :emission-route])))
+    (is (= :sequential-effect-continuation
+           (get-in p [:soac-fused-stats :typed-soac-declined :reason])))
     (is (= '[sc nrows _n_bound] (mapv :name (:abi kernel))))
-    (is (= [:float :long :long] (mapv :dtype (:abi kernel))))
-    (is (= [:sequential]
-           (mapv #(get-in (dialect/operation-parts %) [:attributes :iteration-order])
-                 (filter #(= 'effect-map (dialect/operation-kind %)) equations))))
-    (is (= [1] (get-in kernel [:launch :workgroup-size]))
-        "source admission must not silently assert the stronger cross-loop ownership proof")))
+    (is (= [:float :long :int] (mapv :dtype (:abi kernel))))
+    (is (= [256] (get-in kernel [:launch :workgroup-size])))
+    (is (= [{:value '(clojure.core/* (clojure.core/long nrows) (clojure.core/long n-q))
+             :divisor 256}]
+           (mapv #(into {} %) (get-in kernel [:launch :group-count])))
+        "new source coverage must not serialize the previously parallel row launch")))
 
 (deftest prefill-softmax-keeps-row-values-and-output-tails-on-opencl
   (if-not @probe/opencl-available?
-    (probe/opencl-skip! "typed prefill softmax")
+    (probe/opencl-skip! "parallel prefill softmax")
     (let [runtime (find-ns 'raster.gpu.ocl-runtime)
           register! (ns-resolve runtime 'register-kernel!)
           buffer-of-array (ns-resolve runtime 'buffer-of-array)
@@ -38,7 +36,9 @@
           free! (ns-resolve runtime 'free-buffer!)
           kernel (first (:kernels @compiled))]
       (register! (:kernel-name kernel) kernel)
-      (doseq [width [0 1 3 8]]
+      ;; Direct compatibility launches require a nonempty grid; the frontend execution tests
+      ;; separately cover empty loops. Width 129 crosses a workgroup boundary (258 rows).
+      (doseq [width [1 3 8 129]]
         (let [heads 2 rows (* width heads) n (* rows width)
               input (vec (mapcat (fn [row]
                                   (map #(float (+ (* (- row 3) 1000) (* 0.5 %))) (range width)))
@@ -52,7 +52,7 @@
               scores (buffer-of-array (float-array (concat input [-77 -77])) :float)]
           (try
             (launch! (bind-call (call/make kernel [scores {:type :long :value width}
-                                                   {:type :long :value rows}])))
+                                                   {:type :int :value rows}])))
             (let [actual (vec (read! scores))]
               (is (every? true? (map #(<= (Math/abs (- (double %1) (double %2))) 1.0e-6)
                                      expected (take n actual))))

--- a/test/raster/compiler/passes/parallel/source_continuation_scope_test.clj
+++ b/test/raster/compiler/passes/parallel/source_continuation_scope_test.clj
@@ -1,0 +1,90 @@
+(ns raster.compiler.passes.parallel.source-continuation-scope-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-carried-effect-frontend-test :as fixture]))
+
+(defn- replace-form [form before after]
+  (walk/postwalk #(if (= before %) after %) form))
+
+(defn- execute-source [form]
+  (let [result (fixture/attempt form)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (let [scheduled (:form (segop-lower/segop-lower-pass
+                            (:program result) {:target-device :ze:0 :dtype :float}))]
+      (eval (list 'fn '[x packed scales sums rows width seed]
+                  (:form (par-simd/simd-pass scheduled :min-elements 1)))))))
+
+(deftest carry-body-and-continuation-reuse-source-local-names
+  (let [form (replace-form fixture/source '(aset sums row (float sum))
+                           '(let* [^float v (float sum)]
+                              (loop* [j 0]
+                                (if (< j width)
+                                  (do (aset packed (+ (* row width) j) v)
+                                      (recur (inc j)))
+                                  nil))
+                              (aset sums row v)))
+        execute (execute-source form)
+        packed (float-array (repeat 8 -77)) sums (float-array 2)]
+    (execute (float-array [1 2 3 4 5 6]) packed (float-array 2) sums 2 3 (float 2.5))
+    (is (= [6.25 15.25] (vec sums)))
+    (is (= [6.25 6.25 6.25 15.25 15.25 15.25 -77.0 -77.0] (vec packed)))))
+
+(deftest sibling-continuations-do-not-share-renamed-local-bindings
+  ;; Both carried regions and their continuations reuse sum/acc/v. The second invocation
+  ;; must capture its own value rather than the first continuation's generated local ID.
+  (let [one (nth (nth fixture/source 1) 1)
+        [_ index extent body] one
+        second-body (replace-form body 0.25 1.25)
+        continuation '(let* [^float v (float sum)] (aset sums row v))
+        form (list 'raster.par/map-void! index extent
+                   (list 'do
+                         (replace-form body '(aset sums row (float sum)) continuation)
+                         (replace-form second-body '(aset sums row (float sum)) continuation)))
+        execute (execute-source (list 'let* ['effect form] 'effect))
+        packed (float-array (repeat 4 -77)) sums (float-array 1)]
+    (execute (float-array [1 2 3]) packed (float-array 1) sums 1 3 (float 2.5))
+    (is (= [7.25] (vec sums)))
+    (is (= [1.0 2.0 3.0 -77.0] (vec packed)))))
+
+(deftest checked-continuation-initializer-fails-after-earlier-writes
+  (let [form (replace-form fixture/source '(aset sums row (float sum))
+                           '(let* [^long checked
+                                   ^{:raster.type/tag long}
+                                   (clojure.core/+ 9223372036854775807 width)]
+                              (aset sums row (float checked))))
+        execute (execute-source form)
+        packed (float-array [-77 -77]) scales (float-array [-77]) sums (float-array [-77])]
+    (is (thrown? ArithmeticException
+                 (execute (float-array [9]) packed scales sums 1 1 (float 2.5))))
+    (is (= [9.0 -77.0] (vec packed)))
+    (is (= [2.5] (vec scales)))
+    (is (= [-77.0] (vec sums)))))
+
+(deftest computed-continuation-bound-scopes-over-its-store-loop
+  (let [form (replace-form fixture/source '(aset sums row (float sum))
+                           '(let* [^long stop ^{:raster.type/tag long} (clojure.core/+ width 1)]
+                              (loop* [j 0]
+                                (if (< j stop)
+                                  (do (aset packed j (float sum)) (recur (inc j)))
+                                  nil))
+                              (aset sums row (float sum))))
+        execute (execute-source form)
+        packed (float-array (repeat 5 -77)) sums (float-array 1)]
+    (execute (float-array [1 2 3]) packed (float-array 1) sums 1 3 (float 2.5))
+    (is (= [6.25 6.25 6.25 6.25 -77.0] (vec packed)))
+    (is (= [6.25] (vec sums)))))
+
+(deftest continuation-bound-snapshots-after-stores-and-before-the-next-loop
+  (let [form (replace-form fixture/source '(aset sums row (float sum))
+                           '(let* [^long stop (long (aget packed 0))]
+                              (loop* [j 0]
+                                (if (< j stop)
+                                  (do (aset packed j (float sum)) (recur (inc j))) nil))
+                              (aset sums row (float sum))))
+        execute (execute-source form)
+        packed (float-array (repeat 8 -77)) sums (float-array 1)]
+    (execute (float-array [3 2 1]) packed (float-array 1) sums 1 3 (float 2.5))
+    (is (= [6.25 6.25 6.25 -77.0 -77.0 -77.0 -77.0 -77.0] (vec packed)))
+    (is (= [6.25] (vec sums)))))

--- a/test/raster/compiler/passes/parallel/source_continuation_scope_test.clj
+++ b/test/raster/compiler/passes/parallel/source_continuation_scope_test.clj
@@ -9,10 +9,10 @@
   (walk/postwalk #(if (= before %) after %) form))
 
 (defn- execute-source [form]
-  (let [result (fixture/attempt form)]
-    (is (= :typed-soac (get-in result [:stats :route])))
+  (let [program (fixture/continuation-program form)]
+    (is (= :typed-soac (:dialect program)))
     (let [scheduled (:form (segop-lower/segop-lower-pass
-                            (:program result) {:target-device :ze:0 :dtype :float}))]
+                            program {:target-device :ze:0 :dtype :float}))]
       (eval (list 'fn '[x packed scales sums rows width seed]
                   (:form (par-simd/simd-pass scheduled :min-elements 1)))))))
 

--- a/test/raster/compiler/passes/parallel/typed_carried_effect_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_carried_effect_frontend_test.clj
@@ -143,11 +143,79 @@
     (is (= [6.25 15.25] (vec sums)))
     (is (= (vec (repeat 6 2.5)) (vec packed)))))
 
-(deftest post-carry-local-bindings-still-require-an-ordered-region
-  (let [form (replace-form source '(aset sums row (float sum))
-                           '(let* [^double inverse (/ 1.0 sum)]
-                              (aset sums row (float inverse))))]
-    (is (not= :typed-soac (get-in (attempt form) [:stats :route])))))
+(def normalization-source
+  (replace-form
+   (replace-form source '(+ acc (double v))
+                 (with-meta '(+ acc (double v)) {:raster.type/tag 'double}))
+   '(aset sums row (float sum))
+   '(let* [^double inverse ^{:raster.type/tag double} (/ 1.0 sum)]
+      (do (loop* [j 0]
+            (if (< j width)
+              (do (aset packed (+ (* row width) j)
+                        (float ^{:raster.type/tag double}
+                               (* (double (aget packed (+ (* row width) j))) inverse)))
+                  (recur (inc j))) nil))
+          (aset sums row (float inverse))))))
+
+(deftest post-carry-local-bindings-retain-their-execution-point
+  (let [result (attempt normalization-source)
+        program (:program result)
+        algorithm (-> program :equations first :algorithm)
+        equation (first (dialect/equations algorithm))
+        parts (-> equation dialect/operation-parts :lambda dialect/lambda-parts)
+        effects (mapv dialect/effect-parts (:body-results parts))
+        scheduled (:form (segop-lower/segop-lower-pass program {:target-device :ze:0 :dtype :float}))
+        execute (eval (list 'fn '[x packed scales sums rows width seed]
+                            (:form (par-simd/simd-pass scheduled :min-elements 1))))]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (empty? (:locals parts)))
+    (is (:region (last effects)))
+    (is (= :sequential (-> equation dialect/operation-parts :attributes :iteration-order)))
+    (is (= :read-write (:access (first (filter #(= 'packed (:destination %))
+                                              (dialect/result-storage (dialect/facts algorithm)
+                                                                      (second equation)))))))
+    (doseq [width [0 1 3 8]]
+      (let [n (* 2 width)
+            packed (float-array (repeat (+ n 2) -77))
+            scales (float-array 2) sums (float-array 2)
+            inverses (mapv (fn [row] (/ 1.0 (+ 0.25 (reduce + (range (* row width)
+                                                                      (* (inc row) width))))))
+                           (range 2))]
+        (execute (float-array (range n)) packed scales sums 2 width (float 2.5))
+        (is (= (mapv float inverses) (vec sums)))
+        (is (= (into (vec (mapcat (fn [row inverse]
+                                    (map #(float (* % inverse))
+                                         (range (* row width) (* (inc row) width))))
+                                  (range 2) inverses)) [-77.0 -77.0]) (vec packed)))
+        (is (= [2.5 2.5] (vec scales)))))
+    (doseq [target [:opencl-portable :cuda :hip]]
+      (is (= :kernel-body
+             (get-in (gpu/generate-scheduled-segmap-kernel
+                      (first (soac-lower/lower-typed-effect-map algorithm :ze:0))
+                      :dtype :float :target-dialect target
+                      :array-types {'x :float 'packed :float 'scales :float 'sums :float}
+                      :scalar-types {'rows :long 'width :long 'seed :float})
+                     [:attributes :emission-route]))))))
+
+(deftest post-carry-local-reads-see-the-preceding-loop-writes
+  (let [form (replace-form normalization-source '(/ 1.0 sum)
+                           '(double (aget packed (* row width))))
+        result (attempt form)
+        scheduled (:form (segop-lower/segop-lower-pass (:program result)
+                                                      {:target-device :ze:0 :dtype :float}))
+        execute (eval (list 'fn '[x packed scales sums rows width seed]
+                            (:form (par-simd/simd-pass scheduled :min-elements 1))))
+        packed (float-array (repeat 6 -77)) scales (float-array 2) sums (float-array 2)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (execute (float-array [1 2 3 4 5 6]) packed scales sums 2 3 (float 2.5))
+    (is (= [1.0 4.0] (vec sums)))
+    (is (= [1.0 2.0 3.0 16.0 20.0 24.0] (vec packed)))))
+
+(deftest post-carry-locals-still-require-retained-types
+  (let [untyped (walk/postwalk #(if (and (symbol? %) (= 'inverse %))
+                                 (with-meta % nil) %) normalization-source)
+        untyped (replace-form untyped '(/ 1.0 sum) (with-meta '(/ 1.0 sum) nil))]
+    (is (not= :typed-soac (get-in (attempt untyped) [:stats :route])))))
 
 (deftest shadowed-comparison-casts-are-not-erased
   (doseq [test-form ['(< (long k) width) '(< k (long width))]]

--- a/test/raster/compiler/passes/parallel/typed_carried_effect_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_carried_effect_frontend_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
 
 (def source
@@ -26,6 +27,18 @@
 (defn attempt [form]
   (route/attempt form :float {'x :float 'packed :float 'scales :float 'sums :float}
                  {:scalar-types {'rows :long 'width :long 'seed :float}}))
+
+(defn continuation-program
+  "Exercise frontend/host projection independently of the production performance-admission gate.
+   This intentionally does not claim the production route accepted the source."
+  [form]
+  (let [options {:dtype :float
+                 :array-types {'x :float 'packed :float 'scales :float 'sums :float}
+                 :scalar-types {'rows :long 'width :long 'seed :float}}
+        form (frontend/normalize-source form options)
+        typed (frontend/form->program form options)
+        {:keys [source realized]} (#'route/realize-source form typed)]
+    (#'route/envelope typed source realized)))
 
 (deftest typed-result-valued-store-loop-is-an-ordered-effect-not-a-pure-local
   (let [result (attempt source)
@@ -158,8 +171,7 @@
           (aset sums row (float inverse))))))
 
 (deftest post-carry-local-bindings-retain-their-execution-point
-  (let [result (attempt normalization-source)
-        program (:program result)
+  (let [program (continuation-program normalization-source)
         algorithm (-> program :equations first :algorithm)
         equation (first (dialect/equations algorithm))
         parts (-> equation dialect/operation-parts :lambda dialect/lambda-parts)
@@ -167,7 +179,7 @@
         scheduled (:form (segop-lower/segop-lower-pass program {:target-device :ze:0 :dtype :float}))
         execute (eval (list 'fn '[x packed scales sums rows width seed]
                             (:form (par-simd/simd-pass scheduled :min-elements 1))))]
-    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= :typed-soac (:dialect program)))
     (is (empty? (:locals parts)))
     (is (:region (last effects)))
     (is (= :sequential (-> equation dialect/operation-parts :attributes :iteration-order)))
@@ -197,16 +209,33 @@
                       :scalar-types {'rows :long 'width :long 'seed :float})
                      [:attributes :emission-route]))))))
 
+(deftest production-admission-preserves-parallelism-without-rejecting-the-dialect
+  (let [result (attempt normalization-source)]
+    (is (= :sequential-effect-continuation (get-in result [:declined :reason])))
+    (is (some? (get-in result [:declined :equation])))
+    (is (nil? (:program result))))
+  (let [independent (replace-form
+                     source '(aset sums row (float sum))
+                     '(let* [^double inverse ^{:raster.type/tag double} (/ 1.0 sum)]
+                        (aset sums row (float inverse))))
+        result (attempt independent)
+        equation (-> result :program :equations first :algorithm dialect/equations first)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= :independent (-> equation dialect/operation-parts :attributes :iteration-order)))
+    (is (some :region (map dialect/effect-parts
+                           (-> equation dialect/operation-parts :lambda
+                               dialect/lambda-parts :body-results))))))
+
 (deftest post-carry-local-reads-see-the-preceding-loop-writes
   (let [form (replace-form normalization-source '(/ 1.0 sum)
                            '(double (aget packed (* row width))))
-        result (attempt form)
-        scheduled (:form (segop-lower/segop-lower-pass (:program result)
+        program (continuation-program form)
+        scheduled (:form (segop-lower/segop-lower-pass program
                                                       {:target-device :ze:0 :dtype :float}))
         execute (eval (list 'fn '[x packed scales sums rows width seed]
                             (:form (par-simd/simd-pass scheduled :min-elements 1))))
         packed (float-array (repeat 6 -77)) scales (float-array 2) sums (float-array 2)]
-    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= :typed-soac (:dialect program)))
     (execute (float-array [1 2 3 4 5 6]) packed scales sums 2 3 (float 2.5))
     (is (= [1.0 4.0] (vec sums)))
     (is (= [1.0 2.0 3.0 16.0 20.0 24.0] (vec packed)))))


### PR DESCRIPTION
## Summary

Admit source scalar bindings after result-valued store loops into the existing nested effect-region vertical. Sequential multi-binding lets are exposed without moving pure prefixes or suffixes across the effectful initializer. Scope-aware order rebasing preserves nested locals, loop ordinals and direct-store ordinals.

Continuation initializers participate in capture, read/write and conflict analysis but remain at their original runtime evaluation point. No extra type inference or attention-specific compiler rule.

The production route explicitly declines sequential nested continuations until shared read/write ownership is proved. The initial head exposed a performance regression: prefill moved from parallel WG256 to one work item. Both inspection and the existing CircleCI corpus serialization ratchet caught it. This revision preserves the original parallel compatibility route; it does not weaken or refresh the ratchet. Direct frontend/host/KernelBody tests exercise the new representation without claiming production admission.

## Validation

- 63 focused tests, 520 assertions, zero failures/errors in the existing capped REPL (plus a subsequent recursive admission-gate test).
- Includes actual OpenCL prefill execution at widths 1/3/8/129, stable softmax numerical oracle (absolute tolerance 1e-6), exact untouched tails, and preserved parallel geometry across multiple workgroups. Empty loops remain covered in direct frontend tests; direct compatibility launches require a nonempty grid.
- Adversarial lexical reuse, sibling continuations, checked initializer failure after stores, retained-type rejection, and a post-store buffer-derived bound that is evaluated before the next loop.
- Both dense/padded Q8_K packers still emit two KernelBody kernels with independent effect scheduling and no fallback.
- Existing canonical continuation vendor fixtures remain; public prefill is not claimed as generated coverage. Full suites/CUDA/HIP/OpenCL gates run in CI; no throughput claim.

Independent review found no concrete blocker. Merge only after all seven checks pass on the reviewed head.

## Next

Prove shared row ownership across distinct loop-local coordinates, including read domains, before parallelizing this schedule. The separately documented Arc narrowed-result precision issue is unchanged by this PR.
