### PR TITLE
Lower typed FP32 tile inputs into Intel matrix fragments

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -153,6 +153,19 @@ Local reference evidence (pinned checkout identities):
   `mlir/test/Integration/Dialect/XeVM/GPU/xevm_block_dpas.mlir`, lines 18–46:
   16-bit 8r16 load directly feeding the m8n16k16 A operand.
 
+The next opt-in correctness check executes the generated typed-input matrix lowering:
+
+```clojure
+(require '[raster.compiler.backend.gpu.tile-input-conversion-test :as converted])
+(converted/run-device!)
+```
+
+The `[13 32 32]` Arc run matches all 416 FP32 outputs exactly against independently rounded
+host inputs, including a partial M tile. It uses no conversion temporary. This is not timed and
+does not change public GEMM candidate selection; the public projection graph still needs its
+explicit eligible conversion-fusion rewrite. The separate fragment oracle supplies rounding
+edge-case coverage that this small dyadic matrix does not establish by itself.
+
 ### External comparators
 
 | Workload | Comparators to implement | Fairness boundary |

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -983,6 +983,17 @@ every nonnil input region explicitly: this contract alone does not enable conver
 Store-epilogue collection now excludes load regions. Production enablement must lower the
 matching FP32 prefetch, retain Intel byte-pitch/extent constraints, and validate masked zeros.
 
+The narrow Intel lowering now accepts an explicit lhs FP32→FP16 nearest-even/IEEE cast region
+from a scheduled matrix body. Shared scalar lowering spells the conversion, while the tested
+lane/component mapping packs the fragment. Warm-up and steady prefetches both use FP32 storage;
+the physical contract caps K for four-byte surface widths. Row-tail loads are guarded and fill
+zero. RHS transformations, views, partitioned K, and non-Intel targets remain explicit declines.
+A tiny generated `[13 32 32]` Arc kernel matches all 416 outputs exactly with no temporary buffer.
+This is target-lowering validation, not automatic public GEMM graph fusion or a speed claim.
+Next: broaden numerical/schedule cases, add the eligible conversion→matrix graph rewrite as a
+candidate preserving ABI/effects, then compare changing-activation workloads against the existing
+global conversion strategy with stationary measurements and external baselines.
+
 An additional host boundary probe exposed JVM AOT overflow debt: `compile-aot` of the prebound
 canary with `m=Long/MAX_VALUE, n=2, k=0` previously returned an unchanged sentinel buffer instead
 of throwing on the source long product. The bytecode emitter used `lmul`; the resident descriptor

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -108,22 +108,45 @@
 
 (defn- intel-matrix-plan
   [kernel-body]
-  (let [{:keys [instruction] :as plan} (matrix-plan/analyze kernel-body)
-        {mi :m ni :n ki :k subgroup :subgroup} instruction]
+  (let [{:keys [instruction input-regions input-dtypes prefetches buffer-offsets group-z] :as plan}
+        (matrix-plan/analyze kernel-body)
+        {mi :m ni :n ki :k subgroup :subgroup} instruction
+        region (:lhs input-regions)
+        operation (first (:operations region))]
     (require! (and (= :dpas (:family instruction))
                    (= 8 mi) (= 16 ki)
                    (= 16 subgroup)
                    (= ni subgroup))
               "Intel OpenCL lowering has no builtin for this matrix instruction"
               {:instruction instruction})
+    (require! (and (nil? (:rhs input-regions)) (= :half (:rhs input-dtypes))
+                   (if region
+                     (and (= :float (:lhs input-dtypes))
+                          (= :float (:accumulator-dtype region)) (= :half (:result-dtype region))
+                          (= 1 (count (:operations region)))
+                          (= (into {} (:expression operation))
+                             (into {} (body/cast-expression (first (:parameters region))
+                                                            :half :nearest-even :ieee)))
+                          (= (:result region) (get-in operation [:result :id]))
+                          (= [0 (get-in plan [:dimension-parameters :k])]
+                             [(:k-lower plan) (:k-upper plan)])
+                          (nil? group-z) (every? nil? (vals buffer-offsets)))
+                     (= :half (:lhs input-dtypes))))
+              "Intel matrix lowering has no implementation for this transformed tile input"
+              {:input-regions input-regions :input-dtypes input-dtypes})
+    (require! (every? #(and (= (:lhs input-dtypes) (get-in % [:layout :dtype]))
+                           (or (nil? region)
+                               (= (layout/row-major [mi ki] :float) (:layout %)))) prefetches)
+              "Intel matrix prefetch layout must describe the input storage dtype"
+              {:input-dtypes input-dtypes :prefetches prefetches})
     plan))
 
 (defn- emit-plan
   [kernel-name {:keys [mi ni ki subgroup block-m block-n block-k sg-m sg-n
                        ncols lhs-ids rhs-ids mad-by-operands stores prefetch result-dtype
                        dimension-parameters schedule-parameters group-z k-lower k-upper
-                       buffer-offsets index-dtype k-bounds]}
-   {:keys [epilogue epilogue-params parameter-names]}]
+                       buffer-offsets index-dtype k-bounds input-dtypes]}
+   {:keys [epilogue epilogue-params parameter-names input-value]}]
   (let [index-type (dtype/ctype :opencl index-dtype)
         nms (count lhs-ids)
         nns (count rhs-ids)
@@ -135,6 +158,9 @@
         ns (range nns)
         amul (fn [m] (if (zero? m) "m_base" (str "m_base+" (* m mi))))
         c-type (case result-dtype :float "float" :half "half")
+        a-type (dtype/ctype :opencl (:lhs input-dtypes))
+        a-bytes (dtype/bytes-of (:lhs input-dtypes))
+        a-prefetch (str "intel_sub_group_2d_block_prefetch_" (* 8 a-bytes) "b_8r16x1c")
         store-cast (if (= :half result-dtype) "(half)" "")
         parameter-names (merge (zipmap [(:m dimension-parameters)
                                         (:n dimension-parameters)
@@ -170,15 +196,27 @@
                      "          if (pk < " k-end ") {\n"
                      (apply str
                             (for [m ms]
-                              (str "            intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(pk, " (amul m) "));\n")))
+                              (str "            " a-prefetch
+                                   "((__global void*)A, a_wb, M, a_pb, (int2)(pk, " (amul m) "));\n")))
                      "          } }\n"
                      (apply str
                             (for [n ns]
                               (str "        bp" n " = as_int8(intel_subgroup_block_read_transform_u16_k16((__global void*)B, b_wb, K, b_pb, (int2)(n_base" n ", " kpos ")));\n")))
-                     (apply str
+                     (if input-value
+                       (apply str
+                              (for [m ms]
+                                (str "        sa" m " = (short8)("
+                                     (str/join ", "
+                                               (for [r (range mi)
+                                                     :let [row (str "(" (amul m) " + " r ")")
+                                                           load (str "A[((long)" row ") * K + " kpos " + sg_lid]")]]
+                                                 (str "as_short(" row " < M ? "
+                                                      (input-value load "" "") " : (half)0)")))
+                                     ");\n")))
+                       (str (apply str
                             (for [m ms]
                               (str "        intel_sub_group_2d_block_read_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(" kpos ", " (amul m) "), &a" m ");\n")))
-                     (apply str (for [m ms] (str "        sa" m " = as_short8(a" m ");\n")))
+                            (apply str (for [m ms] (str "        sa" m " = as_short8(a" m ");\n")))))
                      (apply str
                             (for [m ms n ns]
                               (do
@@ -193,7 +231,7 @@
      ", K " block-k ", DPAS " mi "x" ni "x" ki ", sg " subgroup "\n"
      "__attribute__((intel_reqd_sub_group_size(" subgroup ")))\n"
      "__kernel void " kernel-name "(\n"
-     "    __global const half* restrict A,\n    __global const half* restrict B,\n"
+     "    __global const " a-type "* restrict A,\n    __global const half* restrict B,\n"
      "    __global " c-type "* restrict C,\n    int M, int N, int K"
      scalar-params
      epilogue-params
@@ -215,7 +253,7 @@
             (for [m ms]
               (str "    float" mi " "
                    (str/join ", " (for [n ns] (str "acc" m n "=0.0f"))) ";\n")))
-     "    int a_wb = K * 2, a_pb = K * 2;\n    int b_wb = N * 2, b_pb = N * 2;\n"
+     "    int a_wb = K * " a-bytes ", a_pb = K * " a-bytes ";\n    int b_wb = N * 2, b_pb = N * 2;\n"
      "    ushort8 " (str/join ", " (for [m ms] (str "a" m))) ";\n"
      "    short8 " (str/join ", " (for [m ms] (str "sa" m))) ";\n"
      "    int8 " (str/join ", " (for [n ns] (str "bp" n))) ";\n"
@@ -229,7 +267,7 @@
               (str "    if (" position " < " k-end ") {\n"
                    (apply str
                           (for [m ms]
-                            (str "        intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(" position ", " (amul m) "));\n")))
+                            (str "        " a-prefetch "((__global void*)A, a_wb, M, a_pb, (int2)(" position ", " (amul m) "));\n")))
                    "    }\n")))
      "    " index-type " k = " k-begin ";\n"
      "    for (; k + " (dec block-k) " < " k-end "; k += " block-k ") {\n"
@@ -274,9 +312,14 @@
   ([kernel-name kernel-body]
    (emit-matrix-kernel kernel-name kernel-body {}))
   ([kernel-name kernel-body {:keys [parameter-names]}]
-   (let [parameter-names (matrix-parameter-names kernel-body parameter-names)]
-     (emit-plan kernel-name (intel-matrix-plan kernel-body)
+   (let [parameter-names (matrix-parameter-names kernel-body parameter-names)
+         plan (intel-matrix-plan kernel-body)
+         input-region (get-in plan [:input-regions :lhs])
+         input-value (when input-region
+                       (:epilogue (lower-scalar-ssa-region kernel-body input-region parameter-names)))]
+     (emit-plan kernel-name plan
                 (assoc (or (lower-store-region kernel-body parameter-names) {})
+                       :input-value input-value
                        :parameter-names parameter-names)))))
 
 ;; ---------------------------------------------------------------------------
@@ -683,13 +726,13 @@
         row-token (str "__row_" (name (gensym "")))
         col-token (str "__col_" (name (gensym "")))
         initial-context
-        {:names (merge parameter-names
-                       {accumulator accumulator-token row-id row-token col-id col-token})
+        {:names (merge parameter-names {accumulator accumulator-token}
+                       (zipmap (:indices region) [row-token col-token]))
          :types (merge
                  (into {} (map (fn [id] [id (dtype/canon (:dtype (get storage id)))]))
                        (rest (:parameters region)))
-                 {accumulator (dtype/canon (:accumulator-dtype region))
-                  row-id :int col-id :int})}
+                 {accumulator (dtype/canon (:accumulator-dtype region))}
+                 (zipmap (:indices region) [:int :int]))}
         final-context
         (reduce
          (fn [context operation]

--- a/src/raster/compiler/backend/gpu/matrix_body_plan.clj
+++ b/src/raster/compiler/backend/gpu/matrix_body_plan.clj
@@ -212,9 +212,10 @@
                     {:dimension-parameters dimension-parameters
                      :dimension-values dimension-values
                      :storage-dimensions [m-extent n-extent k-extent]})
-        _ (require! (and (= :half (:dtype lhs-param)) (= :half (:dtype rhs-param))
+        _ (require! (and (every? #(= :half (:dtype %))
+                                (filter #(= :dot-operand (get-in % [:layout :kind])) fragments))
                          (contains? #{:half :float} (:dtype out-param)))
-                    "matrix plan requires f16 inputs and an f16 or f32 result"
+                    "matrix plan requires f16 operand fragments and an f16 or f32 result"
                     {:lhs-dtype (:dtype lhs-param) :rhs-dtype (:dtype rhs-param)
                      :result-dtype (:dtype out-param)})
         fragment-map (into {} (map (juxt :id identity)) fragments)
@@ -246,9 +247,6 @@
         inner-ops (butlast (:operations inner-loop))
         prefetches (vec (filter #(record-kind? "TilePrefetch" %) inner-ops))
         loads (vec (filter #(record-kind? "TileLoad" %) inner-ops))
-        _ (require! (not-any? :value-region loads)
-                    "matrix target has no lowering for a transformed tile input"
-                    {:loads loads})
         mads (vec (filter #(record-kind? "MatrixMad" %) inner-ops))
         unknown-inner (remove #(or (record-kind? "TilePrefetch" %)
                                    (record-kind? "TileLoad" %)
@@ -437,6 +435,10 @@
      :block-m block-m :block-n block-n :block-k block-k :sg-m sg-m :sg-n sg-n
      :ncols ncols :lhs-ids lhs-ids :rhs-ids rhs-ids :mad-by-operands mad-by-operands
      :stores stores :prefetch prefetch-distance :result-dtype (:dtype out-param)
+     :input-regions {:lhs (only! "lhs input value region" (distinct (map :value-region lhs-loads)))
+                     :rhs (only! "rhs input value region" (distinct (map :value-region rhs-loads)))}
+     :input-dtypes {:lhs (:dtype lhs-param) :rhs (:dtype rhs-param)}
+     :prefetches prefetches
      :dimension-parameters dimension-parameters
      :index-dtype (get-in outer-loop [:index :type])
      :dimension-values dimension-values

--- a/src/raster/compiler/backend/gpu/matrix_fragment_source.clj
+++ b/src/raster/compiler/backend/gpu/matrix_fragment_source.clj
@@ -174,6 +174,8 @@
   [kernel-name kernel-body target]
   (let [dialect (fragment-dialect! target)
         plan (matrix-plan/analyze kernel-body)
+        _ (decline! target (not-any? some? (vals (:input-regions plan)))
+                    :input-region-not-lowered {:input-regions (:input-regions plan)})
         names (target-names/validate! kernel-name kernel-body
                                       (target-names/parameter-names kernel-body nil))
         region (scalar-emitter/lower-uniform-store-region kernel-body names target)

--- a/src/raster/compiler/backend/gpu/matrix_target.clj
+++ b/src/raster/compiler/backend/gpu/matrix_target.clj
@@ -47,6 +47,10 @@
    (let [body (kernel-body/validate! body)
          plan (matrix-plan/analyze body)
          dialect (c-dialect/resolve! target-dialect)
+         _ (when (and (not= :opencl-intel (:id dialect))
+                       (some some? (vals (:input-regions plan))))
+             (throw (ex-info "matrix target has no lowering for a transformed tile input"
+                             {:reason :matrix-input-region-not-lowered :target target-dialect})))
          parameter-names (target-names/validate!
                           kernel-name body
                           (target-names/parameter-names body parameter-names))

--- a/src/raster/compiler/core/intel_block_io.clj
+++ b/src/raster/compiler/core/intel_block_io.clj
@@ -69,8 +69,12 @@
                      (:indices kernel-body))
         strides (for [view (:views kernel-body) :when (contains? inputs (:buffer view))]
                   (walk/postwalk-replace groups (:element-offset view)))]
-    {:preconditions (into (matrix-preconditions m n k strides)
-                          (partition-preconditions kernel-body k))
+    {:preconditions (cond-> (into (matrix-preconditions m n k strides)
+                                  (partition-preconditions kernel-body k))
+                      ;; A transformed FP32 TileLoad still prefetches the physical FP32 surface.
+                      ;; Preserve the existing 16 MiB byte-width limit with four-byte elements.
+                      (some #(and (= :lhs (:role %)) (= :float (:dtype %))) (:parameters kernel-body))
+                      (conj {:expression k :op :<= :value 4194304}))
      :parameter-alignments (zipmap inputs (repeat 64))}))
 
 (defn static-failure

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -50,9 +50,9 @@
         base-parameters
         (vec
          (concat
-          [(body/->KernelParameter row :input :half (get buffer-shapes row [M K])
+          [(body/->KernelParameter row :input (:dtype row-layout) (get buffer-shapes row [M K])
                                    :global row-layout :lhs)
-           (body/->KernelParameter col :input :half (get buffer-shapes col [K N])
+           (body/->KernelParameter col :input (:dtype col-layout) (get buffer-shapes col [K N])
                                    :global col-layout :rhs)
            (body/->KernelParameter out :output result-dtype (get buffer-shapes out [M N])
                                    :global out-layout :result)
@@ -82,10 +82,13 @@
   `dimensions` are semantic tensor extents while `dimension-parameters` are the ordered compiler
   identities bound to the emitted M/N/K ABI.  Keeping both makes static contraction facts and
   symbolic resident graphs share one body without renaming caller values.  The current matrix
-  instruction is f16×f16→f32; `result-dtype` controls only the final store representation."
+  instruction is f16×f16→f32; `result-dtype` controls only the final store representation.
+  Optional `input-value-regions` maps operand identities to closed typed ScalarSSARegions.
+  Their declared input dtype describes storage; their result remains the instruction's FP16
+  fragment dtype. Target lowering must explicitly admit the resulting representation change."
   [{:keys [id row col out dimensions dimension-parameters axis-symbols tile bindings epilogue
            result-dtype provenance additional-parameters additional-indices buffer-shapes
-           buffer-views operation-buffers k-range launch-group-count attributes]
+           buffer-views operation-buffers k-range launch-group-count attributes input-value-regions]
     :or {dimension-parameters ['M 'N 'K]
          axis-symbols ['i 'j 'k]
          result-dtype :half
@@ -95,8 +98,17 @@
          buffer-shapes {}
          buffer-views []
          operation-buffers {}
+         input-value-regions {}
          attributes {}}}]
-  (let [tile (assoc tile :num-stages (or (:num-stages tile) 3))
+  (let [_ (when-not (and (map? input-value-regions)
+                         (every? #{row col} (keys input-value-regions)))
+            (throw (ex-info "matrix input regions must name existing operands"
+                            {:reason :matrix-input-region-buffer :regions input-value-regions})))
+        row-region (get input-value-regions row)
+        col-region (get input-value-regions col)
+        row-dtype (if row-region (:accumulator-dtype row-region) :half)
+        col-dtype (if col-region (:accumulator-dtype col-region) :half)
+        tile (assoc tile :num-stages (or (:num-stages tile) 3))
         _ (when-not (and (= 3 (count dimension-parameters))
                          (every? compiler-id? dimension-parameters)
                          (= 3 (count (set dimension-parameters))))
@@ -119,8 +131,8 @@
         k-width (max 1 (quot 32 (layout/dtype-bits :half)))
         row-layout (layout/dot-operand 0 acc-layout k-width :half)
         col-layout (layout/dot-operand 1 acc-layout k-width :half)
-        row-storage-layout (layout/row-major (get buffer-shapes row [M K]) :half)
-        col-storage-layout (layout/row-major (get buffer-shapes col [K N]) :half)
+        row-storage-layout (layout/row-major (get buffer-shapes row [M K]) row-dtype)
+        col-storage-layout (layout/row-major (get buffer-shapes col [K N]) col-dtype)
         out-layout (layout/row-major (get buffer-shapes out [M N]) result-dtype)
         buffer-layouts {row row-storage-layout col col-storage-layout out out-layout}
         buffer-views (mapv (fn [view]
@@ -209,13 +221,14 @@
             (body/->TilePrefetch
              row-buffer [(add m-base (* mm matrix-m))
                          (k-add k-fragment (* num-stages matrix-k))]
-             [matrix-m matrix-k] row-layout :prefetch-active num-stages))
+             [matrix-m matrix-k] (if row-region (layout/row-major [matrix-m matrix-k] row-dtype)
+                                     row-layout) :prefetch-active num-stages))
           (for [nn (range n-fragments)]
             (body/->TileLoad (fragment-id "rhs" nn) col-buffer
-                             [k-fragment (n-base nn)] :k-active :cached nil))
+                             [k-fragment (n-base nn)] :k-active :cached col-region))
           (for [mm (range m-fragments)]
             (body/->TileLoad (fragment-id "lhs" mm) row-buffer
-                             [(add m-base (* mm matrix-m)) k-fragment] :k-active :cached nil))
+                             [(add m-base (* mm matrix-m)) k-fragment] :k-active :cached row-region))
           (for [mm (range m-fragments) nn (range n-fragments)]
             (body/->MatrixMad (fragment-id "acc" mm nn)
                               (fragment-id "lhs" mm)

--- a/test/raster/compiler/backend/gpu/tile_input_conversion_test.clj
+++ b/test/raster/compiler/backend/gpu/tile_input_conversion_test.clj
@@ -1,0 +1,105 @@
+(ns raster.compiler.backend.gpu.tile-input-conversion-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.gpu.matrix-target :as target]
+            [raster.compiler.backend.gpu.matrix-fragment-source :as fragment]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.passes.parallel.contraction-schedule :as schedule]
+            [raster.gpu.ocl-runtime :as ocl]))
+
+(defn conversion-region []
+  (body/->ScalarSSARegion
+   ['element] [] [] :float
+   [(body/->ScalarCompute (body/value 'half-value :half)
+                          (body/cast-expression 'element :half :nearest-even :ieee))]
+   'half-value :half))
+
+(defn converted-body []
+  (schedule/matrix-body
+   {:id :converted-tile-input :row 'A :col 'B :out 'C
+    :dimensions [13 32 32] :result-dtype :float
+    :input-value-regions {'A (conversion-region)}
+    :tile {:block-m 16 :block-n 32 :sg-m 8 :sg-n 16 :block-k 32 :num-stages 1
+           :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}}}))
+
+(deftest intel-input-conversion-is-an-explicit-typed-load-and-prefetch
+  (let [kernel (converted-body)
+        emitted (target/emit-matrix-kernel "converted_input" kernel :opencl-intel)
+        source (:source emitted)]
+    (is (= kernel (body/validate! kernel)))
+    (is (= :float (get-in kernel [:parameters 0 :dtype])))
+    (is (re-find #"__global const float\* restrict A" source))
+    (is (re-find #"convert_half_rte" source))
+    (is (re-find #"block_prefetch_32b_8r16x1c" source))
+    (is (not (re-find #"block_prefetch_16b_8r16x1c" source)))
+    (is (re-find #"a_wb = K \* 4, a_pb = K \* 4" source))
+    (is (re-find #"< M \? .* : \(half\)0" source))
+    (is (not (re-find #"block_read_16b_8r16x1c" source)))
+    (is (some #{ {:expression 'K :op :<= :value 4194304}} (:preconditions emitted)))))
+
+(deftest unsupported-input-regions-never-become-implicit-target-casts
+  (let [kernel (converted-body)]
+    (doseq [bad [(walk/postwalk #(if (instance? raster.compiler.ir.kernel_body.ScalarExpr %)
+                                  (assoc-in % [:options :rounding] :toward-zero) %) kernel)
+                 (walk/postwalk #(if (instance? raster.compiler.ir.kernel_body.TilePrefetch %)
+                                  (assoc-in % [:layout :dtype] :half) %) kernel)]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (target/emit-matrix-kernel "bad_input" bad :opencl-intel))))
+    (doseq [dialect [:cuda :hip]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"transformed tile input"
+                            (target/emit-matrix-kernel "bad_target" kernel dialect)))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (fragment/emit-matrix-kernel "bad_direct_target" kernel dialect))))))
+
+(defn run-device!
+  "Opt-in generated-kernel oracle; tiny allocations, no timing or schedule promotion.
+   Includes partial M tiles and compares FP32 output against independently half-rounded inputs."
+  []
+  (ocl/init!)
+  (let [kernel (converted-body)
+        emitted (target/emit-matrix-kernel "converted_input_device" kernel :opencl-intel)
+        slots (mapv (fn [{:keys [id kind dtype role]}]
+                      (abi/slot id kind dtype :role role :c-name (name id)
+                                :alignment (get-in emitted [:parameter-alignments id])))
+                    (:parameters kernel))
+        compiled (artifact/make
+                  {:kernel-name "converted_input_device" :target :opencl-c :source (:source emitted)
+                   :abi (body-abi/project-contracts slots kernel) :arguments '[A B C M N K]
+                   :launch (:launch kernel) :preconditions (:preconditions emitted)
+                   :effects {:kind :matrix-oracle} :provenance {:kernel-body (:id kernel)}
+                   :attributes {:compilation {:language-standard "CL2.0"
+                                              :extensions #{"cl_khr_fp16" "cl_intel_subgroup_2d_block_io"
+                                                            "cl_intel_subgroup_matrix_multiply_accumulate"}}}})
+        a (float-array (map #(/ (- (mod % 13) 6) 8.0) (range (* 13 32))))
+        b (float-array (map #(/ (- (mod % 11) 5) 8.0) (range (* 32 32))))
+        half #(Float/floatToFloat16 (float %))
+        rounded #(double (Float/float16ToFloat (half %)))
+        expected (vec (for [i (range 13) j (range 32)]
+                        (float (reduce + (for [k (range 32)]
+                                           (* (rounded (aget a (+ (* i 32) k)))
+                                              (rounded (aget b (+ (* k 32) j)))))))))
+        live (atom [])
+        buffer! (fn [values dtype]
+                  (let [buf (ocl/make-buffer (count values) dtype)]
+                    (swap! live conj buf)
+                    (ocl/array->buffer! buf values)
+                    buf))]
+    (try
+      (ocl/register-kernel! (:kernel-name compiled) compiled)
+      (let [ab (buffer! a :float) bb (buffer! (short-array (map half b)) :half)
+            cb (buffer! (float-array (repeat (* 13 32) Float/NaN)) :float)]
+        (ocl/launch-registered-bound!
+         (ocl/bind-kernel-call
+          (call/make compiled [ab bb cb {:type :int :value 13}
+                               {:type :int :value 32} {:type :int :value 32}])))
+        (let [actual (vec (ocl/buffer->array cb))]
+          (when-not (= expected actual)
+            (throw (ex-info "generated converted-input GEMM differs from rounded host oracle"
+                            {:expected (take 16 expected) :actual (take 16 actual)})))
+          {:passed? true :elements (count actual) :shape [13 32 32] :comparison :exact
+           :generated-kernel? true :partial-m-tile? true :temporary-buffers 0}))
+      (finally (doseq [buf (reverse @live)] (ocl/free-buffer! buf))))))


### PR DESCRIPTION
Typed scheduled input regions lower through shared scalar conversion into Intel matrix fragments. Matching FP32 prefetches, physical byte-width bounds and M-tail guards preserve storage semantics. Unsupported transformed targets remain explicit declines. Public GEMM graph selection is unchanged; fusion candidate and performance comparison follow.

Validation: 59 focused tests / 324 assertions pass; generated Arc [13 32 32] kernel matches all 416 outputs exactly with no conversion temporary. Independent review prefetch finding fixed and regression-tested. Full suite/vendor gates in CI. No performance claim.