### PR TITLE
Fail before serializing unknown C-family IR

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -704,17 +704,22 @@
     (let [args (rest expr)
           cond-expr (first args)
           then-expr (second args)
-          else-expr (when (>= (count args) 3) (nth args 2))
-          cond-str (emit-expr cond-expr idx-sym array-syms opencl-idx)]
-      (if else-expr
-        (str "if (" cond-str ") { "
-             (emit-stmt then-expr idx-sym array-syms opencl-idx)
-             " } else { "
-             (emit-stmt else-expr idx-sym array-syms opencl-idx)
-             " }")
-        (str "if (" cond-str ") { "
-             (emit-stmt then-expr idx-sym array-syms opencl-idx)
-             " }")))
+          else-expr (when (>= (count args) 3) (nth args 2))]
+      (case (form/constant-if-branch cond-expr)
+        :then (emit-stmt then-expr idx-sym array-syms opencl-idx)
+        :else (if (some? else-expr)
+                (emit-stmt else-expr idx-sym array-syms opencl-idx)
+                "")
+        (let [cond-str (emit-expr cond-expr idx-sym array-syms opencl-idx)]
+          (if (some? else-expr)
+            (str "if (" cond-str ") { "
+                 (emit-stmt then-expr idx-sym array-syms opencl-idx)
+                 " } else { "
+                 (emit-stmt else-expr idx-sym array-syms opencl-idx)
+                 " }")
+            (str "if (" cond-str ") { "
+                 (emit-stmt then-expr idx-sym array-syms opencl-idx)
+                 " }")))))
 
     ;; do block -> emit all as statements
     (and (seq? expr) (= 'do (first expr)))
@@ -941,17 +946,22 @@
     (let [args (rest expr)
           cond-expr (first args)
           then-expr (second args)
-          else-expr (when (>= (count args) 3) (nth args 2))
-          cond-str (emit-expr cond-expr idx-sym array-syms opencl-idx)]
-      (if else-expr
-        (str "if (" cond-str ") { "
-             (emit-loop-expr then-expr var-names var-types idx-sym array-syms opencl-idx)
-             " } else { "
-             (emit-loop-expr else-expr var-names var-types idx-sym array-syms opencl-idx)
-             " }")
-        (str "if (" cond-str ") { "
-             (emit-loop-expr then-expr var-names var-types idx-sym array-syms opencl-idx)
-             " } else { break; }")))
+          else-expr (when (>= (count args) 3) (nth args 2))]
+      (case (form/constant-if-branch cond-expr)
+        :then (emit-loop-expr then-expr var-names var-types idx-sym array-syms opencl-idx)
+        :else (if (some? else-expr)
+                (emit-loop-expr else-expr var-names var-types idx-sym array-syms opencl-idx)
+                "break;")
+        (let [cond-str (emit-expr cond-expr idx-sym array-syms opencl-idx)]
+          (if (some? else-expr)
+            (str "if (" cond-str ") { "
+                 (emit-loop-expr then-expr var-names var-types idx-sym array-syms opencl-idx)
+                 " } else { "
+                 (emit-loop-expr else-expr var-names var-types idx-sym array-syms opencl-idx)
+                 " }")
+            (str "if (" cond-str ") { "
+                 (emit-loop-expr then-expr var-names var-types idx-sym array-syms opencl-idx)
+                 " } else { break; }")))))
 
     ;; do block
     (and (seq? expr) (= 'do (first expr)))
@@ -1241,33 +1251,38 @@
      (let [args (rest expr)
            cond-expr (first args)
            then-expr (second args)
-           else-expr (when (>= (count args) 3) (nth args 2))
-           cond-str (emit-expr cond-expr idx-sym array-syms opencl-idx)]
-       (if (nil? else-expr)
-         ;; void if — should only appear in statement context, but handle gracefully
-         (if (supports-stmt-expr?)
-           (str "({ if (" cond-str ") { "
-                (emit-stmt then-expr idx-sym array-syms opencl-idx) " } })")
-           ;; GLSL: emit as ternary with 0 fallback
-           (str "((" cond-str ") ? ("
-                (emit-expr then-expr idx-sym array-syms opencl-idx) ") : 0)"))
-         (let [side-effects? (or (util/effectful? then-expr)
-                                 (util/effectful? else-expr))]
-           (if (and side-effects? (supports-stmt-expr?))
-             (str "({ " *scalar-type* " _r; if (" cond-str ") { "
-                  (emit-stmts-with-result then-expr idx-sym array-syms opencl-idx "_r")
-                  " } else { "
-                  (emit-stmts-with-result else-expr idx-sym array-syms opencl-idx "_r")
-                  " } _r; })")
-             (do
-               (when (and side-effects? (not (supports-stmt-expr?)))
-                 (throw (ex-info "GLSL: if branches contain side effects but statement expressions are not supported"
-                                 {:expr expr})))
-               ;; Pure ternary
+           else-expr (when (>= (count args) 3) (nth args 2))]
+       (case (form/constant-if-branch cond-expr)
+         :then (emit-expr then-expr idx-sym array-syms opencl-idx)
+         :else (if (some? else-expr)
+                 (emit-expr else-expr idx-sym array-syms opencl-idx)
+                 "0")
+         (let [cond-str (emit-expr cond-expr idx-sym array-syms opencl-idx)]
+           (if (nil? else-expr)
+             ;; void if — should only appear in statement context, but handle gracefully
+             (if (supports-stmt-expr?)
+               (str "({ if (" cond-str ") { "
+                    (emit-stmt then-expr idx-sym array-syms opencl-idx) " } })")
+               ;; GLSL: emit as ternary with 0 fallback
                (str "((" cond-str ") ? ("
-                    (emit-expr then-expr idx-sym array-syms opencl-idx)
-                    ") : ("
-                    (emit-expr else-expr idx-sym array-syms opencl-idx) "))"))))))
+                    (emit-expr then-expr idx-sym array-syms opencl-idx) ") : 0)"))
+             (let [side-effects? (or (util/effectful? then-expr)
+                                     (util/effectful? else-expr))]
+               (if (and side-effects? (supports-stmt-expr?))
+                 (str "({ " *scalar-type* " _r; if (" cond-str ") { "
+                      (emit-stmts-with-result then-expr idx-sym array-syms opencl-idx "_r")
+                      " } else { "
+                      (emit-stmts-with-result else-expr idx-sym array-syms opencl-idx "_r")
+                      " } _r; })")
+                 (do
+                   (when (and side-effects? (not (supports-stmt-expr?)))
+                     (throw (ex-info "GLSL: if branches contain side effects but statement expressions are not supported"
+                                     {:expr expr})))
+                   ;; Pure ternary
+                   (str "((" cond-str ") ? ("
+                        (emit-expr then-expr idx-sym array-syms opencl-idx)
+                        ") : ("
+                        (emit-expr else-expr idx-sym array-syms opencl-idx) "))"))))))))
 
      ;; when -> void if (only meaningful in statement context)
      (and (seq? expr) (= 'when (first expr)))
@@ -1574,15 +1589,12 @@
                 ")")))
 
      :else
-     ;; Loud over silently corrupt: an unhandled IR form pr-str'd into C-family source produces
-     ;; garbage (a cryptic compiler error, or a call to a nonexistent function).  Known `case*`
-     ;; and SIMD-fold gaps now lower explicitly; the residual warning remains until corpus
-     ;; coverage proves this compatibility fallback can become a hard error.
-     (do (binding [*out* *err*]
-           (println (str "WARNING: c-emit unhandled IR form (" (type expr)
-                         ") — emitting as text, likely invalid. Lower it upstream. Form: "
-                         (pr-str expr))))
-         (str expr)))))
+     ;; Never serialize an unknown Clojure value into target source.  Every reachable scalar form
+     ;; must either enter typed KernelBody earlier or have an explicit compatibility lowering here.
+     (throw (ex-info "C-family emitter encountered an unsupported IR value"
+                      {:reason :unsupported-c-family-ir
+                      :expression expr
+                      :expression-type (type expr)})))))
 
 ;; ================================================================
 ;; deftm inlining support

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -100,15 +100,6 @@
       (list 'let* [g (:test description)]
             (form/integer-case-conditional description g)))))
 
-(defn- const-if-taken
-  "For an `if` whose condition is a compile-time constant, which branch is statically
-   taken: :then (true / a keyword — e.g. a `cond`'s :else), :else (nil / false), or nil
-   (a real runtime condition). wasm has no keyword/nil truthiness, so these must fold."
-  [c]
-  (cond (or (true? c) (keyword? c)) :then
-        (or (nil? c) (false? c))    :else
-        :else nil))
-
 (defn- sym-vt
   "Valtype from the walker's stamped :raster.type/tag on a binding symbol — the
    single type source (TC-fed). nil when unstamped (pass-introduced bindings)."
@@ -186,7 +177,7 @@
         ;; has no notion of a keyword/nil "condition".
         (= h 'if)
         (let [[c t e] A]
-          (case (const-if-taken c)
+          (case (form/constant-if-branch c)
             :then (emit-val ctx t)
             :else (emit-val ctx e)
             (let [tv (infer-vt ctx t)
@@ -427,7 +418,7 @@
                               (infer-vt c' (last node)))
           (= 'do h) (infer-vt ctx (last node))           ; value of tail
           (= 'if h) (let [c (nth node 1)]               ; fold constant-truthy conditions
-                      (case (const-if-taken c)
+                      (case (form/constant-if-branch c)
                         :then (infer-vt ctx (nth node 2))
                         :else (infer-vt ctx (nth node 3))
                         (let [tv (infer-vt ctx (nth node 2))]
@@ -489,7 +480,7 @@
         (into init-bytes (vec (mapcat #(emit-effect ctx' %) body))))
       (= h 'if)                                     ; (if c then [else]) in void position
       (let [[c t e] A]
-        (case (const-if-taken c)
+        (case (form/constant-if-branch c)
           :then (emit-effect ctx t)
           :else (if (some? e) (emit-effect ctx e) [])
           (-> (emit-val ctx c)

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -70,6 +70,17 @@
            default
            (reverse clauses))))
 
+(defn constant-if-branch
+  "Return the statically selected branch for a closed-core Clojure condition, or nil.
+
+   Keywords are truthy and occur as the final `cond` test (`:else`). Nil and false select the
+   else arm; true and keywords select the then arm. Other values remain runtime conditions."
+  [condition]
+  (cond
+    (or (true? condition) (keyword? condition)) :then
+    (or (nil? condition) (false? condition)) :else
+    :else nil))
+
 (defn form-info
   "Classify a compiler IR form and return its properties.
 

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -22,6 +22,20 @@
            (catch clojure.lang.ExceptionInfo e
              (:reason (ex-data e)))))))
 
+(deftest unknown-ir-values-fail-before-producing-target-source
+  (is (= "7" (c-emit/emit-expr '(if :else 7 9) nil #{} "idx"))
+      "a cond :else marker is control syntax and is folded before target emission")
+  (is (= :unsupported-c-family-ir
+         (try
+           (c-emit/emit-expr {:source-shaped :value} nil #{} "idx")
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e))))))
+  (is (= :unsupported-c-family-ir
+         (try
+           (c-emit/emit-expr :not-a-numerical-value nil #{} "idx")
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e)))))))
+
 (deftest explicit-unchecked-integer-casts-require-integral-evidence
   (doseq [value [4294967295 (with-meta 'word {:raster.type/tag 'long})]]
     (is (.startsWith (c-emit/emit-expr (list 'clojure.core/unchecked-int value) nil #{} "idx")

--- a/test/raster/compiler/ir/form_test.clj
+++ b/test/raster/compiler/ir/form_test.clj
@@ -260,6 +260,13 @@
              '(case* tag 0 0 nil {1 [4 10] 2 [4 20]} :compact :int)))
       "ambiguous duplicate semantic values decline"))
 
+(deftest closed-core-constant-conditions-have-one-projection
+  (is (= :then (form/constant-if-branch :else)))
+  (is (= :then (form/constant-if-branch true)))
+  (is (= :else (form/constant-if-branch false)))
+  (is (= :else (form/constant-if-branch nil)))
+  (is (nil? (form/constant-if-branch 'runtime-predicate))))
+
 (deftest scope-info-decomposition-test
   (testing "let* — one sequential scope, binders+inits paired"
     (let [{:keys [scopes sequential? outer]} (form/scope-info '(let* [a 1 b (+ a 2)] (+ a b)))]


### PR DESCRIPTION
## Summary
- remove the last textual unknown-value fallback from retained C-family expression emission
- return a structured :unsupported-c-family-ir error instead of malformed target source
- share closed-core constant-branch semantics between WASM and C-family emission
- fix huber-loss-backward's cond :else path, which CI proved had previously emitted invalid literal text

## Validation
- 28 shared-form/C-emitter tests, 224 assertions
- exact huber-loss-backward GPU pipeline regression compiles to one kernel
- previous head: six gates green; CPU OpenCL exposed the :else defect now repaired
- fresh full cross-target/corpus matrix delegated to CI