### PR TITLE
Preserve checked long arithmetic in the JVM bytecode emitter

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -953,12 +953,14 @@ The same comparison probe now retains separate prebound-source identities for si
 multi-row projection observations. Both reach one generated XMX replay entry with exact output;
 external baselines and stationary measurements remain required before a competitiveness claim.
 
-An additional host boundary probe exposed existing JVM AOT overflow debt: `compile-aot` of the
-prebound canary with `m=Long/MAX_VALUE, n=2, k=0` returns an unchanged sentinel buffer instead of
-throwing on the source long product. The JVM bytecode arithmetic emitter directly uses `lmul`;
-the resident descriptor binder evaluates scalar lets through Clojure and checked launch algebra.
-Do not claim cross-target checked-arithmetic parity from the GPU result. Follow up with focused
-source-versus-bytecode boundary tests and a deliberate checked/wrapping policy in the existing
-emitter; this measurement slice does not change integer semantics or expand the fusion proof.
+An additional host boundary probe exposed JVM AOT overflow debt: `compile-aot` of the prebound
+canary with `m=Long/MAX_VALUE, n=2, k=0` previously returned an unchanged sentinel buffer instead
+of throwing on the source long product. The bytecode emitter used `lmul`; the resident descriptor
+binder evaluates scalar lets through Clojure and checked launch algebra. The focused follow-up
+restores checked long add/subtract/multiply/negate/inc/dec with Math exact operations, preserving
+the separate explicit unchecked emitters. Direct source-versus-bytecode boundary tests and the
+public sentinel test retain the distinction. Int arithmetic, narrowing casts, and other targets
+are not certified by this fix; backend-wide long arithmetic may pay overflow-check costs, so
+cross-target semantic parity and performance remain separate acceptance work.
 Shared-memory pipelines or indexed matrix epilogues should be introduced when those measurements
 or workload requirements justify them. Existing scientific/distributed acceptance gates remain.

--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -1657,11 +1657,16 @@
       :double)))
 
 (defn- emit-arith-op
-  "Emit a single arithmetic instruction for the given type and op string."
+  "Emit ordinary arithmetic for the given type and op string. Plain long add/subtract/multiply
+   preserve Clojure's checked semantics; explicit unchecked forms have separate emitters below."
   [code op type]
   (case type
     (:int :bool) (case op "+" (.iadd code) "-" (.isub code) "*" (.imul code) "/" (.idiv code))
-    :long   (case op "+" (.ladd code) "-" (.lsub code) "*" (.lmul code) "/" (.ldiv code))
+    :long   (if (= op "/")
+              (.ldiv code)
+              (.invokestatic code math-cd
+                             (case op "+" "addExact" "-" "subtractExact" "*" "multiplyExact")
+                             (MethodTypeDesc/of J-cd (into-array ClassDesc [J-cd J-cd]))))
     :float  (case op "+" (.fadd code) "-" (.fsub code) "*" (.fmul code) "/" (.fdiv code))
     :double (case op "+" (.dadd code) "-" (.dsub code) "*" (.dmul code) "/" (.ddiv code))))
 
@@ -1676,7 +1681,8 @@
     (let [t (emit-form code (first args) locals ctx)]
       (case t
         (:int :bool) (do (.ineg code) :int)
-        :long   (do (.lneg code) :long)
+        :long   (do (.invokestatic code math-cd "negateExact"
+                                  (MethodTypeDesc/of J-cd (into-array ClassDesc [J-cd]))) :long)
         :float  (do (.fneg code) :float)
         :double (do (.dneg code) :double)
         ;; :ref → coerce to double
@@ -2178,14 +2184,19 @@
     ;; IINC should only be used in the recur handler for single-arg cases.
     ("inc" "dec" "unchecked-inc" "unchecked-dec" "unchecked-inc-int" "unchecked-dec-int")
     (let [t    (emit-form code (first args) locals ctx)
-          inc? (contains? #{"inc" "unchecked-inc" "unchecked-inc-int"} head-name)]
+          inc? (contains? #{"inc" "unchecked-inc" "unchecked-inc-int"} head-name)
+          long-step! (fn []
+                       (.ldc code (long 1))
+                       (if (contains? #{"inc" "dec"} head-name)
+                         (emit-arith-op code (if inc? "+" "-") :long)
+                         (if inc? (.ladd code) (.lsub code)))
+                       :long)]
       (case t
         (:int :bool) (do (.ldc code (int 1))  (if inc? (.iadd code) (.isub code)) :int)
-        :long   (do (.ldc code (long 1)) (if inc? (.ladd code) (.lsub code)) :long)
+        :long   (long-step!)
         :double (do (.ldc code 1.0)      (if inc? (.dadd code) (.dsub code)) :double)
         :float  (do (.ldc code (float 1.0)) (if inc? (.fadd code) (.fsub code)) :float)
-        :ref    (do (emit-coerce code :ref :long)
-                    (.ldc code (long 1)) (if inc? (.ladd code) (.lsub code)) :long)))
+        :ref    (do (emit-coerce code :ref :long) (long-step!))))
     ;; Comparisons → int 0/1 — dispatched to emit-comparison helper
     ("<" "<=" ">" ">=" "==" "not=") (emit-comparison code head-name args locals ctx)
     ;; min/max — dispatched to emit-minmax helper

--- a/test/raster/compiler/backend/jvm/checked_long_test.clj
+++ b/test/raster/compiler/backend/jvm/checked_long_test.clj
@@ -1,0 +1,72 @@
+(ns raster.compiler.backend.jvm.checked-long-test
+  "Small source-versus-bytecode boundary checks; no GPU or full compiler corpus needed."
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.jvm.bytecode :as bytecode])
+  (:import (java.lang.reflect InvocationTargetException)))
+
+(def ^:private cases
+  [{:name 'add :types '[long long] :body '(clojure.core/+ x y)}
+   {:name 'subtract :types '[long long] :body '(clojure.core/- x y)}
+   {:name 'multiply :types '[long long] :body '(clojure.core/* x y)}
+   {:name 'negate :types '[long] :body '(clojure.core/- x)}
+   {:name 'increment :types '[long] :body '(clojure.core/inc x)}
+   {:name 'decrement :types '[long] :body '(clojure.core/dec x)}
+   {:name 'mixed-add :types '[int long] :body '(clojure.core/+ x y)}
+   {:name 'multiply-then-zero :types '[long long] :body '(clojure.core/* x y (long 0))}
+   {:name 'wrap-add :types '[long long] :body '(clojure.core/unchecked-add x y)}
+   {:name 'wrap-subtract :types '[long long] :body '(clojure.core/unchecked-subtract x y)}
+   {:name 'wrap-multiply :types '[long long] :body '(clojure.core/unchecked-multiply x y)}
+   {:name 'wrap-negate :types '[long] :body '(clojure.core/unchecked-negate x)}
+   {:name 'wrap-increment :types '[long] :body '(clojure.core/unchecked-inc x)}
+   {:name 'wrap-decrement :types '[long] :body '(clojure.core/unchecked-dec x)}])
+
+(defn- parameters [types]
+  (mapv #(with-meta %1 {:tag %2}) '[x y z] types))
+
+(defn- outcome [f args]
+  (try
+    {:value (apply f args)}
+    (catch Throwable error
+      {:exception (class (if (instance? InvocationTargetException error)
+                           (.getCause error) error))})))
+
+(deftest checked-and-explicitly-wrapping-long-arithmetic-match-clojure
+  (let [specs (mapv (fn [{:keys [name types body]}]
+                      {:name name :params (parameters types) :walked-body [body]
+                       :source-ns (the-ns 'raster.compiler.backend.jvm.checked-long-test)
+                       :return-tag 'long :element-type 'long}) cases)
+        compiled (bytecode/compile-specialized-class! (str "raster.test.CheckedLong" (gensym)) specs)]
+    (doseq [{:keys [name types body]} cases
+            :let [method (get-in compiled [:methods name])
+                  invoke #(.invoke method nil (object-array %&))
+                  ;; Clojure fn primitive parameters support long/double, not int. Keep the
+                  ;; oracle boxed; Integer inputs still exercise exact mixed-width promotion.
+                  oracle (eval (list 'fn (vec (take (count types) '[x y z])) body))]
+            args (if (= 1 (count types))
+                   [[Long/MIN_VALUE] [-1] [0] [1] [Long/MAX_VALUE]]
+                   (if (= 'int (first types))
+                     [[(int 1) Long/MAX_VALUE] [(int -1) Long/MIN_VALUE]
+                      [(int -7) (long 3)]]
+                     [[Long/MAX_VALUE (long 2)] [Long/MIN_VALUE (long -1)]
+                      [Long/MAX_VALUE (long 1)] [Long/MIN_VALUE (long 1)]
+                      [(long -7) (long 3)] [(long 0) (long 0)]]))]
+      (is (= (outcome oracle args) (outcome invoke args)) (pr-str [name args])))))
+
+(deftest checked-product-fails-before-a-following-store
+  (let [compiled (bytecode/compile-specialized-class!
+                  (str "raster.test.CheckedExtentStore" (gensym))
+                  [{:name 'store :params [(with-meta 'x {:tag 'long})
+                                          (with-meta 'y {:tag 'long})
+                                          (with-meta 'out {:tag 'longs})]
+                    :source-ns (the-ns 'raster.compiler.backend.jvm.checked-long-test)
+                    :return-tag 'long :element-type 'long
+                    :walked-body ['(let* [size (clojure.core/* x y)]
+                                     (clojure.core/aset out 0 size)
+                                     size)]}])
+        method (get-in compiled [:methods 'store])
+        invoke #(.invoke method nil (object-array %&))
+        output (long-array [17])]
+    (is (= {:exception ArithmeticException} (outcome invoke [Long/MAX_VALUE (long 2) output])))
+    (is (= [17] (vec output)))
+    (is (= {:value 12} (outcome invoke [(long 3) (long 4) output])))
+    (is (= [12] (vec output)))))

--- a/test/raster/perf/production_canary_test.clj
+++ b/test/raster/perf/production_canary_test.clj
@@ -6,6 +6,7 @@
             [raster.perf.production-canary :as canary]
             [raster.runtime.microbench :as microbench]
             [raster.gpu.compiled :as compiled]
+            [raster.compiler.pipeline :as pipeline]
             [raster.gpu.device-probe :as probe]))
 
 (defn- once-only [f & _]
@@ -74,6 +75,13 @@
               (link/run! resident)
               (is (= expected (vec (link/download resident (:node output)))))))
           (finally (compiled/close! live)))))))
+
+(deftest public-prebound-extent-overflow-precedes-output-mutation
+  (let [f (pipeline/compile-aot #'canary/gemm-relu-prebound! :dtype :float)
+        output (float-array [17])]
+    (is (thrown? ArithmeticException
+                 (f (float-array 0) (float-array 0) output Long/MAX_VALUE 2 0)))
+    (is (= [17.0] (vec output)))))
 
 (deftest compilation-evidence-retains-existing-dispatch-declines
   (let [diagnostics {:selection :analytic-fixed


### PR DESCRIPTION
## Summary
- Emit Math exact operations for ordinary long addition, subtraction, multiplication, negation, increment, and decrement.
- Preserve the separate explicit unchecked emitters and unchanged int/floating paths; no new type inference or semantic registry.
- Add small direct Clojure-versus-bytecode boundary tests and the public prebound GEMM overflow-before-write regression.

## Validation
- Independent read-only review: no blocking findings.
- Corrected 1 GiB REPL with the project Vector API module: 32 affected JVM tests, 152 assertions, zero failures/errors; public overflow-order regression also passes.
- Explicit wrapping, mixed int/long promotion, and intermediate overflow before a trailing zero are covered.
- Initial broader local test run lacked the Vector API module; rerun with correct startup flags is green.
- Full suite and vendor gates delegated to CI.

## Scope and performance
This restores source semantics across ordinary long arithmetic, not only extents. Overflow checks can affect long index costs; no performance-neutrality claim. Int/narrowing semantics and other targets are not certified by this change.