### PR TITLE
Fuse dynamic contraction result maps with dominating typed extents

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -944,5 +944,10 @@ Next priorities are dynamic GEMM→activation fusion through symbolic extent equ
 scalar placement; correlating observed events with executable evidence; then the projection shape
 ladder and a resident forward/VJP/update. The dynamic extent's checked multiplication cannot simply
 be moved across an output write: fusion must preserve failure behavior as well as values.
+The first dynamic slice handles an extent product already computed before the contraction. Shared
+typed index lowering checks retained widths, and shared axis algebra establishes shape equality;
+the fused result transform retains the extent as a dependency. This permits ordinary prebound
+contraction→map source to reach one generated step without an explicit epilogue API. The original
+post-contraction extent remains a barrier; no speculative motion or inferred range is introduced.
 Shared-memory pipelines or indexed matrix epilogues should be introduced when those measurements
 or workload requirements justify them. Existing scientific/distributed acceptance gates remain.

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -11,8 +11,10 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.fusion-placement :as placement]))
 
 (def ^:private map-equation-rule
@@ -650,16 +652,51 @@
          (= destination (:destination (first storage)))
          (= allowed-access (:access (first storage))))))
 
+(defn- dominating-product-extent
+  "Prove a consumer extent from an already evaluated scalar product. This is a conditional
+   equality, NOT permission to move checked arithmetic. Only a definition before the producer
+   qualifies; its value remains a capture of the fused result transform so evaluation is retained.
+   The shared typed index projection checks widths/casts before the shared axis algebra compares
+   products. No array reads, locals, opaque calls, narrowing or untyped arithmetic are admitted."
+  [program preceding-infos extent output-extent]
+  (let [facts (dialect/facts program)
+        definition (some #(when (= [extent] (:results %)) %) preceding-infos)
+        {:keys [id kind captures parameters locals body-results]} definition
+        values (:values facts)
+        scalar-type #(when (= [] (:shape (get values %))) (:dtype (get values %)))
+        decline! (fn [& _] (throw (ex-info "unproved extent product" {:reason ::extent-proof-decline})))]
+    (when (and (= :scalar kind) (fusible-equation? program id)
+               (= :long (scalar-type extent))
+               (every? #(contains? #{:int :long} (scalar-type %)) captures)
+               (empty? locals) (= 1 (count body-results)))
+      (try
+        (let [expression (util/subst-syms (zipmap parameters captures) (first body-results))
+              _ (when (> (count (take 129 (tree-seq seq? seq expression))) 128) (decline!))
+              lowered (index-expression/lower-typed expression (set captures) scalar-type :long decline!)
+              product-form (fn product-form [x]
+                             (cond
+                               (or (symbol? x) (integer? x)) x
+                               (launch/index-cast? x) (product-form (:argument x))
+                               (and (launch/index-expr? x) (= :mul (:op x)))
+                               (list* '* (map product-form (:arguments x)))
+                               :else (decline!)))]
+          (when (axis-map/index= output-extent (product-form lowered) []) extent))
+        (catch clojure.lang.ExceptionInfo e
+          (when-not (= ::extent-proof-decline (:reason (ex-data e))) (throw e)))))))
+
 (defn- result-map-transform
   "Translate one pointwise map region into a typed post-reduction scalar region.
 
    Pointwise arrays become full-segment operands. Stable captures retain only an axis map proven
    from their flat map index. Uniform captures become typed scalars. Any ambiguous array read
   declines the candidate rather than guessing an address."
-  [program producer consumer consumed-destination]
+  [program preceding-infos producer consumer consumed-destination]
   (let [segment-axes (get-in producer [:attributes :segment-axes])
         output-map (axis-map/of-axes segment-axes)
         output-extent (axis-map/n-elements output-map)
+        consumer-extent (get-in consumer [:attributes :extent])
+        extent-witness (when-not (= output-extent consumer-extent)
+                         (dominating-product-extent program preceding-infos consumer-extent output-extent))
         flat-index (axis-map/index-expr output-map)
         map-index (get-in consumer [:attributes :index])
         producer-parameters (parameter-parts producer)
@@ -699,6 +736,9 @@
         scalars (mapv (fn [[value _]]
                         {:value value :dtype (value-scalar-dtype program value)})
                       scalar-bindings)
+        scalars (cond-> scalars
+                  (and extent-witness (not-any? #(= extent-witness (:value %)) scalars))
+                  (conj {:value extent-witness :dtype :long}))
         element-substitutions
         (into {}
               (map-indexed
@@ -714,7 +754,7 @@
                         (util/subst-syms (merge element-substitutions
                                                 capture-substitutions
                                                 {map-index flat-index})))]
-    (when (and (= output-extent (get-in consumer [:attributes :extent]))
+    (when (and (or (= output-extent consumer-extent) extent-witness)
                (= 1 (count consumed-indices))
                (every? some? indexed-operands)
                (every? :dtype operands)
@@ -751,7 +791,7 @@
                  (get-in facts [:equations (:id consumer)
                                 :attributes :result-storage 0 :destination])
                  transform (when (and consumed-destination consumer-destination)
-                             (result-map-transform program producer consumer
+                             (result-map-transform program (subvec infos 0 producer-index) producer consumer
                                                    consumed-destination))]
            :when (= 1 (count (:results producer)) (count (:body-results producer))
                     (count (:results consumer)) (count (:body-results consumer)))

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -371,6 +371,49 @@
     (is (empty? (get-in operation [:attributes :result-transform :operands])))
     (is (= result (dialect/validate! result)))))
 
+(defn- dynamic-result-map-program [extent-expression placement]
+  (let [producer ['contract-step
+                  '(raster.par/contract C [[i m] [j n]] [[p k]]
+                     (* (clojure.core/aget A (+ (* i k) p))
+                        (clojure.core/aget B (+ (* p n) j))))]
+        extent ['size extent-expression]
+        consumer ['map-step '(raster.par/map! C t size nil
+                               (max (float 0.0) (clojure.core/aget C t)))]]
+    (frontend/form->program
+     (list 'let* (vec (concat (if (= :before placement) (concat extent producer)
+                                 (concat producer extent)) consumer)) 'map-step)
+     {:dtype :float :array-types '{A :float B :float C :float}
+      :scalar-types '{m :long n :long k :long size :long}})))
+
+(deftest dominating-typed-product-proves-dynamic-result-fusion
+  (doseq [product ['(clojure.core/* m n) '(clojure.core/* n m)]]
+    (let [expression (with-meta product {:raster.type/tag 'long})
+          program (dynamic-result-map-program expression :before)
+          [result stats] (typed-fusion/fusion-fixpoint program)
+          equations (dialect/equations result)
+          operation (dialect/operation-parts (second equations))]
+      (is (= 1 (:vertical stats)))
+      (is (= 2 (count equations)))
+      (is (= (first (dialect/equations program)) (first equations))
+          "the checked scalar definition remains before the output write")
+      (is (some #{'size} (:captures operation))
+          "the proof witness remains a dependency even though the epilogue need not read it")
+      (is (= ['size] (mapv :value (get-in operation [:attributes :result-transform :scalars]))))
+      (is (= result (dialect/validate! result))))))
+
+(deftest dynamic-result-fusion-does-not-invent-extent-proofs
+  (doseq [[expression placement]
+          [[(with-meta '(clojure.core/* m n) {:raster.type/tag 'long}) :after]
+           ['(clojure.core/* m n) :before]
+           [(with-meta '(clojure.core/* m n) {:raster.type/tag 'int}) :before]
+           [(with-meta '(unchecked-multiply m n) {:raster.type/tag 'long}) :before]
+           [(with-meta '(clojure.core/* m k) {:raster.type/tag 'long}) :before]
+           [(with-meta '(clojure.core/* (clojure.core/int m) n) {:raster.type/tag 'long}) :before]]]
+    (let [program (dynamic-result-map-program expression placement)
+          [result stats] (typed-fusion/fusion-fixpoint program)]
+      (is (= program result) (pr-str [expression placement]))
+      (is (zero? (:vertical stats))))))
+
 (deftest same-destination-fusion-refuses-neighbor-reads
   (doseq [expression ['(clojure.core/aget C (mod (+ t 1) 32))
                       '(+ (clojure.core/aget C t) (clojure.core/aget C (mod (+ t 1) 32)))]]

--- a/test/raster/perf/production_canary.clj
+++ b/test/raster/perf/production_canary.clj
@@ -41,6 +41,14 @@
                  :init (float 0.0))]
     (raster.par/map! C q (* m n) nil (max (float 0.0) (arrays/aget product q)))))
 
+(deftm gemm-relu-prebound! [A :- (Array float) B :- (Array float) C :- (Array float)
+                           m :- Long n :- Long k :- Long] :- (Array float)
+  (let [size (* m n)
+        product (raster.par/contract C [[i m] [j n]] [[p k]]
+                  (* (arrays/aget A (+ (* i k) p)) (arrays/aget B (+ (* p n) j)))
+                  :init (float 0.0))]
+    (raster.par/map! C q size nil (max (float 0.0) (arrays/aget product q)))))
+
 (deftm gemm-relu! [A :- (Array float) B :- (Array float) C :- (Array float)
                     m :- Long n :- Long k :- Long] :- (Array float)
   (raster.par/contract C [[i m] [j n]] [[p k]]
@@ -136,6 +144,7 @@
                  :plain #'gemm-mnk!
                  :relu #'gemm-relu!
                  :relu-composed #'gemm-relu-composed!
+                 :relu-prebound #'gemm-relu-prebound!
                  (throw (ex-info "unknown GEMM canary variant" {:variant variant})))]
      (compiled/lower entry (into args (map long (checked-shape shape)))
                      (cond-> {:target target :dtype :float :on-non-resident :throw :constants ['A 'B]}
@@ -178,6 +187,7 @@
                    :plain (if parameterized? :gemm-mnk-resident :gemm64-resident)
                    :relu :gemm-relu-resident
                    :relu-composed :gemm-relu-composed-resident
+                   :relu-prebound :gemm-relu-prebound-resident
                    (throw (ex-info "unknown GEMM canary variant" {:variant variant})))
         identity (identity-for workload target :float dimensions
                                :host-synchronized-replay environment-tag)

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -52,6 +52,29 @@
       (is (= :invalid-measurement
              (canary/verdict sample (assoc-in sample [:measurement :median-ns] v)))))))
 
+(deftest dynamic-prebound-composition-retains-one-generated-step
+  (let [shape [3 4 5]
+        args (canary/gemm-arguments shape)
+        prepared (canary/prepare-gemm :ocl:0 args shape
+                                      {:variant :relu-prebound :gemm-precision :f32-scalar})
+        evidence (canary/compilation-evidence prepared)]
+    (is (= 1 (:resident-step-count evidence)))
+    (is (every? #(= {:kernel-body (:entry-point-count %)} (:emission-routes %))
+                (mapcat :alternatives (:steps evidence))))
+    (if-not @probe/opencl-available?
+      (probe/opencl-skip! "dynamic prebound public GEMM plus map fusion")
+      (let [live (compiled/instantiate! prepared)]
+        (try
+          (let [resident (:executable live)
+                output (some #(when (= 'C (:sym %)) %) (:out-tree live))
+                expected (mapv #(max (float 0.0) %)
+                               (canary/gemm-reference (first args) (second args) shape))]
+            (doseq [_ (range 2)]
+              (link/upload! resident (:node output) (float-array (repeat 12 Float/NaN)))
+              (link/run! resident)
+              (is (= expected (vec (link/download resident (:node output)))))))
+          (finally (compiled/close! live)))))))
+
 (deftest compilation-evidence-retains-existing-dispatch-declines
   (let [diagnostics {:selection :analytic-fixed
                      :declines [{:reason :symbolic-dims}]


### PR DESCRIPTION
## Summary
- Prove dynamic output cardinality from a scalar product already evaluated before the contraction, using shared typed index lowering and axis algebra.
- Retain the scalar as an explicit fused-transform dependency; do not move checked arithmetic across writes or invent type/range facts.
- Add an ordinary prebound GEMM-to-ReLU canary that reaches one generated kernel without an explicit epilogue declaration.

## Validation
- 37 focused fusion and public-canary tests, 226 assertions, zero failures/errors.
- Reject late, untyped, narrowing, unchecked, and mismatched extent expressions.
- Poisoned-output replay checks on Arc pass; mixed-precision [8 64 64] records one generated XMX kernel with exact output.
- Full regression and vendor compile gates delegated to CI.

## Scope
The original post-contraction checked extent remains a fusion barrier. This is a conditional equality from a dominating evaluation, not speculative arithmetic motion.