### PR TITLE
Prove effect-row ownership for parallel TypedSOAC emission

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1424,21 +1424,27 @@ The immediate continuation after the verified double-buffered weighted-reduction
    continuation: validation, host realization, and KernelBody lowering retain its evaluation point
    and do not export its locals. Source admission preserves sequential multi-binding lets and
    includes continuation initializers in capture/read/conflict analysis without hoisting them.
-   Production admission temporarily declines sequential nested continuations with the explicit
-   `:sequential-effect-continuation` diagnostic. Prefill softmax retains its existing parallel
-   compatibility launch: replacing it with a single-work-item KernelBody would be a performance
-   regression, not convergence. Direct frontend/host/KernelBody tests exercise the new capability
-   independently of this gate. Removing the gate needs a shared ownership proof for
-   reads and repeated writes by the same work item across distinct loop-local coordinates. Proving
-   each loop separately is insufficient: cross-loop accesses may race across rows. Unsupported
-   indirect or neighboring-row accesses must remain sequential. No attention-specific exception,
-   scalar hoisting, synthetic one-trip loop, or performance claim is needed for this IR extension.
-   Pure zero-origin, unit-step, single-carry Clojure `loop*` recurrences in typed scalar locals are
-   now canonical ordered `Fold` terms before scheduling; effectful loops remain `effect-loop`.
+   Production admission declines an unproved sequential nested continuation with the explicit
+   `:sequential-effect-continuation` diagnostic; replacing an existing parallel compatibility
+   launch with a single-work-item KernelBody is a performance regression, not convergence. A
+   canonical ownership pass now removes that gate when every read and write of the single inout
+   destination has the same injective mixed-radix address over the outer map digit and all lexical
+   Fold/effect-loop digits. The proof is recomputed over the exact canonical program, rejects
+   guarded, indirect, carried-address, mismatched-domain and neighboring-row cases, and only then
+   upgrades the outer iteration and its ordered conflicts to independent/unique. Prefill softmax is
+   the first workload: it retains its 256-work-item launch and emits through KernelBody on the same
+   TypedSOAC path as other kernels. Proving each loop separately would be insufficient because
+   cross-loop accesses may race across rows. This is a general effect-domain proof, not an
+   attention-specific exception, scalar hoist, synthetic one-trip loop, or performance claim.
+   Pure zero-origin, unit-step, single-carry Clojure `loop*` recurrences that are complete typed
+   scalar expressions are now canonical ordered `Fold` terms before scheduling; effectful loops
+   remain `effect-loop`.
    Transformed exits, nonzero origins and other control shapes retain their source spelling until a
    richer canonical construct exists. This reuses the shared loop matcher and the enclosing retained
-   dtype rather than adding a function/type registry. In particular, prefill maximum reduction no
-   longer reaches KernelBody as raw Clojure control syntax.
+   dtype rather than adding a function/type registry. KernelBody consumes Fold directly as a typed
+   ordered loop; conversion does not descend through arbitrary lexical bindings and therefore
+   cannot detach a recurrence from its scope. In particular, prefill maximum reduction no longer
+   reaches KernelBody as raw Clojure control syntax.
    A real Arc normalization probe exposes an unresolved precision boundary: Double SSA division
    followed by nearest-even Float conversion produces an adjacent Float for `1/8.25`. Adding the
    FP64 pragma alone does not change the result. Device integration currently bounds normalized

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1444,7 +1444,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    dtype rather than adding a function/type registry. KernelBody consumes Fold directly as a typed
    ordered loop; conversion does not descend through arbitrary lexical bindings and therefore
    cannot detach a recurrence from its scope. In particular, prefill maximum reduction no longer
-   reaches KernelBody as raw Clojure control syntax.
+   reaches KernelBody as raw Clojure control syntax. A Fold lambda may now carry an ordered typed
+   local-SSA spine, and those local initializers may themselves contain canonical Folds. The shared
+   S-expression scope model, validation, substitution/alpha conversion, host projection and
+   KernelBody lowering all preserve that lexical order. Consequently a nested dot/reduction inside
+   an outer recurrence reaches portable scalar/control emission without a loop-specific backend
+   parser; missing retained local dtypes still decline before canonicalization.
    A real Arc normalization probe exposes an unresolved precision boundary: Double SSA division
    followed by nearest-even Float conversion produces an adjacent Float for `1/8.25`. Adding the
    FP64 pragma alone does not change the result. Device integration currently bounds normalized

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -292,22 +292,39 @@
                                             parsed scopes')]
                           (apply rl form head (concat (when nm [nm]) arities')))))})
 
-        ;; (fold attrs (lambda [acc index] (region [] [step])))
+        ;; (fold attrs (lambda [acc index] (region [(let-value id dtype init) ...] [step])))
+        ;; Synthetic nil initializers let the generic sequential-scope machinery model lambda
+        ;; parameters followed by ordered local SSA definitions without inventing a second,
+        ;; Fold-specific free-variable/substitution implementation.
         :fold
         (let [[_ attributes [_ parameters [_ locals results]]] form]
           (when (and (map? attributes) (vector? parameters)
-                     (vector? locals) (empty? locals) (vector? results))
-            {:sequential? false
-             :scopes [{:binders parameters :inits [] :body results}]
+                     (vector? locals) (vector? results)
+                     (every? #(and (seq? %) (= 4 (count %)) (= 'let-value (first %))
+                                   (symbol? (second %)))
+                             locals))
+            (let [parameter-count (count parameters)
+                  local-dtypes (mapv #(nth % 2) locals)]
+            {:sequential? true
+             :scopes [{:binders (into (vec parameters) (map second locals))
+                       :inits (into (vec (repeat parameter-count nil))
+                                    (map #(nth % 3) locals))
+                       :body results}]
              :outer [(:identity attributes) (:extent attributes)]
              :rebuild
-             (fn [[{:keys [binders body]}] [identity extent]]
-               (let [attributes' (assoc attributes
-                                        :accumulator (first binders)
-                                        :index (second binders)
+             (fn [[{:keys [binders inits body]}] [identity extent]]
+               (let [parameters' (vec (take parameter-count binders))
+                     local-binders (drop parameter-count binders)
+                     local-inits (drop parameter-count inits)
+                     locals' (mapv (fn [id dtype init]
+                                     (list 'let-value id dtype init))
+                                   local-binders local-dtypes local-inits)
+                     attributes' (assoc attributes
+                                        :accumulator (first parameters')
+                                        :index (second parameters')
                                         :identity identity :extent extent)]
                  (rl form 'fold attributes'
-                     (list 'lambda (vec binders) (list 'region [] (vec body))))))}))
+                     (list 'lambda parameters' (list 'region locals' (vec body))))))})))
 
         ;; An effect-region's result binders enter scope only after their loop initializer.
         ;; Nil binder slots retain intervening stores in the same sequential spine.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -750,6 +750,8 @@
                  (or (:carry loop) (strict-effect-scalar-policy? (:effects loop))))))
          effects)))
 
+(declare fail! validate-scalar-fold-scopes!)
+
 (defn validate-scheduled-effect-carries!
   "Check the lexical contract of optional single-result carries in scheduled effect loops.
 
@@ -761,6 +763,7 @@
   (letfn [(fail [message data]
             (throw (ex-info message (assoc data :reason :scheduled-effect-carry))))
           (closed! [expression bound field]
+            (validate-scalar-fold-scopes! expression bound :scheduled-effect)
             (when-let [unbound (seq (util/free-syms expression bound))]
               (fail "effect carry expression is outside its lexical scope"
                     {:field field :unbound (set unbound) :expression expression})))
@@ -882,12 +885,66 @@
     (let [[_ attributes lambda] value]
       {:attributes attributes :lambda lambda})))
 
-(defn- nested-scalar-folds
-  [expressions]
-  (->> expressions
-       (mapcat #(tree-seq coll? seq %))
-       (filter scalar-fold-form?)
-       vec))
+(defn- validate-scalar-fold-scopes!
+  "Validate nested scalar Folds with their actual lexical environments. A flat tree walk loses
+   the outer Fold parameters and ordered local spine, which would either reject valid nested
+   reductions or accidentally admit a free value as a capture."
+  [expression initial-bound equation-id]
+  (letfn [(walk-expression! [expression bound]
+            (cond
+              (scalar-fold-form? expression)
+              (let [{:keys [attributes lambda]} (scalar-fold-parts expression)
+                    {parameters :parameters locals :locals results :body-results}
+                    (lambda-parts lambda)
+                    expected [(:accumulator attributes) (:index attributes)]
+                    extent-unbound (util/free-syms (:extent attributes) bound)]
+                (when-not (and (symbol? (:index attributes))
+                               (= expected parameters)
+                               (= 2 (count (distinct parameters)))
+                               (empty? (set/intersection bound (set parameters)))
+                               (= 1 (count results))
+                               (empty? extent-unbound))
+                  (fail! :typed-soac-scalar-fold
+                         "scalar folds require a closed ordered [accumulator index] region"
+                         {:equation equation-id :fold expression :expected expected
+                          :parameters parameters :results results
+                          :extent-unbound extent-unbound}))
+                (let [final-bound
+                      (reduce
+                       (fn [local-bound {:keys [id dtype init] :as local}]
+                         (when-not (and (symbol? id) (not (contains? local-bound id))
+                                        (dtype/known? dtype) (= dtype (dtype/canon dtype))
+                                        (:scalar-tag (dtype/info dtype)))
+                           (fail! :typed-soac-scalar-fold-local
+                                  "Fold locals require distinct typed scalar SSA identities"
+                                  {:equation equation-id :fold expression :local local}))
+                         (walk-expression! init local-bound)
+                         (let [unbound (util/free-syms init local-bound)]
+                           (when (seq unbound)
+                             (fail! :typed-soac-scalar-fold-local
+                                    "Fold locals may reference only parameters and earlier locals"
+                                    {:equation equation-id :fold expression :local local
+                                     :unbound unbound})))
+                         (conj local-bound id))
+                       (into bound parameters) locals)
+                      result (first results)
+                      result-unbound (util/free-syms result final-bound)]
+                  (walk-expression! result final-bound)
+                  (when (or (seq result-unbound)
+                            (some write-form? (tree-seq coll? seq result)))
+                    (fail! :typed-soac-scalar-fold
+                           "Fold results must be closed and effect free in their lexical region"
+                           {:equation equation-id :fold expression
+                            :result-unbound result-unbound}))))
+
+              (and (seq? expression) (= 'quote (first expression))) nil
+              (map? expression)
+              (doseq [[key value] expression]
+                (walk-expression! key bound)
+                (walk-expression! value bound))
+              (coll? expression) (doseq [child expression] (walk-expression! child bound))
+              :else nil))]
+    (walk-expression! expression initial-bound)))
 
 (defn emit-locals
   "Return local-value forms for normalized local maps."
@@ -1125,6 +1182,7 @@
                           (into (map first (:segment-axes attributes))))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
+                    (validate-scalar-fold-scopes! init bound equation-id)
                     (let [unbound (util/free-syms init bound)]
                       (when (seq unbound)
                         (fail! :typed-soac-unbound-local
@@ -1132,29 +1190,8 @@
                                {:equation equation-id :local local :unbound unbound}))
                       (conj bound id)))
                   initial-bound locals)]
-      (doseq [fold (nested-scalar-folds
-                    (concat (map :init locals) body-results))]
-        (let [{:keys [attributes lambda]} (scalar-fold-parts fold)
-              {fold-parameters :parameters fold-locals :locals
-               fold-results :body-results} (lambda-parts lambda)
-              expected [(:accumulator attributes) (:index attributes)]
-              extent-unbound (util/free-syms (:extent attributes) final-bound)
-              step-bound (into final-bound fold-parameters)
-              step-unbound (when (= 1 (count fold-results))
-                             (util/free-syms (first fold-results) step-bound))]
-          (when-not (and (symbol? (:index attributes))
-                         (= expected fold-parameters)
-                         (empty? fold-locals)
-                         (= 1 (count fold-results))
-                         (empty? extent-unbound)
-                         (empty? step-unbound)
-                         (not (some write-form? fold-results)))
-            (fail! :typed-soac-scalar-fold
-                   "scalar folds require a closed ordered [accumulator index] region"
-                   {:equation equation-id :fold fold :expected expected
-                    :parameters fold-parameters :locals fold-locals
-                    :results fold-results :extent-unbound extent-unbound
-                    :step-unbound step-unbound}))))
+      (doseq [expression (when-not (= 'effect-map kind) body-results)]
+        (validate-scalar-fold-scopes! expression final-bound equation-id))
       (doseq [expression (concat (map :init locals) body-results)
               form (tree-seq coll? seq expression)
               :when (and (seq? form) (symbol? (first form))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -308,7 +308,7 @@
                          body-results :body-results} (dialect/lambda-parts lambda)
                         [accumulator index] parameters
                         fold-type (canon-type (:dtype attributes))
-                        _ (when-not (and (= 2 (count parameters)) (empty? fold-locals)
+                        _ (when-not (and (= 2 (count parameters))
                                          (= 1 (count body-results)) (= fold-type expected))
                             (decline! :typed-scalar-fold-shape
                                       "canonical scalar fold must match its expected typed result"
@@ -319,11 +319,36 @@
                         carry (fresh "fold-carry")
                         result (fresh "fold-result")
                         initial (lower (:identity attributes) fold-type env)
-                        update-expression
-                        (util/subst-syms {index loop-index accumulator carry}
-                                         (first body-results))
-                        update (lower update-expression fold-type
-                                      (assoc env loop-index :long carry fold-type))
+                        local-state
+                        (reduce
+                         (fn [{:keys [operations substitutions environment]} local]
+                           (let [local-type (canon-type (:dtype local))
+                                 local-expression (util/subst-syms substitutions (:init local))
+                                 lowered (lower local-expression local-type environment)
+                                 local-result (:result lowered)
+                                 tag (:scalar-tag (dtype/info local-type))
+                                 local-result (if (and (symbol? local-result) tag)
+                                                (with-meta local-result
+                                                  (assoc (meta local-result)
+                                                         :raster.type/tag tag))
+                                                local-result)]
+                             (when-not (= local-type (:type lowered))
+                               (decline! :typed-scalar-fold-local-dtype
+                                         "canonical Fold local must preserve its retained dtype"
+                                         {:expression expression :local local
+                                          :actual (:type lowered)}))
+                             {:operations (into operations (:operations lowered))
+                              :substitutions (assoc substitutions (:id local) local-result)
+                              :environment (cond-> environment
+                                             (symbol? local-result)
+                                             (assoc local-result local-type))}))
+                         {:operations []
+                          :substitutions {index loop-index accumulator carry}
+                          :environment (assoc env loop-index :long carry fold-type)}
+                         fold-locals)
+                        update-expression (util/subst-syms (:substitutions local-state)
+                                                           (first body-results))
+                        update (lower update-expression fold-type (:environment local-state))
                         _ (when-not (= fold-type (:type initial) (:type update))
                             (decline! :typed-scalar-fold-dtype
                                       "canonical scalar fold carry dtype must remain invariant"
@@ -336,7 +361,8 @@
                          (lower-index (:extent attributes) (set (keys env)))
                          1
                          [(body/->LoopArg (body/value carry fold-type) (:result initial))]
-                         (conj (vec (:operations update)) (body/->Yield [(:result update)]))
+                         (conj (into (vec (:operations local-state)) (:operations update))
+                               (body/->Yield [(:result update)]))
                          [(body/value result fold-type)]
                          (cond-> {:association (:association attributes)
                                   :source-order (= :ordered (:association attributes))}

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2292,6 +2292,31 @@
                   expression (map vector arrays parameters)))
         expressions))
 
+(declare canonicalize-scalar-folds)
+
+(defn- canonical-fold-step-region
+  "Turn the lexical `let*` surrounding a recurrence update into the Fold lambda's typed local
+   spine. Returning nil is an admission decline for this conversion only: source control remains
+   available until every local has an authoritative retained dtype."
+  [expression result-dtype]
+  (if (and (seq? expression) (form/let-head? (first expression)))
+    (let [[_ bindings & results] expression
+          pairs (when (and (vector? bindings) (even? (count bindings)) (= 1 (count results)))
+                  (vec (partition 2 bindings)))
+          typed (when pairs
+                  (mapv (fn [[id init]]
+                          (when-let [local-dtype (some-> (retained-local-dtype id init) dtype/canon)]
+                            {:id id :dtype local-dtype :init init}))
+                        pairs))]
+      (when (and (every? some? typed)
+                 (= (count typed) (count (distinct (map :id typed)))))
+        {:locals (mapv (fn [{:keys [id dtype init]}]
+                         (dialect/local-value id dtype
+                                              (canonicalize-scalar-folds init dtype)))
+                       typed)
+         :result (canonicalize-scalar-folds (first results) result-dtype)}))
+    {:locals [] :result (canonicalize-scalar-folds expression result-dtype)}))
+
 (defn- canonicalize-scalar-folds
   [expression default-dtype]
   (let [expression
@@ -2317,30 +2342,44 @@
                  form))
              form))
          expression)]
-    ;; `loop*` is a surface spelling, not part of canonical TypedSOAC. Translate only a complete
-    ;; scalar initializer/result here: descending beneath an enclosing `let*` would detach the
-    ;; Fold from those lexical binders. Unlike `raster.par/reduce`, a Clojure recurrence promises
-    ;; source order, so even an algebraically associative update remains `:ordered`.
-    (if-let [{:keys [acc-sym acc-init index-sym index-init bound-expr else-expr
-                     scoped-update-expr]}
-             (when (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
-               (patterns/match-ordered-reduce-loop expression))]
-      (let [fold-dtype (some-> default-dtype dtype/canon)
-            carry-dtype (some-> (retained-local-dtype acc-sym acc-init) dtype/canon)]
-        (if (and fold-dtype (or (nil? carry-dtype) (= fold-dtype carry-dtype))
-                 (zero? index-init) (= else-expr acc-sym)
-                 (dialect/scalar-literal? acc-init)
-                 (not (util/effectful? acc-init))
-                 (not (util/effectful? bound-expr))
-                 (not (util/effectful? scoped-update-expr)))
-          (util/remake
-           expression
-           'fold
-           {:accumulator acc-sym :index index-sym :identity acc-init
-            :dtype fold-dtype :extent bound-expr :association :ordered}
-           (dialect/lambda-form [acc-sym index-sym] [scoped-update-expr]))
-          expression))
-      expression)))
+    ;; A result conversion still leaves its operand as the complete scalar expression. Preserve
+    ;; that explicit conversion while canonicalizing the recurrence beneath it; unlike descent
+    ;; through `let*`, this introduces no lexical binders that could be detached.
+    (if (and (seq? expression) (= 2 (count expression))
+             (descriptor/cast-op? (first expression)))
+      (let [target (some-> (descriptor/cast-result-tag (first expression))
+                           dtype/dtype-for-scalar-tag dtype/canon)
+            operand (second expression)
+            canonical (canonicalize-scalar-folds operand (or target default-dtype))]
+        (if (= canonical operand) expression
+            (util/remake expression (first expression) canonical)))
+      ;; `loop*` is a surface spelling, not part of canonical TypedSOAC. Translate only a complete
+      ;; scalar initializer/result here: descending beneath an enclosing `let*` would detach the
+      ;; Fold from those lexical binders. Unlike `raster.par/reduce`, a Clojure recurrence promises
+      ;; source order, so even an algebraically associative update remains `:ordered`.
+      (if-let [{:keys [acc-sym acc-init index-sym index-init bound-expr else-expr
+                       scoped-update-expr]}
+               (when (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
+                 (patterns/match-ordered-reduce-loop expression))]
+        (let [fold-dtype (some-> default-dtype dtype/canon)
+              carry-dtype (some-> (retained-local-dtype acc-sym acc-init) dtype/canon)
+              step-region (when fold-dtype
+                            (canonical-fold-step-region scoped-update-expr fold-dtype))]
+          (if (and step-region fold-dtype (or (nil? carry-dtype) (= fold-dtype carry-dtype))
+                   (zero? index-init) (= else-expr acc-sym)
+                   (dialect/scalar-literal? acc-init)
+                   (not (util/effectful? acc-init))
+                   (not (util/effectful? bound-expr))
+                   (not (util/effectful? scoped-update-expr)))
+            (util/remake
+             expression
+             'fold
+             {:accumulator acc-sym :index index-sym :identity acc-init
+              :dtype fold-dtype :extent bound-expr :association :ordered}
+             (dialect/lambda-form [acc-sym index-sym]
+                                  (:locals step-region) [(:result step-region)]))
+            expression))
+        expression))))
 
 (defn- declare-result-conversion
   "Wrap a map body in the explicit cast to its result element dtype when the body's retained
@@ -2474,15 +2513,20 @@
           (if-let [region (:region effect)]
             (dialect/effect-lambda-region
              (mapv (fn [{:keys [id dtype init]}]
-                     (dialect/local-value id dtype (transform init))) (:locals region))
+                     (dialect/local-value id dtype
+                                          (canonicalize-scalar-folds
+                                           (transform init) dtype))) (:locals region))
              (mapv effect-form (:effects region)))
           (if-let [{loop-index :index loop-locals :locals loop-effects :effects
                     :keys [lower extent carry]} (:loop effect)]
             (let [local-forms (mapv (fn [{:keys [id dtype init]}]
-                                      (dialect/local-value id dtype (transform init)))
+                                      (dialect/local-value id dtype
+                                                           (canonicalize-scalar-folds
+                                                            (transform init) dtype)))
                                     loop-locals)
                   body (cond-> (list 'effect-region local-forms (mapv effect-form loop-effects))
-                         carry (concat [(transform (:update carry))]))
+                         carry (concat [(canonicalize-scalar-folds
+                                         (transform (:update carry)) (:dtype carry))]))
                   attributes (cond-> {:index loop-index :lower lower}
                                carry (assoc :carry (select-keys carry [:parameter :result :dtype])))
                   lambda (list 'lambda (cond-> [loop-index] carry (conj (:parameter carry))) body)]

--- a/src/raster/compiler/passes/parallel/typed_soac_ownership.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_ownership.clj
@@ -1,0 +1,222 @@
+(ns raster.compiler.passes.parallel.typed-soac-ownership
+  "Prove cross-work-item ownership from canonical TypedSOAC effects.
+
+   This pass never recognizes Clojure loop syntax. It consumes explicit Fold/effect-loop scopes
+   and mixed-radix index forms, upgrading a sequential effect-map only when every access to each
+   written destination has one common injective address function modulo lexical inner-index names."
+  (:require [clojure.set :as set]
+            [clojure.walk :as walk]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.index-algebra :as index-algebra]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(declare expression-accesses)
+
+(defn- expressions-accesses
+  [expressions destination-parameters locals loops]
+  (vec (mapcat #(expression-accesses % destination-parameters locals loops) expressions)))
+
+(defn- local-accesses
+  [local-values destination-parameters inherited-locals loops]
+  (loop [remaining local-values, locals (vec inherited-locals), accesses []]
+    (if-let [local (first remaining)]
+      (recur (next remaining) (conj locals local)
+             (into accesses
+                   (expression-accesses (:init local) destination-parameters locals loops)))
+      {:locals locals :accesses accesses})))
+
+(defn- expression-accesses
+  [expression destination-parameters locals loops]
+  (cond
+    (dialect/scalar-fold-form? expression)
+    (let [{:keys [attributes lambda]} (dialect/scalar-fold-parts expression)
+          {fold-locals :locals body-results :body-results} (dialect/lambda-parts lambda)
+          loop {:index (:index attributes) :extent (:extent attributes) :lower 0 :kind :fold}
+          prefix (expressions-accesses [(:identity attributes) (:extent attributes)]
+                                       destination-parameters locals loops)
+          scoped (local-accesses fold-locals destination-parameters locals (conj loops loop))]
+      (into prefix
+            (concat (:accesses scoped)
+                    (expressions-accesses body-results destination-parameters
+                                          (:locals scoped) (conj loops loop)))))
+
+    (descriptor/aget-call? expression)
+    (let [array (descriptor/aget-array-sym expression)
+          arguments (descriptor/call-args expression)
+          indices (vec (rest arguments))]
+      (into (if (and (contains? destination-parameters array) (= 1 (count indices)))
+              [{:kind :read :destination array :index (first indices)
+                :locals locals :loops loops}]
+              (if (contains? destination-parameters array)
+                [{:kind :unsupported :reason :non-scalar-destination-read
+                  :destination array :expression expression}]
+                []))
+            (expressions-accesses indices destination-parameters locals loops)))
+
+    (contains? destination-parameters expression)
+    [{:kind :unsupported :reason :opaque-destination-use :destination expression}]
+
+    (and (seq? expression) (= 'quote (first expression))) []
+    (coll? expression)
+    (expressions-accesses (if (map? expression) (mapcat identity expression) expression)
+                          destination-parameters locals loops)
+    :else []))
+
+(declare effect-accesses)
+
+(defn- region-accesses
+  [region destination-parameters inherited-locals loops]
+  (let [scoped (local-accesses (:locals region) destination-parameters inherited-locals loops)]
+    (into (:accesses scoped)
+          (mapcat #(effect-accesses % destination-parameters (:locals scoped) loops)
+                  (:body-results region)))))
+
+(defn- effect-accesses
+  [effect destination-parameters locals loops]
+  (let [{:keys [region loop index lower extent lambda carry destination destination-index
+                predicate value conflict]}
+        (dialect/effect-parts effect)]
+    (cond
+      region (region-accesses region destination-parameters locals loops)
+
+      loop
+      (let [loop-scope {:index index :extent extent :lower lower :kind :effect-loop}
+            prefix (expressions-accesses (cond-> [lower extent] carry (conj (:init carry)))
+                                         destination-parameters locals loops)
+            body (dialect/lambda-parts lambda)
+            scoped (local-accesses (:locals body) destination-parameters locals
+                                   (conj loops loop-scope))]
+        (into (cond-> prefix
+                (not= 0 lower)
+                (conj {:kind :unsupported :reason :nonzero-effect-loop-origin :lower lower}))
+              (concat (:accesses scoped)
+                      (mapcat #(effect-accesses % destination-parameters (:locals scoped)
+                                               (conj loops loop-scope))
+                              (:body-results body))
+                      (when-let [result (:effect-result body)]
+                        (expression-accesses result destination-parameters (:locals scoped)
+                                             (conj loops loop-scope))))))
+
+      destination
+      (into (cond-> [{:kind :write :destination destination :index destination-index
+                      :locals locals :loops loops}]
+              (not (contains? #{true 1} predicate))
+              (conj {:kind :unsupported :reason :guarded-destination-write
+                     :destination destination :predicate predicate})
+              (not (contains? #{:unique :ordered} conflict))
+              (conj {:kind :unsupported :reason :unsupported-effect-conflict
+                     :destination destination :conflict conflict}))
+            (expressions-accesses [destination-index predicate value]
+                                  destination-parameters locals loops))
+
+      :else [{:kind :unsupported :reason :unknown-effect :effect effect}])))
+
+(defn- ownership-signature
+  [{:keys [index locals loops]} outer-index outer-extent forbidden-index-symbols]
+  (let [loop-indices (into {} (map (juxt :index :extent)) loops)
+        form (index-algebra/index-form index outer-index outer-extent locals loop-indices)
+        inner-indices (mapv :index loops)
+        expected-digits (into #{outer-index} inner-indices)
+        form-symbols (set (filter symbol? (tree-seq coll? seq form)))]
+    (when (and form (index-algebra/injective? form)
+               (empty? (set/intersection forbidden-index-symbols form-symbols))
+               (= expected-digits (set (keys (:terms form))))
+               (= expected-digits (:leaves form))
+               (empty? (:parents form))
+               (nil? (:fixed-leaves form)))
+      {:owner (get-in form [:terms outer-index])
+       :inner (mapv #(get-in form [:terms %]) inner-indices)
+       :offset (:offset form)
+       :quot-facts (:quot-facts form)})))
+
+(defn- carried-symbols
+  "Values that evolve with an inner iteration or are derived from one. They are not invariant
+   address factors even if an affine parser could otherwise treat a free symbol as a scalar."
+  [lambda]
+  (into #{}
+        (mapcat (fn [form]
+                  (cond
+                    (dialect/scalar-fold-form? form)
+                    (let [{:keys [attributes]} (dialect/scalar-fold-parts form)]
+                      [(:accumulator attributes)])
+
+                    (dialect/effect-loop-form? form)
+                    (when-let [carry (:carry (dialect/effect-parts form))]
+                      [(:parameter carry) (:result carry)]))))
+        (filter #(or (dialect/scalar-fold-form? %)
+                     (dialect/effect-loop-form? %))
+                (tree-seq coll? seq lambda))))
+
+(defn- equation-ownership
+  [program equation]
+  (let [{:keys [kind attributes arrays captures destinations lambda]}
+        (dialect/operation-parts equation)
+        layout (when (= 'effect-map kind) (dialect/parameter-layout equation))
+        destination-parameters (set (:destination-parameters layout))
+        values (:values (dialect/facts program))]
+    (when (and (= 'effect-map kind)
+               (= :sequential (:iteration-order attributes))
+               (empty? arrays)
+               (every? #(and (contains? values %) (empty? (:shape (get values %)))) captures)
+               ;; Multiple logical destinations may be rebound to the same physical buffer. The
+               ;; first vertical proves one inout view until ABI no-alias facts are available here.
+               (= 1 (count destinations) (count destination-parameters)))
+      (let [region (dialect/lambda-parts lambda)
+            forbidden-index-symbols (carried-symbols lambda)
+            accesses (region-accesses region destination-parameters [] [])
+            unsupported (filter #(= :unsupported (:kind %)) accesses)
+            memory (filter #(contains? #{:read :write} (:kind %)) accesses)
+            grouped (group-by :destination memory)
+            proofs
+            (into {}
+                  (keep (fn [[destination destination-accesses]]
+                          (let [signatures (mapv #(ownership-signature % (:index attributes)
+                                                                     (:extent attributes)
+                                                                     forbidden-index-symbols)
+                                                 destination-accesses)]
+                            (when (and (some #(= :write (:kind %)) destination-accesses)
+                                       (every? some? signatures)
+                                       (apply = signatures))
+                              [destination {:accesses (count destination-accesses)
+                                            :signature (first signatures)}]))))
+                  grouped)]
+        (when (and (empty? unsupported)
+                   (= destination-parameters (set (keys grouped)) (set (keys proofs))))
+          {:kind :outer-item-owned
+           :equation (second equation)
+           :destinations proofs})))))
+
+(defn- apply-ownership
+  [equation proof]
+  (let [[equals equation-id results operation] equation
+        [kind attributes arrays captures destinations lambda] operation
+        lambda (walk/postwalk
+                (fn [form]
+                  (if (and (seq? form) (= 'effect (first form)) (= :ordered (nth form 2 nil)))
+                    (util/remake form 'effect (second form) :unique
+                                 (nth form 3) (nth form 4) (nth form 5))
+                    form))
+                lambda)
+        attributes (-> attributes
+                       (assoc :iteration-order :independent)
+                       (update :attributes assoc :ownership-proof proof))]
+    (util/remake equation equals equation-id results
+                 (util/remake operation kind attributes arrays captures destinations lambda))))
+
+(defn prove
+  "Recompute canonical outer-item ownership and return `[program stats]`.
+
+   A proof is deliberately local to this exact program version. Any later rewrite of accesses,
+   aliases, bounds or storage must rerun this pass rather than carrying the certificate forward."
+  [program]
+  (let [program (dialect/validate! program)
+        [equations proofs]
+        (reduce (fn [[equations proofs] equation]
+                  (if-let [proof (equation-ownership program equation)]
+                    [(conj equations (apply-ownership equation proof)) (conj proofs proof)]
+                    [(conj equations equation) proofs]))
+                [[] []] (dialect/equations program))
+        result (dialect/make (dialect/facts program) equations (dialect/outputs program))]
+    [result {:effect-row-ownership-proofs (count proofs)
+             :effect-row-ownership-equations (mapv :equation proofs)}]))

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -87,6 +87,8 @@
                                         (map vector destination-parameters destinations)))]
         {:index map-index :region (util/subst-syms substitutions region)}))))
 
+(declare materialize-region)
+
 (defn scalar-folds->source
   "Project explicit scalar Fold terms to Raster's interpreted host vocabulary."
   [expression]
@@ -95,13 +97,11 @@
      (if (dialect/scalar-fold-form? form)
        (let [{:keys [attributes lambda]} (dialect/scalar-fold-parts form)
              {:keys [parameters locals body-results]} (dialect/lambda-parts lambda)
-             [accumulator index] parameters]
-         (when (seq locals)
-           (throw (ex-info "scalar fold projection does not admit local SSA yet"
-                           {:reason :typed-soac-scalar-fold-projection :fold form})))
+             [accumulator index] parameters
+             update (materialize-region locals (first body-results))]
          (with-meta
            (list 'raster.par/reduce accumulator (:identity attributes)
-                 index (:extent attributes) (first body-results))
+                 index (:extent attributes) update)
            {:raster.type/elem-type (:dtype attributes)}))
        form))
    expression))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -13,6 +13,7 @@
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
             [raster.compiler.passes.parallel.typed-soac-resident :as resident]
+            [raster.compiler.passes.parallel.typed-soac-ownership :as ownership]
             [raster.compiler.core.util :as util]))
 
 (def ^:private dtype->allocation
@@ -638,19 +639,20 @@
                    [typed-result resident-stats]
                    (if resident-reductions?
                      (resident/realize typed-result)
-                     [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
+                     [typed-result {:resident-reductions 0 :inlined-scalars 0}])
+                   [typed-result ownership-stats] (ownership/prove typed-result)]
                (if (not-any? #(contains? #{:map :scatter :effect-map :stencil :reduce
                                            :segmented-reduce :contract :product-reduce
                                            :segmented-fold-map :scan}
                                          (:kind (fusion/equation-info %)))
                              (dialect/equations typed-result))
                  {:declined {:reason :no-certified-parallel-equation
-                             :stats (merge typed-stats resident-stats)}}
+                             :stats (merge typed-stats resident-stats ownership-stats)}}
                  (if-let [decline (sequential-continuation-decline typed-result)]
                    {:declined decline}
                    (let [{:keys [source realized]} (realize-source form typed-result)]
                      {:program (envelope typed-result source realized)
-                      :stats (merge typed-stats resident-stats
+                      :stats (merge typed-stats resident-stats ownership-stats
                                     {:route :typed-soac :typed-validated true
                                      :front-end :analyzed-source})}))))))
          (catch clojure.lang.ExceptionInfo exception

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -344,6 +344,8 @@
       (:kernels (equation-first/compile
                  #'qk/quant-act-q8k-padded-rows-gpu! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
+                 #'dl-attention/attn-prefill-softmax! {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!

--- a/test/raster/compiler/core/util_test.clj
+++ b/test/raster/compiler/core/util_test.clj
@@ -203,6 +203,31 @@
   (testing "quote is opaque to substitution"
     (is (= '(quote (+ a a)) (util/subst-syms '{a A} '(quote (+ a a)))))))
 
+(deftest fold-local-scope-utils-test
+  (let [fold '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
+                     :extent n :association :ordered}
+                    (lambda [acc i]
+                      (region [(let-value off :long (+ base i))
+                               (let-value value :float (aget x off))]
+                              [(+ acc value)])))]
+    (testing "Fold parameters and ordered locals are lexical binders"
+      (is (= #{'base 'n 'x} (util/free-syms fold))))
+    (testing "substitution avoids capture by Fold parameters and rewrites ordered local uses"
+      (let [result (util/subst-syms '{base i} fold)
+            [_ _ [_ [acc index] [_ locals body]]] result
+            [_ off _ off-init] (first locals)
+            [_ _ _ value-init] (second locals)]
+        (is (not= 'i index))
+        (is (= #{'i 'n 'x} (util/free-syms result)))
+        (is (= (list '+ 'i index) off-init))
+        (is (= (list 'aget 'x off) value-init))
+        (is (= (list '+ acc (second (second locals))) (first body)))))
+    (testing "alpha conversion renames the complete Fold-local scope and preserves captures"
+      (let [result (util/alpha-convert fold)
+            atoms (set (flatten result))]
+        (is (= #{'base 'n 'x} (util/free-syms result)))
+        (is (not-any? atoms '[acc i off value]))))))
+
 (deftest ftm-source-body-stays-in-sync
   (testing "subst/alpha rename the ftm :raster.walker/source-body CONSISTENTLY with the walked body"
     ;; Regression: the source-body is opaque to free-syms (raw unqualified payload)

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -273,7 +273,21 @@
   (testing "par/reduce — acc + idx binders, init/bound outer"
     (let [{:keys [scopes outer]} (form/scope-info '(raster.par/reduce acc init i n (+ acc (aget a i))))]
       (is (= '[acc i] (:binders (first scopes))))
-      (is (= '[init n] outer)))))
+      (is (= '[init n] outer))))
+  (testing "Fold — parameters precede its ordered typed local SSA spine"
+    (let [fold '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
+                       :extent n :association :ordered}
+                      (lambda [acc i]
+                        (region [(let-value off :long (+ base i))
+                                 (let-value value :float (clojure.core/aget x off))]
+                                [(+ acc value)])))
+          {:keys [scopes outer sequential?]} (form/scope-info fold)
+          scope (first scopes)]
+      (is (true? sequential?))
+      (is (= '[0.0 n] outer))
+      (is (= '[acc i off value] (:binders scope)))
+      (is (= '[nil nil (+ base i) (clojure.core/aget x off)] (:inits scope)))
+      (is (= '[(+ acc value)] (:body scope))))))
 
 (deftest scope-info-rebuild-identity-test
   (testing "rebuild ∘ scope-info is identity for every closed-core binder form"
@@ -290,6 +304,12 @@
                '(raster.par/map! out i n nil (+ (aget in i) 1.0))
                '(raster.par/map! out i n :offset base nil (aget in i))
                '(raster.par/reduce acc 0.0 i n (+ acc (aget in i)))
+               '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
+                       :extent n :association :ordered}
+                      (lambda [acc i]
+                        (region [(let-value off :long (+ base i))
+                                 (let-value value :float (aget in off))]
+                                [(+ acc value)])))
                '(raster.par/scan res acc 0.0 i n nil (+ acc (aget in i)))]]
       (let [{:keys [scopes outer rebuild]} (form/scope-info f)]
         (is (= f (rebuild scopes outer)) (str "round-trip: " (first f)))))))

--- a/test/raster/compiler/passes/parallel/prefill_softmax_route_test.clj
+++ b/test/raster/compiler/passes/parallel/prefill_softmax_route_test.clj
@@ -1,9 +1,11 @@
 (ns raster.compiler.passes.parallel.prefill-softmax-route-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.ir.kernel-call :as call]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-ownership :as ownership]
             [raster.dl.attention :as attention]
             [raster.gpu.device-probe :as probe]))
 
@@ -11,11 +13,14 @@
   (delay (pipeline/show-pipeline #'attention/attn-prefill-softmax!
                                  :target-device :ocl:0 :dtype :float)))
 
-(deftest prefill-maximum-is-a-canonical-ordered-fold-before-admission
+(defn- prefill-program []
   (let [options {:dtype :float :array-types {'sc :float}
-                 :scalar-types {'nrows :long 'n-q :long}}
-        source (frontend/normalize-source (:loop-lifted @compiled) options)
-        program (frontend/form->program source options)
+                 :scalar-types {'nrows :long 'n-q :long}}]
+    (frontend/form->program
+     (frontend/normalize-source (:loop-lifted @compiled) options) options)))
+
+(deftest prefill-maximum-is-a-canonical-ordered-fold-before-admission
+  (let [program (prefill-program)
         nodes (tree-seq coll? seq (dialect/equations program))
         folds (filter dialect/scalar-fold-form? nodes)]
     (is (= program (dialect/validate! program)))
@@ -24,20 +29,66 @@
            (get-in (dialect/scalar-fold-parts (first folds)) [:attributes :association])))
     (is (not-any? #(and (seq? %) (contains? #{'loop 'loop*} (first %))) nodes))))
 
-(deftest prefill-softmax-keeps-parallel-launch-until-ownership-is-proved
+(deftest prefill-softmax-uses-proved-parallel-kernel-body-launch
   (let [p @compiled
         kernel (first (:kernels p))]
     (is (= 1 (count (:kernels p))))
-    (is (= :compatibility-effect-opencl (get-in kernel [:attributes :emission-route])))
-    (is (= :sequential-effect-continuation
-           (get-in p [:soac-fused-stats :typed-soac-declined :reason])))
+    (is (= :typed-soac (get-in p [:soac-fused-stats :route])))
+    (is (= 1 (get-in p [:soac-fused-stats :effect-row-ownership-proofs])))
+    (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
     (is (= '[sc nrows _n_bound] (mapv :name (:abi kernel))))
-    (is (= [:float :long :int] (mapv :dtype (:abi kernel))))
+    (is (= [:float :long :long] (mapv :dtype (:abi kernel))))
     (is (= [256] (get-in kernel [:launch :workgroup-size])))
-    (is (= [{:value '(clojure.core/* (clojure.core/long nrows) (clojure.core/long n-q))
-             :divisor 256}]
+    (is (= [{:value 'rstr_extent_0 :divisor 256}]
            (mapv #(into {} %) (get-in kernel [:launch :group-count])))
-        "new source coverage must not serialize the previously parallel row launch")))
+        "proved source coverage must retain the previously parallel row launch")))
+
+(deftest ownership-proof-declines-cross-row-and-guarded-address-domains
+  (let [program (prefill-program)
+        rewrite (fn [f]
+                  (dialect/make (dialect/facts program)
+                                (mapv #(walk/postwalk f %) (dialect/equations program))
+                                (dialect/outputs program)))
+        shifted (rewrite
+                 #(if (= '(clojure.core/+ (clojure.core/long rstr_local_0)
+                                           (clojure.core/long rstr_loop_index_1)) %)
+                    '(clojure.core/+ (clojure.core/long rstr_local_0)
+                                     (clojure.core/long rstr_loop_index_1) 1)
+                    %))
+        guarded (rewrite
+                 #(if (and (seq? %) (= 'effect (first %)))
+                    (apply list (assoc (vec %) 4 false)) %))
+        carry-parameter
+        (some (fn [form]
+                (when (dialect/effect-loop-form? form)
+                  (get-in (dialect/effect-parts form) [:carry :parameter])))
+              (tree-seq coll? seq (dialect/equations program)))
+        carry-dependent
+        (rewrite
+         #(if (= '(clojure.core/+ (clojure.core/long rstr_local_0)
+                                  (clojure.core/long rstr_loop_index_0)) %)
+            (list 'clojure.core/+ % carry-parameter) %))
+        mismatched-domain
+        (rewrite
+         #(if (and (dialect/effect-loop-form? %)
+                   (nil? (:carry (dialect/effect-parts %))))
+            (apply list (assoc (vec %) 2 (list 'clojure.core/+ (nth % 2) 1))) %))
+        opaque-use
+        (rewrite
+         #(if (and (seq? %) (= 'effect (first %)))
+            (apply list (assoc (vec %) 5 (symbol "%destination0"))) %))]
+    (doseq [[label candidate] [[:neighboring-row shifted]
+                               [:guarded guarded]
+                               [:carry-dependent carry-dependent]
+                               [:mismatched-domain mismatched-domain]
+                               [:opaque-destination-use opaque-use]]]
+      (testing (name label)
+        (let [[result stats] (ownership/prove candidate)
+              equation (second (dialect/equations result))]
+          (is (zero? (:effect-row-ownership-proofs stats)))
+          (is (= :sequential
+                 (get-in (dialect/operation-parts equation)
+                         [:attributes :iteration-order]))))))))
 
 (deftest prefill-softmax-keeps-row-values-and-output-tails-on-opencl
   (if-not @probe/opencl-available?
@@ -51,8 +102,8 @@
           free! (ns-resolve runtime 'free-buffer!)
           kernel (first (:kernels @compiled))]
       (register! (:kernel-name kernel) kernel)
-      ;; Direct compatibility launches require a nonempty grid; the frontend execution tests
-      ;; separately cover empty loops. Width 129 crosses a workgroup boundary (258 rows).
+      ;; Direct launches require a nonempty grid; frontend execution tests separately cover empty
+      ;; loops. Width 129 crosses a workgroup boundary (258 rows).
       (doseq [width [1 3 8 129]]
         (let [heads 2 rows (* width heads) n (* rows width)
               input (vec (mapcat (fn [row]
@@ -67,7 +118,7 @@
               scores (buffer-of-array (float-array (concat input [-77 -77])) :float)]
           (try
             (launch! (bind-call (call/make kernel [scores {:type :long :value width}
-                                                   {:type :int :value rows}])))
+                                                   {:type :long :value rows}])))
             (let [actual (vec (read! scores))]
               (is (every? true? (map #(<= (Math/abs (- (double %1) (double %2))) 1.0e-6)
                                      expected (take n actual))))

--- a/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
@@ -1,12 +1,15 @@
 (ns raster.compiler.passes.parallel.typed-scalar-fold-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
             [raster.nn :as nn]))
 
 (def ^:private dot-map
@@ -37,6 +40,23 @@
   (first
    (filter dialect/scalar-fold-form?
            (tree-seq coll? seq (dialect/equations program)))))
+
+(defn- nested-loop-source []
+  (let [loop-form
+        '(loop* [^{:raster.type/tag long} j 0
+                 ^{:raster.type/tag float} acc 0.0]
+           (if (< (long j) width)
+             (let* [^{:raster.type/tag long} off (* j depth)
+                    ^{:raster.type/tag float}
+                    dot (loop* [^{:raster.type/tag long} d 0
+                                ^{:raster.type/tag float} inner 0.0]
+                          (if (< (long d) depth)
+                            (recur (inc (long d))
+                                   (+ inner (clojure.core/aget x (+ off d))))
+                            inner))]
+               (recur (inc (long j)) (+ acc dot)))
+             acc))]
+    (list 'let* (vector 'y (list 'raster.par/pmap 'row 'rows 'float loop-form)) 'y)))
 
 (deftest fold-is-a-scoped-functional-term
   (let [fold '(fold {:accumulator acc :index i :identity 0.0 :dtype :float
@@ -98,6 +118,28 @@
       (let [result (#'frontend/canonicalize-scalar-folds form :float)]
         (is (not (dialect/scalar-fold-form? result)))
         (is (= form result))))))
+
+(deftest nested-recurrences-use-lexical-fold-locals-through-kernel-body
+  (let [source (nested-loop-source)
+        options {:dtype :float :array-types {'x :float}
+                 :scalar-types {'rows :long 'width :long 'depth :long}}
+        program (frontend/form->program source options)
+        nodes (tree-seq coll? seq (dialect/equations program))
+        folds (filter dialect/scalar-fold-form? nodes)
+        routed (route/attempt source :float {'x :float} options)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          (:program routed) {:dtype :float :target-device :ocl:0}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :float :min-elements 1)
+        kernel (first (:kernels emitted))]
+    (is (= program (dialect/validate! program)))
+    (is (= 2 (count folds)))
+    (is (not-any? #(and (seq? %) (contains? #{'loop 'loop*} (first %))) nodes))
+    (is (= '[off dot]
+           (mapv :id (:locals (dialect/lambda-parts
+                               (:lambda (dialect/scalar-fold-parts (first folds))))))))
+    (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+    (is (= 2 (count (re-seq #"for \(long [^ ]*fold_index_" (:source kernel)))))))
 
 (deftest jvm-consumes-the-typed-fold-without-compatibility-relowering
   (let [execute

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -2,10 +2,10 @@
  :dtype :float,
  :summary
  {:total 236,
-  :typed-soac 103,
+  :typed-soac 104,
   :error 43,
   :scalar 73,
-  :compatibility 17},
+  :compatibility 16},
  :vars
  [{:var raster.dl.array-ops/argmax-rows!,
    :route :typed-soac,
@@ -202,11 +202,10 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.attention/attn-prefill-softmax!,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.attention/batched-causal-attn-dsum,
    :route :typed-soac,
    :typed-validated true,


### PR DESCRIPTION
Supersedes automatically closed #492 after its temporary stacked base was squash-merged and deleted.

## Summary
- prove one destination row is owned by one outer parallel lane across lexical Fold and effect-loop digits
- reject guarded, indirect, carried-address, mismatched-domain, neighboring-row, and multi-destination cases
- migrate prefill softmax to the typed KernelBody route without changing its 256-work-item launch

## Validation
- focused prefill tests and real Arc device execution
- TypedSOAC route suite and corpus coverage
- previous exact stack passed all CircleCI test, OpenCL CPU, CUDA, and HIP gates