### PR TITLE
Preserve typed input transformations through MatrixStage emission

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -333,7 +333,7 @@
   "Build one canonical f16 matrix KernelBody without selecting a target spelling."
   [{:keys [kernel-name id a b c m n k dimension-parameters tile result-dtype provenance
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
-           k-range launch-group-count attributes epilogue]
+           k-range launch-group-count attributes epilogue input-value-regions]
     :or {result-dtype :float provenance {}}}]
   (let [dimension-parameters
         (or dimension-parameters
@@ -350,6 +350,7 @@
       :tile tile
       :bindings {:row a :col b}
       :epilogue epilogue
+      :input-value-regions (or input-value-regions {})
       :result-dtype result-dtype
       :additional-parameters additional-parameters
       :additional-indices additional-indices
@@ -372,7 +373,7 @@
   [{:keys [kernel-name id a b c m n k dimension-parameters tile result-dtype provenance
            target-dialect
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
-           k-range launch-group-count attributes parameter-names epilogue]
+           k-range launch-group-count attributes parameter-names epilogue input-value-regions]
     :or {result-dtype :float provenance {} target-dialect :opencl-intel}}]
   (let [kernel-name (c-emit/c-symbol kernel-name)
         kernel-body (scheduled-matrix-body
@@ -383,7 +384,7 @@
                       :additional-indices additional-indices :buffer-shapes buffer-shapes
                       :buffer-views buffer-views :operation-buffers operation-buffers
                       :k-range k-range :launch-group-count launch-group-count
-                      :attributes attributes :epilogue epilogue})
+                      :attributes attributes :epilogue epilogue :input-value-regions input-value-regions})
         emitted (matrix-target/emit-matrix-kernel
                  kernel-name kernel-body target-dialect {:parameter-names parameter-names})]
     (assoc emitted
@@ -391,13 +392,13 @@
            :workgroup-size (get-in kernel-body [:launch :workgroup-size]))))
 
 (defn- split-k-matrix-spec
-  [{:keys [kernel-name id a b c m n k kc splits tile provenance]}]
+  [{:keys [kernel-name id a b c m n k kc splits tile provenance input-value-regions]}]
   (let [z 'k-slice
         c-view 'split-result-view
         k-lower (kbody/expression :mul z kc)
         k-upper (kbody/expression :min (kbody/expression :add k-lower kc) k)]
     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
-     :tile tile :result-dtype :float :provenance provenance
+     :tile tile :result-dtype :float :provenance provenance :input-value-regions input-value-regions
      :additional-parameters [(kbody/->KernelParameter kc :scalar :int [] nil nil :schedule)
                              (kbody/->KernelParameter splits :scalar :int [] nil nil :schedule)]
      :additional-indices [(kbody/->IndexBinding z :group 2)]
@@ -419,7 +420,7 @@
   (emit-scheduled-matrix-kernel (split-k-matrix-spec spec)))
 
 (defn- batched-matrix-spec
-  [{:keys [kernel-name id a b c m n k batch tile provenance batching]
+  [{:keys [kernel-name id a b c m n k batch tile provenance batching input-value-regions]
     :or {batching {:row true :col true}}}]
   (let [z 'slab
         a-view 'batch-lhs-view
@@ -443,7 +444,7 @@
           row-batched? (assoc a a-view)
           col-batched? (assoc b b-view))]
     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
-     :tile tile :result-dtype :float :provenance provenance
+     :tile tile :result-dtype :float :provenance provenance :input-value-regions input-value-regions
      :additional-parameters [(kbody/->KernelParameter batch :scalar :int [] nil nil :schedule)]
      :additional-indices [(kbody/->IndexBinding z :group 2)]
      :buffer-shapes {a a-shape b b-shape c [batch m n]}
@@ -532,7 +533,8 @@
   [stage kernel-name phase target-dialect scalar-types]
   (let [{stage-id :id a :lhs b :rhs c :result
          [m n k] :dimensions reduction :reduction epilogue :epilogue
-         batching :batching schedule :schedule} (matrix-stage/validate! stage)
+         batching :batching schedule :schedule input-value-regions :input-value-regions}
+        (matrix-stage/validate! stage)
         tile (:tile schedule)
         _ (when-not (and (= :matrix-instruction-tiling (:kind schedule))
                          (= :half (:operand-dtype stage))
@@ -556,6 +558,7 @@
                    :a a :b b :c c :m m :n n :k k
                    :tile tile :result-dtype (:result-dtype stage)
                    :epilogue epilogue
+                   :input-value-regions input-value-regions
                    :phase phase
                    :target-dialect target-dialect
                    :source-operation stage

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -530,6 +530,19 @@
                           (into scope (concat parameters indices)) epilogue-abi)
     region))
 
+(defn- validate-input-region-boundary!
+  [region input-dtype fragment-dtype]
+  (when-not (and (= 1 (count (:parameters region)))
+                 (= [] (:operands region)) (= [] (:indices region))
+                 (every? #(record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" %)
+                         (:operations region))
+                 (= (dtype/canon input-dtype) (dtype/canon (:accumulator-dtype region)))
+                 (= (dtype/canon fragment-dtype) (dtype/canon (:result-dtype region))))
+    (throw (ex-info "tile-load value region must be closed and preserve its typed boundary"
+                    {:reason :kernel-body-tile-load-region :region region
+                     :input-dtype input-dtype :fragment-dtype fragment-dtype})))
+  region)
+
 (defn- validate-operation!
   [operation storage fragments masks scope epilogue-abi]
   (let [parameter (fn [id]
@@ -588,15 +601,7 @@
             ;; The first ScalarSSARegion parameter is the loaded element here, rather than
             ;; a store accumulator. Input transformations are closed pure per-element regions:
             ;; no extra memory reads, external captures, coordinates, or effects.
-            (when-not (and (= 1 (count (:parameters region)))
-                           (= [] (:operands region)) (= [] (:indices region))
-                           (every? #(record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" %)
-                                   (:operations region))
-                           (= (dtype/canon (:dtype p)) (dtype/canon (:accumulator-dtype region)))
-                           (= (dtype/canon (:dtype f)) (dtype/canon (:result-dtype region))))
-              (throw (ex-info "tile-load value region must be closed and preserve its typed boundary"
-                              {:reason :kernel-body-tile-load-region :region region
-                               :buffer p :fragment f})))
+            (validate-input-region-boundary! region (:dtype p) (:dtype f))
             (validate-scalar-ssa-region! region storage masks (set (:parameters region)) []))
           (when-not (= (dtype/canon (:dtype p)) (dtype/canon (:dtype f)))
             (throw (ex-info "tile-load fragment dtype must equal the buffer element dtype"
@@ -1919,6 +1924,18 @@
                        :result (:result region) :declared (:result-dtype region)
                        :actual (:type result)})))
     region))
+
+(defn validate-input-value-region!
+  "Validate a closed typed per-element input transformation independently of a kernel schedule.
+   Matrix stages and TileLoad share this boundary and SSA checker; no external values or memory
+   operations are admitted. Storage/fragment types are explicit, never inferred from operators."
+  [region input-dtype fragment-dtype]
+  (validate-input-region-boundary! region input-dtype fragment-dtype)
+  (validate-scalar-ssa-region! region {} {} (set (:parameters region)) [])
+  (validate-scalar-ssa-dataflow!
+   region {} {:storage {} :stable-reads #{} :masks {} :reserved #{}
+              :control-uniformity lane-varying :launch nil :schedule {}})
+  region)
 
 (defn- validate-async-protocol!
   [operations storage stable-buffers reserved]

--- a/src/raster/compiler/ir/matrix_stage.clj
+++ b/src/raster/compiler/ir/matrix_stage.clj
@@ -2,14 +2,17 @@
   "Exact target-neutral operations introduced by matrix-contraction graph scheduling.
 
    A MatrixStage is later than a semantic SegRed and earlier than KernelBody. It records the
-   representation, batching, reduction partition and result transform chosen for one graph node;
+   representation, batching, reduction partition and input/result transforms chosen for one graph node;
    distinct direct, split-K and batched stages therefore cannot share a fabricated source
-   identity in refinement certificates."
-  (:require [raster.compiler.core.dtype :as dtype]))
+   identity in refinement certificates. Input value regions map physical operand elements to
+   operand-dtype fragments; the closed typed SSA region retains the conversion policy without
+   introducing a second scalar language or assuming target support."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.kernel-body :as kernel-body]))
 
 (defrecord MatrixStage
            [id lhs rhs result dimensions batching reduction result-shape epilogue
-            operand-dtype accumulator-dtype result-dtype schedule])
+            operand-dtype accumulator-dtype result-dtype schedule input-value-regions])
 
 (defn matrix-stage?
   [value]
@@ -22,7 +25,7 @@
     (throw (ex-info "expected a MatrixStage"
                     {:reason :matrix-stage-type :actual (type stage)})))
   (let [{:keys [id lhs rhs result dimensions batching reduction result-shape epilogue
-                operand-dtype accumulator-dtype result-dtype schedule]} stage]
+                operand-dtype accumulator-dtype result-dtype schedule input-value-regions]} stage]
     (doseq [[field value] [[:id id] [:lhs lhs] [:rhs rhs] [:result result]]]
       (when (nil? value)
         (throw (ex-info "matrix stage is missing an identity"
@@ -61,13 +64,24 @@
       (when-not (and (dtype/known? value) (= value (dtype/canon value)))
         (throw (ex-info "matrix stage requires canonical numerical dtypes"
                         {:reason :matrix-stage-dtype :field field :dtype value}))))
+    (when-not (and (map? input-value-regions)
+                   (every? (set [lhs rhs]) (keys input-value-regions)))
+      (throw (ex-info "matrix input regions must name current operands"
+                      {:reason :matrix-stage-input-regions :regions input-value-regions})))
+    (doseq [[input region] input-value-regions
+            :let [physical-dtype (:accumulator-dtype region)]]
+      (when-not (and (dtype/known? physical-dtype)
+                     (= physical-dtype (dtype/canon physical-dtype)))
+        (throw (ex-info "matrix input region requires a canonical physical input dtype"
+                        {:reason :matrix-stage-input-dtype :input input :dtype physical-dtype})))
+      (kernel-body/validate-input-value-region! region physical-dtype operand-dtype))
     stage))
 
 (defn make
   [{:keys [id lhs rhs result dimensions batching reduction result-shape epilogue
-           operand-dtype accumulator-dtype result-dtype schedule]
-    :or {operand-dtype :half accumulator-dtype :float result-dtype :float}}]
+           operand-dtype accumulator-dtype result-dtype schedule input-value-regions]
+    :or {operand-dtype :half accumulator-dtype :float result-dtype :float input-value-regions {}}}]
   (validate!
    (->MatrixStage id lhs rhs result (vec dimensions) batching reduction (vec result-shape)
                   epilogue (dtype/canon operand-dtype) (dtype/canon accumulator-dtype)
-                  (dtype/canon result-dtype) schedule)))
+                  (dtype/canon result-dtype) schedule input-value-regions)))

--- a/test/raster/compiler/ir/matrix_stage_test.clj
+++ b/test/raster/compiler/ir/matrix_stage_test.clj
@@ -1,0 +1,78 @@
+(ns raster.compiler.ir.matrix-stage-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.matrix-stage :as matrix-stage]
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
+
+(defn- cast-region []
+  (body/->ScalarSSARegion
+   ['loaded] [] [] :float
+   [(body/->ScalarCompute (body/value 'converted :half)
+                          (body/cast-expression 'loaded :half :nearest-even :ieee))]
+   'converted :half))
+
+(defn- stage-spec []
+  {:id [:matrix-input-stage :contract] :lhs 'A :rhs 'B :result 'C
+   :dimensions [13 32 32] :result-shape [13 32]
+   :reduction {:kind :full :range [0 32]}
+   :schedule {:kind :matrix-instruction-tiling
+              :tile {:block-m 16 :block-n 32 :sg-m 8 :sg-n 16 :block-k 32 :num-stages 1
+                     :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}}}})
+
+(deftest matrix-stage-keeps-fragment-types-separate-from-physical-inputs
+  (let [plain (matrix-stage/make (stage-spec))
+        region (cast-region)
+        converted (matrix-stage/make (assoc (stage-spec) :input-value-regions {'A region}))]
+    (is (= {} (:input-value-regions plain)))
+    (is (= 'A (:rhs (matrix-stage/make (assoc (stage-spec) :rhs 'A)))))
+    (is (= :half (:operand-dtype converted)))
+    (is (= :float (get-in converted [:input-value-regions 'A :accumulator-dtype])))
+    (is (identical? region (get-in converted [:input-value-regions 'A])))
+    (is (= region (body/validate-input-value-region! region :float :half)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (matrix-stage/make (assoc (stage-spec) :input-value-regions {'missing region}))))
+    (doseq [bad [(assoc region :result-dtype :float)
+                 (assoc region :parameters ['loaded 'capture])
+                 (assoc region :indices ['i])
+                 (assoc region :result 'missing)
+                 (assoc-in region [:operations 0 :expression :arguments] ['outside])
+                 (assoc-in region [:operations 0 :expression :options :rounding] nil)
+                 (assoc region :operations
+                        [(body/->ScalarLoad (body/value 'converted :half) 'B [0 0]
+                                            nil nil :cached)])]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (matrix-stage/make (assoc (stage-spec) :input-value-regions {'A bad})))))))
+
+(deftest transformed-matrix-stage-reaches-the-certified-body-and-physical-abi
+  (let [stage (matrix-stage/make (assoc (stage-spec) :input-value-regions {'A (cast-region)}))
+        uses [(graph/->ValueUse 'A :read) (graph/->ValueUse 'B :read) (graph/->ValueUse 'C :write)]
+        original (graph/make
+                  {:inputs [(graph/buffer 'A :float 416 :device :input)
+                            (graph/buffer 'B :half 1024 :device :input)]
+                   :outputs [(graph/buffer 'C :float 416 :device :output)]
+                   :temporaries [] :scalars []
+                   :nodes [(graph/->ScheduledKernel (:id stage) stage uses #{} [])]
+                   :abi [(abi/slot 'A :input :float) (abi/slot 'B :input :half)
+                         (abi/slot 'C :output :float)]
+                   :arguments '[A B C]
+                   :effects {:reads ['A 'B] :writes ['C]}})
+        emitted (gemm/emit-scheduled-stage-graph original
+                                                {:prefix "matrix_input_stage" :target-dialect :opencl-intel})
+        node (first (:nodes emitted))
+        a (:operation node)
+        scheduled (artifact/attribute a :scheduled-kernel-body)
+        kernel (:body scheduled)]
+    (is (= (graph/boundary-contract original) (graph/boundary-contract emitted)))
+    (is (= (graph/dataflow-contract original) (graph/dataflow-contract emitted)))
+    (is (identical? stage (:source scheduled)))
+    (is (= [:float :half :float] (mapv :dtype (take 3 (:abi a)))))
+    (is (= :no-write-alias (:aliasing (first (:abi a)))))
+    (is (= :float (get-in kernel [:parameters 0 :dtype])))
+    (is (re-find #"convert_half_rte" (:source a)))
+    (is (= scheduled (scheduled-body/validate-against-node! scheduled (first (:nodes original)) original)))
+    (is (= a (scheduled-body/validate-artifact-projection! scheduled a)))
+    (is (= [] (:temporaries emitted)))))


### PR DESCRIPTION
## Summary
Retain closed typed input SSA regions in MatrixStage and carry them through scheduled matrix lowering into KernelBody and the emitted physical ABI. Reuse the existing scalar SSA boundary and dataflow validators rather than introducing another scalar language or type registry. Split and batched wrappers preserve the regions so unsupported targets fail closed instead of silently dropping transformations.

This is the stage-preservation prerequisite for conversion-to-matrix fusion, not automatic graph fusion or a schedule promotion. Existing public defaults remain unchanged. The transformed physical A input retains its no-write-alias contract; future candidate selection must account for this stricter requirement.

## Validation
- Focused MatrixStage, GEMM, KernelBody and tile-input tests: 61 tests, 928 assertions, zero failures/errors.
- Final MatrixStage tests including repeated operands and alias-contract preservation: 2 tests, 24 assertions, zero failures/errors.
- Exact stage identity, graph boundary/dataflow, physical FP32 input ABI, emitted RNE conversion, and artifact projection checked.
- Invalid captures, memory operations, rounding and dtype boundaries rejected.
- Full suite and vendor compile gates left to CI; no performance claim.