### PR TITLE
Represent nested scalar recurrences as lexical typed Folds

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1444,7 +1444,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    dtype rather than adding a function/type registry. KernelBody consumes Fold directly as a typed
    ordered loop; conversion does not descend through arbitrary lexical bindings and therefore
    cannot detach a recurrence from its scope. In particular, prefill maximum reduction no longer
-   reaches KernelBody as raw Clojure control syntax.
+   reaches KernelBody as raw Clojure control syntax. A Fold lambda may now carry an ordered typed
+   local-SSA spine, and those local initializers may themselves contain canonical Folds. The shared
+   S-expression scope model, validation, substitution/alpha conversion, host projection and
+   KernelBody lowering all preserve that lexical order. Consequently a nested dot/reduction inside
+   an outer recurrence reaches portable scalar/control emission without a loop-specific backend
+   parser; missing retained local dtypes still decline before canonicalization.
    A real Arc normalization probe exposes an unresolved precision boundary: Double SSA division
    followed by nearest-even Float conversion produces an adjacent Float for `1/8.25`. Adding the
    FP64 pragma alone does not change the result. Device integration currently bounds normalized

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -292,22 +292,39 @@
                                             parsed scopes')]
                           (apply rl form head (concat (when nm [nm]) arities')))))})
 
-        ;; (fold attrs (lambda [acc index] (region [] [step])))
+        ;; (fold attrs (lambda [acc index] (region [(let-value id dtype init) ...] [step])))
+        ;; Synthetic nil initializers let the generic sequential-scope machinery model lambda
+        ;; parameters followed by ordered local SSA definitions without inventing a second,
+        ;; Fold-specific free-variable/substitution implementation.
         :fold
         (let [[_ attributes [_ parameters [_ locals results]]] form]
           (when (and (map? attributes) (vector? parameters)
-                     (vector? locals) (empty? locals) (vector? results))
-            {:sequential? false
-             :scopes [{:binders parameters :inits [] :body results}]
+                     (vector? locals) (vector? results)
+                     (every? #(and (seq? %) (= 4 (count %)) (= 'let-value (first %))
+                                   (symbol? (second %)))
+                             locals))
+            (let [parameter-count (count parameters)
+                  local-dtypes (mapv #(nth % 2) locals)]
+            {:sequential? true
+             :scopes [{:binders (into (vec parameters) (map second locals))
+                       :inits (into (vec (repeat parameter-count nil))
+                                    (map #(nth % 3) locals))
+                       :body results}]
              :outer [(:identity attributes) (:extent attributes)]
              :rebuild
-             (fn [[{:keys [binders body]}] [identity extent]]
-               (let [attributes' (assoc attributes
-                                        :accumulator (first binders)
-                                        :index (second binders)
+             (fn [[{:keys [binders inits body]}] [identity extent]]
+               (let [parameters' (vec (take parameter-count binders))
+                     local-binders (drop parameter-count binders)
+                     local-inits (drop parameter-count inits)
+                     locals' (mapv (fn [id dtype init]
+                                     (list 'let-value id dtype init))
+                                   local-binders local-dtypes local-inits)
+                     attributes' (assoc attributes
+                                        :accumulator (first parameters')
+                                        :index (second parameters')
                                         :identity identity :extent extent)]
                  (rl form 'fold attributes'
-                     (list 'lambda (vec binders) (list 'region [] (vec body))))))}))
+                     (list 'lambda parameters' (list 'region locals' (vec body))))))})))
 
         ;; An effect-region's result binders enter scope only after their loop initializer.
         ;; Nil binder slots retain intervening stores in the same sequential spine.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -750,6 +750,8 @@
                  (or (:carry loop) (strict-effect-scalar-policy? (:effects loop))))))
          effects)))
 
+(declare fail! validate-scalar-fold-scopes!)
+
 (defn validate-scheduled-effect-carries!
   "Check the lexical contract of optional single-result carries in scheduled effect loops.
 
@@ -761,6 +763,7 @@
   (letfn [(fail [message data]
             (throw (ex-info message (assoc data :reason :scheduled-effect-carry))))
           (closed! [expression bound field]
+            (validate-scalar-fold-scopes! expression bound :scheduled-effect)
             (when-let [unbound (seq (util/free-syms expression bound))]
               (fail "effect carry expression is outside its lexical scope"
                     {:field field :unbound (set unbound) :expression expression})))
@@ -882,12 +885,66 @@
     (let [[_ attributes lambda] value]
       {:attributes attributes :lambda lambda})))
 
-(defn- nested-scalar-folds
-  [expressions]
-  (->> expressions
-       (mapcat #(tree-seq coll? seq %))
-       (filter scalar-fold-form?)
-       vec))
+(defn- validate-scalar-fold-scopes!
+  "Validate nested scalar Folds with their actual lexical environments. A flat tree walk loses
+   the outer Fold parameters and ordered local spine, which would either reject valid nested
+   reductions or accidentally admit a free value as a capture."
+  [expression initial-bound equation-id]
+  (letfn [(walk-expression! [expression bound]
+            (cond
+              (scalar-fold-form? expression)
+              (let [{:keys [attributes lambda]} (scalar-fold-parts expression)
+                    {parameters :parameters locals :locals results :body-results}
+                    (lambda-parts lambda)
+                    expected [(:accumulator attributes) (:index attributes)]
+                    extent-unbound (util/free-syms (:extent attributes) bound)]
+                (when-not (and (symbol? (:index attributes))
+                               (= expected parameters)
+                               (= 2 (count (distinct parameters)))
+                               (empty? (set/intersection bound (set parameters)))
+                               (= 1 (count results))
+                               (empty? extent-unbound))
+                  (fail! :typed-soac-scalar-fold
+                         "scalar folds require a closed ordered [accumulator index] region"
+                         {:equation equation-id :fold expression :expected expected
+                          :parameters parameters :results results
+                          :extent-unbound extent-unbound}))
+                (let [final-bound
+                      (reduce
+                       (fn [local-bound {:keys [id dtype init] :as local}]
+                         (when-not (and (symbol? id) (not (contains? local-bound id))
+                                        (dtype/known? dtype) (= dtype (dtype/canon dtype))
+                                        (:scalar-tag (dtype/info dtype)))
+                           (fail! :typed-soac-scalar-fold-local
+                                  "Fold locals require distinct typed scalar SSA identities"
+                                  {:equation equation-id :fold expression :local local}))
+                         (walk-expression! init local-bound)
+                         (let [unbound (util/free-syms init local-bound)]
+                           (when (seq unbound)
+                             (fail! :typed-soac-scalar-fold-local
+                                    "Fold locals may reference only parameters and earlier locals"
+                                    {:equation equation-id :fold expression :local local
+                                     :unbound unbound})))
+                         (conj local-bound id))
+                       (into bound parameters) locals)
+                      result (first results)
+                      result-unbound (util/free-syms result final-bound)]
+                  (walk-expression! result final-bound)
+                  (when (or (seq result-unbound)
+                            (some write-form? (tree-seq coll? seq result)))
+                    (fail! :typed-soac-scalar-fold
+                           "Fold results must be closed and effect free in their lexical region"
+                           {:equation equation-id :fold expression
+                            :result-unbound result-unbound}))))
+
+              (and (seq? expression) (= 'quote (first expression))) nil
+              (map? expression)
+              (doseq [[key value] expression]
+                (walk-expression! key bound)
+                (walk-expression! value bound))
+              (coll? expression) (doseq [child expression] (walk-expression! child bound))
+              :else nil))]
+    (walk-expression! expression initial-bound)))
 
 (defn emit-locals
   "Return local-value forms for normalized local maps."
@@ -1125,6 +1182,7 @@
                           (into (map first (:segment-axes attributes))))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
+                    (validate-scalar-fold-scopes! init bound equation-id)
                     (let [unbound (util/free-syms init bound)]
                       (when (seq unbound)
                         (fail! :typed-soac-unbound-local
@@ -1132,29 +1190,8 @@
                                {:equation equation-id :local local :unbound unbound}))
                       (conj bound id)))
                   initial-bound locals)]
-      (doseq [fold (nested-scalar-folds
-                    (concat (map :init locals) body-results))]
-        (let [{:keys [attributes lambda]} (scalar-fold-parts fold)
-              {fold-parameters :parameters fold-locals :locals
-               fold-results :body-results} (lambda-parts lambda)
-              expected [(:accumulator attributes) (:index attributes)]
-              extent-unbound (util/free-syms (:extent attributes) final-bound)
-              step-bound (into final-bound fold-parameters)
-              step-unbound (when (= 1 (count fold-results))
-                             (util/free-syms (first fold-results) step-bound))]
-          (when-not (and (symbol? (:index attributes))
-                         (= expected fold-parameters)
-                         (empty? fold-locals)
-                         (= 1 (count fold-results))
-                         (empty? extent-unbound)
-                         (empty? step-unbound)
-                         (not (some write-form? fold-results)))
-            (fail! :typed-soac-scalar-fold
-                   "scalar folds require a closed ordered [accumulator index] region"
-                   {:equation equation-id :fold fold :expected expected
-                    :parameters fold-parameters :locals fold-locals
-                    :results fold-results :extent-unbound extent-unbound
-                    :step-unbound step-unbound}))))
+      (doseq [expression (when-not (= 'effect-map kind) body-results)]
+        (validate-scalar-fold-scopes! expression final-bound equation-id))
       (doseq [expression (concat (map :init locals) body-results)
               form (tree-seq coll? seq expression)
               :when (and (seq? form) (symbol? (first form))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -308,7 +308,7 @@
                          body-results :body-results} (dialect/lambda-parts lambda)
                         [accumulator index] parameters
                         fold-type (canon-type (:dtype attributes))
-                        _ (when-not (and (= 2 (count parameters)) (empty? fold-locals)
+                        _ (when-not (and (= 2 (count parameters))
                                          (= 1 (count body-results)) (= fold-type expected))
                             (decline! :typed-scalar-fold-shape
                                       "canonical scalar fold must match its expected typed result"
@@ -319,11 +319,36 @@
                         carry (fresh "fold-carry")
                         result (fresh "fold-result")
                         initial (lower (:identity attributes) fold-type env)
-                        update-expression
-                        (util/subst-syms {index loop-index accumulator carry}
-                                         (first body-results))
-                        update (lower update-expression fold-type
-                                      (assoc env loop-index :long carry fold-type))
+                        local-state
+                        (reduce
+                         (fn [{:keys [operations substitutions environment]} local]
+                           (let [local-type (canon-type (:dtype local))
+                                 local-expression (util/subst-syms substitutions (:init local))
+                                 lowered (lower local-expression local-type environment)
+                                 local-result (:result lowered)
+                                 tag (:scalar-tag (dtype/info local-type))
+                                 local-result (if (and (symbol? local-result) tag)
+                                                (with-meta local-result
+                                                  (assoc (meta local-result)
+                                                         :raster.type/tag tag))
+                                                local-result)]
+                             (when-not (= local-type (:type lowered))
+                               (decline! :typed-scalar-fold-local-dtype
+                                         "canonical Fold local must preserve its retained dtype"
+                                         {:expression expression :local local
+                                          :actual (:type lowered)}))
+                             {:operations (into operations (:operations lowered))
+                              :substitutions (assoc substitutions (:id local) local-result)
+                              :environment (cond-> environment
+                                             (symbol? local-result)
+                                             (assoc local-result local-type))}))
+                         {:operations []
+                          :substitutions {index loop-index accumulator carry}
+                          :environment (assoc env loop-index :long carry fold-type)}
+                         fold-locals)
+                        update-expression (util/subst-syms (:substitutions local-state)
+                                                           (first body-results))
+                        update (lower update-expression fold-type (:environment local-state))
                         _ (when-not (= fold-type (:type initial) (:type update))
                             (decline! :typed-scalar-fold-dtype
                                       "canonical scalar fold carry dtype must remain invariant"
@@ -336,7 +361,8 @@
                          (lower-index (:extent attributes) (set (keys env)))
                          1
                          [(body/->LoopArg (body/value carry fold-type) (:result initial))]
-                         (conj (vec (:operations update)) (body/->Yield [(:result update)]))
+                         (conj (into (vec (:operations local-state)) (:operations update))
+                               (body/->Yield [(:result update)]))
                          [(body/value result fold-type)]
                          (cond-> {:association (:association attributes)
                                   :source-order (= :ordered (:association attributes))}

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2292,6 +2292,31 @@
                   expression (map vector arrays parameters)))
         expressions))
 
+(declare canonicalize-scalar-folds)
+
+(defn- canonical-fold-step-region
+  "Turn the lexical `let*` surrounding a recurrence update into the Fold lambda's typed local
+   spine. Returning nil is an admission decline for this conversion only: source control remains
+   available until every local has an authoritative retained dtype."
+  [expression result-dtype]
+  (if (and (seq? expression) (form/let-head? (first expression)))
+    (let [[_ bindings & results] expression
+          pairs (when (and (vector? bindings) (even? (count bindings)) (= 1 (count results)))
+                  (vec (partition 2 bindings)))
+          typed (when pairs
+                  (mapv (fn [[id init]]
+                          (when-let [local-dtype (some-> (retained-local-dtype id init) dtype/canon)]
+                            {:id id :dtype local-dtype :init init}))
+                        pairs))]
+      (when (and (every? some? typed)
+                 (= (count typed) (count (distinct (map :id typed)))))
+        {:locals (mapv (fn [{:keys [id dtype init]}]
+                         (dialect/local-value id dtype
+                                              (canonicalize-scalar-folds init dtype)))
+                       typed)
+         :result (canonicalize-scalar-folds (first results) result-dtype)}))
+    {:locals [] :result (canonicalize-scalar-folds expression result-dtype)}))
+
 (defn- canonicalize-scalar-folds
   [expression default-dtype]
   (let [expression
@@ -2317,30 +2342,44 @@
                  form))
              form))
          expression)]
-    ;; `loop*` is a surface spelling, not part of canonical TypedSOAC. Translate only a complete
-    ;; scalar initializer/result here: descending beneath an enclosing `let*` would detach the
-    ;; Fold from those lexical binders. Unlike `raster.par/reduce`, a Clojure recurrence promises
-    ;; source order, so even an algebraically associative update remains `:ordered`.
-    (if-let [{:keys [acc-sym acc-init index-sym index-init bound-expr else-expr
-                     scoped-update-expr]}
-             (when (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
-               (patterns/match-ordered-reduce-loop expression))]
-      (let [fold-dtype (some-> default-dtype dtype/canon)
-            carry-dtype (some-> (retained-local-dtype acc-sym acc-init) dtype/canon)]
-        (if (and fold-dtype (or (nil? carry-dtype) (= fold-dtype carry-dtype))
-                 (zero? index-init) (= else-expr acc-sym)
-                 (dialect/scalar-literal? acc-init)
-                 (not (util/effectful? acc-init))
-                 (not (util/effectful? bound-expr))
-                 (not (util/effectful? scoped-update-expr)))
-          (util/remake
-           expression
-           'fold
-           {:accumulator acc-sym :index index-sym :identity acc-init
-            :dtype fold-dtype :extent bound-expr :association :ordered}
-           (dialect/lambda-form [acc-sym index-sym] [scoped-update-expr]))
-          expression))
-      expression)))
+    ;; A result conversion still leaves its operand as the complete scalar expression. Preserve
+    ;; that explicit conversion while canonicalizing the recurrence beneath it; unlike descent
+    ;; through `let*`, this introduces no lexical binders that could be detached.
+    (if (and (seq? expression) (= 2 (count expression))
+             (descriptor/cast-op? (first expression)))
+      (let [target (some-> (descriptor/cast-result-tag (first expression))
+                           dtype/dtype-for-scalar-tag dtype/canon)
+            operand (second expression)
+            canonical (canonicalize-scalar-folds operand (or target default-dtype))]
+        (if (= canonical operand) expression
+            (util/remake expression (first expression) canonical)))
+      ;; `loop*` is a surface spelling, not part of canonical TypedSOAC. Translate only a complete
+      ;; scalar initializer/result here: descending beneath an enclosing `let*` would detach the
+      ;; Fold from those lexical binders. Unlike `raster.par/reduce`, a Clojure recurrence promises
+      ;; source order, so even an algebraically associative update remains `:ordered`.
+      (if-let [{:keys [acc-sym acc-init index-sym index-init bound-expr else-expr
+                       scoped-update-expr]}
+               (when (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
+                 (patterns/match-ordered-reduce-loop expression))]
+        (let [fold-dtype (some-> default-dtype dtype/canon)
+              carry-dtype (some-> (retained-local-dtype acc-sym acc-init) dtype/canon)
+              step-region (when fold-dtype
+                            (canonical-fold-step-region scoped-update-expr fold-dtype))]
+          (if (and step-region fold-dtype (or (nil? carry-dtype) (= fold-dtype carry-dtype))
+                   (zero? index-init) (= else-expr acc-sym)
+                   (dialect/scalar-literal? acc-init)
+                   (not (util/effectful? acc-init))
+                   (not (util/effectful? bound-expr))
+                   (not (util/effectful? scoped-update-expr)))
+            (util/remake
+             expression
+             'fold
+             {:accumulator acc-sym :index index-sym :identity acc-init
+              :dtype fold-dtype :extent bound-expr :association :ordered}
+             (dialect/lambda-form [acc-sym index-sym]
+                                  (:locals step-region) [(:result step-region)]))
+            expression))
+        expression))))
 
 (defn- declare-result-conversion
   "Wrap a map body in the explicit cast to its result element dtype when the body's retained
@@ -2474,15 +2513,20 @@
           (if-let [region (:region effect)]
             (dialect/effect-lambda-region
              (mapv (fn [{:keys [id dtype init]}]
-                     (dialect/local-value id dtype (transform init))) (:locals region))
+                     (dialect/local-value id dtype
+                                          (canonicalize-scalar-folds
+                                           (transform init) dtype))) (:locals region))
              (mapv effect-form (:effects region)))
           (if-let [{loop-index :index loop-locals :locals loop-effects :effects
                     :keys [lower extent carry]} (:loop effect)]
             (let [local-forms (mapv (fn [{:keys [id dtype init]}]
-                                      (dialect/local-value id dtype (transform init)))
+                                      (dialect/local-value id dtype
+                                                           (canonicalize-scalar-folds
+                                                            (transform init) dtype)))
                                     loop-locals)
                   body (cond-> (list 'effect-region local-forms (mapv effect-form loop-effects))
-                         carry (concat [(transform (:update carry))]))
+                         carry (concat [(canonicalize-scalar-folds
+                                         (transform (:update carry)) (:dtype carry))]))
                   attributes (cond-> {:index loop-index :lower lower}
                                carry (assoc :carry (select-keys carry [:parameter :result :dtype])))
                   lambda (list 'lambda (cond-> [loop-index] carry (conj (:parameter carry))) body)]

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -87,6 +87,8 @@
                                         (map vector destination-parameters destinations)))]
         {:index map-index :region (util/subst-syms substitutions region)}))))
 
+(declare materialize-region)
+
 (defn scalar-folds->source
   "Project explicit scalar Fold terms to Raster's interpreted host vocabulary."
   [expression]
@@ -95,13 +97,11 @@
      (if (dialect/scalar-fold-form? form)
        (let [{:keys [attributes lambda]} (dialect/scalar-fold-parts form)
              {:keys [parameters locals body-results]} (dialect/lambda-parts lambda)
-             [accumulator index] parameters]
-         (when (seq locals)
-           (throw (ex-info "scalar fold projection does not admit local SSA yet"
-                           {:reason :typed-soac-scalar-fold-projection :fold form})))
+             [accumulator index] parameters
+             update (materialize-region locals (first body-results))]
          (with-meta
            (list 'raster.par/reduce accumulator (:identity attributes)
-                 index (:extent attributes) (first body-results))
+                 index (:extent attributes) update)
            {:raster.type/elem-type (:dtype attributes)}))
        form))
    expression))

--- a/test/raster/compiler/core/util_test.clj
+++ b/test/raster/compiler/core/util_test.clj
@@ -203,6 +203,31 @@
   (testing "quote is opaque to substitution"
     (is (= '(quote (+ a a)) (util/subst-syms '{a A} '(quote (+ a a)))))))
 
+(deftest fold-local-scope-utils-test
+  (let [fold '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
+                     :extent n :association :ordered}
+                    (lambda [acc i]
+                      (region [(let-value off :long (+ base i))
+                               (let-value value :float (aget x off))]
+                              [(+ acc value)])))]
+    (testing "Fold parameters and ordered locals are lexical binders"
+      (is (= #{'base 'n 'x} (util/free-syms fold))))
+    (testing "substitution avoids capture by Fold parameters and rewrites ordered local uses"
+      (let [result (util/subst-syms '{base i} fold)
+            [_ _ [_ [acc index] [_ locals body]]] result
+            [_ off _ off-init] (first locals)
+            [_ _ _ value-init] (second locals)]
+        (is (not= 'i index))
+        (is (= #{'i 'n 'x} (util/free-syms result)))
+        (is (= (list '+ 'i index) off-init))
+        (is (= (list 'aget 'x off) value-init))
+        (is (= (list '+ acc (second (second locals))) (first body)))))
+    (testing "alpha conversion renames the complete Fold-local scope and preserves captures"
+      (let [result (util/alpha-convert fold)
+            atoms (set (flatten result))]
+        (is (= #{'base 'n 'x} (util/free-syms result)))
+        (is (not-any? atoms '[acc i off value]))))))
+
 (deftest ftm-source-body-stays-in-sync
   (testing "subst/alpha rename the ftm :raster.walker/source-body CONSISTENTLY with the walked body"
     ;; Regression: the source-body is opaque to free-syms (raw unqualified payload)

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -273,7 +273,21 @@
   (testing "par/reduce — acc + idx binders, init/bound outer"
     (let [{:keys [scopes outer]} (form/scope-info '(raster.par/reduce acc init i n (+ acc (aget a i))))]
       (is (= '[acc i] (:binders (first scopes))))
-      (is (= '[init n] outer)))))
+      (is (= '[init n] outer))))
+  (testing "Fold — parameters precede its ordered typed local SSA spine"
+    (let [fold '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
+                       :extent n :association :ordered}
+                      (lambda [acc i]
+                        (region [(let-value off :long (+ base i))
+                                 (let-value value :float (clojure.core/aget x off))]
+                                [(+ acc value)])))
+          {:keys [scopes outer sequential?]} (form/scope-info fold)
+          scope (first scopes)]
+      (is (true? sequential?))
+      (is (= '[0.0 n] outer))
+      (is (= '[acc i off value] (:binders scope)))
+      (is (= '[nil nil (+ base i) (clojure.core/aget x off)] (:inits scope)))
+      (is (= '[(+ acc value)] (:body scope))))))
 
 (deftest scope-info-rebuild-identity-test
   (testing "rebuild ∘ scope-info is identity for every closed-core binder form"
@@ -290,6 +304,12 @@
                '(raster.par/map! out i n nil (+ (aget in i) 1.0))
                '(raster.par/map! out i n :offset base nil (aget in i))
                '(raster.par/reduce acc 0.0 i n (+ acc (aget in i)))
+               '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
+                       :extent n :association :ordered}
+                      (lambda [acc i]
+                        (region [(let-value off :long (+ base i))
+                                 (let-value value :float (aget in off))]
+                                [(+ acc value)])))
                '(raster.par/scan res acc 0.0 i n nil (+ acc (aget in i)))]]
       (let [{:keys [scopes outer rebuild]} (form/scope-info f)]
         (is (= f (rebuild scopes outer)) (str "round-trip: " (first f)))))))

--- a/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
@@ -1,12 +1,15 @@
 (ns raster.compiler.passes.parallel.typed-scalar-fold-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
             [raster.nn :as nn]))
 
 (def ^:private dot-map
@@ -37,6 +40,23 @@
   (first
    (filter dialect/scalar-fold-form?
            (tree-seq coll? seq (dialect/equations program)))))
+
+(defn- nested-loop-source []
+  (let [loop-form
+        '(loop* [^{:raster.type/tag long} j 0
+                 ^{:raster.type/tag float} acc 0.0]
+           (if (< (long j) width)
+             (let* [^{:raster.type/tag long} off (* j depth)
+                    ^{:raster.type/tag float}
+                    dot (loop* [^{:raster.type/tag long} d 0
+                                ^{:raster.type/tag float} inner 0.0]
+                          (if (< (long d) depth)
+                            (recur (inc (long d))
+                                   (+ inner (clojure.core/aget x (+ off d))))
+                            inner))]
+               (recur (inc (long j)) (+ acc dot)))
+             acc))]
+    (list 'let* (vector 'y (list 'raster.par/pmap 'row 'rows 'float loop-form)) 'y)))
 
 (deftest fold-is-a-scoped-functional-term
   (let [fold '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
@@ -98,6 +118,28 @@
       (let [result (#'frontend/canonicalize-scalar-folds form :float)]
         (is (not (dialect/scalar-fold-form? result)))
         (is (= form result))))))
+
+(deftest nested-recurrences-use-lexical-fold-locals-through-kernel-body
+  (let [source (nested-loop-source)
+        options {:dtype :float :array-types {'x :float}
+                 :scalar-types {'rows :long 'width :long 'depth :long}}
+        program (frontend/form->program source options)
+        nodes (tree-seq coll? seq (dialect/equations program))
+        folds (filter dialect/scalar-fold-form? nodes)
+        routed (route/attempt source :float {'x :float} options)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          (:program routed) {:dtype :float :target-device :ocl:0}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :float :min-elements 1)
+        kernel (first (:kernels emitted))]
+    (is (= program (dialect/validate! program)))
+    (is (= 2 (count folds)))
+    (is (not-any? #(and (seq? %) (contains? #{'loop 'loop*} (first %))) nodes))
+    (is (= '[off dot]
+           (mapv :id (:locals (dialect/lambda-parts
+                               (:lambda (dialect/scalar-fold-parts (first folds))))))))
+    (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+    (is (= 2 (count (re-seq #"for \(long [^ ]*fold_index_" (:source kernel)))))))
 
 (deftest jvm-consumes-the-typed-fold-without-compatibility-relowering
   (let [execute


### PR DESCRIPTION
## Summary
- retain ordered typed local SSA inside canonical Fold lambdas
- canonicalize nested scalar recurrences without crossing lexical binders
- share Fold scope semantics across validation, substitution, alpha conversion, host projection, and KernelBody lowering

## Validation
- 49 focused tests / 294 assertions
- 155 broader TypedSOAC, effect-region, route, and quant tests / 1166 assertions
- nested Fold program emits through the KernelBody OpenCL route with two structured loops

Stacked on #492.