### PR TITLE
Do not emit discarded C helper reference bodies

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1457,9 +1457,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    Monolithic CPU-C declarations now consume that same retained binding-result dtype before looking
    at a rewritten initializer. Inlining Q6_K's pure integer dot may rebuild its outer `let*`, but its
    typed `dp` binding still declares a `long`; the emitter no longer guesses from the rebuilt helper
-   expression. Untyped compatibility expressions remain instrumented separately. The x8 SIMD lane
-   form is the next measured source-only case and must join typed vector/scalar lowering rather than
-   grow another structural type rule.
+   expression. Untyped compatibility expressions remain instrumented separately. Registered native
+   C helper overrides also share one canonical naming function with calls and generated helpers;
+   selecting the x8 VNNI override no longer translates and discards its scalar reference body merely
+   to discover that name. Target-owned code and portable reference semantics remain separate facts.
    A real Arc normalization probe exposes an unresolved precision boundary: Double SSA division
    followed by nearest-even Float conversion produces an adjacent Float for `1/8.25`. Adding the
    FP64 pragma alone does not change the result. Device integration currently bounds normalized

--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -428,13 +428,16 @@
                       ;; generate-c-helper returns {:c-name :source}; its c-name matches
                       ;; the call site exactly (shared invariant). Use that c-name; take
                       ;; the body from the :c-helper override when registered, else its source.
-                      (let [gen (ce/generate-c-helper h)
-                            ;; resolve-op-descriptor strips the _m_ type-mangle so the
-                            ;; override registered under the base op name is found.
-                            ov (:c-helper (first (descriptor/resolve-op-descriptor (:sym h))))]
+                      (let [;; Resolve the override before translating the reference body. A
+                            ;; registered target helper already owns emission; generating and
+                            ;; discarding its scalar deftm body used to trigger source-only
+                            ;; vector/type warnings and wasted compile work merely to obtain a name.
+                            ov (:c-helper (first (descriptor/resolve-op-descriptor (:sym h))))
+                            c-name (ce/gpu-helper-c-name (:sym h))]
                         (if ov
-                          {:inc (:includes ov "") :def ((:gen ov) (:c-name gen))}
-                          {:inc "" :def (:source gen)})))]
+                          {:inc (:includes ov "") :def ((:gen ov) c-name)}
+                          (let [gen (ce/generate-c-helper h)]
+                            {:inc "" :def (:source gen)}))))]
         [(clojure.string/join "" (distinct (keep (comp not-empty :inc) entries)))
          (clojure.string/join "\n" (map :def entries))]))))
 

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -657,7 +657,7 @@
 
 (declare emit-expr emit-stmt emit-stmts-with-result
          emit-loop-body emit-loop-expr try-inline-deftm
-         resolve-gpu-inlinable-var)
+         resolve-gpu-inlinable-var gpu-helper-c-name)
 
 (defn emit-stmt
   "Emit an S-expression as a C statement (with trailing semicolon)."
@@ -1462,7 +1462,7 @@
                           (str "((" ea " % " eb " + " eb ") % " eb ")")))
          ;; Non-arithmetic deftm helper -> C helper invocation. Array-sym args are passed
          ;; as the bare pointer (the helper takes a pointer + offset), not element access.
-         (let [c-name (str "gpufn_" (c-symbol sym))
+         (let [c-name (gpu-helper-c-name sym)
                emit-arg (fn [a] (if (and (symbol? a) (contains? array-syms a))
                                   (c-symbol a)
                                   (emit-expr a idx-sym array-syms opencl-idx)))]
@@ -1506,7 +1506,7 @@
          ;; Non-arithmetic deftm helper -> C helper invocation (array-sym args as bare ptr).
          (let [base-sym (symbol (str (.-ns ^clojure.lang.Var resolved-var))
                                 (str (:name (meta resolved-var))))
-               c-name (str "gpufn_" (c-symbol base-sym))
+               c-name (gpu-helper-c-name base-sym)
                emit-arg (fn [a] (if (and (symbol? a) (contains? array-syms a))
                                   (c-symbol a)
                                   (emit-expr a idx-sym array-syms opencl-idx)))]
@@ -1961,6 +1961,14 @@
      body)
     @result))
 
+(defn gpu-helper-c-name
+  "Return the one canonical C-family symbol for a resolved deftm helper.
+
+  Call sites, generated reference helpers, and registered target overrides must
+  agree on this name without requiring source emission as a naming side effect."
+  [sym]
+  (str "gpufn_" (c-symbol sym)))
+
 (defn intrinsic-helper-module
   "Select intrinsic implementations and their compiler requirements together.
    Selection is explicit target policy, not semantic or type inference."
@@ -2013,7 +2021,7 @@
 (defn generate-c-helper
   "Generate a static C helper function from a GPU-inlinable deftm."
   [{:keys [sym var params tags source-body]}]
-  (let [c-name (str "gpufn_" (c-symbol sym))
+  (let [c-name (gpu-helper-c-name sym)
         ;; Return type from var metadata, not from tags (which are param-only dispatch tags)
         ret-tag (or (:raster.core/return-tag (meta var)) (last tags))
         ret-type (get tag->ctype-helper ret-tag "double")

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -35,6 +35,10 @@
   (is (= "rstr__device__" (c-emit/c-symbol '__device__)))
   (is (c-emit/c-identifier? "ordinary_kernel")))
 
+(deftest helper-naming-is-independent-of-helper-source-emission
+  (is (= "gpufn_wi8_dot_q4_x8"
+         (c-emit/gpu-helper-c-name 'raster.quant.kernels/wi8-dot-q4-x8))))
+
 (deftest retained-scalar-dtypes-are-not-collapsed-to-the-kernel-element-type
   (is (= :long (c-emit/scalar-parameter-dtype 'iteration {'iteration :int64} :float)))
   (is (= :byte (c-emit/scalar-parameter-dtype 'quantized {'quantized :int8} :float)))

--- a/test/raster/quant/x8_simd_test.clj
+++ b/test/raster/quant/x8_simd_test.clj
@@ -8,11 +8,21 @@
             [raster.compiler.backend.cpu.quant :as cq]
             [raster.quant.kernels :as k]
             [raster.compiler.backend.cpu.aot :as aot]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.cpu.codegen :as cpu]))
 
 (defn- clang-avx2? []
   (try (cpu/compile-source! "#include <immintrin.h>\nint main(){__m256 v=_mm256_setzero_ps();return (int)_mm256_cvtss_f32(v);}\n") true
        (catch Throwable _ false)))
+
+(deftest registered-x8-helper-override-does-not-emit-its-reference-body
+  (when (clang-avx2?)
+    (with-redefs [c-emit/generate-c-helper
+                  (fn [_]
+                    (throw (ex-info "target override emitted the discarded reference body" {})))]
+      (is (re-find #"gpufn_wi8_dot_q4_x8"
+                   (:c-source
+                    (meta (aot/compile-aot-c #'k/qmatmul-q4-x8! :float :simd? true))))))))
 
 (deftest x8-simd-fold-vectorizes-and-matches
   (when (clang-avx2?)


### PR DESCRIPTION
## Summary
- centralize C-family deftm helper naming for call sites, generated helpers, and native overrides
- resolve registered C overrides before translating a scalar reference body
- avoid generating and discarding the x8 scalar lane form merely to recover its helper name
- keep portable reference semantics separate from target-owned AVX/VNNI emission

## Validation
- emitter + x8 SIMD slice: 8 tests, 42 assertions, zero failures/errors
- strict instrumentation reports zero scalar-default fallbacks
- regression test makes reference-helper generation fail if the registered x8 override tries to use it
- 