### PR TITLE
Share direct matrix fragment emission machinery

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -880,3 +880,23 @@ laptop hot loop. Resident training/model validation, distributed simulation and 
 durable manifests, and numerical PDE/AMR acceptance retain their existing completion gates.
 Fused GEMM plus auxiliary reductions (CK's mean/mean-square example), warp specialization,
 and TMA remain workload-driven follow-ups rather than vocabulary added in anticipation.
+
+### Shared fragment-emitter prerequisite
+
+The CUDA direct-fragment mainloop spelling is separated from target admission. Ordered ABI,
+instruction legality, aligned dimensions, view/slice declines and uniform store-region lowering
+remain checked by the CUDA entry point. The internal renderer consumes the analyzed body plan;
+it does not introduce a second schedule, an allocation, or source-level type inference. CUDA is
+its only admitted dialect in this slice. This prepares HIP without copying the GEMM algorithm.
+
+Hardware-free reference probes with rocWMMA `b5a884dc` (ROCm 5.7.1) and the laptop HIP 5.7 /
+Clang 21 toolchain compiled f16×f16→f32 fragments for both gfx90a and gfx1100. Unbundling the
+code objects and disassembling confirmed `v_mfma_f32_16x16x16f16` and
+`v_wmma_f32_16x16x16_f16`, respectively. These are reference-library feasibility results, not
+Raster-generated kernels, numerical validation or performance evidence. The newer reference
+checkout requires ROCm 6.4 headers; it cannot be assumed compatible with the laptop installation.
+The first Raster HIP matrix row should use the existing CDNA MFMA/wave64 witness, with a
+separate architecture compile gate. RDNA WMMA/wave32 requires its own explicit capability;
+the current gfx1100 scalar compile gate must not be mistaken for MFMA coverage. A pinned
+header/toolchain contract, generated-body compilation, physical ABI requirements and public
+route tests remain prerequisites before enabling either route.

--- a/src/raster/compiler/backend/gpu/cuda_codegen.clj
+++ b/src/raster/compiler/backend/gpu/cuda_codegen.clj
@@ -11,7 +11,8 @@
             [raster.compiler.backend.gpu.kernel-body-opencl :as scalar-emitter]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.matrix-target-names :as target-names]
-            [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]))
+            [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
+            [raster.compiler.backend.gpu.matrix-fragment-source :as fragment-source]))
 
 (defn- decline!
   [condition reason data]
@@ -50,12 +51,10 @@
 
 (defn- emit-plan
   [kernel-name {:keys [instruction dimensions dimension-values parameters
-                       mi ni ki subgroup block-m block-n sg-m sg-n
-                       block-k lhs-ids rhs-ids stores prefetch result-dtype
+                       block-m block-n block-k result-dtype
                        dimension-parameters schedule-parameters group-z k-lower k-upper
-                       buffer-offsets index-dtype]} epilogue]
-  (let [[M N K] dimensions
-        index-type (c-dialect/type-name (c-dialect/resolve! :cuda) index-dtype)]
+                       buffer-offsets] :as plan} epilogue]
+  (let [[M N K] dimensions]
     (decline! (= {:family :mma :m 16 :n 16 :k 16 :subgroup 32} instruction)
               :cuda-mma-instruction-unsupported {:instruction instruction})
     (decline! (= :float result-dtype)
@@ -82,63 +81,8 @@
                                   (:k dimension-parameters)])
           _ (decline! (= dimensions specialized-dimensions)
                       :cuda-mma-dimension-specialization-invalid
-                      {:dimensions dimensions :dimension-values dimension-values})
-          nms (count lhs-ids) nns (count rhs-ids)      ;; fragments per warp (M, N)
-          ncols (quot block-n sg-n)                   ;; warp columns
-          ksteps (quot block-k ki)
-          ms (range nms) ns (range nns)
-          warps-per-block (* (quot block-m sg-m) (quot block-n sg-n))
-          frag (fn [role & [layout]] (str "wmma::fragment<wmma::" role ", " mi ", " ni ", " ki ", "
-                                          (if (= role "accumulator") "float" (str "half, wmma::" layout))
-                                          ">"))]
-      (str
-       "using namespace nvcuda;\n\n"
-       "// Tiled WMMA GEMM (parametric): block " block-m "x" block-n ", warp-tile " sg-m "x" sg-n
-       ", K " block-k ", frag " mi "x" ni "x" ki ", warp " subgroup
-       ", warps/block " warps-per-block "\n"
-       "extern \"C\" __global__ void " kernel-name "(\n    "
-       (str/join ",\n    " declarations) ") {\n"
-       "  if (M != " M " || N != " N " || K != " K ") { asm volatile(\"trap;\"); return; }\n"
-       "  int warpId = threadIdx.x / " subgroup ";\n"
-       "  int warp_row = warpId / " ncols ";\n"
-       "  int warp_col = warpId % " ncols ";\n"
-       "  int m_base = blockIdx.y * " block-m " + warp_row * " sg-m ";\n"
-       "  int n_base = blockIdx.x * " block-n " + warp_col * " sg-n ";\n"
-       ;; accumulator fragments
-       (apply str (for [m ms n ns] (str "  " (frag "accumulator") " acc" m "_" n ";\n")))
-       (apply str (for [m ms n ns] (str "  wmma::fill_fragment(acc" m "_" n ", 0.0f);\n")))
-       "  " (frag "matrix_a" "row_major") " " (str/join ", " (for [m ms] (str "a" m))) ";\n"
-       "  " (frag "matrix_b" "row_major") " " (str/join ", " (for [n ns] (str "b" n))) ";\n"
-       "  for (" index-type " k = 0; k < K; k += " block-k ") {\n"
-       (apply str
-              (for [ks (range ksteps)]
-                (let [koff (* ks ki)]
-                  (str
-                   "    { " index-type " pk = k + " (+ koff (* prefetch ki)) ";\n"
-                   "      if (pk < K && ((int)threadIdx.x % " subgroup ") == 0) {\n"
-                   (apply str
-                          (for [m ms]
-                            (str "        #pragma unroll\n"
-                                 "        for (int pr = 0; pr < " mi "; ++pr) {\n"
-                                 "          const half* pp = A + (m_base + " (* m mi)
-                                 " + pr) * K + pk;\n"
-                                 "          asm volatile(\"prefetch.global.L2 [%0];\" :: \"l\"(pp));\n"
-                                 "        }\n")))
-                   "      } }\n"
-                   (apply str (for [m ms] (str "    wmma::load_matrix_sync(a" m ", A + (m_base + " (* m mi) ") * K + k + " koff ", K);\n")))
-                   (apply str (for [n ns] (str "    wmma::load_matrix_sync(b" n ", B + (k + " koff ") * N + n_base + " (* n ni) ", N);\n")))
-                   (apply str (for [m ms n ns] (str "    wmma::mma_sync(acc" m "_" n ", a" m ", b" n ", acc" m "_" n ");\n")))))))
-       "  }\n"
-       (apply str (for [m ms n ns]
-                    (str (when epilogue
-                           (let [acc (str "acc" m "_" n)
-                                 value (str acc ".x[rstr_epilogue_element]")]
-                             (str "  #pragma unroll\n"
-                                  "  for (int rstr_epilogue_element = 0; rstr_epilogue_element < " acc ".num_elements; ++rstr_epilogue_element) {\n"
-                                  "    " value " = " (epilogue value "" "") ";\n  }\n")))
-                         "  wmma::store_matrix_sync(C + (m_base + " (* m mi) ") * N + n_base + " (* n ni)
-                         ", acc" m "_" n ", N, wmma::mem_row_major);\n")))
-       "}\n"))))
+                      {:dimensions dimensions :dimension-values dimension-values})]
+      (fragment-source/emit-direct kernel-name plan declarations epilogue :cuda))))
 
 (defn emit-matrix-kernel
   "Lower the currently supported CUDA WMMA subset of a verified matrix KernelBody.

--- a/src/raster/compiler/backend/gpu/matrix_fragment_source.clj
+++ b/src/raster/compiler/backend/gpu/matrix_fragment_source.clj
@@ -1,0 +1,82 @@
+(ns raster.compiler.backend.gpu.matrix-fragment-source
+  "Shared direct-fragment mainloop spelling for analyzed matrix bodies.
+   Target admission stays in the target emitter; this internal renderer introduces no schedules,
+   layouts, storage, or precision decisions. The dialect selects instruction spellings only."
+  (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]))
+
+(defn- fragment-dialect! [target]
+  (case target
+    :cuda {:namespace "wmma" :operand-type "half"
+           :namespace-declaration "using namespace nvcuda;\n\n"
+           :dimension-failure "asm volatile(\"trap;\");"
+           :prefetch "asm volatile(\"prefetch.global.L2 [%0];\" :: \"l\"(pp));"}
+    (throw (ex-info "matrix fragment dialect is not implemented"
+                    {:reason :matrix-fragment-dialect-not-lowered :target target}))))
+
+(defn emit-direct
+  "Render an admitted matrix plan. Declarations preserve the caller's checked ordered ABI;
+   epilogue is the existing typed scalar-region lowering, never a user kernel template."
+  [kernel-name {:keys [dimensions mi ni ki subgroup block-m block-n sg-m sg-n
+                       block-k lhs-ids rhs-ids prefetch index-dtype]} declarations epilogue target]
+  (let [dialect (fragment-dialect! target)
+        fragment-namespace (:namespace dialect)
+        operand-type (:operand-type dialect)
+        [M N K] dimensions
+        index-type (c-dialect/type-name (c-dialect/resolve! target) index-dtype)
+        nms (count lhs-ids) nns (count rhs-ids)      ;; fragments per warp (M, N)
+          ncols (quot block-n sg-n)                   ;; warp columns
+          ksteps (quot block-k ki)
+          ms (range nms) ns (range nns)
+          warps-per-block (* (quot block-m sg-m) (quot block-n sg-n))
+          frag (fn [role & [layout]] (str fragment-namespace "::fragment<" fragment-namespace "::" role ", " mi ", " ni ", " ki ", "
+                                          (if (= role "accumulator") "float" (str operand-type ", " fragment-namespace "::" layout))
+                                          ">"))]
+      (str
+       (:namespace-declaration dialect)
+       "// Tiled WMMA GEMM (parametric): block " block-m "x" block-n ", warp-tile " sg-m "x" sg-n
+       ", K " block-k ", frag " mi "x" ni "x" ki ", warp " subgroup
+       ", warps/block " warps-per-block "\n"
+       "extern \"C\" __global__ void " kernel-name "(\n    "
+       (str/join ",\n    " declarations) ") {\n"
+       "  if (M != " M " || N != " N " || K != " K ") { " (:dimension-failure dialect) " return; }\n"
+       "  int warpId = threadIdx.x / " subgroup ";\n"
+       "  int warp_row = warpId / " ncols ";\n"
+       "  int warp_col = warpId % " ncols ";\n"
+       "  int m_base = blockIdx.y * " block-m " + warp_row * " sg-m ";\n"
+       "  int n_base = blockIdx.x * " block-n " + warp_col * " sg-n ";\n"
+       ;; accumulator fragments
+       (apply str (for [m ms n ns] (str "  " (frag "accumulator") " acc" m "_" n ";\n")))
+       (apply str (for [m ms n ns] (str "  " fragment-namespace "::fill_fragment(acc" m "_" n ", 0.0f);\n")))
+       "  " (frag "matrix_a" "row_major") " " (str/join ", " (for [m ms] (str "a" m))) ";\n"
+       "  " (frag "matrix_b" "row_major") " " (str/join ", " (for [n ns] (str "b" n))) ";\n"
+       "  for (" index-type " k = 0; k < K; k += " block-k ") {\n"
+       (apply str
+              (for [ks (range ksteps)]
+                (let [koff (* ks ki)]
+                  (str
+                   "    { " index-type " pk = k + " (+ koff (* prefetch ki)) ";\n"
+                   "      if (pk < K && ((int)threadIdx.x % " subgroup ") == 0) {\n"
+                   (apply str
+                          (for [m ms]
+                            (str "        #pragma unroll\n"
+                                 "        for (int pr = 0; pr < " mi "; ++pr) {\n"
+                                 "          const " operand-type "* pp = A + (m_base + " (* m mi)
+                                 " + pr) * K + pk;\n"
+                                 "          " (:prefetch dialect) "\n"
+                                 "        }\n")))
+                   "      } }\n"
+                   (apply str (for [m ms] (str "    " fragment-namespace "::load_matrix_sync(a" m ", A + (m_base + " (* m mi) ") * K + k + " koff ", K);\n")))
+                   (apply str (for [n ns] (str "    " fragment-namespace "::load_matrix_sync(b" n ", B + (k + " koff ") * N + n_base + " (* n ni) ", N);\n")))
+                   (apply str (for [m ms n ns] (str "    " fragment-namespace "::mma_sync(acc" m "_" n ", a" m ", b" n ", acc" m "_" n ");\n")))))))
+       "  }\n"
+       (apply str (for [m ms n ns]
+                    (str (when epilogue
+                           (let [acc (str "acc" m "_" n)
+                                 value (str acc ".x[rstr_epilogue_element]")]
+                             (str "  #pragma unroll\n"
+                                  "  for (int rstr_epilogue_element = 0; rstr_epilogue_element < " acc ".num_elements; ++rstr_epilogue_element) {\n"
+                                  "    " value " = " (epilogue value "" "") ";\n  }\n")))
+                         "  " fragment-namespace "::store_matrix_sync(C + (m_base + " (* m mi) ") * N + n_base + " (* n ni)
+                         ", acc" m "_" n ", N, " fragment-namespace "::mem_row_major);\n")))
+       "}\n")))


### PR DESCRIPTION
## Summary

- Extract direct-fragment mainloop source spelling from CUDA target admission, preparing HIP without copying the GEMM algorithm.
- Keep the checked ordered ABI, instruction family, aligned dimensions, slice/view declines and shared typed FP32 epilogues at the CUDA entry point.
- Record pinned HIP feasibility results and the remaining architecture, ABI and public-route gates in the existing campaign. No HIP production route is enabled.

## Validation

- Focused CUDA/matrix-target tests: 9 tests, 64 assertions, zero failures/errors; includes nvcc cubin compilation and HMMA inspection.
- One-off comparison against the pre-extraction emitter: byte-identical CUDA source for two tile sizes, both identity and scaling/ReLU epilogues (four cases).
- Reference-only rocWMMA 5.7.1 probes compile for gfx90a and gfx1100; disassembly confirms MFMA and WMMA respectively. These are not Raster kernels or numerical/performance evidence.
- Existing mandatory CUDA/HIP compilation and CPU OpenCL/full test gates remain unchanged. No full local suite.
