### PR TITLE
Represent closed typed TileLoad input regions without implicit conversion

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -975,6 +975,13 @@ source and reference identities are retained in the comparison protocol. This is
 not a production conversion route or performance admission. Next introduce a pure typed input
 value region, preserve it in the structural matrix plan, lower only the proved mapping, and
 test every other emitter's explicit decline before enabling a measured graph-fusion candidate.
+The first contract slice adds `TileLoad.value-region` using the existing `ScalarSSARegion`, not
+a new numerical dialect. It accepts only closed, pure, one-element regions, checks source/storage
+and result/fragment dtypes, and runs shared SSA typing with no external initial values. Existing
+loads retain nil regions and strict storage/fragment equality. Matrix targets currently reject
+every nonnil input region explicitly: this contract alone does not enable conversion fusion.
+Production enablement must also separate load-region collection from store epilogues, lower the
+matching FP32 prefetch, retain Intel byte-pitch/extent constraints, and validate masked zeros.
 
 An additional host boundary probe exposed JVM AOT overflow debt: `compile-aot` of the prebound
 canary with `m=Long/MAX_VALUE, n=2, k=0` previously returned an unchanged sentinel buffer instead

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -980,7 +980,7 @@ a new numerical dialect. It accepts only closed, pure, one-element regions, chec
 and result/fragment dtypes, and runs shared SSA typing with no external initial values. Existing
 loads retain nil regions and strict storage/fragment equality. Matrix targets currently reject
 every nonnil input region explicitly: this contract alone does not enable conversion fusion.
-Production enablement must also separate load-region collection from store epilogues, lower the
+Store-epilogue collection now excludes load regions. Production enablement must lower the
 matching FP32 prefetch, retain Intel byte-pitch/extent constraints, and validate masked zeros.
 
 An additional host boundary probe exposed JVM AOT overflow debt: `compile-aot` of the prebound

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -748,7 +748,9 @@
   Opaque matrix fragments can apply this region independently to each stored element. Tensor
   reads and logical coordinates require a separately scheduled layout conversion."
   [kernel-body parameter-names target-dialect]
-  (let [regions (keep :value-region (nested-operations (:operations kernel-body)))
+  (let [regions (keep :value-region
+                      (filter #(record-kind? "TileStore" %)
+                              (nested-operations (:operations kernel-body))))
         storage (into {} (map (juxt :id identity)) (:parameters kernel-body))]
     (doseq [region regions]
       (when-not

--- a/src/raster/compiler/backend/gpu/matrix_body_plan.clj
+++ b/src/raster/compiler/backend/gpu/matrix_body_plan.clj
@@ -246,6 +246,9 @@
         inner-ops (butlast (:operations inner-loop))
         prefetches (vec (filter #(record-kind? "TilePrefetch" %) inner-ops))
         loads (vec (filter #(record-kind? "TileLoad" %) inner-ops))
+        _ (require! (not-any? :value-region loads)
+                    "matrix target has no lowering for a transformed tile input"
+                    {:loads loads})
         mads (vec (filter #(record-kind? "MatrixMad" %) inner-ops))
         unknown-inner (remove #(or (record-kind? "TilePrefetch" %)
                                    (record-kind? "TileLoad" %)

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -59,7 +59,11 @@
 (defrecord AsyncWait [groups pending-groups semantics participation])
 
 (defrecord FragmentInit [fragment value])
-(defrecord TileLoad [fragment buffer coordinates mask cache])
+;; An optional closed ScalarSSARegion transforms each valid loaded element before it enters
+;; the fragment. Its first parameter is typed by :accumulator-dtype (the shared region input
+;; field); :result-dtype must match the fragment. Masked/inactive elements remain zero-filled,
+;; not transformed padding. Targets must lower this region explicitly or reject the load.
+(defrecord TileLoad [fragment buffer coordinates mask cache value-region])
 (defrecord TilePrefetch [buffer coordinates shape layout mask distance])
 (defrecord MatrixMad [accumulator lhs rhs instruction])
 (defrecord Guard [mask operations])
@@ -579,10 +583,25 @@
           (throw (ex-info "tile-load coordinates must match the buffer rank"
                           {:reason :kernel-body-tile-load-rank
                            :buffer p :coordinates (:coordinates operation)})))
-        (when-not (= (dtype/canon (:dtype p)) (dtype/canon (:dtype f)))
-          (throw (ex-info "tile-load fragment dtype must equal the buffer element dtype"
-                          {:reason :kernel-body-tile-load-dtype
-                           :buffer p :fragment f})))
+        (if-let [region (:value-region operation)]
+          (do
+            ;; The first ScalarSSARegion parameter is the loaded element here, rather than
+            ;; a store accumulator. Input transformations are closed pure per-element regions:
+            ;; no extra memory reads, external captures, coordinates, or effects.
+            (when-not (and (= 1 (count (:parameters region)))
+                           (= [] (:operands region)) (= [] (:indices region))
+                           (every? #(record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" %)
+                                   (:operations region))
+                           (= (dtype/canon (:dtype p)) (dtype/canon (:accumulator-dtype region)))
+                           (= (dtype/canon (:dtype f)) (dtype/canon (:result-dtype region))))
+              (throw (ex-info "tile-load value region must be closed and preserve its typed boundary"
+                              {:reason :kernel-body-tile-load-region :region region
+                               :buffer p :fragment f})))
+            (validate-scalar-ssa-region! region storage masks (set (:parameters region)) []))
+          (when-not (= (dtype/canon (:dtype p)) (dtype/canon (:dtype f)))
+            (throw (ex-info "tile-load fragment dtype must equal the buffer element dtype"
+                            {:reason :kernel-body-tile-load-dtype
+                             :buffer p :fragment f}))))
         (mask (:mask operation))
         (when-not (contains? cache-policies (:cache operation))
           (throw (ex-info "tile load has an unsupported cache policy"
@@ -1865,16 +1884,16 @@
 
     :else []))
 
-(defn- scalar-ssa-store-regions
-  [operations]
+(defn- scalar-ssa-value-regions
+  [operations operation-kind]
   (mapcat
    (fn [operation]
      (concat
-      (when (and (record-kind? "raster.compiler.ir.kernel_body.TileStore" operation)
+      (when (and (record-kind? operation-kind operation)
                  (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion"
                                (:value-region operation)))
         [(:value-region operation)])
-      (mapcat scalar-ssa-store-regions (nested-operation-regions operation))))
+      (mapcat #(scalar-ssa-value-regions % operation-kind) (nested-operation-regions operation))))
    operations))
 
 (defn- validate-scalar-ssa-dataflow!
@@ -2410,8 +2429,10 @@
                      :schedule schedule}]
         (doseq [view views]
           (expression-info! (:element-offset view) initial-values))
-        (doseq [region (scalar-ssa-store-regions operations)]
+        (doseq [region (scalar-ssa-value-regions operations "raster.compiler.ir.kernel_body.TileStore")]
           (validate-scalar-ssa-dataflow! region initial-values context))
+        (doseq [region (scalar-ssa-value-regions operations "raster.compiler.ir.kernel_body.TileLoad")]
+          (validate-scalar-ssa-dataflow! region {} context))
         (validate-dataflow-operations! operations initial-values context))))
   body)
 

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -212,10 +212,10 @@
              [matrix-m matrix-k] row-layout :prefetch-active num-stages))
           (for [nn (range n-fragments)]
             (body/->TileLoad (fragment-id "rhs" nn) col-buffer
-                             [k-fragment (n-base nn)] :k-active :cached))
+                             [k-fragment (n-base nn)] :k-active :cached nil))
           (for [mm (range m-fragments)]
             (body/->TileLoad (fragment-id "lhs" mm) row-buffer
-                             [(add m-base (* mm matrix-m)) k-fragment] :k-active :cached))
+                             [(add m-base (* mm matrix-m)) k-fragment] :k-active :cached nil))
           (for [mm (range m-fragments) nn (range n-fragments)]
             (body/->MatrixMad (fragment-id "acc" mm nn)
                               (fragment-id "lhs" mm)

--- a/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
@@ -32,6 +32,8 @@
                     (assoc node :value-region region) node))
                 (matrix-body :dpas))]
     (is (= kernel (body/validate! kernel)))
+    (is (nil? (opencl/lower-uniform-store-region kernel {} :cuda))
+        "an input transformation is not a store epilogue")
     (doseq [target [:opencl-intel :cuda :hip]]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transformed tile input"
                             (matrix-target/emit-matrix-kernel "transformed_input" kernel target))))))

--- a/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
+++ b/test/raster/compiler/backend/gpu/matrix_body_plan_test.clj
@@ -3,6 +3,7 @@
             [clojure.walk :as walk]
             [raster.compiler.backend.gpu.kernel-body-opencl :as opencl]
             [raster.compiler.backend.gpu.matrix-body-plan :as matrix-plan]
+            [raster.compiler.backend.gpu.matrix-target :as matrix-target]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
@@ -18,6 +19,22 @@
       :row 'a :col 'b :out 'c
       :dimensions [64 64 64]
       :tile (assoc (hardware/derive-gemm-tile {}) :matrix matrix)})))
+
+(deftest matrix-targets-cannot-ignore-a-typed-input-transformation
+  (let [region (body/->ScalarSSARegion
+                ['element] [] [] :half
+                [(body/->ScalarCompute (body/value 'twice :half)
+                                       (body/scalar-expression :+ :half ['element 'element]))]
+                'twice :half)
+        kernel (walk/postwalk
+                (fn [node]
+                  (if (instance? raster.compiler.ir.kernel_body.TileLoad node)
+                    (assoc node :value-region region) node))
+                (matrix-body :dpas))]
+    (is (= kernel (body/validate! kernel)))
+    (doseq [target [:opencl-intel :cuda :hip]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transformed tile input"
+                            (matrix-target/emit-matrix-kernel "transformed_input" kernel target))))))
 
 (deftest matrix-plan-is-neutral-over-instruction-families
   (let [plan (matrix-plan/analyze (matrix-body :mma))]

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -57,8 +57,8 @@
                   [(body/->FragmentInit :acc 0.0)
                    (body/->ForLoop
                     (body/value 'k :int) 0 16 16 []
-                    [(body/->TileLoad :lhs 'A ['group-x 'k] :in-bounds :cached)
-                     (body/->TileLoad :rhs 'B ['k 'group-x] :in-bounds :cached)
+                    [(body/->TileLoad :lhs 'A ['group-x 'k] :in-bounds :cached nil)
+                     (body/->TileLoad :rhs 'B ['k 'group-x] :in-bounds :cached nil)
                      (body/->MatrixMad :acc :lhs :rhs matrix)
                      (body/->Yield [])] [] {:unroll true})
                    (body/->TileStore 'C :acc ['group-x 0] :in-bounds nil)])]
@@ -66,6 +66,31 @@
     :launch (launch/spec {:workgroup-size [16] :group-count [1]})
     :provenance {:dialect :test}
     :attributes {:kind :matrix-contraction}}))
+
+(deftest tile-input-regions-have-a-closed-typed-element-boundary
+  (let [path [:operations 0 :operations 1 :operations 0 :value-region]
+        region (body/->ScalarSSARegion
+                ['loaded] [] [] :float
+                [(body/->ScalarCompute (body/value 'converted :half)
+                                       (body/cast-expression 'loaded :half :nearest-even :ieee))]
+                'converted :half)
+        kernel (-> (minimal-body)
+                   (assoc-in [:parameters 0 :dtype] :float)
+                   (assoc-in [:parameters 0 :layout] (layout/row-major [16 16] :float))
+                   (assoc-in path region))]
+    (is (= kernel (body/validate! kernel)))
+    (is (thrown? clojure.lang.ExceptionInfo (body/validate! (assoc-in kernel path nil))))
+    (doseq [bad [(assoc region :accumulator-dtype :half)
+                 (assoc region :result-dtype :float)
+                 (assoc region :indices ['group-x])
+                 (assoc region :parameters ['loaded 'capture])
+                 (assoc region :result 'missing)
+                 (assoc-in region [:operations 0 :expression :arguments] ['group-x])
+                 (assoc-in region [:operations 0 :expression :options :rounding] nil)
+                 (assoc region :operations
+                        [(body/->ScalarLoad (body/value 'converted :half) 'B [0 0]
+                                            nil nil :cached)])]]
+      (is (thrown? clojure.lang.ExceptionInfo (body/validate! (assoc-in kernel path bad)))))))
 
 (deftest a-kernel-body-makes-schedule-decisions-explicit
   (let [kernel (minimal-body)


### PR DESCRIPTION
## Summary
- Reuse ScalarSSARegion as an explicit TileLoad value-region.
- Verify closed one-element scope, pure operations, source/storage and result/fragment dtype boundaries, and shared SSA typing.
- Update existing constructor sites to nil regions, preserving strict dtype equality for existing schedules.
- Reject transformed loads at the common matrix-plan boundary until target lowering is implemented; OpenCL/CUDA/HIP cannot silently drop the transformation.
- No production conversion route or performance claim in this prerequisite slice.

## Validation
- Focused REPL: 57 tests, 307 assertions, zero failures/errors (KernelBody, matrix plan, contraction schedule, matrix targets).
- Independent review found no blocker; identified store-region collector to narrow before production enablement.
- Full suite and vendor compile gates in CI.

Stacked on #515; retarget after squash.