### PR TITLE
Lower indexed subgroup score reuse through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -348,6 +348,15 @@ that body unchanged, the same body emits for OpenCL/CUDA/HIP, and the vendor for
 hardware-free compiler gates. This is a reference schedule, not a claim that page assignment has
 been tuned; routing and cache ownership remain outside target emission.
 
+Indexed dense weighted reductions likewise lower both static/dynamic reference schedules and
+the subgroup score-reuse schedule through KernelBody. The subgroup schedule uses a strided
+per-lane dot loop, full-participation reduction/broadcast, and guarded value accumulation; its
+handwritten OpenCL source template is removed. The same body compiles to CUDA and HIP, while
+production selection remains Intel-gated pending cross-vendor execution evidence. Ordered
+edge-list traversal still scans all edges for each destination/head/component tile. Destination
+bounding and measured schedule selection remain performance work, not consequences of emitter
+unification. Invalid endpoints poison active head components; unused row tails remain zero.
+
 The verifier still forbids
 pending asynchronous state and live staged storage from escaping an ordinary structured region,
 but `PipelinedFor` now carries a complete ordered async queue across loop iterations, verifies each

--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -1,12 +1,9 @@
 (ns raster.compiler.backend.gpu.indexed-attention
-  "Direct correctness lowering for recognized indexed graph attention.
+  "Artifact and ABI construction for indexed weighted-reduction schedules.
 
-   One work-item owns one destination/feature output and scans the edge list. The schedule is
-   intentionally simple, but it is genuinely fused: scores, clamped exponential weights,
-   denominator and weighted values remain private scalars and no edge-sized intermediates are
-   materialized."
-  (:require [clojure.string :as str]
-            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+   Reference and subgroup schedules lower through KernelBody and the common C-family emitter.
+   Scores, weights and reduction state stay private; no edge-sized intermediates are materialized."
+  (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-opencl]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.kernel-abi :as kabi]
@@ -127,17 +124,6 @@
         subgroup (long (or (:subgroup-size desc) 16))
         maximum (long (or (:max-workgroup-size desc) 256))]
     (long (max 1 (min total-dim subgroup maximum)))))
-
-(defn- c-type
-  [dtype]
-  (case dtype :float "float" :double "double"))
-
-(defn- fp-literal
-  [dtype value]
-  (str (if (= :float dtype)
-         (Float/toString (float value))
-         (Double/toString (double value)))
-       (when (= :float dtype) "f")))
 
 (defn- kernel-name
   [plan shape]
@@ -266,81 +252,6 @@
   [desc]
   (long (or (:subgroup-size desc) 16)))
 
-(defn- score-reuse-source
-  [plan fields subgroup-size name]
-  (let [dtype (:accumulator-dtype plan)
-        ctype (c-type dtype)
-        zero (fp-literal dtype 0.0)
-        one (fp-literal dtype 1.0)
-        bound (fp-literal dtype (double (get-in plan [:score :arguments 2 :value])))
-        epsilon (fp-literal dtype (double (get-in plan [:normalization :epsilon])))
-        scalar-signature (->> fields
-                              (map (fn [{:keys [c-name]}] (str "    long " c-name)))
-                              (str/join ",\n"))]
-    (str (when (= :double dtype)
-           "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
-         "__attribute__((intel_reqd_sub_group_size(" subgroup-size ")))\n"
-         "__kernel void " name "(\n"
-         "    __global const " ctype "* q,\n"
-         "    __global const " ctype "* k,\n"
-         "    __global const " ctype "* v,\n"
-         "    __global const long* destination_indices,\n"
-         "    __global const long* source_indices,\n"
-         "    __global " ctype "* output,\n"
-         scalar-signature ") {\n"
-         "  const long lane = (long)get_sub_group_local_id();\n"
-         "  const long component_tile = (long)get_group_id(0);\n"
-         "  const long head = (long)get_group_id(1);\n"
-         "  const long destination = (long)get_group_id(2);\n"
-         "  const long component = component_tile * " subgroup-size "L + lane;\n"
-         "  const long feature = head * n_components + component;\n"
-         "  const int active = component < n_components && feature < total_dim;\n"
-         "  " ctype " numerator = " zero ";\n"
-         "  " ctype " denominator = " zero ";\n"
-         "  const int invalid_shape = n_edges < 0L || n_heads <= 0L || n_components <= 0L\n"
-         "        || n_heads > total_dim / n_components;\n"
-         "  int invalid = invalid_shape;\n"
-         "  for (long edge = 0L; edge < n_edges; ++edge) {\n"
-         "    const long edge_destination = destination_indices[edge];\n"
-         "    const long source = source_indices[edge];\n"
-         "    if (edge_destination < 0L || edge_destination >= n_entities\n"
-         "        || source < 0L || source >= n_entities) invalid = 1;\n"
-         "    const int visible = !invalid && edge_destination == destination;\n"
-         "    " ctype " partial_dot = " zero ";\n"
-         "    if (visible) {\n"
-         "      const long q_base = destination * total_dim + head * n_components;\n"
-         "      const long k_base = source * total_dim + head * n_components;\n"
-         "      for (long x = lane; x < n_components; x += " subgroup-size "L)\n"
-         "        partial_dot += q[q_base + x] * k[k_base + x];\n"
-         "    }\n"
-         "    const " ctype " dot = sub_group_reduce_add(partial_dot);\n"
-         "    " ctype " weight = " zero ";\n"
-         "    if (lane == 0L && visible) {\n"
-         "        const " ctype " scaled = dot * ((" ctype ")" one
-         " / sqrt((" ctype ")n_components));\n"
-         "        const " ctype " score = isnan(scaled) ? scaled\n"
-         "            : fmin((" ctype ")" bound ", fmax(-(" ctype ")" bound ", scaled));\n"
-         "        weight = exp(score);\n"
-         "    }\n"
-         "    weight = sub_group_broadcast(weight, 0);\n"
-         "    denominator += weight;\n"
-         "    if (active && visible)\n"
-         "      numerator += weight * v[source * total_dim + feature];\n"
-         "  }\n"
-         "  if (active) {\n"
-         "    const long output_index = destination * total_dim + feature;\n"
-         "    output[output_index] = invalid ? (" ctype ")NAN\n"
-         "        : (denominator == " zero " ? " zero
-         " : numerator / (denominator + (" ctype ")" epsilon "));\n"
-         "  }\n"
-         "  if (head == 0L && component_tile == 0L) {\n"
-         "    const long active_width = n_heads * n_components;\n"
-         "    for (long tail = active_width + lane; tail < total_dim; tail += "
-         subgroup-size "L)\n"
-         "      output[destination * total_dim + tail] = invalid_shape ? (" ctype ")NAN : " zero ";\n"
-         "  }\n"
-         "}\n")))
-
 (defn emit-dynamic-score-reuse
   "Emit a 3-D destination/head/component-tile schedule. One hardware subgroup cooperatively
    reduces each edge score and broadcasts its weight across component lanes. This retains the
@@ -356,15 +267,19 @@
         inputs (swr/ordered-input-ids plan)
         output (get-in plan [:output :id])
         dtype (:accumulator-dtype plan)
-        abi (dynamic-abi plan fields)
+        target-dialect (or (gpu-target/kernel-body-c-dialect desc) :opencl-portable)
+        dialect (c-dialect/resolve! target-dialect)
+        kernel-body (indexed-body/lower-dynamic-score-reuse plan subgroup-size)
+        base-abi (dynamic-abi plan fields)
+        parameter-names (into {} (map (juxt :name :c-name)) base-abi)
+        abi (body-abi/project-contracts base-abi kernel-body)
         arguments (into (conj inputs output) values)]
     (kart/make
      {:kernel-name name
-      ;; This handwritten leaf is still Intel OpenCL-only, but it participates in the same
-      ;; logical dispatch as the portable KernelBody reference.  Kernel artifacts name the
-      ;; source-language target (`:opencl-c`), not the runtime backend (`:opencl`).
-      :target :opencl-c
-      :source (score-reuse-source plan fields subgroup-size name)
+      :target (c-dialect/target dialect)
+      :source (body-opencl/emit-scalar-kernel
+               name kernel-body
+               {:parameter-names parameter-names :target-dialect target-dialect})
       :abi abi
       :arguments arguments
       :launch (klaunch/spec
@@ -387,6 +302,8 @@
                    :dynamic-shape? true
                    :out-elems output-elements
                    :score-reuse-width subgroup-size
+                   :kernel-body kernel-body
+                   :target-dialect target-dialect
                    :materialized-intermediates []
                    :complexity :destination-head-edge-dot-plus-value}})))
 

--- a/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/indexed_weighted_reduction_body.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.passes.parallel.indexed-weighted-reduction-body
-  "Target-neutral scalar correctness schedule for indexed dense weighted reductions."
+  "Target-neutral reference and subgroup schedules for indexed dense weighted reductions."
   (:require [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
@@ -258,3 +258,160 @@
                     {:entities 'n_entities :edges 'n_edges :heads 'n_heads
                      :components 'n_components :total-dim 'total_dim}
                     workgroup-x true))
+
+(defn lower-dynamic-score-reuse
+  "One subgroup owns a destination/head/component tile. Edge traversal is uniform; each
+  lane accumulates a strided dot fragment, then the subgroup shares one score. No collective
+  occurs inside the lane-varying dot loop or the guarded value update."
+  [plan width]
+  (let [plan (swr/validate! plan)
+        [q k v dst src] (mapv :id (:operands plan))
+        out (get-in plan [:output :id])
+        dtype (:accumulator-dtype plan)
+        zero (lit 0.0 dtype)
+        nan (lit Double/NaN dtype)
+        integer-op (fn [op & args]
+                     (body/scalar-expression op :long args {:overflow :wrap}))
+        load (fn [id type buffer coords]
+               (body/->ScalarLoad (body/value id type) buffer coords nil nil :cached))
+        yield (fn [& xs] (body/->Yield (vec xs)))
+        bound (double (get-in plan [:score :arguments 2 :value]))
+        epsilon (double (get-in plan [:normalization :epsilon]))
+        dot-loop
+        (body/->ForLoop
+         (body/value 'x :long) (body/index-cast 'lane :long :exact)
+         (body/index-cast 'n_components :long :exact) width
+         [(body/->LoopArg (body/value 'dot-state dtype) zero)]
+         [(compute 'qk-component :long
+                   (integer-op :+ (integer-op :* 'head 'n_components) 'x))
+          (load 'q-element dtype q ['destination 'qk-component])
+          (load 'k-element dtype k ['safe-source 'qk-component])
+          (compute 'dot-next dtype
+                   (expr :+ dtype 'dot-state (expr :* dtype 'q-element 'k-element)))
+          (yield 'dot-next)]
+         [(body/value 'partial-dot dtype)] {})
+        edge-loop
+        (body/->ForLoop
+         (body/value 'edge :long) (body/index-cast 0 :long :exact)
+         (body/index-cast 'n_edges :long :exact) 1
+         [(body/->LoopArg (body/value 'valid-state :predicate) 'shape-valid)
+          (body/->LoopArg (body/value 'numerator-state dtype) zero)
+          (body/->LoopArg (body/value 'denominator-state dtype) zero)]
+         [(load 'edge-destination :long dst ['edge])
+          (load 'edge-source :long src ['edge])
+          (compute 'edge-valid :predicate
+                   (conjunction (expr :le :predicate (lit 0 :long) 'edge-destination)
+                                (expr :lt :predicate 'edge-destination 'n_entities)
+                                (expr :le :predicate (lit 0 :long) 'edge-source)
+                                (expr :lt :predicate 'edge-source 'n_entities)))
+          (compute 'valid-next :predicate (conjunction 'valid-state 'edge-valid))
+          (compute 'visible :predicate
+                   (conjunction 'valid-next
+                                (expr :eq :predicate 'edge-destination 'destination)))
+          (compute 'safe-source :long
+                   (expr :min :long (expr :max :long 'edge-source (lit 0 :long))
+                         'final-entity))
+          (body/->IfRegion 'visible [dot-loop (yield 'partial-dot)] [(yield zero)]
+                           [(body/value 'local-dot dtype)])
+          (body/->Collective (body/value 'dot dtype) :reduce :subgroup width
+                             'local-dot :+ nil (body/full-participation)
+                             :implementation-defined)
+          (compute 'score-owner :predicate
+                   (conjunction 'visible (expr :eq :predicate 'lane-long (lit 0 :long))))
+          (body/->IfRegion
+           'score-owner
+           [(compute 'scaled dtype (expr :* dtype 'dot 'scale-value))
+            (compute 'scaled-is-nan :predicate (expr :isnan :predicate 'scaled))
+            (compute 'clamped dtype
+                     (expr :min dtype (lit bound dtype)
+                           (expr :max dtype (lit (- bound) dtype) 'scaled)))
+            (compute 'score dtype (select 'scaled-is-nan 'scaled 'clamped dtype))
+            (compute 'local-weight-value dtype (expr :exp dtype 'score))
+            (yield 'local-weight-value)]
+           [(yield zero)] [(body/value 'local-weight dtype)])
+          (body/->Collective (body/value 'weight dtype) :broadcast :subgroup width
+                             'local-weight nil 0 (body/full-participation) nil)
+          (compute 'denominator-next dtype (expr :+ dtype 'denominator-state 'weight))
+          (compute 'value-active :predicate (conjunction 'active 'visible))
+          (body/->IfRegion
+           'value-active
+           [(load 'value-element dtype v ['safe-source 'feature])
+            (compute 'numerator-updated dtype
+                     (expr :+ dtype 'numerator-state (expr :* dtype 'weight 'value-element)))
+            (yield 'numerator-updated)]
+           [(yield 'numerator-state)] [(body/value 'numerator-next dtype)])
+          (yield 'valid-next 'numerator-next 'denominator-next)]
+         [(body/value 'final-valid :predicate) (body/value 'final-numerator dtype)
+          (body/value 'final-denominator dtype)] {})
+        fp-parameter (fn [id kind role]
+                       (body/->KernelParameter id kind dtype ['n_entities 'total_dim] :global
+                                               (layout/row-major ['n_entities 'total_dim] dtype) role))]
+    (body/make
+     {:id [:indexed-score-reuse-body (:id plan) width]
+      :parameters (into [(fp-parameter q :input :query) (fp-parameter k :input :key)
+                         (fp-parameter v :input :value)
+                         (body/->KernelParameter dst :input :long ['n_edges] :global
+                                                 (layout/row-major ['n_edges] :long) :destination-indices)
+                         (body/->KernelParameter src :input :long ['n_edges] :global
+                                                 (layout/row-major ['n_edges] :long) :source-indices)
+                         (fp-parameter out :output :result)]
+                        (map #(body/->KernelParameter % :scalar :long [] nil nil :shape)
+                             '[n_entities n_edges total_dim n_heads n_components output_elements]))
+      :stable-reads (mapv body/stable-read [q k v dst src])
+      :indices [(body/->IndexBinding 'lane :lane 0)
+                (body/->IndexBinding 'tile-index :group 0)
+                (body/->IndexBinding 'head-index :group 1)
+                (body/->IndexBinding 'destination-index :group 2)
+                (body/->IndexCompute 'lane-long (body/index-cast 'lane :long :exact))
+                (body/->IndexCompute 'tile (body/index-cast 'tile-index :long :exact))
+                (body/->IndexCompute 'head (body/index-cast 'head-index :long :exact))
+                (body/->IndexCompute 'destination (body/index-cast 'destination-index :long :exact))]
+      :operations
+      [(compute 'component :long (integer-op :+ (integer-op :* 'tile (lit width :long)) 'lane-long))
+       (compute 'feature :long (integer-op :+ (integer-op :* 'head 'n_components) 'component))
+       (compute 'active :predicate
+                (conjunction (expr :lt :predicate 'component 'n_components)
+                             (expr :lt :predicate 'feature 'total_dim)))
+       (compute 'safe-components :long (expr :max :long 'n_components (lit 1 :long)))
+       (compute 'shape-valid :predicate
+                (conjunction (expr :lt :predicate (lit 0 :long) 'n_entities)
+                             (expr :le :predicate (lit 0 :long) 'n_edges)
+                             (expr :lt :predicate (lit 0 :long) 'n_heads)
+                             (expr :lt :predicate (lit 0 :long) 'n_components)
+                             (expr :le :predicate 'n_heads
+                                   (expr :quot :long 'total_dim 'safe-components))))
+       (compute 'final-entity :long (integer-op :- (expr :max :long 'n_entities (lit 1 :long)) (lit 1 :long)))
+       (compute 'components-fp dtype (body/cast-expression 'n_components dtype :nearest-even :exact))
+       (compute 'scale-value dtype (expr :div dtype (lit 1.0 dtype) (expr :sqrt dtype 'components-fp)))
+       edge-loop
+       (body/->IfRegion
+        'active
+        [(compute 'denominator-zero :predicate (expr :eq :predicate 'final-denominator zero))
+         (compute 'normalized-value dtype
+                  (expr :div dtype 'final-numerator (expr :+ dtype 'final-denominator (lit epsilon dtype))))
+         (compute 'nonempty-result dtype (select 'denominator-zero zero 'normalized-value dtype))
+         (compute 'result dtype (select 'final-valid 'nonempty-result nan dtype))
+         (body/->ScalarStore out ['destination 'feature] 'result nil) (yield)]
+        [(yield)] [])
+       (compute 'tail-owner :predicate
+                (conjunction (expr :eq :predicate 'head (lit 0 :long))
+                             (expr :eq :predicate 'tile (lit 0 :long))))
+       (body/->IfRegion
+        'tail-owner
+        [(compute 'tail-start :long
+                  (integer-op :+ (integer-op :* 'n_heads 'n_components) 'lane-long))
+         (compute 'tail-value dtype (select 'shape-valid zero nan dtype))
+         (body/->ForLoop (body/value 'tail :long) (body/index-cast 'tail-start :long :exact)
+                         (body/index-cast 'total_dim :long :exact) width []
+                         [(body/->ScalarStore out ['destination 'tail] 'tail-value nil) (yield)] [] {})
+         (yield)] [(yield)] [])]
+      :schedule {:strategy :indexed-segmented-reduction-subgroup-score-reuse
+                 :subgroup-size width :membership-traversal :ordered-edge-list
+                 :score-reuse :component-tile}
+      :launch (launch/spec {:workgroup-size [width 1 1]
+                            :group-count [(launch/ceil-div 'n_components width)
+                                          (launch/runtime-value 'n_heads)
+                                          (launch/runtime-value 'n_entities)]})
+      :provenance {:dialect :kernel-body :semantic-op :segmented-weighted-reduction
+                   :algebra-plan-id (:id plan) :lowering :indexed-score-reuse-kernel-body}
+      :attributes {:dynamic-shape? true :membership-kind :edge-list-by-destination}})))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -497,6 +497,9 @@
            (write-artifact! directory suffix "indexed-weighted-reduction-dynamic"
                             (indexed-attention-emit/emit-dynamic-reference
                              (indexed-attention-plan) descriptor))
+           (write-artifact! directory suffix "indexed-weighted-reduction-score-reuse"
+                            (indexed-attention-emit/emit-dynamic-score-reuse
+                             (indexed-attention-plan) descriptor))
            (write-source! directory suffix "split-k-combine"
                           (:source
                            (gemm-emit/emit-split-k-combine-kernel

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -178,8 +178,11 @@
     (is (str/includes? source "sub_group_reduce_add"))
     (is (str/includes? source "sub_group_broadcast"))
     (is (str/includes? source "intel_reqd_sub_group_size(16)"))
-    (is (= 1 (count (re-seq #"for \(long x" source)))
-        "one score loop is shared across the component tile")))
+    (let [operations (nested-operations (get-in artifact [:attributes :kernel-body :operations]))]
+      (is (= 1 (count (filter #(= 'partial-dot (get-in % [:results 0 :id])) operations)))
+          "one dot loop is shared across the component tile")
+      (is (= [:reduce :broadcast]
+             (mapv :kind (filter #(= "Collective" (some-> % class .getSimpleName)) operations)))))))
 
 (deftest score-reuse-decline-falls-through-to-reference
   (let [{:keys [leaf strategy]}

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -115,16 +115,29 @@
     (device-probe/opencl-skip! "indexed malformed endpoint agreement" :subgroups)
     (doseq [strategy [:reference :subgroup-score-reuse]
             endpoint ['dst 'src]
-            invalid [-1 Long/MAX_VALUE]]
+            invalid [-1 Long/MAX_VALUE]
+            edge [1 3]]
       (let [case (test-case)
             indices (aclone ^longs (get-in case [:buffers endpoint]))
             expected (float-array (for [i (range 15)]
                                     (if (= 4 (mod i 5)) 0.0 Float/NaN)))]
-        ;; Put the invalid edge last so earlier valid work cannot mask the error.
-        (aset-long indices 3 invalid)
+        ;; Exercise both sticky poisoning before subsequent edges and a late error.
+        (aset-long indices edge invalid)
         (run-case :ocl:0 strategy
                   (-> case (assoc-in [:buffers endpoint] indices)
                       (assoc :expected expected)))))))
+
+(deftest indexed-schedules-preserve-nan-scores
+  (if-not @device-probe/opencl-subgroups-available?
+    (device-probe/opencl-skip! "indexed NaN score propagation" :subgroups)
+    (doseq [strategy [:reference :subgroup-score-reuse]
+            operand ['Q 'K]]
+      (let [{:keys [plan shape-env buffers] :as case} (test-case)
+            values (aclone ^floats (get buffers operand))
+            _ (aset-float values 0 Float/NaN)
+            buffers (assoc buffers operand values)
+            expected (reference/evaluate plan {:buffers buffers :scalars shape-env})]
+        (run-case :ocl:0 strategy (assoc case :buffers buffers :expected expected))))))
 
 (deftest level-zero-indexed-attention-matches-independent-plan-oracle
   (if-not @gp/gpu-available?
@@ -243,7 +256,8 @@
     (let [descriptor (pipeline/compile-gpu-program
                       #'resident-indexed-attention-probe :ocl:0 :dtype :float)
           small (production-case descriptor 4)
-          wide (production-case descriptor 512)]
+          ;; 257 components require a partial seventeenth tile, plus one unused row tail.
+          wide (production-case descriptor 515)]
       (is (= :indexed-segmented-reduction-reference (:selected small)))
       (is (= :indexed-segmented-reduction-subgroup-score-reuse (:selected wide)))
       (is (< (:max-error small) 2.0e-5))


### PR DESCRIPTION
The indexed weighted-reduction subgroup schedule previously assembled an OpenCL source template. It now constructs a verified KernelBody and emits through the common C-family backend, preserving the three-dimensional launch, ordered ABI, score sharing, and resident dispatch. The source template and its private type/literal printers are deleted.

The body represents uniform edge traversal, lane-strided dot accumulation, full-subgroup reduction/broadcast, guarded value loads, and tail stores. Stable-read contracts are projected to the public ABI. CUDA and HIP compile the same scheduled body; production subgroup selection remains Intel-gated pending cross-vendor device validation.

Validation: 15 focused tests / 106 assertions passed, including Intel Arc numerical execution, malformed-endpoint agreement, and public runtime selection. The exact generated subgroup source compiled with nvcc sm_80 and hipcc gfx1100 and joins mandatory vendor CI fixtures. No throughput improvement is claimed; destination-bounded traversal is a separate schedule improvement.

Review-driven device coverage also passes: 6 tests / 79 assertions, including 257-component heads with a partial tile and unused row tail, malformed endpoints before later valid edges, and NaN Q/K score propagation. These supersede the earlier device subset; route tests remain unchanged.
