### PR TITLE
Lower dynamic indexed reductions through KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -139,14 +139,6 @@
          (Double/toString (double value)))
        (when (= :float dtype) "f")))
 
-(defn- long-expression
-  [value]
-  (if (number? value) (str value "L") (str "(" value ")")))
-
-(defn- fp-expression
-  [dtype value]
-  (if (number? value) (fp-literal dtype value) (str value)))
-
 (defn- kernel-name
   [plan shape]
   (let [identity {:schedule (swr/schedule-key plan) :shape shape}
@@ -155,76 +147,6 @@
                         "ref")]
     (format "raster_indexed_attention_%s_%08x" schedule-name
             (bit-and 0xffffffff (long (hash identity))))))
-
-(defn- source*
-  [plan {:keys [entities edges components total-dim active-width scale bound epsilon
-                scalar-signature invalid-shape]} name]
-  (let [entities (long-expression entities)
-        edges (long-expression edges)
-        components (long-expression components)
-        total-dim (long-expression total-dim)
-        active-width (long-expression active-width)
-        dtype (:accumulator-dtype plan)
-        ctype (c-type dtype)
-        bound (fp-expression dtype bound)
-        epsilon (fp-expression dtype epsilon)
-        scale (fp-expression dtype scale)
-        zero (fp-literal dtype 0.0)]
-    (str (when (= :double dtype)
-           "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
-         "__kernel void " name "(\n"
-         "    __global const " ctype "* q,\n"
-         "    __global const " ctype "* k,\n"
-         "    __global const " ctype "* v,\n"
-         "    __global const long* destination_indices,\n"
-         "    __global const long* source_indices,\n"
-         "    __global " ctype "* output"
-         (when (seq scalar-signature) (str ",\n" scalar-signature))
-         ") {\n"
-         "  const long feature = (long)get_global_id(0);\n"
-         "  const long destination = (long)get_global_id(1);\n"
-         "  if (feature >= " total-dim " || destination >= " entities ") return;\n"
-         "  const long output_index = destination * " total-dim " + feature;\n"
-         (when invalid-shape
-           (str "  if (" invalid-shape ") {\n"
-                "    output[output_index] = (" ctype ")NAN;\n"
-                "    return;\n"
-                "  }\n"))
-         "  if (feature >= " active-width ") {\n"
-         "    output[output_index] = " zero ";\n"
-         "    return;\n"
-         "  }\n"
-         "  const long head = feature / " components ";\n"
-         "  const long component = feature - head * " components ";\n"
-         "  " ctype " numerator = " zero ";\n"
-         "  " ctype " denominator = " zero ";\n"
-         "  for (long edge = 0; edge < " edges "; ++edge) {\n"
-         "    const long edge_destination = destination_indices[edge];\n"
-         "    const long source = source_indices[edge];\n"
-         "    if (edge_destination < 0L || edge_destination >= " entities
-         " || source < 0L || source >= " entities ") {\n"
-         "      output[output_index] = (" ctype ")NAN;\n"
-         "      return;\n"
-         "    }\n"
-         "    if (edge_destination != destination) continue;\n"
-         "    const long q_base = destination * " total-dim " + head * " components ";\n"
-         "    const long kv_base = source * " total-dim " + head * " components ";\n"
-         "    " ctype " dot = " zero ";\n"
-         "    for (long x = 0; x < " components "; ++x)\n"
-         "      dot += q[q_base + x] * k[kv_base + x];\n"
-         "    const " ctype " scaled = dot * (" ctype ")" scale ";\n"
-         ;; Java Math/min and Math/max propagate NaN; OpenCL fmin/fmax select the numeric operand.
-         ;; Preserve the recognized source semantics explicitly instead of inheriting that drift.
-         "    const " ctype " score = isnan(scaled) ? scaled\n"
-         "        : fmin((" ctype ")" bound
-         ", fmax(-(" ctype ")" bound ", scaled));\n"
-         "    const " ctype " weight = exp(score);\n"
-         "    numerator += weight * v[kv_base + component];\n"
-         "    denominator += weight;\n"
-         "  }\n"
-         "  output[output_index] = denominator == " zero " ? " zero
-         " : numerator / (denominator + (" ctype ")" epsilon ");\n"
-         "}\n")))
 
 (defn- ordered-abi
   [plan]
@@ -267,13 +189,18 @@
         fp (:accumulator-dtype plan)]
     (kabi/validate!
      (into
-      [(kabi/slot (:id q) :input fp :c-name "q" :role :query)
-       (kabi/slot (:id k) :input fp :c-name "k" :role :key)
-       (kabi/slot (:id v) :input fp :c-name "v" :role :value)
+      [(kabi/slot (:id q) :input fp :c-name "q" :role :query
+                  :aliasing :no-write-alias)
+       (kabi/slot (:id k) :input fp :c-name "k" :role :key
+                  :aliasing :no-write-alias)
+       (kabi/slot (:id v) :input fp :c-name "v" :role :value
+                  :aliasing :no-write-alias)
        (kabi/slot (:id destination-indices) :input :long
-                  :c-name "destination_indices" :role :destination-indices)
+                  :c-name "destination_indices" :role :destination-indices
+                  :aliasing :no-write-alias)
        (kabi/slot (:id source-indices) :input :long
-                  :c-name "source_indices" :role :source-indices)
+                  :c-name "source_indices" :role :source-indices
+                  :aliasing :no-write-alias)
        (kabi/slot (:id output) :output fp :c-name "output" :role :result)]
       (map (fn [{:keys [name c-name]}]
              (kabi/slot name :scalar :long :c-name c-name :role :shape))
@@ -289,39 +216,29 @@
   (let [plan (indexed-attention-plan! plan)
         fields (dynamic-fields plan)
         values (mapv :value fields)
-        field-code (into {} (map (juxt :name :c-name)) fields)
         [entities _ total-dim _ _ output-elements] values
         workgroup-x (dynamic-workgroup-x desc)
         name (kernel-name plan :dynamic)
         inputs (swr/ordered-input-ids plan)
         output (get-in plan [:output :id])
         dtype (:accumulator-dtype plan)
-        ctype (c-type dtype)
-        scalar-signature
-        (->> fields
-             (map (fn [{:keys [c-name]}] (str "    long " c-name)))
-             (str/join ",\n"))
-        code {:entities (get field-code 'n_entities)
-              :edges (get field-code 'n_edges)
-              :total-dim (get field-code 'total_dim)
-              :heads (get field-code 'n_heads)
-              :components (get field-code 'n_components)
-              :active-width (str (get field-code 'n_heads) " * "
-                                 (get field-code 'n_components))
-              :scale (str "((" ctype ")" (fp-literal dtype 1.0)
-                          " / sqrt((" ctype ")" (get field-code 'n_components) "))")
-              :bound (double (get-in plan [:score :arguments 2 :value]))
-              :epsilon (double (get-in plan [:normalization :epsilon]))
-              :scalar-signature scalar-signature
-              :invalid-shape
-              "n_edges < 0L || n_heads <= 0L || n_components <= 0L || n_heads > total_dim / n_components"}
-        abi (dynamic-abi plan fields)
+        target-dialect (or (gpu-target/kernel-body-c-dialect desc) :opencl-portable)
+        dialect (c-dialect/resolve! target-dialect)
+        kernel-body (indexed-body/lower-dynamic-reference plan workgroup-x)
+        base-abi (dynamic-abi plan fields)
+        parameter-names (into {} (map (juxt :name :c-name)) base-abi)
+        abi (body-abi/project-contracts base-abi kernel-body)
         arguments (into (conj inputs output) values)]
     (kart/make
      {:kernel-name name
-      :source (source* plan code name)
+      :target (c-dialect/target dialect)
+      :source (body-opencl/emit-scalar-kernel
+               name kernel-body
+               {:parameter-names parameter-names :target-dialect target-dialect})
       :abi abi
       :arguments arguments
+      ;; KernelBody names target ABI scalars; the artifact launch resolves the corresponding
+      ;; logical argument expressions at the public call boundary.
       :launch (klaunch/spec
                {:workgroup-size [workgroup-x 1]
                 :group-count [(klaunch/ceil-div total-dim workgroup-x)
@@ -340,6 +257,8 @@
                    :duplicate-policy :multiset
                    :dynamic-shape? true
                    :out-elems output-elements
+                   :kernel-body kernel-body
+                   :target-dialect target-dialect
                    :materialized-intermediates []
                    :complexity :quadratic-in-edges-and-head-components}})))
 
@@ -440,6 +359,10 @@
         arguments (into (conj inputs output) values)]
     (kart/make
      {:kernel-name name
+      ;; This handwritten leaf is still Intel OpenCL-only, but it participates in the same
+      ;; logical dispatch as the portable KernelBody reference.  Kernel artifacts name the
+      ;; source-language target (`:opencl-c`), not the runtime backend (`:opencl`).
+      :target :opencl-c
       :source (score-reuse-source plan fields subgroup-size name)
       :abi abi
       :arguments arguments

--- a/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
@@ -17,21 +17,23 @@
   (reduce #(select %1 %2 (lit false :predicate) :predicate)
           (lit true :predicate) predicates))
 
-(defn lower-reference
-  "Lower one static indexed edge-list reduction to KernelBody.
+(defn- lower-reference*
+  "Lower one indexed edge-list reduction to KernelBody.
 
   One work-item owns one destination/feature. It retains the historical correctness schedule:
   ordered multiset traversal, private numerator/denominator, no edge-sized intermediates, and a
   NaN result for every output when any edge index is malformed."
-  [plan {:keys [entities edges heads components total-dim] :as shape} workgroup-x]
+  [plan {:keys [entities edges heads components total-dim] :as shape} workgroup-x dynamic?]
   (let [plan (swr/validate! plan)
         [q k v destination-indices source-indices] (:operands plan)
         output (:output plan)
         dtype (:accumulator-dtype plan)
-        active-width (* heads components)
+        long-value (fn [value] (if dynamic? value (lit value :long)))
+        active-width (if dynamic? 'active-width (* heads components))
+        final-entity (if dynamic? 'final-entity (lit (dec entities) :long))
         bound (double (get-in plan [:score :arguments 2 :value]))
         epsilon (double (get-in plan [:normalization :epsilon]))
-        scale (/ 1.0 (Math/sqrt (double components)))
+        scale (if dynamic? 'scale-value (/ 1.0 (Math/sqrt (double components))))
         group-x 'indexed-group-x
         group-y 'indexed-group-y
         lane-x 'indexed-lane-x
@@ -44,9 +46,13 @@
          (body/value x :long)
          (body/index-cast 0 :long :exact) (body/index-cast components :long :exact) 1
          [(body/->LoopArg (body/value 'dot-state dtype) (lit 0.0 dtype))]
-          [(compute 'qk-component :long
-                   (bounded-expr :+ :long
-                                 (bounded-expr :* :long 'head (lit components :long)) x))
+         [(compute 'qk-component :long
+                   (body/scalar-expression
+                    :+ :long
+                    [(body/scalar-expression
+                      :* :long ['head (long-value components)]
+                      {:overflow (if dynamic? :wrap :no-overflow)}) x]
+                    {:overflow (if dynamic? :wrap :no-overflow)}))
           (body/->ScalarLoad (body/value 'q-element dtype) (:id q)
                              [destination 'qk-component] nil nil :cached)
           (body/->ScalarLoad (body/value 'k-element dtype) (:id k)
@@ -69,11 +75,11 @@
           (compute 'edge-destination-nonnegative :predicate
                    (expr :le :predicate (lit 0 :long) 'edge-destination))
           (compute 'edge-destination-bounded :predicate
-                   (expr :lt :predicate 'edge-destination (lit entities :long)))
+                   (expr :lt :predicate 'edge-destination (long-value entities)))
           (compute 'edge-source-nonnegative :predicate
                    (expr :le :predicate (lit 0 :long) 'edge-source))
           (compute 'edge-source-bounded :predicate
-                   (expr :lt :predicate 'edge-source (lit entities :long)))
+                   (expr :lt :predicate 'edge-source (long-value entities)))
           (compute 'edge-valid :predicate
                    (conjunction 'edge-destination-nonnegative 'edge-destination-bounded
                                 'edge-source-nonnegative 'edge-source-bounded))
@@ -82,16 +88,16 @@
           (compute 'safe-source :long
                    (expr :min :long
                          (expr :max :long 'edge-source (lit 0 :long))
-                         (lit (dec entities) :long)))
+                         final-entity))
           (compute 'destination-match :predicate
                    (expr :eq :predicate 'edge-destination destination))
           (compute 'member-applies :predicate
                    (conjunction 'edge-valid 'destination-match))
           (body/->IfRegion
            'member-applies
-           [(compute 'head :long (expr :quot :long feature (lit components :long)))
+           [(compute 'head :long (expr :quot :long feature (long-value components)))
             dot-loop
-            (compute 'scaled dtype (expr :* dtype 'dot (lit scale dtype)))
+            (compute 'scaled dtype (expr :* dtype 'dot (if dynamic? scale (lit scale dtype))))
             (compute 'scaled-is-nan :predicate
                      (body/scalar-expression :isnan :predicate ['scaled]))
             (compute 'clamped dtype
@@ -120,21 +126,84 @@
                           (expr :div dtype 'final-numerator
                                 (expr :+ dtype 'final-denominator (lit epsilon dtype))))
         result (compute 'valid-result dtype
-                        (select 'denominator-zero (lit 0.0 dtype) 'normalized-value dtype))]
+                        (select 'denominator-zero (lit 0.0 dtype) 'normalized-value dtype))
+        active-operations
+        [(compute 'feature-active :predicate
+                  (expr :lt :predicate feature (if dynamic? active-width
+                                                    (lit active-width :long))))
+         (body/->IfRegion
+          'feature-active
+          [edge-loop denominator-zero quotient result
+           (compute 'final-result dtype
+                    (select 'final-valid 'valid-result (lit Double/NaN dtype) dtype))
+           (body/->ScalarStore (:id output) [destination feature] 'final-result nil)
+           (body/->Yield [])]
+          [(body/->ScalarStore (:id output) [destination feature] (lit 0.0 dtype) nil)
+           (body/->Yield [])]
+          [])
+         (body/->Yield [])]
+        dynamic-derived
+        (when dynamic?
+          [(compute 'entities-positive :predicate
+                    (expr :lt :predicate (lit 0 :long) entities))
+           (compute 'edges-nonnegative :predicate
+                    (expr :le :predicate (lit 0 :long) edges))
+           (compute 'heads-positive :predicate
+                    (expr :lt :predicate (lit 0 :long) heads))
+           (compute 'components-positive :predicate
+                    (expr :lt :predicate (lit 0 :long) components))
+           (compute 'safe-components :long
+                    (expr :max :long components (lit 1 :long)))
+           (compute 'head-layout-fits :predicate
+                    (expr :le :predicate heads (expr :quot :long total-dim 'safe-components)))
+           (compute 'shape-valid :predicate
+                    (conjunction 'entities-positive 'edges-nonnegative 'heads-positive
+                                 'components-positive 'head-layout-fits))
+           (compute 'active-width :long
+                    (body/scalar-expression :* :long [heads components] {:overflow :wrap}))
+           (compute 'final-entity :long
+                    (body/scalar-expression
+                     :- :long [(expr :max :long entities (lit 1 :long)) (lit 1 :long)]
+                     {:overflow :wrap}))
+           (compute 'components-fp dtype
+                    (body/cast-expression components dtype :nearest-even :exact))
+           (compute 'scale-value dtype
+                    (expr :div dtype (lit 1.0 dtype) (expr :sqrt dtype 'components-fp)))])
+        feature-operations
+        (if dynamic?
+          [(body/->IfRegion
+            'shape-valid active-operations
+            [(body/->ScalarStore (:id output) [destination feature] (lit Double/NaN dtype) nil)
+             (body/->Yield [])]
+            [])
+           (body/->Yield [])]
+          active-operations)
+        scalar-parameters
+        (when dynamic?
+          (mapv #(body/->KernelParameter % :scalar :long [] nil nil :shape)
+                [entities edges total-dim heads components 'output_elements]))]
     (body/make
      {:id [:indexed-weighted-reduction-body (:id plan) shape]
-      :parameters [(body/->KernelParameter (:id q) :input dtype [entities total-dim] :global
-                                           (layout/row-major [entities total-dim] dtype) :query)
-                   (body/->KernelParameter (:id k) :input dtype [entities total-dim] :global
-                                           (layout/row-major [entities total-dim] dtype) :key)
-                   (body/->KernelParameter (:id v) :input dtype [entities total-dim] :global
-                                           (layout/row-major [entities total-dim] dtype) :value)
-                   (body/->KernelParameter (:id destination-indices) :input :long [edges] :global
-                                           (layout/row-major [edges] :long) :destination-indices)
-                   (body/->KernelParameter (:id source-indices) :input :long [edges] :global
-                                           (layout/row-major [edges] :long) :source-indices)
-                   (body/->KernelParameter (:id output) :output dtype [entities total-dim] :global
-                                           (layout/row-major [entities total-dim] dtype) :result)]
+      :parameters (vec (concat
+                        [(body/->KernelParameter
+                          (:id q) :input dtype [entities total-dim] :global
+                          (layout/row-major [entities total-dim] dtype) :query)
+                         (body/->KernelParameter
+                          (:id k) :input dtype [entities total-dim] :global
+                          (layout/row-major [entities total-dim] dtype) :key)
+                         (body/->KernelParameter
+                          (:id v) :input dtype [entities total-dim] :global
+                          (layout/row-major [entities total-dim] dtype) :value)
+                         (body/->KernelParameter
+                          (:id destination-indices) :input :long [edges] :global
+                          (layout/row-major [edges] :long) :destination-indices)
+                         (body/->KernelParameter
+                          (:id source-indices) :input :long [edges] :global
+                          (layout/row-major [edges] :long) :source-indices)
+                         (body/->KernelParameter
+                          (:id output) :output dtype [entities total-dim] :global
+                          (layout/row-major [entities total-dim] dtype) :result)]
+                        scalar-parameters))
       :stable-reads (mapv body/stable-read (swr/ordered-input-ids plan))
       :indices [(body/->IndexBinding group-x :group 0)
                 (body/->IndexBinding lane-x :local 0)
@@ -149,36 +218,42 @@
                                       :long :exact))]
       :masks []
       :operations
-      [(compute 'feature-bounded :predicate
-                (expr :lt :predicate feature (lit total-dim :long)))
+      (vec (concat dynamic-derived
+       [(compute 'feature-bounded :predicate
+                (expr :lt :predicate feature (long-value total-dim)))
        (body/->IfRegion
         'feature-bounded
-        [(compute 'feature-active :predicate
-                  (expr :lt :predicate feature (lit active-width :long)))
-         (body/->IfRegion
-          'feature-active
-          [edge-loop denominator-zero quotient result
-           (compute 'final-result dtype
-                    (select 'final-valid 'valid-result (lit Double/NaN dtype) dtype))
-           (body/->ScalarStore (:id output) [destination feature] 'final-result nil)
-           (body/->Yield [])]
-          [(body/->ScalarStore (:id output) [destination feature] (lit 0.0 dtype) nil)
-           (body/->Yield [])]
-          [])
-         (body/->Yield [])]
+        feature-operations
         [(body/->Yield [])]
-        [])]
+        [])]))
       :schedule {:strategy :indexed-segmented-reduction-reference
                  :membership-traversal :ordered-edge-list
                  :score-reuse :per-output-component}
       :launch (launch/spec
                {:workgroup-size [workgroup-x 1]
-                :group-count [(long (quot (+ total-dim (dec workgroup-x)) workgroup-x))
-                              entities]})
+                :group-count (if dynamic?
+                               [(launch/ceil-div (launch/runtime-value total-dim) workgroup-x)
+                                (launch/runtime-value entities)]
+                               [(long (quot (+ total-dim (dec workgroup-x)) workgroup-x))
+                                entities])})
       :provenance {:dialect :kernel-body
                    :semantic-op :segmented-weighted-reduction
                    :algebra-plan-id (:id plan)
                    :lowering :indexed-reference-kernel-body}
       :attributes {:storage-kind :indexed-dense-values
                    :membership-kind :edge-list-by-destination
-                   :duplicate-policy :multiset}})))
+                   :duplicate-policy :multiset
+                   :dynamic-shape? dynamic?}})))
+
+(defn lower-reference
+  "Lower a statically specialized indexed edge-list correctness schedule."
+  [plan shape workgroup-x]
+  (lower-reference* plan shape workgroup-x false))
+
+(defn lower-dynamic-reference
+  "Lower the same correctness schedule with ordered int64 runtime extents."
+  [plan workgroup-x]
+  (lower-reference* plan
+                    {:entities 'n_entities :edges 'n_edges :heads 'n_heads
+                     :components 'n_components :total-dim 'total_dim}
+                    workgroup-x true))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -494,6 +494,9 @@
                              (indexed-attention-plan)
                              {'n-nodes 3 'n-edges 4 'dk 2 'emb-dim 5 'n-heads 2}
                              descriptor))
+           (write-artifact! directory suffix "indexed-weighted-reduction-dynamic"
+                            (indexed-attention-emit/emit-dynamic-reference
+                             (indexed-attention-plan) descriptor))
            (write-source! directory suffix "split-k-combine"
                           (:source
                            (gemm-emit/emit-split-k-combine-kernel

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -86,7 +86,7 @@
         (route/route-dynamic! (plan)
                               {:device-type :gpu :subgroup-size 16
                                :max-workgroup-size 256})
-        runtime-values (vec (concat (repeat 6 (Object.))
+        runtime-values (vec (concat (repeatedly 6 #(Object.))
                                     (map (fn [value] {:type :long :value value})
                                          [3 4 5 2 2 15])))
         call (kcall/make artifact runtime-values)
@@ -98,7 +98,11 @@
                             (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
         graph-call (kgcall/make graph graph-buffers graph-scalars)
         output-elements (launch/product 'n-nodes 'emb-dim)
-        graph-output (first (:outputs graph))]
+        graph-output (first (:outputs graph))
+        kernel-body (get-in artifact [:attributes :kernel-body])
+        operations (nested-operations (:operations kernel-body))
+        scale-value (some #(when (= 'scale-value (get-in % [:result :id])) %) operations)
+        components-cast (some #(when (= 'components-fp (get-in % [:result :id])) %) operations)]
     (is (= '[Q K V dst src normalized
              n_entities n_edges total_dim n_heads n_components output_elements]
            (mapv :name (:abi artifact))))
@@ -127,7 +131,9 @@
                 (filter (comp #{'dst 'src} :id) (:inputs graph))))
     (is (= 15 (kgcall/resolve-integer graph-scalars (:elements graph-output))))
     (is (str/includes? (:source artifact) "long n_entities"))
-    (is (str/includes? (:source artifact) "sqrt((float)n_components)"))))
+    (is (= {:rounding :nearest-even :overflow :exact}
+           (get-in components-cast [:expression :options])))
+    (is (= :sqrt (get-in scale-value [:expression :arguments 1 :op])))))
 
 (deftest leaf-selection-depends-on-plan-descriptors-not-attention-provenance
   (let [generic-plan (-> (plan)
@@ -149,11 +155,11 @@
                        :subgroup-size 16
                        :max-workgroup-size 256
                        :segmented-weighted-reduction-schedule :subgroup-score-reuse})
-        runtime-values (vec (concat (repeat 6 (Object.))
+        runtime-values (vec (concat (repeatedly 6 #(Object.))
                                     (map (fn [value] {:type :long :value value})
                                          [3 4 5 2 2 15])))
         call (kcall/make artifact runtime-values)
-        wide-values (vec (concat (repeat 6 (Object.))
+        wide-values (vec (concat (repeatedly 6 #(Object.))
                                  (map (fn [value] {:type :long :value value})
                                       [3 4 260 2 128 780])))
         wide-call (kcall/make artifact wide-values)


### PR DESCRIPTION
## Summary
- share one verified KernelBody between static and shape-polymorphic indexed reductions
- preserve ABI memory contracts and runtime launch expressions through graph dispatch
- compile the dynamic artifact with OpenCL, CUDA, and HIP target spellings
- delete the duplicate handwritten correctness template

## Validation
- focused route/lowering: 10 tests, 66 assertions
- Intel Arc device: 4 tests, 15 assertions
- nvcc sm_80 compile gate
- hipcc gfx1100 compile gate
- git diff --check