### PR TITLE
Preserve exact inclusive and dynamic Fold domains

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1436,11 +1436,15 @@ The immediate continuation after the verified double-buffered weighted-reduction
    TypedSOAC path as other kernels. Proving each loop separately would be insufficient because
    cross-loop accesses may race across rows. This is a general effect-domain proof, not an
    attention-specific exception, scalar hoist, synthetic one-trip loop, or performance claim.
-   Pure zero-origin, unit-step, single-carry Clojure `loop*` recurrences that are complete typed
-   scalar expressions are now canonical ordered `Fold` terms before scheduling; effectful loops
-   remain `effect-loop`.
-   Transformed exits, nonzero origins and other control shapes retain their source spelling until a
-   richer canonical construct exists. This reuses the shared loop matcher and the enclosing retained
+   Pure unit-step, single-carry Clojure `loop*` recurrences that are complete typed scalar
+   expressions are now canonical ordered `Fold` terms before scheduling; effectful loops remain
+   `effect-loop`. Fold domains retain an exact typed lower expression and an exclusive or inclusive
+   upper-bound mode. KernelBody emits inclusive termination with a guarded final advance, so a
+   `Long/MAX_VALUE` endpoint never requires constructing or executing an overflowing successor.
+   This removes the last verified-SegMap fallback from the batched causal SDPA dQ/dK/dV kernels:
+   their causal inclusive bound and row-dependent nonzero lower bound now remain ordinary Fold
+   facts. Transformed exits and other control shapes retain their source spelling until a richer
+   canonical construct exists. This reuses the shared loop matcher and the enclosing retained
    dtype rather than adding a function/type registry. KernelBody consumes Fold directly as a typed
    ordered loop; conversion does not descend through arbitrary lexical bindings and therefore
    cannot detach a recurrence from its scope. In particular, prefill maximum reduction no longer

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -771,7 +771,9 @@
    signed-edge domains retain the guarded advance; no overflow policy is weakened."
   [operation index-name index-type names depth]
   (let [{:keys [lower upper step]} operation
-        ordinary? (and (every? integer? [lower upper step])
+        inclusive? (= :inclusive (get-in operation [:attributes :upper-bound] :exclusive))
+        ordinary? (and (not inclusive?)
+                       (every? integer? [lower upper step])
                        (every? #(scalar-range/literal % index-type) [lower upper step])
                        (scalar-range/contained-in-dtype?
                         (scalar-range/counted-loop-index-range lower upper step) index-type))
@@ -779,14 +781,16 @@
         step-source (if (integer? step) (str step) (emit-index-expression step names))
         unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* index-type)]
     {:loop-header (str "for (" (target-type index-type) " " index-name " = "
-                       (emit-index-expression lower names) "; " index-name " < " upper-source ";"
+                       (emit-index-expression lower names) "; " index-name
+                       (if inclusive? " <= " " < ") upper-source ";"
                        (when ordinary? (str " " index-name " += " step-source)) ") {")
      :checked-advance
      (when-not ordinary?
        (str (indent-lines
              (inc depth)
              (str "if ((" unsigned-type ")(" upper-source ") - (" unsigned-type ")(" index-name
-                  ") <= (" unsigned-type ")(" step-source ")) break;"))
+                  ") " (if inclusive? "<" "<=") " (" unsigned-type ")(" step-source
+                  ")) break;"))
             (indent-lines (inc depth) (str index-name " += " step-source ";"))))}))
 
 (declare emit-scalar-operations)

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -310,19 +310,20 @@
                        :inits (into (vec (repeat parameter-count nil))
                                     (map #(nth % 3) locals))
                        :body results}]
-             :outer [(:identity attributes) (:extent attributes)]
+             :outer [(:identity attributes) (get attributes :lower 0) (:extent attributes)]
              :rebuild
-             (fn [[{:keys [binders inits body]}] [identity extent]]
+             (fn [[{:keys [binders inits body]}] [identity lower extent]]
                (let [parameters' (vec (take parameter-count binders))
                      local-binders (drop parameter-count binders)
                      local-inits (drop parameter-count inits)
                      locals' (mapv (fn [id dtype init]
                                      (list 'let-value id dtype init))
                                    local-binders local-dtypes local-inits)
-                     attributes' (assoc attributes
-                                        :accumulator (first parameters')
-                                        :index (second parameters')
-                                        :identity identity :extent extent)]
+                     attributes' (cond-> (assoc attributes
+                                                :accumulator (first parameters')
+                                                :index (second parameters')
+                                                :identity identity :extent extent)
+                                   (contains? attributes :lower) (assoc :lower lower))]
                  (rl form 'fold attributes'
                      (list 'lambda parameters' (list 'region locals' (vec body))))))})))
 

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -85,6 +85,15 @@
 (def ^:private async-transfer-widths #{4 8 16})
 (def ^:private pipeline-tail-policies #{:exact :separate-epilogue})
 
+(defn- loop-upper-bound-mode!
+  [operation]
+  (let [upper-bound (get-in operation [:attributes :upper-bound] :exclusive)]
+    (when-not (contains? #{:exclusive :inclusive} upper-bound)
+      (throw (ex-info "kernel loop upper-bound mode must be inclusive or exclusive"
+                      {:reason :kernel-body-loop-upper-bound
+                       :upper-bound upper-bound :loop operation})))
+    upper-bound))
+
 (defn- record-kind? [class-name value]
   (and value (= class-name (.getName (class value)))))
 
@@ -767,6 +776,7 @@
           (value-spec! "loop carried binding" (:binding arg)))
         (let [uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
               bindings (set (map (comp :id :binding) (:iter-args operation)))]
+          (loop-upper-bound-mode! operation)
           (when-not (and (set? uniform-iter-args)
                          (set/subset? uniform-iter-args bindings))
             (throw (ex-info
@@ -816,6 +826,7 @@
           (value-spec! "pipelined loop carried binding" (:binding arg)))
         (let [uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
               bindings (set (map (comp :id :binding) (:iter-args operation)))]
+          (loop-upper-bound-mode! operation)
           (when-not (and (set? uniform-iter-args)
                          (set/subset? uniform-iter-args bindings))
             (throw (ex-info
@@ -1434,7 +1445,9 @@
         type (some-> (get-in args [0 :binding :type]) canonical-type)
         expression (:expression update-op)
         operands (:arguments expression)
-        trips (scalar-range/counted-loop-trips (:lower operation) (:upper operation) (:step operation))]
+        trips (scalar-range/counted-loop-trips
+               (:lower operation) (:upper operation) (:step operation)
+               (get-in operation [:attributes :upper-bound] :exclusive))]
     (when (and (= 1 (count args)) (some? trips) (contains? #{:byte :int :long} type)
                (record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" update-op)
                (record-kind? "raster.compiler.ir.kernel_body.Yield" yield-op)
@@ -1590,6 +1603,7 @@
           uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
           results (:results operation)
           initials (mapv #(scalar-value-info! (:initial %) values) iter-args)]
+      (loop-upper-bound-mode! operation)
       (when-not (= index-type (:type lower-info) (:type upper-info))
         (throw (ex-info "kernel for-loop index and bounds must have one integral type"
                         {:reason :kernel-body-loop-index-dtype :index index
@@ -1680,6 +1694,7 @@
           initials (mapv #(scalar-value-info! (:initial %) values) iter-args)
           pipeline-yield (terminal-pipeline-yield!
                           "kernel pipelined-for body" (:operations operation))]
+      (loop-upper-bound-mode! operation)
       (when-not (= index-type (:type lower-info) (:type upper-info))
         (throw (ex-info "kernel pipelined-for index and bounds must have one integral type"
                         {:reason :kernel-body-loop-index-dtype :index index

--- a/src/raster/compiler/ir/scalar_range.clj
+++ b/src/raster/compiler/ir/scalar_range.clj
@@ -58,10 +58,18 @@
         nil))))
 
 (defn counted-loop-trips
-  "Exact trip count for static positive-step exclusive-upper loops; unknown bounds decline."
-  [lower upper step]
-  (when (and (integer? lower) (integer? upper) (integer? step) (pos? step))
-    (quot (+' (max 0 (-' upper lower)) (dec step)) step)))
+  "Exact trip count for static positive-step loops; unknown bounds decline. Proof arithmetic is
+   unbounded, including an inclusive endpoint at the maximum finite-width integer."
+  ([lower upper step]
+   (counted-loop-trips lower upper step :exclusive))
+  ([lower upper step upper-bound]
+   (when (and (integer? lower) (integer? upper) (integer? step) (pos? step)
+              (contains? #{:exclusive :inclusive} upper-bound))
+     (case upper-bound
+       :exclusive (quot (+' (max 0 (-' upper lower)) (dec step)) step)
+       :inclusive (if (> lower upper)
+                    0
+                    (inc (quot (-' upper lower) step)))))))
 
 (defn counted-loop-index-range
   "Static positive-step counted-loop indices, INCLUDING the increment which exits the loop.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -897,17 +897,26 @@
                     {parameters :parameters locals :locals results :body-results}
                     (lambda-parts lambda)
                     expected [(:accumulator attributes) (:index attributes)]
+                    upper-bound (:upper-bound attributes :exclusive)
+                    lower-bound (:lower attributes 0)
+                    lower-unbound (util/free-syms lower-bound bound)
                     extent-unbound (util/free-syms (:extent attributes) bound)]
                 (when-not (and (symbol? (:index attributes))
+                               (contains? #{:exclusive :inclusive} upper-bound)
                                (= expected parameters)
                                (= 2 (count (distinct parameters)))
                                (empty? (set/intersection bound (set parameters)))
                                (= 1 (count results))
-                               (empty? extent-unbound))
+                               (empty? lower-unbound)
+                               (empty? extent-unbound)
+                               (not (util/effectful? lower-bound))
+                               (not (util/effectful? (:extent attributes))))
                   (fail! :typed-soac-scalar-fold
                          "scalar folds require a closed ordered [accumulator index] region"
                          {:equation equation-id :fold expression :expected expected
                           :parameters parameters :results results
+                          :upper-bound upper-bound
+                          :lower-bound lower-bound :lower-unbound lower-unbound
                           :extent-unbound extent-unbound}))
                 (let [final-bound
                       (reduce

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -564,12 +564,16 @@
                     (= test-var sym1) [sym1 init1 sym2 init2]
                     (= test-var sym2) [sym2 init2 sym1 init1]
                     :else nil)]
-              ;; SOAC recognition remains zero-origin. Ordered scalar loops may instead keep
-              ;; an explicit nonnegative literal origin; do not translate it into an extent.
+              ;; SOAC recognition remains zero-origin. Ordered scalar loops retain their exact
+              ;; lower bound; its lexical closure, dtype and purity are proved by the owning
+              ;; TypedSOAC/scalar region rather than guessed by this structural matcher.
               (when (and idx-sym
                          (or (int-zero? idx-init)
-                             (and allow-nonzero-origin? (integer? idx-init)
-                                  (<= 0 idx-init Long/MAX_VALUE))))
+                             (and allow-nonzero-origin?
+                                  (or (and (integer? idx-init)
+                                           (<= Long/MIN_VALUE idx-init Long/MAX_VALUE))
+                                      (symbol? idx-init)
+                                      (seq? idx-init)))))
                 (cond-> {:kind :reduce-loop
                  :index-sym idx-sym
                  :acc-sym acc-sym
@@ -588,7 +592,7 @@
   (normalize-loop* form false))
 
 (defn normalize-ordered-loop
-  "Normalize a scalar counted loop, retaining a nonnegative literal :index-init.
+  "Normalize a scalar counted loop, retaining its exact :index-init expression.
    Unlike SOAC recognition, this boundary does not assume a [0,bound) iteration domain."
   [form]
   (when (and (seq? form) (= 3 (count form))
@@ -598,7 +602,6 @@
           normalized (normalize-loop* form true)
           {:keys [index-sym index-init body-form]} normalized
           test (second body-form)
-          then-branch (nth body-form 2 nil)
           lhs (first (descriptor/call-args test))
           ;; A long loop cannot inherit a narrowing int comparison just because a generic
           ;; SOAC recognizer can strip cast syntax. Only the explicit widening spelling is safe.
@@ -609,11 +612,7 @@
                  (every? symbol? ids) (= 2 (count (set ids)))
                  (= 4 (count body-form))
                  (= 2 (count (descriptor/call-args test)))
-                 (= index-sym lhs)
-                 ;; New nonzero-origin coverage is deliberately direct-recursive. Lexical
-                 ;; wrappers keep their existing zero-origin coverage, not a broader promise.
-                 (or (zero? index-init)
-                     (and (seq? then-branch) (= 'recur (first then-branch)))))
+                 (= index-sym lhs))
         (assoc normalized :index-slot (.indexOf ids index-sym))))))
 
 ;; ================================================================
@@ -732,7 +731,7 @@
 (defn- match-reduce-loop*
   "Generic matcher for reduction loops.
 	Returns a structural descriptor of the loop/update shape or nil."
-  [loop-form normalize]
+  [loop-form normalize comparison-kind bound-mode]
   (when-let [normalized (normalize loop-form)]
     (when (= :reduce-loop (:kind normalized))
       (let [{:keys [acc-sym acc-init index-sym body-form]} normalized
@@ -755,12 +754,13 @@
 
                   :else [nil nil])]
             (when (and update-expr
-                       ;; only (< i n) → contiguous [0,bound) iteration
-                       (descriptor/less-than-op? (descriptor/semantic-op test)))
+                       (= comparison-kind
+                          (descriptor/comparison-kind (descriptor/semantic-op test))))
               (cond-> {:acc-sym acc-sym
                :acc-init acc-init
                :index-sym index-sym
                :bound-expr (second (test-index+bound test))
+               :bound-mode bound-mode
                :test-expr test
                :then-branch then-branch
                :else-expr else-branch
@@ -774,7 +774,7 @@
 (defn match-reduce-loop
   "Match a zero-origin reduction for SOAC recognition."
   [loop-form]
-  (match-reduce-loop* loop-form normalize-loop))
+  (match-reduce-loop* loop-form normalize-loop :lt :exclusive))
 
 (defn ordered-unit-step?
   "A long induction step may widen explicitly, but must not erase a narrowing conversion."
@@ -786,9 +786,12 @@
                  (tree-seq coll? seq expression))))
 
 (defn match-ordered-reduce-loop
-  "Match an ordered scalar reduction and retain its literal induction origin."
+  "Match an ordered scalar reduction and retain its literal induction origin and exact bound mode."
   [loop-form]
-  (when-let [matched (match-reduce-loop* loop-form normalize-ordered-loop)]
+  (when-let [matched (or (match-reduce-loop* loop-form normalize-ordered-loop
+                                             :lt :exclusive)
+                         (match-reduce-loop* loop-form normalize-ordered-loop
+                                             :le :inclusive))]
     (let [normalized (normalize-ordered-loop loop-form)
           recur-args (vec (rest (:recur-form matched)))]
       (when (and (:scoped-update-expr matched)

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -30,34 +30,10 @@
 (defn- match-ordered-loop
   "Recognize the canonical one-index/one-carry loop without authorizing reassociation."
   [expression]
-  (or
-   (when-let [matched (patterns/match-ordered-reduce-loop expression)]
-     (assoc matched :inclusive? false
-            :update-expr (:scoped-update-expr matched)))
-   (when-let [{:keys [kind index-sym index-init index-slot acc-sym acc-init body-form bound]}
-              (patterns/normalize-ordered-loop expression)]
-     (when (and (= :reduce-loop kind)
-                (= :le (descriptor/comparison-kind
-                        (descriptor/semantic-op (second body-form)))))
-       (let [[_ _test then-branch else-expr] body-form
-             recur-form (patterns/find-recur-form then-branch)
-             recur-args (vec (rest recur-form))
-             index-update? #(= 1 (descriptor/affine-step % index-sym))
-             [update-expr index-update]
-             (cond
-               (and (= 2 (count recur-args)) (index-update? (second recur-args)))
-               [(first recur-args) (second recur-args)]
-
-               (and (= 2 (count recur-args)) (index-update? (first recur-args)))
-               [(second recur-args) (first recur-args)]
-
-               :else [nil nil])]
-         (when (and update-expr index-update
-                    (= 'recur (first then-branch))
-                    (patterns/ordered-unit-step? (nth recur-args index-slot) index-sym))
-           {:acc-sym acc-sym :acc-init acc-init :index-sym index-sym :index-init index-init
-            :bound-expr bound :else-expr else-expr :update-expr update-expr
-            :inclusive? true}))))))
+  (when-let [matched (patterns/match-ordered-reduce-loop expression)]
+    (assoc matched
+           :inclusive? (= :inclusive (:bound-mode matched))
+           :update-expr (:scoped-update-expr matched))))
 
 (defn make-lowerer
   "Build a scalar-expression lowerer.
@@ -357,7 +333,7 @@
                         loop-operation
                         (body/->ForLoop
                          (body/value loop-index :long)
-                         (body/index-cast 0 :long :exact)
+                         (lower-index (:lower attributes 0) (set (keys env)))
                          (lower-index (:extent attributes) (set (keys env)))
                          1
                          [(body/->LoopArg (body/value carry fold-type) (:result initial))]
@@ -366,6 +342,8 @@
                          [(body/value result fold-type)]
                          (cond-> {:association (:association attributes)
                                   :source-order (= :ordered (:association attributes))}
+                           (= :inclusive (:upper-bound attributes))
+                           (assoc :upper-bound :inclusive)
                            (:algebra attributes) (assoc :algebra (:algebra attributes))))]
                     {:operations (conj (vec (:operations initial)) loop-operation)
                      :result result :type fold-type})
@@ -405,10 +383,6 @@
                                           {:expression expression :initial loop-type
                                            :update (:type lowered)}))
                             upper (lower-index bound-expr (set (keys env)))
-                            upper (if inclusive?
-                                    (body/expression :add upper
-                                                     (body/index-cast 1 :long :exact))
-                                    upper)
                             loop (body/->ForLoop
                                   (body/value loop-index :long)
                                   (body/index-cast index-init :long :exact)
@@ -418,7 +392,8 @@
                                   (conj (vec (:operations lowered))
                                         (body/->Yield [(:result lowered)]))
                                   [(body/value result loop-type)]
-                                  {:association :ordered})
+                                  (cond-> {:association :ordered}
+                                    inclusive? (assoc :upper-bound :inclusive)))
                             exit (when exit?
                                    (lower (util/subst-syms {acc-sym result} else-expr)
                                           expected (assoc env result loop-type)))]

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2357,7 +2357,7 @@
       ;; scalar initializer/result here: descending beneath an enclosing `let*` would detach the
       ;; Fold from those lexical binders. Unlike `raster.par/reduce`, a Clojure recurrence promises
       ;; source order, so even an algebraically associative update remains `:ordered`.
-      (if-let [{:keys [acc-sym acc-init index-sym index-init bound-expr else-expr
+      (if-let [{:keys [acc-sym acc-init index-sym index-init bound-expr bound-mode else-expr
                        scoped-update-expr]}
                (when (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
                  (patterns/match-ordered-reduce-loop expression))]
@@ -2366,16 +2366,19 @@
               step-region (when fold-dtype
                             (canonical-fold-step-region scoped-update-expr fold-dtype))]
           (if (and step-region fold-dtype (or (nil? carry-dtype) (= fold-dtype carry-dtype))
-                   (zero? index-init) (= else-expr acc-sym)
+                   (= else-expr acc-sym)
                    (dialect/scalar-literal? acc-init)
                    (not (util/effectful? acc-init))
+                   (not (util/effectful? index-init))
                    (not (util/effectful? bound-expr))
                    (not (util/effectful? scoped-update-expr)))
             (util/remake
              expression
              'fold
-             {:accumulator acc-sym :index index-sym :identity acc-init
-              :dtype fold-dtype :extent bound-expr :association :ordered}
+             (cond-> {:accumulator acc-sym :index index-sym :identity acc-init
+                      :lower index-init
+                      :dtype fold-dtype :extent bound-expr :association :ordered}
+               (= :inclusive bound-mode) (assoc :upper-bound :inclusive))
              (dialect/lambda-form [acc-sym index-sym]
                                   (:locals step-region) [(:result step-region)]))
             expression))

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -98,10 +98,28 @@
        (let [{:keys [attributes lambda]} (dialect/scalar-fold-parts form)
              {:keys [parameters locals body-results]} (dialect/lambda-parts lambda)
              [accumulator index] parameters
-             update (materialize-region locals (first body-results))]
+             update (materialize-region locals (first body-results))
+             projected
+             (if (or (= :inclusive (:upper-bound attributes))
+                     (not= 0 (:lower attributes 0)))
+               (let [typed-index (with-meta index {:raster.type/tag 'long})
+                     typed-accumulator
+                     (with-meta accumulator
+                       {:raster.type/tag (dtype/scalar-tag-for-dtype (:dtype attributes))})]
+                 (list 'loop*
+                       [typed-index (:lower attributes 0)
+                        typed-accumulator (:identity attributes)]
+                       (list 'if (list (if (= :inclusive (:upper-bound attributes))
+                                        'clojure.core/<= 'clojure.core/<)
+                                      (list 'clojure.core/long index)
+                                      (list 'clojure.core/long (:extent attributes)))
+                             (list 'recur (list 'clojure.core/inc (list 'clojure.core/long index))
+                                   update)
+                             accumulator)))
+               (list 'raster.par/reduce accumulator (:identity attributes)
+                     index (:extent attributes) update))]
          (with-meta
-           (list 'raster.par/reduce accumulator (:identity attributes)
-                 index (:extent attributes) update)
+           projected
            {:raster.type/elem-type (:dtype attributes)}))
        form))
    expression))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -288,6 +288,20 @@
     :provenance {:dialect :test}
     :attributes {:kind :scalar}}))
 
+(defn- inclusive-signed-limit-loop-body []
+  (body/make
+   {:id :inclusive-signed-limit-loop
+    :operations
+    [(body/->ForLoop
+      (body/value 'edge-iteration :long)
+      (body/index-cast (dec Long/MAX_VALUE) :long :exact)
+      (body/index-cast Long/MAX_VALUE :long :exact) 1 []
+      [(body/->Yield [])] []
+      {:association :ordered :upper-bound :inclusive})]
+    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+    :provenance {:dialect :test}
+    :attributes {:kind :scalar}}))
+
 (deftest positive-loop-steps-cannot-overflow-the-signed-induction-variable
   (let [kernel (near-signed-limit-loop-body)
         sources (mapv (fn [target]
@@ -368,6 +382,26 @@
             {:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
                                          "-fsyntax-only" "-" :in source)]
         (is (zero? exit) err)))))
+
+(deftest inclusive-loop-bound-does-not-require-an-overflowing-successor
+  (let [sources (mapv (fn [target]
+                        (opencl/emit-scalar-kernel
+                         "inclusive_signed_limit" (inclusive-signed-limit-loop-body)
+                         {:target-dialect target}))
+                      [:opencl-portable :cuda :hip])]
+    (doseq [source sources]
+      (is (str/includes? source "rstr_edge_iteration <= "))
+      (is (str/includes? source "9223372036854775807"))
+      (is (str/includes? source ") < "))
+      (is (not (str/includes? source "9223372036854775807 + 1")))))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"upper-bound mode"
+       (body/make
+        {:id :invalid-loop-bound-mode
+         :operations [(body/->ForLoop (body/value 'i :long) 0 1 1 []
+                                      [(body/->Yield [])] [] {:upper-bound :closed})]
+         :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+         :provenance {:dialect :test} :attributes {}}))))
 
 (deftest source-integral-arithmetic-retains-its-overflow-semantics
   (let [decline! (fn [rule message data]

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -284,7 +284,7 @@
           {:keys [scopes outer sequential?]} (form/scope-info fold)
           scope (first scopes)]
       (is (true? sequential?))
-      (is (= '[0.0 n] outer))
+      (is (= '[0.0 0 n] outer))
       (is (= '[acc i off value] (:binders scope)))
       (is (= '[nil nil (+ base i) (clojure.core/aget x off)] (:inits scope)))
       (is (= '[(+ acc value)] (:body scope))))))

--- a/test/raster/compiler/ir/scalar_range_test.clj
+++ b/test/raster/compiler/ir/scalar_range_test.clj
@@ -46,7 +46,12 @@
       (is (every? #(<= (:lower entry) % (:upper entry)) (butlast prefixes)))
       (is (every? #(<= (:lower result) % (:upper result)) prefixes))))
   (is (= (bigint "18446744073709551615")
-         (ranges/counted-loop-trips Long/MIN_VALUE Long/MAX_VALUE 1))))
+         (ranges/counted-loop-trips Long/MIN_VALUE Long/MAX_VALUE 1)))
+  (is (= (bigint "18446744073709551616")
+         (ranges/counted-loop-trips Long/MIN_VALUE Long/MAX_VALUE 1 :inclusive)))
+  (is (= 2 (ranges/counted-loop-trips (dec Long/MAX_VALUE) Long/MAX_VALUE
+                                      1 :inclusive)))
+  (is (zero? (ranges/counted-loop-trips 1 0 1 :inclusive))))
 
 (deftest quotient-proof-requires-a-positive-constant-divisor
   (doseq [lo (range -9 10) hi (range lo 10) divisor [1 2 7]]

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -357,7 +357,7 @@
                    :provenance {:dialect :test} :attributes {}})))))
 
 (deftest ordered-loop-origin-is-retained-without-widening-soac-recognition
-  (doseq [origin [0 1 3 Long/MAX_VALUE]]
+  (doseq [origin [Long/MIN_VALUE -1 0 1 3 Long/MAX_VALUE]]
     (let [form (list 'loop ['r origin 'acc (body/literal 7.0 :float)]
                      '(if (< r n) (recur (inc r) (+ acc (float r))) acc))
           result ((:lower-region (lowerer)) {:bindings [] :results [form]}
@@ -367,10 +367,14 @@
       (is (= (zero? origin) (some? (patterns/match-reduce-loop form))))
       (is (= (body/index-cast origin :long :exact) (:lower loop)))
       (is (= :ordered (get-in loop [:attributes :association])))))
-  (doseq [origin [-1 0.5 'start 9223372036854775808N]]
+  (doseq [origin [0.5 9223372036854775808N]]
     (let [form (list 'loop ['r origin 'acc 0.0]
                      '(if (< r n) (recur (inc r) (+ acc r)) acc))]
-      (is (nil? (patterns/match-ordered-reduce-loop form))))))
+      (is (nil? (patterns/match-ordered-reduce-loop form)))))
+  (doseq [origin ['start '(+ base 1)]]
+    (let [form (list 'loop ['r origin 'acc 0.0]
+                     '(if (< r n) (recur (inc r) (+ acc r)) acc))]
+      (is (= origin (:index-init (patterns/match-ordered-reduce-loop form)))))))
 
 (deftest ordered-loop-admission-does-not-drop-effects-or-swap-recur-slots
   (doseq [form ['(loop [r 1 acc 0.0]

--- a/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
@@ -105,8 +105,30 @@
                             [:attributes :association])))
     (is (not-any? #(and (seq? %) (contains? #{'loop 'loop*} (first %)))
                   (tree-seq coll? seq fold))))
-  (testing "nonzero origins and transformed exits retain their source spelling"
-    (doseq [form ['(loop* [^{:raster.type/tag long} i 1
+  (testing "an inclusive upper bound is retained without overflow-prone bound arithmetic"
+    (let [form '(loop* [^{:raster.type/tag long} i 0
+                        ^{:raster.type/tag float} acc 0.0]
+                  (if (<= (long i) limit)
+                    (let* [^{:raster.type/tag float} value (clojure.core/aget w i)]
+                      (recur (inc (long i)) (+ acc value)))
+                    acc))
+          fold (#'frontend/canonicalize-scalar-folds form :float)
+          attributes (:attributes (dialect/scalar-fold-parts fold))
+          projected (projection/scalar-folds->source fold)]
+      (is (= :inclusive (:upper-bound attributes)))
+      (is (= 'loop* (first projected)))
+      (is (= 'clojure.core/<= (first (second (nth projected 2)))))))
+  (testing "a dynamic lower bound remains an explicit part of the Fold domain"
+    (let [form '(loop* [^{:raster.type/tag long} i start
+                        ^{:raster.type/tag float} acc 0.0]
+                  (if (< (long i) width)
+                    (recur (inc (long i)) (+ acc (clojure.core/aget w i)))
+                    acc))
+          fold (#'frontend/canonicalize-scalar-folds form :float)]
+      (is (= 'start (get-in (dialect/scalar-fold-parts fold) [:attributes :lower])))
+      (is (= 'start (second (second (projection/scalar-folds->source fold)))))))
+  (testing "non-integral origins and transformed exits retain their source spelling"
+    (doseq [form ['(loop* [^{:raster.type/tag long} i 0.5
                             ^{:raster.type/tag float} acc 0.0]
                      (if (< (long i) width)
                        (recur (inc (long i)) (+ acc (clojure.core/aget w i))) acc))


### PR DESCRIPTION
## Summary
- retain exact dynamic lower bounds and inclusive/exclusive upper modes in canonical ordered Folds
- lower both modes to KernelBody without reconstructing source control
- emit inclusive loops with a guarded final advance, avoiding an overflowing upper-plus-one transform
- centralize the ordered-loop matcher and remove the duplicate inclusive parser

## Proof and workload evidence
- inclusive trip-count proofs use unbounded host arithmetic
- full signed-long inclusive endpoint is covered
- batched causal SDPA dQ, dK, and dV now emit 5/5, 5/5, and 3/3 KernelBody kernels with zero declines
- f32/f64 SDPA finite-difference oracles remain green
- 95 focused tests / 1966 assertions and 155 broader tests / 1166 assertions

Stacked on #493, whose ownership parent is now #494.