### PR TITLE
Lower static indexed weighted reductions through KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -6,11 +6,16 @@
    denominator and weighted values remain private scalars and no edge-sized intermediates are
    materialized."
   (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as body-opencl]
+            [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
-            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.passes.parallel.indexed-weighted-reduction-body :as indexed-body]))
 
 (defn- fail
   [message reason data]
@@ -220,16 +225,6 @@
          "  output[output_index] = denominator == " zero " ? " zero
          " : numerator / (denominator + (" ctype ")" epsilon ");\n"
          "}\n")))
-
-(defn- source
-  [plan {:keys [heads components] :as shape} name]
-  (source* plan
-           (assoc shape
-                  :active-width (* heads components)
-                  :scale (/ 1.0 (Math/sqrt (double components)))
-                  :bound (double (get-in plan [:score :arguments 2 :value]))
-                  :epsilon (double (get-in plan [:normalization :epsilon])))
-           name))
 
 (defn- ordered-abi
   [plan]
@@ -480,11 +475,20 @@
         workgroup-x (reference-workgroup-x plan shape-env desc)
         name (kernel-name plan shape)
         inputs (swr/ordered-input-ids plan)
-        output (get-in plan [:output :id])]
+        output (get-in plan [:output :id])
+        target-dialect (or (gpu-target/kernel-body-c-dialect desc) :opencl-portable)
+        dialect (c-dialect/resolve! target-dialect)
+        kernel-body (indexed-body/lower-reference plan shape workgroup-x)
+        base-abi (ordered-abi plan)
+        parameter-names (into {} (map (juxt :name :c-name)) base-abi)
+        abi (body-abi/project-contracts base-abi kernel-body)]
     (kart/make
      {:kernel-name name
-      :source (source plan shape name)
-      :abi (ordered-abi plan)
+      :target (c-dialect/target dialect)
+      :source (body-opencl/emit-scalar-kernel
+               name kernel-body
+               {:parameter-names parameter-names :target-dialect target-dialect})
+      :abi abi
       :arguments (conj inputs output)
       :launch (klaunch/spec
                {:workgroup-size [workgroup-x 1]
@@ -504,6 +508,8 @@
                    :membership :edge-list-by-destination
                    :duplicate-policy :multiset
                    :shape shape
+                   :kernel-body kernel-body
+                   :target-dialect target-dialect
                    :materialized-intermediates []
                    :complexity :quadratic-in-edges-and-head-components}})))
 

--- a/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
@@ -1,0 +1,184 @@
+(ns raster.compiler.passes.parallel.indexed-weighted-reduction-body
+  "Target-neutral scalar correctness schedule for indexed dense weighted reductions."
+  (:require [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(defn- lit [value type] (body/literal value type))
+(defn- expr [op type & arguments] (body/scalar-expression op type arguments))
+(defn- bounded-expr [op type & arguments]
+  (body/scalar-expression op type arguments {:overflow :no-overflow}))
+(defn- compute [id type expression]
+  (body/->ScalarCompute (body/value id type) expression))
+(defn- select [condition if-true if-false type]
+  (expr :select type condition if-true if-false))
+(defn- conjunction [& predicates]
+  (reduce #(select %1 %2 (lit false :predicate) :predicate)
+          (lit true :predicate) predicates))
+
+(defn lower-reference
+  "Lower one static indexed edge-list reduction to KernelBody.
+
+  One work-item owns one destination/feature. It retains the historical correctness schedule:
+  ordered multiset traversal, private numerator/denominator, no edge-sized intermediates, and a
+  NaN result for every output when any edge index is malformed."
+  [plan {:keys [entities edges heads components total-dim] :as shape} workgroup-x]
+  (let [plan (swr/validate! plan)
+        [q k v destination-indices source-indices] (:operands plan)
+        output (:output plan)
+        dtype (:accumulator-dtype plan)
+        active-width (* heads components)
+        bound (double (get-in plan [:score :arguments 2 :value]))
+        epsilon (double (get-in plan [:normalization :epsilon]))
+        scale (/ 1.0 (Math/sqrt (double components)))
+        group-x 'indexed-group-x
+        group-y 'indexed-group-y
+        lane-x 'indexed-lane-x
+        feature 'feature
+        destination 'destination
+        edge 'edge
+        x 'x
+        dot-loop
+        (body/->ForLoop
+         (body/value x :long)
+         (body/index-cast 0 :long :exact) (body/index-cast components :long :exact) 1
+         [(body/->LoopArg (body/value 'dot-state dtype) (lit 0.0 dtype))]
+          [(compute 'qk-component :long
+                   (bounded-expr :+ :long
+                                 (bounded-expr :* :long 'head (lit components :long)) x))
+          (body/->ScalarLoad (body/value 'q-element dtype) (:id q)
+                             [destination 'qk-component] nil nil :cached)
+          (body/->ScalarLoad (body/value 'k-element dtype) (:id k)
+                             ['safe-source 'qk-component] nil nil :cached)
+          (compute 'dot-product dtype (expr :* dtype 'q-element 'k-element))
+          (compute 'dot-next dtype (expr :+ dtype 'dot-state 'dot-product))
+          (body/->Yield ['dot-next])]
+         [(body/value 'dot dtype)] {})
+        edge-loop
+        (body/->ForLoop
+         (body/value edge :long)
+         (body/index-cast 0 :long :exact) (body/index-cast edges :long :exact) 1
+         [(body/->LoopArg (body/value 'valid-state :predicate) (lit true :predicate))
+          (body/->LoopArg (body/value 'numerator-state dtype) (lit 0.0 dtype))
+          (body/->LoopArg (body/value 'denominator-state dtype) (lit 0.0 dtype))]
+         [(body/->ScalarLoad (body/value 'edge-destination :long) (:id destination-indices)
+                             [edge] nil nil :cached)
+          (body/->ScalarLoad (body/value 'edge-source :long) (:id source-indices)
+                             [edge] nil nil :cached)
+          (compute 'edge-destination-nonnegative :predicate
+                   (expr :le :predicate (lit 0 :long) 'edge-destination))
+          (compute 'edge-destination-bounded :predicate
+                   (expr :lt :predicate 'edge-destination (lit entities :long)))
+          (compute 'edge-source-nonnegative :predicate
+                   (expr :le :predicate (lit 0 :long) 'edge-source))
+          (compute 'edge-source-bounded :predicate
+                   (expr :lt :predicate 'edge-source (lit entities :long)))
+          (compute 'edge-valid :predicate
+                   (conjunction 'edge-destination-nonnegative 'edge-destination-bounded
+                                'edge-source-nonnegative 'edge-source-bounded))
+          (compute 'valid-next :predicate
+                   (select 'valid-state 'edge-valid (lit false :predicate) :predicate))
+          (compute 'safe-source :long
+                   (expr :min :long
+                         (expr :max :long 'edge-source (lit 0 :long))
+                         (lit (dec entities) :long)))
+          (compute 'destination-match :predicate
+                   (expr :eq :predicate 'edge-destination destination))
+          (compute 'member-applies :predicate
+                   (conjunction 'edge-valid 'destination-match))
+          (body/->IfRegion
+           'member-applies
+           [(compute 'head :long (expr :quot :long feature (lit components :long)))
+            dot-loop
+            (compute 'scaled dtype (expr :* dtype 'dot (lit scale dtype)))
+            (compute 'scaled-is-nan :predicate
+                     (body/scalar-expression :isnan :predicate ['scaled]))
+            (compute 'clamped dtype
+                     (expr :min dtype (lit bound dtype)
+                           (expr :max dtype (lit (- bound) dtype) 'scaled)))
+            (compute 'score dtype (select 'scaled-is-nan 'scaled 'clamped dtype))
+            (compute 'weight dtype (expr :exp dtype 'score))
+            (body/->ScalarLoad (body/value 'value-element dtype) (:id v)
+                               ['safe-source feature] nil nil :cached)
+            (compute 'weighted-value dtype (expr :* dtype 'weight 'value-element))
+            (compute 'numerator-updated dtype
+                     (expr :+ dtype 'numerator-state 'weighted-value))
+            (compute 'denominator-updated dtype
+                     (expr :+ dtype 'denominator-state 'weight))
+            (body/->Yield ['numerator-updated 'denominator-updated])]
+           [(body/->Yield ['numerator-state 'denominator-state])]
+           [(body/value 'numerator-next dtype)
+            (body/value 'denominator-next dtype)])
+          (body/->Yield ['valid-next 'numerator-next 'denominator-next])]
+         [(body/value 'final-valid :predicate)
+          (body/value 'final-numerator dtype)
+          (body/value 'final-denominator dtype)] {})
+        denominator-zero (compute 'denominator-zero :predicate
+                                  (expr :eq :predicate 'final-denominator (lit 0.0 dtype)))
+        quotient (compute 'normalized-value dtype
+                          (expr :div dtype 'final-numerator
+                                (expr :+ dtype 'final-denominator (lit epsilon dtype))))
+        result (compute 'valid-result dtype
+                        (select 'denominator-zero (lit 0.0 dtype) 'normalized-value dtype))]
+    (body/make
+     {:id [:indexed-weighted-reduction-body (:id plan) shape]
+      :parameters [(body/->KernelParameter (:id q) :input dtype [entities total-dim] :global
+                                           (layout/row-major [entities total-dim] dtype) :query)
+                   (body/->KernelParameter (:id k) :input dtype [entities total-dim] :global
+                                           (layout/row-major [entities total-dim] dtype) :key)
+                   (body/->KernelParameter (:id v) :input dtype [entities total-dim] :global
+                                           (layout/row-major [entities total-dim] dtype) :value)
+                   (body/->KernelParameter (:id destination-indices) :input :long [edges] :global
+                                           (layout/row-major [edges] :long) :destination-indices)
+                   (body/->KernelParameter (:id source-indices) :input :long [edges] :global
+                                           (layout/row-major [edges] :long) :source-indices)
+                   (body/->KernelParameter (:id output) :output dtype [entities total-dim] :global
+                                           (layout/row-major [entities total-dim] dtype) :result)]
+      :stable-reads (mapv body/stable-read (swr/ordered-input-ids plan))
+      :indices [(body/->IndexBinding group-x :group 0)
+                (body/->IndexBinding lane-x :local 0)
+                (body/->IndexBinding group-y :group 1)
+                (body/->IndexCompute destination
+                                     (body/index-cast group-y :long :exact))
+                (body/->IndexCompute feature
+                                     (body/index-cast
+                                      (body/expression :add
+                                                       (body/expression :mul group-x workgroup-x)
+                                                       lane-x)
+                                      :long :exact))]
+      :masks []
+      :operations
+      [(compute 'feature-bounded :predicate
+                (expr :lt :predicate feature (lit total-dim :long)))
+       (body/->IfRegion
+        'feature-bounded
+        [(compute 'feature-active :predicate
+                  (expr :lt :predicate feature (lit active-width :long)))
+         (body/->IfRegion
+          'feature-active
+          [edge-loop denominator-zero quotient result
+           (compute 'final-result dtype
+                    (select 'final-valid 'valid-result (lit Double/NaN dtype) dtype))
+           (body/->ScalarStore (:id output) [destination feature] 'final-result nil)
+           (body/->Yield [])]
+          [(body/->ScalarStore (:id output) [destination feature] (lit 0.0 dtype) nil)
+           (body/->Yield [])]
+          [])
+         (body/->Yield [])]
+        [(body/->Yield [])]
+        [])]
+      :schedule {:strategy :indexed-segmented-reduction-reference
+                 :membership-traversal :ordered-edge-list
+                 :score-reuse :per-output-component}
+      :launch (launch/spec
+               {:workgroup-size [workgroup-x 1]
+                :group-count [(long (quot (+ total-dim (dec workgroup-x)) workgroup-x))
+                              entities]})
+      :provenance {:dialect :kernel-body
+                   :semantic-op :segmented-weighted-reduction
+                   :algebra-plan-id (:id plan)
+                   :lowering :indexed-reference-kernel-body}
+      :attributes {:storage-kind :indexed-dense-values
+                   :membership-kind :edge-list-by-destination
+                   :duplicate-policy :multiset}})))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -4,6 +4,7 @@
             [raster.arrays]
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.gemm :as gemm-emit]
+            [raster.compiler.backend.gpu.indexed-attention :as indexed-attention-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
             [raster.compiler.backend.gpu.kernel-body-target :as body-target]
@@ -24,6 +25,7 @@
             [raster.compiler.passes.parallel.attention-route :as attention-route]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contract-route :as contract-route]
+            [raster.compiler.passes.parallel.indexed-attention-recognize :as indexed-recognize]
             [raster.compiler.passes.parallel.segmap-capacity-fixture :as capacity-fixture]
             [raster.compiler.passes.parallel.carried-effect-loop-fixture :as carried-fixture]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
@@ -109,6 +111,24 @@
   [input :- (Array float) indices :- (Array int) blocks :- Long stride :- Long] :- (Array float)
   (let [output (float-array (* blocks stride))]
     (raster.par/scatter! output input indices blocks stride)))
+
+(defn- indexed-attention-plan
+  []
+  (first
+   (indexed-recognize/recognize
+    '(let* [raw (raster.dl.array-ops/indexed-dot
+                 Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+            weights (raster.dl.array-ops/scale-clamp-exp
+                     raw (raster.numeric// 1.0 (raster.numeric/sqrt dk))
+                     5.0 (clojure.core/* n-edges n-heads))
+            denominator (raster.dl.array-ops/scatter-add
+                         weights dst n-nodes n-edges n-heads)
+            weighted (raster.dl.array-ops/scatter-mul-add
+                      weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+            normalized (raster.dl.array-ops/segment-div
+                        weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
+           normalized)
+    :dtype :float :accumulator-dtype :float)))
 
 (defn- reduction-artifact
   [dialect]
@@ -469,6 +489,11 @@
                               :page-size 4 :physical-pages 5})
                             {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}
                             dialect)))
+           (write-artifact! directory suffix "indexed-weighted-reduction-reference"
+                            (indexed-attention-emit/emit-reference
+                             (indexed-attention-plan)
+                             {'n-nodes 3 'n-edges 4 'dk 2 'emb-dim 5 'n-heads 2}
+                             descriptor))
            (write-source! directory suffix "split-k-combine"
                           (:source
                            (gemm-emit/emit-split-k-combine-kernel

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -27,6 +27,15 @@
 (def ^:private shape-env
   {'n-nodes 3 'n-edges 4 'dk 2 'emb-dim 5 'n-heads 2})
 
+(defn- nested-operations
+  [operations]
+  (mapcat (fn [operation]
+            (cons operation
+                  (concat (nested-operations (or (:operations operation) []))
+                          (nested-operations (or (:then-operations operation) []))
+                          (nested-operations (or (:else-operations operation) [])))))
+          operations))
+
 (defn- plan
   ([] (plan :float))
   ([dtype]
@@ -52,12 +61,15 @@
     (is (= [] (:temporaries graph)))
     (is (= [15 15 15 4 4] (mapv :elements (:inputs graph))))
     (is (= [15] (mapv :elements (:outputs graph))))
-    (let [source (:source artifact)]
-      (is (str/includes? source "for (long edge = 0; edge < 4L; ++edge)"))
-      (is (str/includes? source "fmin((float)5.0f"))
-      (is (str/includes? source "isnan(scaled) ? scaled"))
-      (is (str/includes? source "denominator + (float)1.0E-6f"))
-      (is (str/includes? source "feature >= 4L"))
+    (let [source (:source artifact)
+          kernel-body (get-in artifact [:attributes :kernel-body])
+          operations (nested-operations (:operations kernel-body))
+          scalar-ops (into #{} (keep #(get-in % [:expression :op])) operations)]
+      (is (= :kernel-body (get-in kernel-body [:provenance :dialect])))
+      (is (= :ordered-edge-list (get-in kernel-body [:schedule :membership-traversal])))
+      (is (= 2 (count (filter #(= "ForLoop" (some-> % class .getSimpleName)) operations))))
+      (is (every? scalar-ops [:min :isnan :exp :div]))
+      (is (str/includes? source "rstr_feature_active"))
       (is (not (str/includes? source "raw_scores")))
       (is (not (str/includes? source "weights[")))
       (is (not (str/includes? source "denominator["))))))


### PR DESCRIPTION
## Outcome
- replaces the handwritten static indexed-attention OpenCL leaf with verified target-neutral scalar/control KernelBody
- preserves ordered multiset traversal, NaN/error behavior, fusion, ABI, and zero materialized intermediates
- emits the same body through OpenCL, CUDA, and HIP dialects
- adds the production body to CUDA/HIP compiler gates and tests structure instead of brittle source spellings

## Validation
- indexed-attention route: 10 tests, 65 assertions
- Intel Arc device suite: 4 tests, 15 assertions
- generated CUDA compiled to sm_80 PTX with nvcc
- generated HIP compiled to gfx1100 code object with hipcc
