### PR TITLE
Canonicalize closed-core integer case lowering

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -659,6 +659,18 @@
          emit-loop-body emit-loop-expr try-inline-deftm
          resolve-gpu-inlinable-var gpu-helper-c-name)
 
+(defn- closed-integer-case!
+  "Return the canonical scalar projection for a Clojure closed-core integer case.
+
+   Closed source lowering binds a non-trivial test before producing `case*`; accepting only that
+   shape keeps repeated ternary comparisons from duplicating an effectful test."
+  [expression]
+  (let [description (form/integer-case-descriptor expression)]
+    (when-not (and description (symbol? (:test description)))
+      (throw (ex-info "C-family emitter cannot lower this closed-core case representation"
+                      {:reason :unsupported-c-family-case :expression expression})))
+    (form/integer-case-conditional description (:test description))))
+
 (defn emit-stmt
   "Emit an S-expression as a C statement (with trailing semicolon)."
   [expr idx-sym array-syms opencl-idx]
@@ -831,6 +843,11 @@
                           (partition 2 pairs)))
            " }"))
 
+    ;; Closed-core case* has one canonical semantic projection.  Do not interpret its dispatch
+    ;; hash map here; source lowering has already bound a non-trivial test expression once.
+    (and (seq? expr) (= 'case* (first expr)))
+    (emit-stmt (closed-integer-case! expr) idx-sym array-syms opencl-idx)
+
     ;; case in void context -> switch
     (and (seq? expr) (= 'case (first expr)))
     (let [[_ test-expr & clauses] expr
@@ -913,6 +930,11 @@
                                    (str (c-symbol sym) " = _t" i ";"))
                                  indexed))]
       (str temps " " assigns " continue;"))
+
+    ;; Canonical closed-core integer branch in loop control.
+    (and (seq? expr) (= 'case* (first expr)))
+    (emit-loop-expr (closed-integer-case! expr)
+                    var-names var-types idx-sym array-syms opencl-idx)
 
     ;; if in loop body
     (and (seq? expr) (= 'if (first expr)))
@@ -1209,6 +1231,10 @@
                (throw (ex-info "GLSL: do block has non-tail forms with side effects but statement expressions are not supported"
                                {:expr expr}))
                (emit-expr (last stmts) idx-sym array-syms opencl-idx))))))
+
+     ;; Closed-core integer case joins the ordinary scalar branch vocabulary before emission.
+     (and (seq? expr) (= 'case* (first expr)))
+     (emit-expr (closed-integer-case! expr) idx-sym array-syms opencl-idx)
 
      ;; if -> ternary (pure) or compound statement (side-effectful)
      (and (seq? expr) (= 'if (first expr)))
@@ -1548,13 +1574,10 @@
                 ")")))
 
      :else
-     ;; Loud over silently corrupt: an unhandled IR form pr-str'd into the C/OpenCL
-     ;; source produces garbage (a cryptic clang/ocloc error, or a call to a
-     ;; nonexistent function). Surfacing this as a WARNING (was fully silent) flagged
-     ;; two real backend gaps: `case*` branch-maps (abm/firms, blelloch-scan,
-     ;; autotuner) and a SIMD-fold vector `[L 8]` (x8-simd-fold) — both stringified
-     ;; into invalid C. TODO: lower case* → cond and handle the SIMD vector, THEN
-     ;; flip this to `throw` (the true loud form). Tracked in compiler_consolidation.
+     ;; Loud over silently corrupt: an unhandled IR form pr-str'd into C-family source produces
+     ;; garbage (a cryptic compiler error, or a call to a nonexistent function).  Known `case*`
+     ;; and SIMD-fold gaps now lower explicitly; the residual warning remains until corpus
+     ;; coverage proves this compatibility fallback can become a hard error.
      (do (binding [*out* *err*]
            (println (str "WARNING: c-emit unhandled IR form (" (type expr)
                          ") — emitting as text, likely invalid. Lower it upstream. Form: "

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -89,14 +89,16 @@
    into a let*-bound nested-if chain: the test is bound once and compared against
    each integer testval. The exhaustive-case `default` (a throw) becomes the final
    else and lowers to `unreachable`. Only `:int` test-types occur in numeric
-   kernels (the walker keys cases on integers)."
+  kernels (the walker keys cases on integers)."
   [args]
-  (let [[test _shift _mask default clause-map] args
-        g (gensym "case_g_")
-        clauses (vals clause-map)]                       ; each = [testval result]
-    (list 'let* [g test]
-          (reduce (fn [els [k e]] (list 'if (list 'clojure.core/== g k) e els))
-                  default (reverse clauses)))))
+  (let [expression (cons 'case* args)
+        description (form/integer-case-descriptor expression)]
+    (when-not description
+      (throw (ex-info "WASM cannot lower this closed-core case representation"
+                      {:reason :unsupported-wasm-case :expression expression})))
+    (let [g (gensym "case_g_")]
+      (list 'let* [g (:test description)]
+            (form/integer-case-conditional description g)))))
 
 (defn- const-if-taken
   "For an `if` whose condition is a compile-time constant, which branch is statically
@@ -430,7 +432,7 @@
                         :else (infer-vt ctx (nth node 3))
                         (let [tv (infer-vt ctx (nth node 2))]
                           (if (= tv :i32) (infer-vt ctx (nth node 3)) tv))))
-          (= 'case* h) (infer-vt ctx (second (first (vals (nth node 5))))) ; first clause's result
+          (= 'case* h) (infer-vt ctx (synth-case* (rest node)))
           (and (symbol? h) (#{"zero?" "pos?" "neg?"} (name h))) :i32   ; predicate → bool
           ;; integer steppers (match emit-val's inc/dec) — i32 result, made explicit
           ;; so it's intentional rather than relying on the unknown-head default

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -32,6 +32,44 @@
    closed-IR `loop*`."
   #{'loop 'clojure.core/loop 'loop*})
 
+(defn integer-case-descriptor
+  "Decode Clojure's closed-core integer `case*` representation.
+
+   The clause-map keys are compiler dispatch hashes, not source case values.  The exact
+   semantic values live in each `[test-value result]` entry.  Returning one ordered descriptor
+   here keeps that implementation detail out of TypedSOAC and target emitters.  Unsupported
+   case encodings return nil instead of being guessed at by a backend."
+  [expression]
+  (when (and (seq? expression) (= 'case* (first expression)))
+    (let [[_ test _shift _mask default clause-map _switch-type test-type] expression
+          ordered (when (and (= :int test-type)
+                             (map? clause-map)
+                             (every? integer? (keys clause-map)))
+                    (->> clause-map (sort-by key) (mapv val)))
+          semantic-values (mapv first ordered)]
+      (when (and ordered
+                 (every? #(and (vector? %) (= 2 (count %))
+                                (integer? (first %)))
+                         ordered)
+                 (= (count semantic-values) (count (distinct semantic-values))))
+        {:test test
+         :default default
+         :clauses ordered}))))
+
+(defn integer-case-conditional
+  "Project an `integer-case-descriptor` into the shared scalar `if` vocabulary.
+
+   The two-argument form permits a backend to substitute an evaluate-once temporary for the
+   original test expression."
+  ([expression]
+   (when-let [description (integer-case-descriptor expression)]
+     (integer-case-conditional description (:test description))))
+  ([{:keys [clauses default]} test]
+   (reduce (fn [otherwise [test-value result]]
+             (list 'if (list 'clojure.core/== test test-value) result otherwise))
+           default
+           (reverse clauses))))
+
 (defn form-info
   "Classify a compiler IR form and return its properties.
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -152,33 +152,6 @@
                  (every? :dtype locals))
         locals))))
 
-(defn- integer-case-chain
-  "Project one closed-core integer `case*` into the conditional scalar vocabulary.
-
-   Clojure has already bound the tested expression before producing `case*`, so accepting only a
-   symbolic test preserves its evaluate-once semantics.  The clause map's dispatch hashes are an
-   implementation detail; exact integer test values are retained in its `[test-value result]`
-   entries.  Other case representations decline instead of leaking hash/keyword interpretation
-   into a target emitter."
-  [expression]
-  (when (and (seq? expression) (= 'case* (first expression)))
-    (let [[_ test _shift _mask default clauses _switch-type test-type] expression
-          ordered-clauses (when (and (map? clauses) (every? integer? (keys clauses)))
-                            (->> clauses
-                                 (sort-by key)
-                                 (mapv val)))]
-      (when (and (symbol? test)
-                 (= :int test-type)
-                 (map? clauses)
-                 (every? integer? (keys clauses))
-                 (every? #(and (vector? %) (= 2 (count %))
-                                (integer? (first %)))
-                         ordered-clauses))
-        (reduce (fn [otherwise [test-value result]]
-                  (list 'if (list 'clojure.core/== test test-value)
-                        result otherwise))
-                default (reverse ordered-clauses))))))
-
 (defn- substitute-store
   [substitutions store]
   (reduce (fn [store field]
@@ -573,8 +546,11 @@
                   (:stores else-region)))))}))
 
     (and (seq? body) (= 'case* (first body)))
-    (when-let [conditional (integer-case-chain body)]
-      (store-region conditional index))
+    (when-let [description (form/integer-case-descriptor body)]
+      ;; Closed Clojure core binds a non-trivial case test before constructing case*. Requiring
+      ;; that shape here preserves evaluate-once semantics in this source-to-region projection.
+      (when (symbol? (:test description))
+        (store-region (form/integer-case-conditional description (:test description)) index)))
 
     (and (seq? body) (symbol? (first body))
          (or (form/loop-head? (first body))

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -7,6 +7,21 @@
     (is (= (c-emit/emit-expr (list cast 'x) 'i #{} "i")
            (c-emit/emit-expr (list (symbol "clojure.core" (name cast)) 'x) 'i #{} "i")))))
 
+(deftest closed-core-integer-case-uses-the-canonical-scalar-projection
+  (let [source (c-emit/emit-expr
+                '(case* tag 0 0 99 {20 [7 70] 10 [3 30]} :compact :int)
+                nil #{} "idx")]
+    (is (not (.contains source "case*")))
+    (is (.contains source "tag == 3"))
+    (is (.contains source "tag == 7")))
+  (is (= :unsupported-c-family-case
+         (try
+           (c-emit/emit-expr
+            '(case* tag 0 0 nil {1 ["not-an-integer" 2]} :hash-equiv :hash-equiv)
+            nil #{} "idx")
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e)))))))
+
 (deftest explicit-unchecked-integer-casts-require-integral-evidence
   (doseq [value [4294967295 (with-meta 'word {:raster.type/tag 'long})]]
     (is (.startsWith (c-emit/emit-expr (list 'clojure.core/unchecked-int value) nil #{} "idx")

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -244,6 +244,22 @@
     (is (nil? (form/scope-info 'x))
         "a bare symbol is not a binder")))
 
+(deftest closed-core-integer-case-has-one-semantic-projection
+  (let [expression '(case* tag 0 0 99 {20 [7 70] 10 [3 30]} :compact :int)
+        description (form/integer-case-descriptor expression)]
+    (is (= {:test 'tag :default 99 :clauses [[3 30] [7 70]]}
+           description)
+        "dispatch hashes order clauses, but the vector entries carry their semantic values")
+    (is (= '(if (clojure.core/== tag 3)
+              30
+              (if (clojure.core/== tag 7) 70 99))
+           (form/integer-case-conditional description 'tag))))
+  (is (nil? (form/integer-case-descriptor
+             '(case* tag 0 0 nil {1 ["not-an-integer" 2]} :hash-equiv :hash-equiv))))
+  (is (nil? (form/integer-case-descriptor
+             '(case* tag 0 0 nil {1 [4 10] 2 [4 20]} :compact :int)))
+      "ambiguous duplicate semantic values decline"))
+
 (deftest scope-info-decomposition-test
   (testing "let* — one sequential scope, binders+inits paired"
     (let [{:keys [scopes sequential? outer]} (form/scope-info '(let* [a 1 b (+ a 2)] (+ a b)))]


### PR DESCRIPTION
## Summary
- decode closed-core integer case dispatch once in the shared form IR
- reuse the deterministic scalar projection in TypedSOAC, WASM, and C-family emission
- reject unsupported case representations instead of inferring from arbitrary arms or stringifying maps

## Validation
- 81 focused IR/C/TypedSOAC tests, 465 assertions
- 30 WASM tests, 229 assertions
- 12 equation-first C-family integration tests, 142 assertions
- git diff --check