### PR TITLE
Compile a shared-fragment HIP MFMA candidate with fused epilogues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,9 @@ jobs:
             for source in gpu-compile-gates/hip/*.hip; do
               hipcc --offload-arch=gfx1100 --genco -o "${source}.hsaco" "${source}"
             done
+      - run:
+          name: Compile generated MFMA candidate and verify instruction selection without a GPU
+          command: bash scripts/ci-compile-hip-matrix.sh
 
   opencl-cpu-gate:
     # Executes the OpenCL-gated namespaces on a CPU OpenCL implementation so emitted kernels are

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -900,3 +900,26 @@ separate architecture compile gate. RDNA WMMA/wave32 requires its own explicit c
 the current gfx1100 scalar compile gate must not be mistaken for MFMA coverage. A pinned
 header/toolchain contract, generated-body compilation, physical ABI requirements and public
 route tests remain prerequisites before enabling either route.
+
+### HIP MFMA source candidate shares CUDA's admission and fragment lowering
+
+The direct-fragment backend now checks ordered pointer/scalar roles, matrix instruction,
+aligned static dimensions, whole-K traversal and unsupported views once for CUDA and the HIP
+candidate. CUDA's existing entry delegates to it. The HIP candidate consumes a verified
+MFMA 16×16×16 / wave64 body and the same coordinate-free Float store region, including
+scaling/ReLU. It does not copy a rocWMMA GEMM: only fragment load, multiply-accumulate and
+store operations use the pinned library's target spelling. Prefetch remains a compiler hint,
+not an asynchronous-copy or completion guarantee.
+
+Mandatory HIP CI compiles that generated body for gfx90a, requires the expected MFMA in its
+disassembly and rejects gfx1100 compilation. The header archive is pinned by revision and
+SHA-256. The scalar RDNA3 gate stays separate. Local validation can use the same script and
+archive without downloading or accessing a GPU.
+
+This remains deliberately source-only. The common matrix-target boundary still declines HIP:
+the current artifact compilation contract admits OpenCL language/extension requirements, not
+external C++ header dependencies. Before production admission, represent the resolved header
+and compiler/architecture identity in artifact compilation and caching, prove physical pointer
+alignment/launch requirements, and preserve those through binding. Then require public-route
+acceptance and AMD numerical validation. No throughput or CUDA/AMD numerical parity claim is
+made from source compilation or disassembly.

--- a/scripts/ci-compile-hip-matrix.sh
+++ b/scripts/ci-compile-hip-matrix.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Compile a Raster-generated candidate, not a prewritten rocWMMA GEMM. No GPU is required.
+set -euo pipefail
+
+source_file=${1:-gpu-compile-gates/hip-matrix/mfma-uniform-epilogue.hip}
+test -s "$source_file"
+matrix_workdir=$(mktemp -d "${TMPDIR:-/tmp}/raster-hip-matrix.XXXXXX")
+trap 'rm -r -- "$matrix_workdir"' EXIT
+revision=b5a884dc764d2cb3de480294466895ee7e5efd6a
+archive="$matrix_workdir/rocwmma.tar.gz"
+if [[ -n "${RASTER_ROCWMMA_ARCHIVE:-}" ]]; then
+  cp "$RASTER_ROCWMMA_ARCHIVE" "$archive"
+else
+  curl --fail --location --retry 3 \
+    "https://codeload.github.com/ROCm/rocWMMA/tar.gz/$revision" -o "$archive"
+fi
+echo "64fd8396ed44b32a56e6271d057b9b639fe28d7d5aa61bdf014e31486bf4ca7b  $archive" | sha256sum --check
+tar -xzf "$archive" -C "$matrix_workdir"
+include="$matrix_workdir/rocWMMA-$revision/library/include"
+binary="$matrix_workdir/candidate.hsaco"
+hipcc -D__HIP_PLATFORM_AMD__ -std=c++17 --offload-arch=gfx90a --genco \
+  -I "$include" "$source_file" -o "$binary"
+
+# hipcc versions produce either an ELF code object or a Clang offload bundle.
+objdump=${HIP_OBJDUMP:-/opt/rocm/llvm/bin/llvm-objdump}
+bundler=${HIP_BUNDLER:-/opt/rocm/llvm/bin/clang-offload-bundler}
+assembly="$matrix_workdir/candidate.s"
+if ! "$objdump" -d "$binary" > "$assembly" 2> "$matrix_workdir/objdump.log"; then
+  "$bundler" --unbundle --type=o --input="$binary" \
+    --targets=hipv4-amdgcn-amd-amdhsa--gfx90a --output="$matrix_workdir/candidate.elf"
+  "$objdump" -d "$matrix_workdir/candidate.elf" > "$assembly"
+fi
+grep 'v_mfma_f32_16x16x16f16' "$assembly"
+
+if hipcc -D__HIP_PLATFORM_AMD__ -std=c++17 --offload-arch=gfx1100 --genco \
+  -I "$include" "$source_file" -o "$binary" > "$matrix_workdir/wrong-target.log" 2>&1; then
+  echo 'ERROR: the MFMA/wave64 candidate compiled for RDNA3/wave32' >&2
+  exit 1
+fi
+grep 'Raster MFMA candidate requires gfx90a' "$matrix_workdir/wrong-target.log"
+echo 'Generated MFMA candidate compiled; matrix instruction confirmed; incompatible architecture rejected.'

--- a/src/raster/compiler/backend/gpu/cuda_codegen.clj
+++ b/src/raster/compiler/backend/gpu/cuda_codegen.clj
@@ -1,103 +1,10 @@
 (ns raster.compiler.backend.gpu.cuda-codegen
-  "CUDA-C target lowering for verified matrix KernelBody values.
-
-  The first row deliberately covers direct, aligned f16×f16→f32 WMMA bodies. Unsupported body
-   structure fails before source emission. Coordinate-free FP32 store regions use the shared scalar
-   emitter over fragment elements; indexed epilogues, masks, views and slices are never silently
-   discarded. Shared-memory staging and WGMMA are later schedules over the same
-  typed contraction and KernelBody vocabulary."
-  (:require [clojure.string :as str]
-            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
-            [raster.compiler.backend.gpu.kernel-body-opencl :as scalar-emitter]
-            [raster.compiler.backend.gpu.c-emit :as c-emit]
-            [raster.compiler.backend.gpu.matrix-target-names :as target-names]
-            [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
-            [raster.compiler.backend.gpu.matrix-fragment-source :as fragment-source]))
-
-(defn- decline!
-  [condition reason data]
-  (when-not condition
-    (throw (ex-info "CUDA matrix lowering does not implement this verified body"
-                    (assoc data :reason reason :target :cuda)))))
-
-(defn- parameter-declarations
-  [parameters dimension-parameters]
-  (let [dimension-name (into {} (map (fn [[axis id]] [id (str/upper-case (name axis))]))
-                             dimension-parameters)]
-    (mapv
-     (fn [{:keys [id kind dtype role] :as parameter}]
-       (cond
-         (and (= :lhs role) (= :input kind) (= :half dtype))
-         "const half* __restrict__ A"
-
-         (and (= :rhs role) (= :input kind) (= :half dtype))
-         "const half* __restrict__ B"
-
-         (and (= :result role) (= :output kind) (= :float dtype))
-         "float* __restrict__ C"
-
-         (and (= :dimension role) (= :scalar kind) (= :int dtype)
-              (contains? dimension-name id))
-         (str "int " (get dimension-name id))
-
-         (and (= :epilogue role) (= :scalar kind) (= :float dtype))
-         (str "float " (c-emit/c-symbol id))
-
-         :else
-         (throw (ex-info "CUDA matrix lowering cannot render this ordered ABI parameter"
-                         {:reason :cuda-mma-extra-abi-unsupported
-                          :target :cuda :parameter parameter}))))
-     parameters)))
-
-(defn- emit-plan
-  [kernel-name {:keys [instruction dimensions dimension-values parameters
-                       block-m block-n block-k result-dtype
-                       dimension-parameters schedule-parameters group-z k-lower k-upper
-                       buffer-offsets] :as plan} epilogue]
-  (let [[M N K] dimensions]
-    (decline! (= {:family :mma :m 16 :n 16 :k 16 :subgroup 32} instruction)
-              :cuda-mma-instruction-unsupported {:instruction instruction})
-    (decline! (= :float result-dtype)
-              :cuda-mma-result-dtype-unsupported {:result-dtype result-dtype})
-    (decline! (and (every? #(and (integer? %) (pos? %)) dimensions)
-                   (zero? (mod M block-m))
-                   (zero? (mod N block-n))
-                   (zero? (mod K block-k)))
-              :cuda-mma-requires-aligned-static-dimensions
-              {:dimensions dimensions :block [block-m block-n block-k]})
-    (decline! (= [0 (:k dimension-parameters)] [k-lower k-upper])
-              :cuda-mma-k-slice-unsupported {:k-range [k-lower k-upper]})
-    (decline! (and (nil? group-z) (empty? schedule-parameters)
-                   (every? nil? (vals buffer-offsets)))
-              :cuda-mma-views-or-schedule-parameters-unsupported
-              {:group-z group-z :schedule-parameters schedule-parameters
-               :buffer-offsets buffer-offsets})
-    (let [declarations (parameter-declarations parameters dimension-parameters)
-          _ (decline! (= 6 (count (remove #(= :epilogue (:role %)) parameters)))
-                      :cuda-mma-extra-abi-unsupported {:parameters parameters})
-          specialized-dimensions
-          (mapv dimension-values [(:m dimension-parameters)
-                                  (:n dimension-parameters)
-                                  (:k dimension-parameters)])
-          _ (decline! (= dimensions specialized-dimensions)
-                      :cuda-mma-dimension-specialization-invalid
-                      {:dimensions dimensions :dimension-values dimension-values})]
-      (fragment-source/emit-direct kernel-name plan declarations epilogue :cuda))))
+  "CUDA-C entry point for verified direct matrix KernelBody values.
+   Admission, fragment mainloop spelling and uniform typed epilogues share the fragment backend."
+  (:require [raster.compiler.backend.gpu.matrix-fragment-source :as fragment-source]))
 
 (defn emit-matrix-kernel
-  "Lower the currently supported CUDA WMMA subset of a verified matrix KernelBody.
-
-  This boundary takes no tile, dimension, launch or ABI side channel. The returned source is a
-  target spelling of the analyzed body; unsupported verified bodies fail with a structured reason."
+  "Lower the supported CUDA WMMA subset of a verified matrix KernelBody.
+   No tile, dimension, launch or ABI side channel is accepted."
   [kernel-name kernel-body]
-  (let [plan (matrix-plan/analyze kernel-body)
-        names (target-names/validate! kernel-name kernel-body
-                                      (target-names/parameter-names kernel-body nil))
-        region (scalar-emitter/lower-uniform-store-region kernel-body names :cuda)
-        source (emit-plan kernel-name plan (:epilogue region))
-        helpers (c-emit/intrinsic-helper-module source :cuda {})]
-    (decline! (empty? (:compilation helpers)) :cuda-mma-helper-compilation-unsupported
-              {:compilation (:compilation helpers)})
-    (str "#include <mma.h>\n#include <math.h>\n"
-         (c-dialect/helper-source (c-dialect/resolve! :cuda) (:source helpers))
-         "\n" source)))
+  (fragment-source/emit-matrix-kernel kernel-name kernel-body :cuda))

--- a/src/raster/compiler/backend/gpu/matrix_fragment_source.clj
+++ b/src/raster/compiler/backend/gpu/matrix_fragment_source.clj
@@ -3,14 +3,30 @@
    Target admission stays in the target emitter; this internal renderer introduces no schedules,
    layouts, storage, or precision decisions. The dialect selects instruction spellings only."
   (:require [clojure.string :as str]
-            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]))
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as scalar-emitter]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.backend.gpu.matrix-target-names :as target-names]
+            [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]))
 
 (defn- fragment-dialect! [target]
   (case target
-    :cuda {:namespace "wmma" :operand-type "half"
+    :cuda {:diagnostic-prefix "cuda-mma-"
+           :instruction {:family :mma :m 16 :n 16 :k 16 :subgroup 32}
+           :header "#include <mma.h>\n#include <math.h>\n"
+           :namespace "wmma" :operand-type "half"
            :namespace-declaration "using namespace nvcuda;\n\n"
            :dimension-failure "asm volatile(\"trap;\");"
            :prefetch "asm volatile(\"prefetch.global.L2 [%0];\" :: \"l\"(pp));"}
+    :hip {:diagnostic-prefix "hip-mfma-"
+          :instruction {:family :mfma :m 16 :n 16 :k 16 :subgroup 64}
+          :header (str "#include <hip/hip_runtime.h>\n#include <rocwmma/rocwmma.hpp>\n#include <math.h>\n"
+                       "#if defined(__HIP_DEVICE_COMPILE__) && !defined(__gfx90a__)\n"
+                       "#error Raster MFMA candidate requires gfx90a (wave64)\n#endif\n")
+          :namespace "rocwmma" :operand-type "rocwmma::float16_t"
+          :namespace-declaration ""
+          :dimension-failure "__builtin_trap();"
+          :prefetch "__builtin_prefetch(pp, 0, 3);"}
     (throw (ex-info "matrix fragment dialect is not implemented"
                     {:reason :matrix-fragment-dialect-not-lowered :target target}))))
 
@@ -80,3 +96,91 @@
                          "  " fragment-namespace "::store_matrix_sync(C + (m_base + " (* m mi) ") * N + n_base + " (* n ni)
                          ", acc" m "_" n ", N, " fragment-namespace "::mem_row_major);\n")))
        "}\n")))
+
+(defn- decline!
+  [target condition reason data]
+  (when-not condition
+    (throw (ex-info "matrix fragment lowering does not implement this verified body"
+                    (assoc data :reason (keyword (str (:diagnostic-prefix (fragment-dialect! target))
+                                                     (name reason)))
+                           :target target)))))
+
+(defn- parameter-declarations
+  [parameters dimension-parameters target]
+  (let [dimension-name (into {} (map (fn [[axis id]] [id (str/upper-case (name axis))]))
+                             dimension-parameters)]
+    (mapv
+     (fn [{:keys [id kind dtype role] :as parameter}]
+       (cond
+         (and (= :lhs role) (= :input kind) (= :half dtype))
+         (str "const " (:operand-type (fragment-dialect! target)) "* __restrict__ A")
+
+         (and (= :rhs role) (= :input kind) (= :half dtype))
+         (str "const " (:operand-type (fragment-dialect! target)) "* __restrict__ B")
+
+         (and (= :result role) (= :output kind) (= :float dtype))
+         "float* __restrict__ C"
+
+         (and (= :dimension role) (= :scalar kind) (= :int dtype)
+              (contains? dimension-name id))
+         (str "int " (get dimension-name id))
+
+         (and (= :epilogue role) (= :scalar kind) (= :float dtype))
+         (str "float " (c-emit/c-symbol id))
+
+         :else
+         (decline! target false :extra-abi-unsupported {:parameter parameter})))
+     parameters)))
+
+(defn- emit-admitted-plan
+  [kernel-name {:keys [instruction dimensions dimension-values parameters
+                       block-m block-n block-k result-dtype
+                       dimension-parameters schedule-parameters group-z k-lower k-upper
+                       buffer-offsets] :as plan} epilogue target]
+  (let [[M N K] dimensions]
+    (decline! target (= (:instruction (fragment-dialect! target)) instruction)
+              :instruction-unsupported {:instruction instruction})
+    (decline! target (= :float result-dtype)
+              :result-dtype-unsupported {:result-dtype result-dtype})
+    (decline! target (and (every? #(and (integer? %) (pos? %)) dimensions)
+                   (zero? (mod M block-m))
+                   (zero? (mod N block-n))
+                   (zero? (mod K block-k)))
+              :requires-aligned-static-dimensions
+              {:dimensions dimensions :block [block-m block-n block-k]})
+    (decline! target (= [0 (:k dimension-parameters)] [k-lower k-upper])
+              :k-slice-unsupported {:k-range [k-lower k-upper]})
+    (decline! target (and (nil? group-z) (empty? schedule-parameters)
+                   (every? nil? (vals buffer-offsets)))
+              :views-or-schedule-parameters-unsupported
+              {:group-z group-z :schedule-parameters schedule-parameters
+               :buffer-offsets buffer-offsets})
+    (let [declarations (parameter-declarations parameters dimension-parameters target)
+          _ (decline! target (= 6 (count (remove #(= :epilogue (:role %)) parameters)))
+                      :extra-abi-unsupported {:parameters parameters})
+          specialized-dimensions
+          (mapv dimension-values [(:m dimension-parameters)
+                                  (:n dimension-parameters)
+                                  (:k dimension-parameters)])
+          _ (decline! target (= dimensions specialized-dimensions)
+                      :dimension-specialization-invalid
+                      {:dimensions dimensions :dimension-values dimension-values})]
+      (emit-direct kernel-name plan declarations epilogue target))))
+
+(defn emit-matrix-kernel
+  "Emit the direct fragment subset for a verified body.
+   HIP is a source-only candidate requiring the separately pinned rocWMMA compile environment;
+   it is not admitted by matrix-target or advertised as a runtime-supported artifact."
+  [kernel-name kernel-body target]
+  (let [dialect (fragment-dialect! target)
+        plan (matrix-plan/analyze kernel-body)
+        names (target-names/validate! kernel-name kernel-body
+                                      (target-names/parameter-names kernel-body nil))
+        region (scalar-emitter/lower-uniform-store-region kernel-body names target)
+        source (emit-admitted-plan kernel-name plan (:epilogue region) target)
+        helpers (c-emit/intrinsic-helper-module source target {})]
+    (decline! target (empty? (:compilation helpers)) :helper-compilation-unsupported
+              {:compilation (:compilation helpers)})
+    (str (:header dialect)
+         (c-dialect/helper-source (c-dialect/resolve! target) (:source helpers))
+         "\n" source)))

--- a/test/raster/compiler/backend/gpu/hip_matrix_candidate_test.clj
+++ b/test/raster/compiler/backend/gpu/hip_matrix_candidate_test.clj
@@ -1,0 +1,66 @@
+(ns raster.compiler.backend.gpu.hip-matrix-candidate-test
+  "Source-only MFMA candidate coverage; mandatory architecture compilation runs in CI."
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.java.io :as io]
+            [clojure.java.shell :as sh]
+            [raster.compiler.backend.gpu.matrix-fragment-source :as fragment]
+            [raster.compiler.backend.gpu.matrix-target :as target]
+            [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
+
+(defn candidate-body
+  "The same scheduled candidate is emitted by the mandatory HIP matrix compile fixture."
+  ([] (candidate-body {:family :mfma :m 16 :n 16 :k 16 :subgroup 64}))
+  ([instruction]
+   (schedule/matrix-body
+    {:id :hip-mfma-candidate :row 'a :col 'b :out 'c
+     :dimensions [64 64 64] :result-dtype :float
+     :tile {:block-m 64 :block-n 64 :sg-m 32 :sg-n 32 :block-k 32
+            :num-stages 3 :matrix instruction}
+     :epilogue {:acc 'acc
+                :expr '(raster.numeric/max (raster.numeric/* acc alpha) (float 0.0))
+                :scalars [{:sym 'alpha :dtype :float}]}})))
+
+(deftest mfma-candidate-retains-the-typed-body-and-uniform-epilogue
+  (let [body (candidate-body)
+        source (fragment/emit-matrix-kernel "mfma_candidate" body :hip)]
+    (is (re-find #"rocwmma::mma_sync" source))
+    (is (re-find #"threadIdx.x / 64" source))
+    (is (re-find #"const rocwmma::float16_t\* __restrict__ A" source))
+    (is (re-find #"float alpha" source))
+    (is (re-find #"\.x\[rstr_epilogue_element\] = .*alpha" source))
+    (is (re-find #"fmax\(" source))
+    (is (re-find #"!defined\(__gfx90a__\)" source))
+    (is (not (re-find #"__shared__|nvcuda|wmma::fragment<wmma::" source)))
+    (try
+      (target/emit-matrix-kernel "not_runtime_ready" body :hip)
+      (is false "a candidate requiring external headers must not become a runtime artifact")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :matrix-target-dialect-not-lowered (:reason (ex-data e))))))
+    (doseq [instruction [{:family :mma :m 16 :n 16 :k 16 :subgroup 32}
+                         {:family :mfma :m 16 :n 16 :k 16 :subgroup 32}]]
+      (try
+        (fragment/emit-matrix-kernel "bad_instruction" (candidate-body instruction) :hip)
+        (is false "target family and wave width must match the admitted MFMA instruction")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :hip-mfma-instruction-unsupported (:reason (ex-data e)))))))))
+
+(deftest pinned-mfma-candidate-compiles-without-amd-hardware
+  (if-let [include (System/getenv "RASTER_ROCWMMA_INCLUDE")]
+    (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                       "raster-mfma-" (make-array java.nio.file.attribute.FileAttribute 0)))
+          source (io/file dir "candidate.hip")
+          output (io/file dir "candidate.hsaco")]
+      (try
+        (spit source (fragment/emit-matrix-kernel "mfma_candidate" (candidate-body) :hip))
+        (let [compile! (fn [arch]
+                         (sh/sh "hipcc" "-D__HIP_PLATFORM_AMD__" "-std=c++17"
+                                (str "--offload-arch=" arch) "--genco" "-I" include
+                                (.getPath source) "-o" (.getPath output)))
+              accepted (compile! "gfx90a")
+              rejected (compile! "gfx1100")]
+          (is (zero? (:exit accepted)) (:err accepted))
+          (is (not (zero? (:exit rejected))))
+          (is (re-find #"Raster MFMA candidate requires gfx90a" (:err rejected))))
+        (finally
+          (doseq [file (reverse (file-seq dir))] (io/delete-file file)))))
+    (println "HIP matrix local compile not run: set RASTER_ROCWMMA_INCLUDE; mandatory CI covers it.")))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -5,6 +5,8 @@
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.gemm :as gemm-emit]
             [raster.compiler.backend.gpu.cuda-codegen :as cuda-emit]
+            [raster.compiler.backend.gpu.matrix-fragment-source :as fragment-emit]
+            [raster.compiler.backend.gpu.hip-matrix-candidate-test :as hip-matrix-fixture]
             [raster.compiler.backend.gpu.indexed-attention :as indexed-attention-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
@@ -558,6 +560,12 @@
                            (body-fixtures/pipelined-staging-body 32 :preferred)
                            {:target-dialect dialect :target-features descriptor}))]
           (concat
+           (when (= :hip target)
+             (let [matrix-directory (io/file root "hip-matrix")]
+               (.mkdirs matrix-directory)
+               [(write-source! matrix-directory suffix "mfma-uniform-epilogue"
+                               (fragment-emit/emit-matrix-kernel
+                                "mfma_uniform_epilogue" (hip-matrix-fixture/candidate-body) :hip))]))
            (when (= :cuda target)
              [(write-source!
                directory suffix "matrix-uniform-epilogue"


### PR DESCRIPTION
## Summary

- Add a source-only HIP MFMA/wave64 candidate over verified matrix KernelBody, sharing CUDA's admission checks, ordered ABI, fragment mainloop and typed uniform FP32 epilogues.
- Restrict the candidate to gfx90a at compile time. Matrix-target still rejects HIP runtime artifacts: external C++ header and toolchain identity are not yet represented by the artifact compilation contract.
- Add a mandatory hardware-free HIP CI step: verify the pinned rocWMMA archive checksum, compile the generated candidate, require MFMA in disassembly, and prove gfx1100 is rejected.
- Keep existing scalar RDNA3 and CUDA gates separate and unchanged; record production-admission obligations in the current campaign.

## Validation

- Focused CUDA/matrix-target/HIP candidate suite: 11 tests, 78 assertions, zero failures/errors (including actual nvcc and hipcc compilation).
- Ran the exact new CI script locally: generated scaling/ReLU GEMM contains v_mfma_f32_16x16x16f16, and incompatible architecture compilation fails with the intended diagnostic.
- bash syntax and git whitespace checks pass. Full tests deferred to CI.

## Scope

rocWMMA supplies fragment operations, not a black-box GEMM. The loops and epilogue are Raster-generated from the checked body. This is source/instruction validation, not AMD numerical execution, public compiler-route acceptance, or competitive performance evidence. No runtime fallback is enabled or removed by this candidate.
