### PR TITLE
Align indexed schedule tails for malformed edges

### DIFF
--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -297,8 +297,9 @@
          "  const int active = component < n_components && feature < total_dim;\n"
          "  " ctype " numerator = " zero ";\n"
          "  " ctype " denominator = " zero ";\n"
-         "  int invalid = n_edges < 0L || n_heads <= 0L || n_components <= 0L\n"
+         "  const int invalid_shape = n_edges < 0L || n_heads <= 0L || n_components <= 0L\n"
          "        || n_heads > total_dim / n_components;\n"
+         "  int invalid = invalid_shape;\n"
          "  for (long edge = 0L; edge < n_edges; ++edge) {\n"
          "    const long edge_destination = destination_indices[edge];\n"
          "    const long source = source_indices[edge];\n"
@@ -336,7 +337,7 @@
          "    const long active_width = n_heads * n_components;\n"
          "    for (long tail = active_width + lane; tail < total_dim; tail += "
          subgroup-size "L)\n"
-         "      output[destination * total_dim + tail] = invalid ? (" ctype ")NAN : " zero ";\n"
+         "      output[destination * total_dim + tail] = invalid_shape ? (" ctype ")NAN : " zero ";\n"
          "  }\n"
          "}\n")))
 

--- a/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
@@ -22,7 +22,8 @@
 
   One work-item owns one destination/feature. It retains the historical correctness schedule:
   ordered multiset traversal, private numerator/denominator, no edge-sized intermediates, and a
-  NaN result for every output when any edge index is malformed."
+  NaN result for every active head component when any edge index is malformed. Unused row
+  tails remain zero; malformed shapes produce NaN for every launched output."
   [plan {:keys [entities edges heads components total-dim] :as shape} workgroup-x dynamic?]
   (let [plan (swr/validate! plan)
         [q k v destination-indices source-indices] (:operands plan)

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -65,15 +65,15 @@
     {:plan plan :shape-env shape-env :buffers buffers :expected expected}))
 
 (defn- run-case
-  [device-id]
-  (let [{:keys [plan shape-env buffers expected]} (test-case)
-        graph (:graph (route/route-dynamic!
+  ([device-id] (run-case device-id :subgroup-score-reuse (test-case)))
+  ([device-id strategy {:keys [plan shape-env buffers expected]}]
+  (let [graph (:graph (route/route-dynamic!
                        plan
                        {:device-type :gpu
                         :vendor "Intel"
                         :subgroup-size 16
                         :max-workgroup-size 256
-                        :segmented-weighted-reduction-schedule :subgroup-score-reuse}))
+                        :segmented-weighted-reduction-schedule strategy}))
         output-elements (get-in plan [:output :elements])
         scalar-values
         (assoc (into {} (map (fn [[name value]]
@@ -98,15 +98,33 @@
             (is (= (count expected) (alength actual)))
             (is (every? true?
                         (map (fn [wanted got]
-                               (< (Math/abs (- (double wanted) (double got))) 2.0e-5))
+                               (if (Double/isNaN (double wanted))
+                                 (Double/isNaN (double got))
+                                 (< (Math/abs (- (double wanted) (double got))) 2.0e-5)))
                              expected actual)))
-            (is (= [0.0 0.0 0.0 0.0 0.0]
-                   (subvec (vec actual) 5 10))
-                "a destination with no incoming edges is zero")
-            (is (= 0.0 (double (aget actual 4)))
-                "the non-head tail is explicitly zeroed"))
+            (is (every? #(= 0.0 (double (aget actual %))) [4 9 14])
+                "every unused row tail is zero, including malformed-edge inputs")
+            (when (every? zero? (subvec (vec expected) 5 10))
+              (is (= [0.0 0.0 0.0 0.0 0.0] (subvec (vec actual) 5 10))
+                  "a destination with no incoming edges is zero")))
           (finally
-            (gpu/release-kernel-graph! session handle)))))))
+            (gpu/release-kernel-graph! session handle))))))))
+
+(deftest indexed-schedules-agree-on-malformed-endpoints
+  (if-not @device-probe/opencl-subgroups-available?
+    (device-probe/opencl-skip! "indexed malformed endpoint agreement" :subgroups)
+    (doseq [strategy [:reference :subgroup-score-reuse]
+            endpoint ['dst 'src]
+            invalid [-1 Long/MAX_VALUE]]
+      (let [case (test-case)
+            indices (aclone ^longs (get-in case [:buffers endpoint]))
+            expected (float-array (for [i (range 15)]
+                                    (if (= 4 (mod i 5)) 0.0 Float/NaN)))]
+        ;; Put the invalid edge last so earlier valid work cannot mask the error.
+        (aset-long indices 3 invalid)
+        (run-case :ocl:0 strategy
+                  (-> case (assoc-in [:buffers endpoint] indices)
+                      (assoc :expected expected)))))))
 
 (deftest level-zero-indexed-attention-matches-independent-plan-oracle
   (if-not @gp/gpu-available?


### PR DESCRIPTION
Both indexed weighted-reduction schedules must agree when a resident edge buffer contains an invalid endpoint. Previously the subgroup schedule wrote NaN into unused row tails, while the reference schedule left those tails zero. Keep malformed-edge status separate from malformed-shape status so both schedules produce NaN in active head components and zero in unused tails.

The device regression exercises negative and Long/MAX_VALUE endpoints in both source and destination buffers, through both schedules. The malformed edge comes after valid edges. Existing valid-input, empty-destination, and runtime dispatch checks remain in the focused suite.

This fixes schedule agreement before migrating the subgroup implementation to KernelBody. The subgroup source template remains for that follow-up.
