### PR TITLE
Lower uniform matrix epilogues through the CUDA scalar emitter

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -855,3 +855,28 @@ separately from Float scale arithmetic. Public Arc execution of 1024 products of
 then two products of 1 by 1, gives ordered Float result16777216 rather than Int-then-Float16777218.
 The public workload enters vendor compile fixtures. This is correctness/generalization work;
 packed replacement of a floating fold still requires an independent equivalence proof.
+
+### CUDA/HIP baseline findings integrated into the existing campaign (2026-09-12)
+
+The reference review used local JAX/Pallas, Triton, CUTLASS `147295a3`, Composable Kernel
+`704ff575`, and rocWMMA `97562d3`. It does not introduce a separate IR-redesign campaign.
+Raster already schedules workgroup reduction/scan trees and typed matrix store epilogues.
+The next portability increments belong to the current emitter-retirement and measurement work:
+
+1. Finish indexed subgroup KernelBody emission and retain its numerical/dispatch tests.
+2. Lower existing coordinate-free FP32 TileStore regions on CUDA WMMA, initially uniform
+   scalar transforms such as scaling and ReLU. Logical row/column indices and tensor operands
+   must decline: WMMA fragment slot mappings are opaque.
+3. Add a direct HIP matrix row from the existing instruction/body contract when its selected
+   instruction and wave geometry can be compiled and validated. rocWMMA is a reference for
+   fragment load/MMA/store, not a mandatory semantic dependency.
+4. Admit staged matrix mainloops and indexed epilogues only with schedule-visible storage,
+   coordinate ownership, barriers, and resource accounting. CuTe's mapped output partitions
+   and rocWMMA's double-buffered LDS GEMM are the concrete references.
+
+Each row needs public compiler-path acceptance before being called a completed vertical;
+target-only compile fixtures are prerequisites. Cold performance comparisons stay outside the
+laptop hot loop. Resident training/model validation, distributed simulation and execution,
+durable manifests, and numerical PDE/AMR acceptance retain their existing completion gates.
+Fused GEMM plus auxiliary reductions (CK's mean/mean-square example), warp specialization,
+and TMA remain workload-driven follow-ups rather than vocabulary added in anticipation.

--- a/src/raster/compiler/backend/gpu/cuda_codegen.clj
+++ b/src/raster/compiler/backend/gpu/cuda_codegen.clj
@@ -2,11 +2,15 @@
   "CUDA-C target lowering for verified matrix KernelBody values.
 
   The first row deliberately covers direct, aligned f16×f16→f32 WMMA bodies. Unsupported body
-  structure fails before source emission; masks, views, slices, epilogues and extra ABI values are
-  never silently discarded. Shared-memory staging and WGMMA are later schedules over the same
+   structure fails before source emission. Coordinate-free FP32 store regions use the shared scalar
+   emitter over fragment elements; indexed epilogues, masks, views and slices are never silently
+   discarded. Shared-memory staging and WGMMA are later schedules over the same
   typed contraction and KernelBody vocabulary."
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as scalar-emitter]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.backend.gpu.matrix-target-names :as target-names]
             [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]))
 
 (defn- decline!
@@ -14,10 +18,6 @@
   (when-not condition
     (throw (ex-info "CUDA matrix lowering does not implement this verified body"
                     (assoc data :reason reason :target :cuda)))))
-
-(defn- identity-store?
-  [store]
-  (nil? (:value-region store)))
 
 (defn- parameter-declarations
   [parameters dimension-parameters]
@@ -39,6 +39,9 @@
               (contains? dimension-name id))
          (str "int " (get dimension-name id))
 
+         (and (= :epilogue role) (= :scalar kind) (= :float dtype))
+         (str "float " (c-emit/c-symbol id))
+
          :else
          (throw (ex-info "CUDA matrix lowering cannot render this ordered ABI parameter"
                          {:reason :cuda-mma-extra-abi-unsupported
@@ -50,7 +53,7 @@
                        mi ni ki subgroup block-m block-n sg-m sg-n
                        block-k lhs-ids rhs-ids stores prefetch result-dtype
                        dimension-parameters schedule-parameters group-z k-lower k-upper
-                       buffer-offsets index-dtype]}]
+                       buffer-offsets index-dtype]} epilogue]
   (let [[M N K] dimensions
         index-type (c-dialect/type-name (c-dialect/resolve! :cuda) index-dtype)]
     (decline! (= {:family :mma :m 16 :n 16 :k 16 :subgroup 32} instruction)
@@ -70,10 +73,8 @@
               :cuda-mma-views-or-schedule-parameters-unsupported
               {:group-z group-z :schedule-parameters schedule-parameters
                :buffer-offsets buffer-offsets})
-    (decline! (every? identity-store? stores)
-              :cuda-mma-store-region-unsupported {:stores stores})
     (let [declarations (parameter-declarations parameters dimension-parameters)
-          _ (decline! (= 6 (count declarations))
+          _ (decline! (= 6 (count (remove #(= :epilogue (:role %)) parameters)))
                       :cuda-mma-extra-abi-unsupported {:parameters parameters})
           specialized-dimensions
           (mapv dimension-values [(:m dimension-parameters)
@@ -91,7 +92,6 @@
                                           (if (= role "accumulator") "float" (str "half, wmma::" layout))
                                           ">"))]
       (str
-       "#include <mma.h>\n"
        "using namespace nvcuda;\n\n"
        "// Tiled WMMA GEMM (parametric): block " block-m "x" block-n ", warp-tile " sg-m "x" sg-n
        ", K " block-k ", frag " mi "x" ni "x" ki ", warp " subgroup
@@ -130,7 +130,13 @@
                    (apply str (for [m ms n ns] (str "    wmma::mma_sync(acc" m "_" n ", a" m ", b" n ", acc" m "_" n ");\n")))))))
        "  }\n"
        (apply str (for [m ms n ns]
-                    (str "  wmma::store_matrix_sync(C + (m_base + " (* m mi) ") * N + n_base + " (* n ni)
+                    (str (when epilogue
+                           (let [acc (str "acc" m "_" n)
+                                 value (str acc ".x[rstr_epilogue_element]")]
+                             (str "  #pragma unroll\n"
+                                  "  for (int rstr_epilogue_element = 0; rstr_epilogue_element < " acc ".num_elements; ++rstr_epilogue_element) {\n"
+                                  "    " value " = " (epilogue value "" "") ";\n  }\n")))
+                         "  wmma::store_matrix_sync(C + (m_base + " (* m mi) ") * N + n_base + " (* n ni)
                          ", acc" m "_" n ", N, wmma::mem_row_major);\n")))
        "}\n"))))
 
@@ -140,4 +146,14 @@
   This boundary takes no tile, dimension, launch or ABI side channel. The returned source is a
   target spelling of the analyzed body; unsupported verified bodies fail with a structured reason."
   [kernel-name kernel-body]
-  (emit-plan kernel-name (matrix-plan/analyze kernel-body)))
+  (let [plan (matrix-plan/analyze kernel-body)
+        names (target-names/validate! kernel-name kernel-body
+                                      (target-names/parameter-names kernel-body nil))
+        region (scalar-emitter/lower-uniform-store-region kernel-body names :cuda)
+        source (emit-plan kernel-name plan (:epilogue region))
+        helpers (c-emit/intrinsic-helper-module source :cuda {})]
+    (decline! (empty? (:compilation helpers)) :cuda-mma-helper-compilation-unsupported
+              {:compilation (:compilation helpers)})
+    (str "#include <mma.h>\n#include <math.h>\n"
+         (c-dialect/helper-source (c-dialect/resolve! :cuda) (:source helpers))
+         "\n" source)))

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -743,6 +743,35 @@
      :epilogue-params params
      :region region}))
 
+(defn lower-uniform-store-region
+  "Lower a coordinate-free floating matrix epilogue through the shared scalar emitter.
+  Opaque matrix fragments can apply this region independently to each stored element. Tensor
+  reads and logical coordinates require a separately scheduled layout conversion."
+  [kernel-body parameter-names target-dialect]
+  (let [regions (keep :value-region (nested-operations (:operations kernel-body)))
+        storage (into {} (map (juxt :id identity)) (:parameters kernel-body))]
+    (doseq [region regions]
+      (when-not
+       (and (empty? (:operands region))
+            (= :float (:accumulator-dtype region) (:result-dtype region))
+            (every? #(and (= :scalar (:kind (get storage %)))
+                          (= :float (:dtype (get storage %))))
+                    (rest (:parameters region)))
+            (every? #(and (record-kind? "ScalarCompute" %)
+                          (contains? #{:float :predicate} (get-in % [:result :type])))
+                    (:operations region))
+            (every? #(or (not (record-kind? "ScalarExpr" %))
+                        (contains? #{:float :predicate} (:result-type %)))
+                    (tree-seq coll? seq (mapv :expression (:operations region))))
+            (not-any? (set (:indices region))
+                      (tree-seq coll? seq
+                                [(:result region) (mapv :expression (:operations region))])))
+        (throw (ex-info "opaque matrix fragments require a coordinate-free floating store region"
+                        {:reason :matrix-store-region-requires-coordinate-layout
+                         :region region}))))
+    (binding [*scalar-dialect* (c-dialect/resolve! target-dialect)]
+      (lower-store-region kernel-body parameter-names))))
+
 (defn- emit-mask-predicate
   [predicate names]
   (let [arguments (:arguments predicate)]

--- a/src/raster/compiler/backend/gpu/matrix_target.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target.clj
@@ -6,66 +6,12 @@
    fork at which DPAS and MMA diverge; callers may not select a target template directly or pass a
    second tile/launch/ABI description beside the body."
   (:require [raster.compiler.backend.gpu.cuda-codegen :as cuda-codegen]
-            [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.backend.gpu.matrix-target-names :as target-names]
             [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
             [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.kernel-body :as kernel-body]))
-
-(defn- target-parameter-names
-  [body overrides]
-  (let [{:keys [m n k]} (get-in body [:attributes :dimension-parameters])]
-    (merge
-     (into {}
-           (map (fn [{:keys [id role]}]
-                  [id (case role
-                        :lhs "A"
-                        :rhs "B"
-                        :result "C"
-                        (c-emit/c-symbol id))]))
-           (:parameters body))
-     {m "M" n "N" k "K"}
-     overrides)))
-
-(def ^:private matrix-local-names
-  #{"warpId" "warp_row" "warp_col" "sg_id" "sg_lid" "sg_row" "sg_col"
-    "m_base" "k" "pk" "pr" "row" "col" "k_begin" "k_end"
-    "a_wb" "a_pb" "b_wb" "b_pb"})
-
-(defn- generated-matrix-local?
-  [generated-locals c-name]
-  (or (contains? generated-locals c-name)
-      (boolean (re-matches #"(?:a|b|sa|bp|acc|n_base)[0-9]+(?:_[0-9]+)?" c-name))))
-
-(defn- matrix-generated-locals
-  [body]
-  (into matrix-local-names
-        (comp (filter #(and (= :group (:source %)) (= 2 (:axis %))))
-              (map #(c-emit/c-symbol (:id %))))
-        (:indices body)))
-
-(defn- validate-target-names!
-  [kernel-name body names]
-  (when-not (c-emit/c-identifier? kernel-name)
-    (throw (ex-info "matrix kernel entry point is not a portable C-family identifier"
-                    {:reason :matrix-target-entry-point :kernel-name kernel-name})))
-  (let [ordered-names (mapv #(get names (:id %)) (:parameters body))
-        generated-locals (matrix-generated-locals body)]
-    (doseq [[parameter c-name] (map vector (:parameters body) ordered-names)]
-      (when-not (c-emit/c-identifier? c-name)
-        (throw (ex-info "matrix ABI parameter is not a portable C-family identifier"
-                        {:reason :matrix-target-parameter-name
-                         :parameter parameter :c-name c-name})))
-      (when (generated-matrix-local? generated-locals c-name)
-        (throw (ex-info "matrix ABI parameter collides with a generated kernel local"
-                        {:reason :matrix-target-name-collision
-                         :parameter parameter :c-name c-name}))))
-    (when-not (= (count ordered-names) (count (set ordered-names)))
-      (throw (ex-info "matrix ABI parameter names are not unique after target spelling"
-                      {:reason :matrix-target-name-collision
-                       :parameters (:parameters body) :c-names ordered-names})))
-    names))
 
 (defn physical-requirements
   "Return target-derived ABI requirements and identity-bearing physical lowering facts."
@@ -101,10 +47,10 @@
    (let [body (kernel-body/validate! body)
          plan (matrix-plan/analyze body)
          dialect (c-dialect/resolve! target-dialect)
-         parameter-names (validate-target-names!
+         parameter-names (target-names/validate!
                           kernel-name body
-                          (target-parameter-names body parameter-names))
-         default-names (target-parameter-names body nil)
+                          (target-names/parameter-names body parameter-names))
+         default-names (target-names/parameter-names body nil)
          _ (when (and (= :cuda (:id dialect)) (not= default-names parameter-names))
              (throw (ex-info "CUDA matrix lowering does not support ABI spelling overrides"
                              {:reason :cuda-mma-parameter-spelling-unsupported

--- a/src/raster/compiler/backend/gpu/matrix_target_names.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target_names.clj
@@ -1,0 +1,58 @@
+(ns raster.compiler.backend.gpu.matrix-target-names
+  "Shared ordered ABI spelling and generated-local collision checks for matrix targets."
+  (:require [raster.compiler.backend.gpu.c-emit :as c-emit]))
+
+(defn parameter-names
+  [body overrides]
+  (let [{:keys [m n k]} (get-in body [:attributes :dimension-parameters])]
+    (merge
+     (into {}
+           (map (fn [{:keys [id role]}]
+                  [id (case role
+                        :lhs "A"
+                        :rhs "B"
+                        :result "C"
+                        (c-emit/c-symbol id))]))
+           (:parameters body))
+     {m "M" n "N" k "K"}
+     overrides)))
+
+(def ^:private matrix-local-names
+  #{"warpId" "warp_row" "warp_col" "sg_id" "sg_lid" "sg_row" "sg_col"
+    "m_base" "n_base" "k" "pk" "pr" "row" "col" "k_begin" "k_end"
+    "a_wb" "a_pb" "b_wb" "b_pb" "rstr_epilogue_element"})
+
+(defn- generated-matrix-local?
+  [generated-locals c-name]
+  (or (contains? generated-locals c-name)
+      (boolean (re-matches #"(?:a|b|sa|bp|acc|n_base)[0-9]+(?:_[0-9]+)?" c-name))))
+
+(defn- matrix-generated-locals
+  [body]
+  (into matrix-local-names
+        (comp (filter #(and (= :group (:source %)) (= 2 (:axis %))))
+              (map #(c-emit/c-symbol (:id %))))
+        (:indices body)))
+
+(defn validate!
+  [kernel-name body names]
+  (when-not (c-emit/c-identifier? kernel-name)
+    (throw (ex-info "matrix kernel entry point is not a portable C-family identifier"
+                    {:reason :matrix-target-entry-point :kernel-name kernel-name})))
+  (let [ordered-names (mapv #(get names (:id %)) (:parameters body))
+        generated-locals (matrix-generated-locals body)]
+    (doseq [[parameter c-name] (map vector (:parameters body) ordered-names)]
+      (when-not (c-emit/c-identifier? c-name)
+        (throw (ex-info "matrix ABI parameter is not a portable C-family identifier"
+                        {:reason :matrix-target-parameter-name
+                         :parameter parameter :c-name c-name})))
+      (when (generated-matrix-local? generated-locals c-name)
+        (throw (ex-info "matrix ABI parameter collides with a generated kernel local"
+                        {:reason :matrix-target-name-collision
+                         :parameter parameter :c-name c-name}))))
+    (when-not (= (count ordered-names) (count (set ordered-names)))
+      (throw (ex-info "matrix ABI parameter names are not unique after target spelling"
+                      {:reason :matrix-target-name-collision
+                       :parameters (:parameters body) :c-names ordered-names})))
+    names))
+

--- a/test/raster/compiler/backend/gpu/cuda_mma_compile_test.clj
+++ b/test/raster/compiler/backend/gpu/cuda_mma_compile_test.clj
@@ -7,8 +7,10 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.shell :as sh]
             [clojure.java.io :as io]
+            [clojure.walk :as walk]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.backend.gpu.cuda-codegen :as cuda]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
 
 (defn- nvcc-available? []
@@ -84,6 +86,49 @@
             (catch clojure.lang.ExceptionInfo exception
               (is (= :cuda-mma-result-dtype-unsupported
                      (:reason (ex-data exception)))))))))))
+
+(deftest cuda-uniform-epilogue-uses-the-existing-store-region
+  (let [tile {:block-m 64 :block-n 64 :sg-m 32 :sg-n 32 :block-k 32
+              :num-stages 3 :matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32}}
+        body (schedule/matrix-body
+              {:id :uniform-epilogue :row 'a :col 'b :out 'c
+               :dimensions [64 64 64] :tile tile :result-dtype :float
+               :epilogue {:acc 'acc
+                          :expr '(raster.numeric/max (raster.numeric/* acc alpha) (float 0.0))
+                          :scalars [{:sym 'alpha :dtype :float}]}})
+        source (cuda/emit-matrix-kernel "uniform_epilogue" body)]
+    (is (re-find #"float alpha" source))
+    (is (re-find #"\.x\[rstr_epilogue_element\] = .*alpha" source))
+    (is (re-find #"fmax\(" source))
+    (is (not (re-find #"__shared__" source))
+        "a coordinate-free transform needs no hidden scratch")
+    (doseq [id ['rstr_epilogue_element 'n_base 'warpId]]
+      (try
+        (cuda/emit-matrix-kernel "collision"
+                                (walk/postwalk-replace {'alpha id} body))
+        (is false "direct CUDA emission must reject scalar/generated-name collisions")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :matrix-target-name-collision (:reason (ex-data e)))))))
+    (when (nvcc-available?)
+      (let [{:keys [compiled? sass err]} (compile-cu source)]
+        (is compiled? err)
+        (is (re-find #"HMMA" (or sass "")))))))
+
+(deftest cuda-opaque-fragments-reject-coordinate-dependent-epilogues
+  (let [tile {:block-m 64 :block-n 64 :sg-m 32 :sg-n 32 :block-k 32
+              :num-stages 3 :matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32}}
+        body (schedule/matrix-body
+              {:id :coordinate-epilogue :row 'a :col 'b :out 'c
+               :dimensions [64 64 64] :tile tile :result-dtype :float
+               :epilogue {:acc 'acc
+                          :expr '(raster.numeric/+ acc (clojure.core/aget bias j))
+                          :operands [{:sym 'bias :dtype :float
+                                      :map (axis-map/of-axes [['j 64]])}]}})]
+    (try
+      (cuda/emit-matrix-kernel "coordinate_epilogue" body)
+      (is false "logical row identity cannot be recovered from opaque fragment slots")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :matrix-store-region-requires-coordinate-layout (:reason (ex-data e))))))))
 
 (deftest cuda-signature-follows-the-ordered-kernel-body-abi
   (let [matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32}

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -4,6 +4,7 @@
             [raster.arrays]
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.gemm :as gemm-emit]
+            [raster.compiler.backend.gpu.cuda-codegen :as cuda-emit]
             [raster.compiler.backend.gpu.indexed-attention :as indexed-attention-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
@@ -557,6 +558,19 @@
                            (body-fixtures/pipelined-staging-body 32 :preferred)
                            {:target-dialect dialect :target-features descriptor}))]
           (concat
+           (when (= :cuda target)
+             [(write-source!
+               directory suffix "matrix-uniform-epilogue"
+               (cuda-emit/emit-matrix-kernel
+                "matrix_uniform_epilogue"
+                (contraction-schedule/matrix-body
+                 {:id :matrix-uniform-epilogue :row 'a :col 'b :out 'c
+                  :dimensions [64 64 64] :result-dtype :float
+                  :tile {:block-m 64 :block-n 64 :sg-m 32 :sg-n 32 :block-k 32
+                         :num-stages 3 :matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32}}
+                  :epilogue {:acc 'acc
+                             :expr '(raster.numeric/max (raster.numeric/* acc alpha) (float 0.0))
+                             :scalars [{:sym 'alpha :dtype :float}]}})))])
            (map-indexed
             (fn [index artifact]
               (write-artifact! directory suffix (str "equation-first-" index) artifact))


### PR DESCRIPTION
CUDA WMMA previously rejected every nonidentity TileStore region. It now lowers verified coordinate-free FP32 transforms, including uniform scaling and ReLU, through the existing scalar SSA emitter and applies them to each accumulator fragment element before storage. This adds no hidden memory or barriers and preserves ordered scalar ABI arguments.

Tensor operands, logical matrix coordinates, and nonfloating intermediate arithmetic remain explicit declines. Indexed bias/residual epilogues require a separate schedule with coordinate ownership; this change does not assume a WMMA fragment layout. Direct CUDA emission and the shared matrix target now use one ABI-name validator, including the new fragment-element loop local. Existing intrinsic helper selection is reused.

The alpha/ReLU fixture is compiled to CUDA cubin and checked for HMMA instructions locally, and joins the mandatory generated-source CUDA CI gate. Tests also cover bias rejection, ordered ABI, and scalar/generated-local name collisions. This is a matrix target-lowering increment; NVIDIA numerical execution and performance remain unmeasured.

The existing compiler campaign now records the reviewed CUDA/HIP priorities alongside its training, distributed, and scientific completion gates.

Focused validation: 9 tests, 64 assertions, zero failures/errors, including local nvcc/cubin compilation and HMMA inspection. The full suite and generated-source gates run in CI.
