### PR TITLE
Fuse private casts into explicit typed matrix input candidates

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -30,6 +30,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
+            [raster.compiler.passes.parallel.matrix-input-fusion :as input-fusion]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
 
 (def ^:private default-min-split-chunk 1024)
@@ -852,11 +853,30 @@
             :attributes {:strategy strategy :variant variant :precision :mixed-f16-f32
                          :tile tile :vector-width vector-width
                          :requested-splits requested-splits}})
+          stage-graph (if (:fuse-lhs-cast? spec)
+                        (or (input-fusion/fuse-lhs-cast stage-graph convert-a-id contract-id)
+                            (throw (ex-info "matrix input cast fusion obligations are not satisfied"
+                                            {:reason :matrix-input-fusion-ineligible :id id})))
+                        stage-graph)
           emit-spec (assoc spec :strategy strategy)
           refinement (make-refinement stage-graph source-operation source-graph emit-spec)]
       (emit-scheduled-stage-graph
        stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
                     :prefix prefix :refinement refinement}))))
+
+(defn emit-matrix-input-fusion-alternative
+  "Emit an explicit Intel direct-matrix candidate with an inlined lhs FP32→FP16 cast.
+   Not included in automatic dispatch: binding requires physical A/C disjointness, which a
+   shape-only selector cannot prove. Retains the ordinary public ABI and original semantic
+   refinement source. Unsupported layouts/targets fail closed; no implicit fallback."
+  [{:keys [variant target-dialect] :as spec}]
+  (when-not (and (contains? #{:nn :nt} variant)
+                 (= :opencl-intel (or target-dialect :opencl-intel)))
+    (throw (ex-info "matrix input fusion requires Intel direct NN/NT storage"
+                    {:reason :matrix-input-fusion-target :variant variant :target target-dialect})))
+  (xmx-graph (assoc spec :split-k? false :fuse-lhs-cast? true
+                   :vector-width (get spec :vector-width 4)
+                   :strategy :xmx-direct-lhs-tile-cast)))
 
 (defn emit-batched-matrix-alternative
   "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.

--- a/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
+++ b/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
@@ -41,7 +41,7 @@
         (when (and (= :cast (:operation cast))
                    (= [:float :half] ((juxt :input-dtype :output-dtype) cast))
                    (= {:rounding :nearest-even :overflow :ieee}
-                      (select-keys (:policy cast) [:rounding :overflow]))
+                      (dissoc (:policy cast) :vector-width))
                    (= :half (:operand-dtype stage))
                    (= temporary (:lhs stage))
                    (not= temporary (:rhs stage))

--- a/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
+++ b/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
@@ -1,0 +1,101 @@
+(ns raster.compiler.passes.parallel.matrix-input-fusion
+  "Fuse a private representation cast into a matrix input, before target emission.
+   This constructs a candidate, not a universally legal replacement: physical input/output
+   disjointness is required by its emitted ABI and must be proved before automatic selection."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.layout-stage :as layout]
+            [raster.compiler.ir.matrix-stage :as matrix]))
+
+(defn- same-extent? [a b]
+  (and (some? a) (some? b)
+       (or (= a b)
+           (and (empty? (launch/expression-references a))
+                (empty? (launch/expression-references b))
+                (= (launch/resolve-expression {} a) (launch/resolve-expression {} b))))))
+
+(defn fuse-lhs-cast
+  "Return an eligible candidate graph, or nil when this rewrite cannot prove its obligations.
+   Accepts only an exact, full-reduction, unbatched matrix consumer of a private FP32→FP16 cast.
+   No source expressions or operator inference participate. Target support is checked later."
+  [g producer-id consumer-id]
+  (let [g (graph/validate! g)
+        nodes (:nodes g)
+        by-id (into {} (map (juxt :id identity)) nodes)
+        producer (get by-id producer-id)
+        consumer (get by-id consumer-id)
+        cast (:operation producer)
+        stage (:operation consumer)]
+    (when (and (layout/layout-stage? cast) (matrix/matrix-stage? stage))
+      (layout/validate! cast)
+      (matrix/validate! stage)
+      (let [input (:input cast) temporary (:output cast)
+            input-buffer (first (filter #(= input (:id %)) (:inputs g)))
+            temp-buffer (first (filter #(= temporary (:id %)) (:temporaries g)))
+            uses-of (fn [id] (for [node nodes use (:uses node) :when (= id (:buffer use))]
+                              [(:id node) (:access use)]))
+            [m _ k] (:dimensions stage)
+            extent (launch/product m k)]
+        (when (and (= :cast (:operation cast))
+                   (= [:float :half] ((juxt :input-dtype :output-dtype) cast))
+                   (= {:rounding :nearest-even :overflow :ieee}
+                      (select-keys (:policy cast) [:rounding :overflow]))
+                   (= :half (:operand-dtype stage))
+                   (= temporary (:lhs stage))
+                   (not= temporary (:rhs stage))
+                   (not-any? #(= temporary (:sym %)) (get-in stage [:epilogue :operands]))
+                   (empty? (:input-value-regions stage))
+                   (nil? (:batching stage))
+                   (= {:kind :full :range [0 k]} (:reduction stage))
+                   (= 1 (count (:input-shape cast)))
+                   (same-extent? extent (first (:input-shape cast)))
+                   (= :float (:dtype input-buffer)) (= :half (:dtype temp-buffer))
+                   (same-extent? extent (:elements input-buffer))
+                   (same-extent? extent (:elements temp-buffer))
+                   (= [[input :read] [temporary :write]]
+                      (mapv (juxt :buffer :access) (:uses producer)))
+                   (= #{[producer-id :write] [consumer-id :read]}
+                      (set (uses-of temporary)))
+                   (= 2 (count (uses-of temporary)))
+                   (not-any? #(= input (:buffer %)) (:uses consumer))
+                   (every? #(= :read (second %)) (uses-of input))
+                   (some #{producer-id} (:dependencies consumer))
+                   (every? #(or (= consumer-id (:id %))
+                                (not (some #{producer-id} (:dependencies %)))) nodes))
+          (let [reserved (set (concat (map :id (concat (:inputs g) (:outputs g)
+                                                      (:temporaries g) (:scalars g)))
+                                     (keys (:epilogue stage))))
+                local (fn [prefix]
+                        (first (remove reserved (map #(symbol (str prefix %)) (range)))))
+                loaded (local "tile_input_") converted (local "tile_cast_")
+                region (body/->ScalarSSARegion
+                        [loaded] [] [] :float
+                        [(body/->ScalarCompute
+                          (body/value converted :half)
+                          (body/cast-expression loaded :half :nearest-even :ieee))]
+                        converted :half)
+                replacement (matrix/validate!
+                             (assoc stage :lhs input :input-value-regions {input region}))
+                consumer (-> consumer
+                             (assoc :operation replacement)
+                             (update :uses (fn [uses] (mapv #(if (= temporary (:buffer %))
+                                                             (assoc % :buffer input) %) uses)))
+                             (update :scalar-uses set/union (:scalar-uses producer))
+                             (update :dependencies
+                                     #(vec (distinct (concat (remove #{producer-id} %)
+                                                             (:dependencies producer))))))
+                candidate (-> g
+                              (assoc :nodes (into [] (comp (remove #(= producer-id (:id %)))
+                                                          (map #(if (= consumer-id (:id %)) consumer %))) nodes))
+                              (update :temporaries #(filterv (fn [b] (not= temporary (:id b))) %))
+                              (assoc-in [:attributes :input-fusion]
+                                        {:producer producer :consumer (:operation (get by-id consumer-id))
+                                         :physical-precondition :input-output-disjoint
+                                         :selection :explicit-only}))]
+            (graph/validate! candidate)
+            (when-not (= (graph/boundary-contract g) (graph/boundary-contract candidate))
+              (throw (ex-info "matrix input fusion changed the public boundary"
+                              {:reason :matrix-input-fusion-boundary})))
+            candidate))))))

--- a/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
@@ -59,6 +59,7 @@
 (deftest changed-policy-shape-storage-or-consumer-declines
   (let [g (stage-graph)]
     (doseq [bad [(assoc-in g [:nodes 0 :operation :policy :rounding] :toward-zero)
+                 (assoc-in g [:nodes 0 :operation :policy :nan-policy] :canonicalize)
                  (-> g (assoc-in [:nodes 0 :operation :input-shape] [448])
                      (assoc-in [:nodes 0 :operation :output-shape] [448]))
                  (assoc-in g [:temporaries 0 :elements] 448)

--- a/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
@@ -1,0 +1,112 @@
+(ns raster.compiler.passes.parallel.matrix-input-fusion-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.layout-stage :as layout]
+            [raster.compiler.ir.matrix-stage :as matrix]
+            [raster.compiler.passes.parallel.matrix-input-fusion :as fusion]))
+
+(defn- stage-graph []
+  (let [cast (layout/make {:id [:test :cast] :operation :cast :input 'A :output 'A16
+                           :input-shape [416] :output-shape [416]
+                           :input-dtype :float :output-dtype :half
+                           :policy {:rounding :nearest-even :overflow :ieee}})
+        matrix (matrix/make
+                {:id [:test :matrix] :lhs 'A16 :rhs 'B :result 'C
+                 :dimensions [13 32 32] :result-shape [13 32]
+                 :reduction {:kind :full :range [0 32]}
+                 :schedule {:kind :matrix-instruction-tiling
+                            :tile {:block-m 16 :block-n 32 :sg-m 8 :sg-n 16 :block-k 32
+                                   :num-stages 1
+                                   :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}}}})]
+    (graph/make
+     {:inputs [(graph/buffer 'A :float 416 :device :input)
+               (graph/buffer 'B :half 1024 :device :input)]
+      :outputs [(graph/buffer 'C :float 416 :device :output)]
+      :temporaries [(graph/buffer 'A16 :half 416 :device :temporary)] :scalars []
+      :nodes [(graph/->ScheduledKernel [:test :cast] cast
+                                      [(graph/->ValueUse 'A :read) (graph/->ValueUse 'A16 :write)] #{} [])
+              (graph/->ScheduledKernel [:test :matrix] matrix
+                                      [(graph/->ValueUse 'A16 :read) (graph/->ValueUse 'B :read)
+                                       (graph/->ValueUse 'C :write)] #{} [[:test :cast]])]
+      :abi [(abi/slot 'A :input :float) (abi/slot 'B :input :half) (abi/slot 'C :output :float)]
+      :arguments '[A B C] :effects {:reads ['A 'B] :writes ['C]}})))
+
+(defn- fuse [g] (fusion/fuse-lhs-cast g [:test :cast] [:test :matrix]))
+
+(deftest private-cast-becomes-a-typed-load-region
+  (let [original (stage-graph) candidate (fuse original)
+        stage (get-in candidate [:nodes 0 :operation])
+        emitted (gemm/emit-scheduled-stage-graph candidate {:target-dialect :opencl-intel})
+        artifact (get-in emitted [:nodes 0 :operation])]
+    (is (some? candidate))
+    (is (= (graph/boundary-contract original) (graph/boundary-contract candidate)))
+    (is (= [] (:temporaries candidate)))
+    (is (= 1 (count (:nodes candidate))))
+    (is (= [] (get-in candidate [:nodes 0 :dependencies])))
+    (is (= 'A (:lhs stage)))
+    (is (= :float (get-in stage [:input-value-regions 'A :accumulator-dtype])))
+    (is (= :explicit-only (get-in candidate [:attributes :input-fusion :selection])))
+    (is (identical? (get-in original [:nodes 1 :operation])
+                    (get-in candidate [:attributes :input-fusion :consumer])))
+    (is (= :no-write-alias (get-in artifact [:abi 0 :aliasing])))
+    (is (re-find #"convert_half_rte" (:source artifact)))
+    (is (identical? stage (get-in artifact [:attributes :scheduled-kernel-body :source])))))
+
+(deftest changed-policy-shape-storage-or-consumer-declines
+  (let [g (stage-graph)]
+    (doseq [bad [(assoc-in g [:nodes 0 :operation :policy :rounding] :toward-zero)
+                 (-> g (assoc-in [:nodes 0 :operation :input-shape] [448])
+                     (assoc-in [:nodes 0 :operation :output-shape] [448]))
+                 (assoc-in g [:temporaries 0 :elements] 448)
+                 (assoc-in g [:inputs 0 :elements] 448)
+                 (assoc-in g [:inputs 0 :elements] nil)
+                 (assoc-in g [:nodes 1 :operation :rhs] 'A16)
+                 (assoc-in g [:nodes 1 :operation :epilogue] {:operands [{:sym 'A16}]})
+                 (assoc-in g [:nodes 1 :operation :batching] {:extent 2 :lhs true :rhs true})
+                 (update g :nodes conj
+                         (graph/->ScheduledKernel [:test :observer] :observer
+                                                  [(graph/->ValueUse 'A16 :read)] #{} [[:test :cast]]))]]
+      (is (nil? (fuse bad))))))
+
+(deftest explicit-production-candidate-retains-weight-conversion
+  (let [spec {:id :fused-test :a 'A :b 'B :c 'C :m 16 :n 32 :k 32 :variant :nn
+              :fill-workgroups 16
+              :tile (get-in (stage-graph) [:nodes 1 :operation :schedule :tile])}
+        candidate (gemm/emit-matrix-input-fusion-alternative spec)
+        ordinary (gemm/emit-matrix-alternatives spec)]
+    (is (= :xmx-direct-lhs-tile-cast (get-in candidate [:attributes :strategy])))
+    (is (= [:convert-b :contract] (mapv (comp last :id) (:nodes candidate))))
+    (is (= [:b16] (mapv (comp last :id) (:temporaries candidate))))
+    (is (= :xmx-direct (get-in ordinary [:selector :default])))
+    (is (not-any? #(= :xmx-direct-lhs-tile-cast (get-in % [:attributes :strategy]))
+                  (:alternatives ordinary)))
+    (doseq [override [{:variant :tn} {:variant :tt} {:target-dialect :cuda}
+                     {:target-dialect :hip}]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (gemm/emit-matrix-input-fusion-alternative (merge spec override)))))))
+
+(deftest fused-leaf-requires-disjoint-physical-input-and-output
+  (let [spec {:id :alias-test :a 'A :b 'B :c 'C :m 16 :n 32 :k 32 :variant :nn
+              :fill-workgroups 16
+              :tile (get-in (stage-graph) [:nodes 1 :operation :schedule :tile])}
+        fused (gemm/emit-matrix-input-fusion-alternative spec)
+        ordinary (first (:alternatives (gemm/emit-matrix-alternatives spec)))
+        calls (fn [g overlap?]
+                (let [buffers (into {} (for [b (concat (:inputs g) (:outputs g) (:temporaries g))]
+                                         [(:id b) {:id (:id b) :alignment 64 :dtype (:dtype b)}]))
+                      buffers (cond-> buffers overlap? (assoc 'C (get buffers 'A)))]
+                  (mapv (fn [{a :operation}]
+                          (call/make a (mapv (fn [slot value]
+                                               (if (= :scalar (:kind slot))
+                                                 {:type (:dtype slot) :value (launch/resolve-expression {} value)}
+                                                 (get buffers value)))
+                                             (:abi a) (:arguments a)))) (:nodes g))))]
+    (is (= 3 (count (calls ordinary true))) "global conversion snapshots A before C is written")
+    (is (= 2 (count (calls fused false))))
+    (is (= :kernel-abi-no-write-alias
+           (try (calls fused true) nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1287,6 +1287,22 @@
           (is false "a source graph with different semantic effects must not validate")
           (catch clojure.lang.ExceptionInfo exception
             (is (= :scheduled-graph-refinement-source (:reason (ex-data exception))))))))
+    (testing "input fusion retains the exact typed source and rewritten stage graph"
+      (let [source-graph (:source direct-refinement)
+            candidate (gpu-gemm/emit-matrix-input-fusion-alternative
+                       {:id :typed-input-fusion :a 'A :b 'B :c 'C :m 'm :n 'n :k 'k
+                        :variant :nn :tile (get-in direct-graph [:attributes :tile])
+                        :source-operation operation :source-graph source-graph
+                        :external-interface (select-keys source-graph [:abi :arguments :effects])})
+            refinement (get-in candidate [:attributes :scheduled-graph-refinement])
+            stages (graph-refinement/scheduled-graph refinement)]
+        (is (identical? operation (graph-refinement/source-operation refinement)))
+        (is (= source-graph (:source refinement)))
+        (is (= [:convert-b :contract] (mapv (comp last :id) (:nodes stages))))
+        (is (kernel-graph/dataflow-equivalent? stages candidate))
+        (doseq [[stage-node emitted-node] (map vector (:nodes stages) (:nodes candidate))]
+          (is (identical? (:operation stage-node)
+                          (get-in emitted-node [:operation :attributes :scheduled-kernel-body :source]))))))
     (testing "mixed-precision alternatives refine the exact typed SegRed through stage graphs"
       (doseq [[graph refinement expected-types]
               [[direct-graph direct-refinement


### PR DESCRIPTION
## Summary
Add a checked pre-emission graph rewrite from a private FP32-to-FP16 LayoutStage cast into the sole MatrixStage lhs input region. Prove exact policy, extents, temporary uses and dependency obligations; retain source identities and revalidate the graph boundary. Unknown policy keys, hidden epilogue uses, unsupported extents and extra consumers decline.

Expose an explicit Intel NN/NT direct candidate that removes convert-A and A16 while retaining weight conversion. It is deliberately absent from ordinary alternatives and automatic selectors: its physical A/C disjointness requirement cannot be established by a scalar-only selector. Target emission and ABI checks remain authoritative. No performance or default-promotion claim.

## Validation
- Focused GEMM/MatrixStage/fusion integration: 30 tests, 769 assertions, zero failures/errors.
- Final fusion regressions after review: 4 tests, 34 assertions, zero failures/errors.
- Exact typed-source route test: 1 test, 75 assertions, zero failures/errors.
- Actual KernelCall validation accepts ordinary staged overlap and disjoint fused calls, and rejects fused A/C overlap.
- Independent review completed; unknown semantic cast-policy handling fixed.
- Full suite and vendor compiler checks run in CI.