### PR TITLE
Lower paged KV append through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -338,7 +338,17 @@ code object in mandatory hardware-free CI jobs, while real Intel execution remai
 oracle. The compiler fixtures now stage values through both synchronous workgroup memory and the
 verified async issue/commit/wait contract; the exact async body is compiled to CUDA sm_80 PTX and
 an RDNA3 HIP code object in hardware-free CI. CUDA/HIP runtime registration, launch and on-device
-numerical coverage remain deliberately separate from source legality. The verifier still forbids
+numerical coverage remain deliberately separate from source legality.
+
+Paged K/V assignment likewise retains its storage-specific semantic descriptor and unique-slot
+ownership contract, but no longer owns an OpenCL source template. Its one-component-per-work-item
+schedule is a typed scalar/control KernelBody with a two-dimensional launch, guarded routed-page
+stores and explicit nearest-even Float-to-Half conversion. The ordered inout ABI is projected from
+that body unchanged, the same body emits for OpenCL/CUDA/HIP, and the vendor forms join the
+hardware-free compiler gates. This is a reference schedule, not a claim that page assignment has
+been tuned; routing and cache ownership remain outside target emission.
+
+The verifier still forbids
 pending asynchronous state and live staged storage from escaping an ordinary structured region,
 but `PipelinedFor` now carries a complete ordered async queue across loop iterations, verifies each
 rotating stage's layout and lifetime, and requires an explicit exact or separate-epilogue tail

--- a/src/raster/compiler/backend/gpu/paged_kv_append.clj
+++ b/src/raster/compiler/backend/gpu/paged_kv_append.clj
@@ -1,10 +1,13 @@
 (ns raster.compiler.backend.gpu.paged-kv-append
-  "Portable OpenCL-C reference lowering for paged FP32-to-FP16 K/V assignment."
-  (:require [raster.compiler.ir.kernel-abi :as kabi]
+  "C-family target lowering for paged FP32-to-FP16 K/V assignment."
+  (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emitter]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
             [raster.compiler.ir.kernel-graph :as graph]
-            [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.paged-kv-append :as append]))
+            [raster.compiler.ir.paged-kv-append :as append]
+            [raster.compiler.passes.parallel.paged-kv-append-body :as append-body]))
 
 (defn- kernel-name
   [problem]
@@ -26,35 +29,6 @@
         maximum (long (or (:max-workgroup-size desc) 256))]
     (long (max 1 (min width subgroup maximum)))))
 
-(defn- source
-  [problem name]
-  (let [{:keys [batch-size key-elements-per-token value-elements-per-token]}
-        (append/validate! problem)
-        slots (append/physical-slots problem)]
-    (str "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
-         "__kernel void " name "(\n"
-         "    __global const float* key_rows,\n"
-         "    __global const float* value_rows,\n"
-         "    __global const int* slot_mapping,\n"
-         "    __global half* key_pages,\n"
-         "    __global half* value_pages) {\n"
-         "  const int component = (int)get_global_id(0);\n"
-         "  const int lane = (int)get_global_id(1);\n"
-         "  if (lane >= " batch-size ") return;\n"
-         "  const int slot = slot_mapping[lane];\n"
-         "  if (slot < 0 || (long)slot >= " slots "L) return;\n"
-         "  if (component < " key-elements-per-token ") {\n"
-         "    const long src = (long)lane * " key-elements-per-token " + component;\n"
-         "    const long dst = (long)slot * " key-elements-per-token " + component;\n"
-         "    key_pages[dst] = convert_half_rte(key_rows[src]);\n"
-         "  }\n"
-         "  if (component < " value-elements-per-token ") {\n"
-         "    const long src = (long)lane * " value-elements-per-token " + component;\n"
-         "    const long dst = (long)slot * " value-elements-per-token " + component;\n"
-         "    value_pages[dst] = convert_half_rte(value_rows[src]);\n"
-         "  }\n"
-         "}\n")))
-
 (defn- ordered-abi
   [problem]
   (let [{:keys [key-rows value-rows slot-mapping key-pages value-pages]}
@@ -67,32 +41,39 @@
       (kabi/slot value-pages :inout :half :c-name "value_pages" :role :value-pages)])))
 
 (defn emit-fp32-to-fp16-reference
-  "Emit the portable assignment kernel as a verified KernelArtifact."
-  [problem desc]
-  (let [{:keys [id batch-size key-elements-per-token value-elements-per-token]
-         :as problem} (append/validate! problem)
-        name (kernel-name problem)
-        workgroup-x (reference-workgroup-x problem desc)
-        width (max key-elements-per-token value-elements-per-token)
-        inputs (append/ordered-input-buffer-ids problem)
-        outputs (append/ordered-output-buffer-ids problem)]
-    (artifact/make
-     {:kernel-name name
-      :source (source problem name)
-      :abi (ordered-abi problem)
-      :arguments (into inputs outputs)
-      :launch (launch/spec
-               {:workgroup-size [workgroup-x 1]
-                :group-count [(long (quot (+ width (dec workgroup-x)) workgroup-x))
-                              batch-size]})
-      :effects {:kind :paged-kv-append :reads inputs :writes outputs}
-      :provenance {:operation-id id :semantic-op :paged-kv-append
-                   :lowering :fp32-to-fp16-reference}
-      :attributes {:strategy :fp32-to-fp16-reference
-                   :optimization-tier :reference
-                   :assignment :unique-slot
-                   :rounding-mode :round-to-nearest-even
-                   :input-dtype :float :storage-dtype :half}})))
+  "Schedule the portable assignment as KernelBody and emit one C-family artifact."
+  ([problem desc]
+   (emit-fp32-to-fp16-reference problem desc :opencl-intel))
+  ([problem desc target-dialect]
+   (let [{:keys [id] :as problem} (append/validate! problem)
+         name (kernel-name problem)
+         workgroup-x (reference-workgroup-x problem desc)
+         inputs (append/ordered-input-buffer-ids problem)
+         outputs (append/ordered-output-buffer-ids problem)
+         kernel-body (append-body/lower problem workgroup-x)
+         base-abi (ordered-abi problem)
+         abi (body-abi/project-contracts base-abi kernel-body)
+         dialect (c-dialect/resolve! target-dialect)
+         parameter-names (into {} (map (juxt :name :c-name)) base-abi)]
+     (artifact/make
+      {:kernel-name name
+       :target (c-dialect/target dialect)
+       :source (emitter/emit-scalar-kernel
+                name kernel-body
+                {:target-dialect target-dialect :parameter-names parameter-names})
+       :abi abi
+       :arguments (into inputs outputs)
+       :launch (:launch kernel-body)
+       :effects {:kind :paged-kv-append :reads inputs :writes outputs}
+       :provenance {:operation-id id :semantic-op :paged-kv-append
+                    :lowering :kernel-body-fp32-to-fp16}
+       :attributes {:strategy :fp32-to-fp16-reference
+                    :optimization-tier :reference
+                    :assignment :unique-slot
+                    :rounding-mode :round-to-nearest-even
+                    :input-dtype :float :storage-dtype :half
+                    :kernel-body kernel-body
+                    :target-dialect target-dialect}}))))
 
 (defn kernel-graph
   "Wrap one append artifact in a verified graph with explicit in-place page effects."

--- a/src/raster/compiler/passes/parallel/paged_kv_append_body.clj
+++ b/src/raster/compiler/passes/parallel/paged_kv_append_body.clj
@@ -1,0 +1,100 @@
+(ns raster.compiler.passes.parallel.paged-kv-append-body
+  "Target-neutral one-work-item-per-component schedule for routed K/V assignment."
+  (:require [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.paged-kv-append :as append]))
+
+(defn lower
+  "Lower a validated PagedKVAppend to typed scalar/control KernelBody.
+
+   A host-validated slot map promises unique active destinations. The device guard retains safe
+   behavior for inactive (-1) and out-of-range slots; component masks cover unequal K/V widths."
+  [problem workgroup-x]
+  (let [{:keys [id batch-size key-elements-per-token value-elements-per-token
+                key-rows value-rows slot-mapping key-pages value-pages]}
+        (append/validate! problem)
+        slots (append/physical-slots problem)
+        width (max key-elements-per-token value-elements-per-token)
+        group-x :append-group-x
+        lane-x :append-lane-x
+        lane :append-lane
+        component :append-component
+        slot :append-slot
+        converted (fn [prefix input output mask]
+                    (let [loaded (keyword (str prefix "-loaded"))
+                          half-value (keyword (str prefix "-half"))]
+                      [(body/->ScalarLoad (body/value loaded :float) input [lane component]
+                                         mask (body/literal 0.0 :float) :streaming)
+                       (body/->ScalarCompute
+                        (body/value half-value :half)
+                        (body/cast-expression loaded :half :nearest-even :ieee))
+                       (body/->ScalarStore output [slot component] half-value mask)]))]
+    (body/make
+     {:id [:paged-kv-append-body id]
+      :parameters [(body/->KernelParameter key-rows :input :float
+                                           [batch-size key-elements-per-token] :global
+                                           (layout/row-major [batch-size key-elements-per-token] :float)
+                                           :key-rows)
+                   (body/->KernelParameter value-rows :input :float
+                                           [batch-size value-elements-per-token] :global
+                                           (layout/row-major [batch-size value-elements-per-token] :float)
+                                           :value-rows)
+                   (body/->KernelParameter slot-mapping :input :int [batch-size] :global
+                                           (layout/row-major [batch-size] :int) :slot-mapping)
+                   (body/->KernelParameter key-pages :inout :half
+                                           [slots key-elements-per-token] :global
+                                           (layout/row-major [slots key-elements-per-token] :half)
+                                           :key-pages)
+                   (body/->KernelParameter value-pages :inout :half
+                                           [slots value-elements-per-token] :global
+                                           (layout/row-major [slots value-elements-per-token] :half)
+                                           :value-pages)]
+      :stable-reads [(body/stable-read key-rows)
+                     (body/stable-read value-rows)
+                     (body/stable-read slot-mapping)]
+      :indices [(body/->IndexBinding group-x :group 0)
+                (body/->IndexBinding lane-x :local 0)
+                (body/->IndexBinding lane :group 1)
+                (body/->IndexCompute
+                 component
+                 (body/index-cast
+                  (body/expression :add
+                                   (body/expression :mul group-x workgroup-x)
+                                   lane-x)
+                  :long :exact))]
+      :masks [(body/->Mask :append-key-active
+                           [(body/predicate :lt component key-elements-per-token)])
+              (body/->Mask :append-value-active
+                           [(body/predicate :lt component value-elements-per-token)])]
+      :operations
+      [(body/->ScalarLoad (body/value slot :int) slot-mapping [lane]
+                          nil nil :cached)
+       (body/->ScalarCompute
+        (body/value :append-slot-nonnegative :predicate)
+        (body/scalar-expression :le :predicate [(body/literal 0 :int) slot]))
+       (body/->ScalarCompute
+        (body/value :append-slot-bounded :predicate)
+        (body/scalar-expression :lt :predicate [slot (body/literal slots :int)]))
+       (body/->IfRegion
+        :append-slot-nonnegative
+        [(body/->IfRegion
+          :append-slot-bounded
+          (vec (concat (converted "append-key" key-rows key-pages :append-key-active)
+                       (converted "append-value" value-rows value-pages :append-value-active)
+                       [(body/->Yield [])]))
+          [(body/->Yield [])]
+          [])
+         (body/->Yield [])]
+        [(body/->Yield [])]
+        [])]
+      :schedule {:strategy :paged-kv-append-component
+                 :assignment :unique-slot
+                 :rounding :nearest-even}
+      :launch (launch/spec {:workgroup-size [workgroup-x 1]
+                            :group-count [(long (quot (+ width (dec workgroup-x)) workgroup-x))
+                                          batch-size]})
+      :provenance {:dialect :kernel-body :source-dialect :paged-kv-append}
+      :attributes {:kind :paged-kv-append :operation-id id
+                   :input-dtype :float :storage-dtype :half
+                   :no-write-alias true}})))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -9,6 +9,7 @@
             [raster.compiler.backend.gpu.kernel-body-target :as body-target]
             [raster.compiler.backend.gpu.staged-contraction-fixtures :as staged-fixtures]
             [raster.compiler.backend.gpu.layout-transform :as layout-transform]
+            [raster.compiler.backend.gpu.paged-kv-append :as paged-append-emit]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.equation-first :as equation-first]
@@ -17,6 +18,7 @@
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.paged-kv-append :as paged-append]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.attention-route :as attention-route]
@@ -454,6 +456,19 @@
                             {:kernel-name "layout_transpose_mixed_width" :input 'in :output 'out
                              :row-extent-dtype :long :column-extent-dtype :int
                              :element-dtype :half :target-dialect dialect})))
+           (write-source! directory suffix "paged-kv-append"
+                          (:source
+                           (paged-append-emit/emit-fp32-to-fp16-reference
+                            (paged-append/make
+                             {:id :compile-fixture-paged-append
+                              :key-rows 'key-rows :value-rows 'value-rows
+                              :slot-mapping 'slot-mapping
+                              :key-pages 'key-pages :value-pages 'value-pages
+                              :batch-size 3 :key-elements-per-token 8
+                              :value-elements-per-token 6
+                              :page-size 4 :physical-pages 5})
+                            {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}
+                            dialect)))
            (write-source! directory suffix "split-k-combine"
                           (:source
                            (gemm-emit/emit-split-k-combine-kernel

--- a/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
+++ b/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
@@ -1,7 +1,9 @@
 (ns raster.compiler.passes.parallel.paged-kv-append-route-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.paged-kv-append :as emit]
             [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.paged-kv-append :as append]
             [raster.compiler.passes.parallel.paged-kv-append-route :as route]))
@@ -45,11 +47,15 @@
 
 (deftest routed-artifact-is-assignment-with-in-place-page-effects
   (let [{:keys [artifact graph strategy]} (route/route! (problem))
-        source (:source artifact)]
+        source (:source artifact)
+        kernel-body (get-in artifact [:attributes :kernel-body])]
     (is (= :fp32-to-fp16-reference strategy))
-    (is (str/includes? source "key_pages[dst] = convert_half_rte(key_rows[src]);"))
-    (is (str/includes? source "value_pages[dst] = convert_half_rte(value_rows[src]);"))
-    (is (str/includes? source "if (slot < 0"))
+    (is (identical? kernel-body (body/validate! kernel-body)))
+    (is (= :kernel-body-fp32-to-fp16 (get-in artifact [:provenance :lowering])))
+    (is (str/includes? source "convert_half_rte"))
+    (is (str/includes? source "rstr_append_slot_nonnegative"))
+    (is (str/includes? source "key_pages["))
+    (is (str/includes? source "value_pages["))
     (is (not (str/includes? source "atomic")))
     (is (= ['key-rows 'value-rows 'slots 'key-pages 'value-pages]
            (:arguments artifact)))
@@ -73,3 +79,13 @@
   (testing "a failed route retains a stable top-level reason"
     (is (= :paged-kv-append-no-kernel-route
            (reason #(route/route! (problem {:value-storage-dtype :double})))))))
+
+(deftest one-kernel-body-emits-for-both-vendor-c-family-targets
+  (doseq [[target emitted-target] [[:cuda :cuda-c] [:hip :hip-cpp]]]
+    (let [artifact (emit/emit-fp32-to-fp16-reference
+                    (problem) {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}
+                    target)]
+      (is (= emitted-target (:target artifact)))
+      (is (= target (get-in artifact [:attributes :target-dialect])))
+      (is (str/includes? (:source artifact) "extern \"C\" __global__ void"))
+      (is (str/includes? (:source artifact) "rstr_append_slot_bounded")))))


### PR DESCRIPTION
## Summary
- replace the paged FP32-to-FP16 K/V append OpenCL template with a target-neutral typed KernelBody schedule
- retain the unique-slot ownership, ordered inout ABI, guarded routed-page stores, 2-D launch, and nearest-even conversion contract
- emit the same body through OpenCL, CUDA, and HIP C-family lowering
- add the production body to hardware-free CUDA/HIP compiler fixtures

## Validation
- 5 route/body/vendor-source tests, 37 assertions
- real Intel Arc/OpenCL execution: 2 tests, 84 assertions
- KernelBody validation and ABI projection exercised directly
- full suite and CUDA/HIP compiler gates delegated to CI