### PR TITLE
Share complete external graph alias preflight with runtime binding

### DIFF
--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -35,6 +35,49 @@
   (filterv (fn [[slot _]] (= :scalar (:kind slot)))
            (mapv vector (:abi graph) (:arguments graph))))
 
+(defn external-alias-violations
+  "Return graph access/dependency hazards for complete public physical bindings, without driver
+   work. overlaps? must conservatively compare physical values/ranges. Private allocations are
+   not supplied. Dtype, capacity, scalar preconditions and node ABI checks remain separate.
+   Incomplete bindings throw: missing information is not proof of disjointness."
+  [graph bindings overlaps?]
+  (let [graph (kgraph/validate! graph)
+        ids (set (map :id (concat (:inputs graph) (:outputs graph))))]
+    (when-not (and (map? bindings) (= ids (set (keys bindings))) (every? some? (vals bindings)))
+      (throw (ex-info "graph alias preflight requires exactly every public physical binding"
+                      {:reason :kernel-graph-alias-bindings :expected ids
+                       :bound (when (map? bindings) (set (keys bindings)))})))
+    (when-not (ifn? overlaps?)
+      (throw (ex-info "graph alias preflight requires an overlap predicate"
+                      {:reason :kernel-graph-alias-predicate})))
+    (let [writes? #(contains? #{:write :read-write} (:access %))
+          hazard? (fn [left right]
+                    (and (contains? ids (:buffer left)) (contains? ids (:buffer right))
+                         (overlaps? (get bindings (:buffer left)) (get bindings (:buffer right)))
+                         (or (writes? left) (writes? right))))
+          nodes (:nodes graph)]
+      (into
+       (vec (for [node nodes [index left] (map-indexed vector (:uses node))
+                  right (drop (inc index) (:uses node)) :when (hazard? left right)]
+              {:reason :kernel-graph-writable-alias :node (:id node)
+               :left (:buffer left) :right (:buffer right)}))
+       (for [[index later] (map-indexed vector nodes) earlier (take index nodes)
+             :when (some (fn [left] (some #(hazard? left %) (:uses later))) (:uses earlier))
+             :when (not (contains? (set (:dependencies later)) (:id earlier)))]
+         {:reason :kernel-graph-alias-dependency :node (:id later) :missing (:id earlier)})))))
+
+(defn validate-external-aliases!
+  "Enforce graph access/dependency preflight and return the complete physical bindings."
+  [graph bindings overlaps?]
+  (when-let [violation (first (external-alias-violations graph bindings overlaps?))]
+    (throw (ex-info (case (:reason violation)
+                     :kernel-graph-writable-alias
+                     "one kernel cannot bind overlapping writable graph buffer views"
+                     :kernel-graph-alias-dependency
+                     "kernel graph omits a dependency introduced by overlapping resident views")
+                    violation)))
+  bindings)
+
 (defn direct-scalar-range-preconditions
   "Project physical integer ranges for direct public scalar bindings into selector conditions.
   This is deliberately partial: computed node arguments, allocation products and artifact

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1178,10 +1178,6 @@
   [graph]
   (set (map :id (concat (:inputs graph) (:outputs graph)))))
 
-(defn- write-access?
-  [access]
-  (contains? #{:write :read-write} access))
-
 (defn- resolve-graph-elements
   [scalar-values expression]
   (let [bound (get scalar-values expression ::not-bound)
@@ -1224,42 +1220,6 @@
                        :shape (:shape view) :strides (:strides view)})))
     view))
 
-(defn- node-physical-hazard?
-  [external-bindings earlier later]
-  (boolean
-   (some (fn [earlier-use]
-           (some (fn [later-use]
-                   (let [earlier-view (get-in external-bindings [(:buffer earlier-use) :view])
-                         later-view (get-in external-bindings [(:buffer later-use) :view])]
-                     (and earlier-view later-view
-                          (bview/overlaps? earlier-view later-view)
-                          (or (write-access? (:access earlier-use))
-                              (write-access? (:access later-use))))))
-                 (:uses later)))
-         (:uses earlier))))
-
-(defn- validate-physical-aliases!
-  "Prove hazards introduced when distinct graph identities are bound to overlapping views. The
-   symbolic graph validator cannot see these aliases, so binding must reject same-kernel writable
-   aliases and require the same explicit dependency rule across kernels."
-  [graph external-bindings]
-  (doseq [node (:nodes graph)
-          [index left] (map-indexed vector (:uses node))
-          right (drop (inc index) (:uses node))]
-    (let [left-view (get-in external-bindings [(:buffer left) :view])
-          right-view (get-in external-bindings [(:buffer right) :view])]
-      (when (and left-view right-view
-                 (bview/overlaps? left-view right-view)
-                 (or (write-access? (:access left)) (write-access? (:access right))))
-        (throw (ex-info "one kernel cannot bind overlapping writable graph buffer views"
-                        {:node (:id node) :left (:buffer left) :right (:buffer right)})))))
-  (doseq [[later-index later] (map-indexed vector (:nodes graph))
-          earlier (take later-index (:nodes graph))
-          :when (node-physical-hazard? external-bindings earlier later)
-          :when (not (contains? (set (:dependencies later)) (:id earlier)))]
-    (throw (ex-info "kernel graph omits a dependency introduced by overlapping resident views"
-                    {:node (:id later) :missing (:id earlier)})))
-  external-bindings)
 
 (defn- runtime-buffer-for-view
   [device-id buffer view]
@@ -1465,7 +1425,7 @@
                                    buffer-keys)
            _ (doseq [[id {:keys [view]}] external-bindings]
                (validate-external-view! (get graph-buffer-by-id id) view scalar-values))
-           _ (validate-physical-aliases! graph external-bindings)
+           _ (kgcall/validate-external-aliases! graph (update-vals external-bindings :view) bview/overlaps?)
            _ (release-graph-events! sess graph-key)
            temporary-specs (kgcall/temporary-specs graph scalar-values)
            temporary-buffers (alloc-buffers-transactional temporary-specs device-id)

--- a/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.layout-stage :as layout]
@@ -106,6 +107,13 @@
                                                  {:type (:dtype slot) :value (launch/resolve-expression {} value)}
                                                  (get buffers value)))
                                              (:abi a) (:arguments a)))) (:nodes g))))]
+    (is (= [] (graph-call/external-alias-violations
+               ordinary {'A :shared-ac 'B :weights 'C :shared-ac} =)))
+    (is (= [:kernel-graph-writable-alias]
+           (mapv :reason (graph-call/external-alias-violations
+                          fused {'A :shared-ac 'B :weights 'C :shared-ac} =))))
+    (is (= [] (graph-call/external-alias-violations
+               fused {'A :activation 'B :weights 'C :result} =)))
     (is (= 3 (count (calls ordinary true))) "global conversion snapshots A before C is written")
     (is (= 2 (count (calls fused false))))
     (is (= :kernel-abi-no-write-alias

--- a/test/raster/gpu/buffer_view_test.clj
+++ b/test/raster/gpu/buffer_view_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.gpu.core :as gpu]))
 
 (defn- allocation [id bytes ownership]
@@ -65,19 +66,30 @@
         overlap (bview/view allocation {:id :overlap :byte-offset 16 :dtype :float :shape [8]})
         use (fn [id access] (kgraph/->ValueUse id access))
         node (fn [id uses deps] (kgraph/->ScheduledKernel id :mock uses nil deps))
-        validate! (ns-resolve 'raster.gpu.core 'validate-physical-aliases!)]
+        graph (fn [nodes]
+                (kgraph/make {:inputs [(kgraph/buffer :a :float 8 :shared :inout)
+                                      (kgraph/buffer :b :float 8 :shared :inout)]
+                              :nodes nodes}))
+        validate! (fn [g bindings] (graph-call/validate-external-aliases! g bindings bview/overlaps?))]
     (testing "disjoint views of one allocation are legal"
-      (is (map? (validate! {:nodes [(node :one [(use :a :read) (use :b :write)] [])]}
-                           {:a {:view left} :b {:view right}}))))
+      (is (map? (validate! (graph [(node :one [(use :a :read) (use :b :write)] [])])
+                           {:a left :b right}))))
     (testing "one kernel cannot receive contradictory overlapping writable identities"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"overlapping writable"
-                            (validate! {:nodes [(node :one [(use :a :read) (use :b :write)] [])]}
-                                       {:a {:view left} :b {:view overlap}}))))
+                            (validate! (graph [(node :one [(use :a :read) (use :b :write)] [])])
+                                       {:a left :b overlap}))))
+    (testing "missing, excess and nil bindings are not alias proofs"
+      (let [g (graph [(node :one [(use :a :read) (use :b :write)] [])])]
+        (doseq [bindings [{:a left} {:a left :b right :extra left} {:a left :b nil}]]
+          (is (= :kernel-graph-alias-bindings
+                 (try (validate! g bindings) nil (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+        (is (= [{:reason :kernel-graph-writable-alias :node :one :left :a :right :b}]
+               (graph-call/external-alias-violations g {:a left :b overlap} bview/overlaps?)))))
     (testing "an alias-induced cross-kernel hazard needs an edge"
       (let [first-node (node :first [(use :a :write)] [])
             unsafe (node :second [(use :b :read)] [])
             safe (assoc unsafe :dependencies [:first])
-            bindings {:a {:view left} :b {:view overlap}}]
+            bindings {:a left :b overlap}]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"omits a dependency"
-                              (validate! {:nodes [first-node unsafe]} bindings)))
-        (is (map? (validate! {:nodes [first-node safe]} bindings)))))))
+                              (validate! (graph [first-node unsafe]) bindings)))
+        (is (map? (validate! (graph [first-node safe]) bindings)))))))


### PR DESCRIPTION
Extract the existing same-node writable-alias and cross-node dependency checks from gpu.core into kernel-graph-call. The runtime reuses this pure preflight before allocation. Require exactly all non-nil public bindings, so missing facts cannot masquerade as disjointness, and expose structured violations for future candidate admission.

This is specifically graph access/dependency legality: dtype, capacity, scalar and node ABI checks remain separate. No pointer predicates were added to selector IR, no arbitrary binder exceptions are swallowed, and no automatic fallback/default change is introduced yet.

Validation:
- Graph-call, graph-runner and BufferView suites: 16 tests, 92 assertions, zero failures/errors.
- Real staged/fused graph applicability tests: 4 tests, 37 assertions, zero failures/errors.
- Real Level Zero constant-weight replay after extraction: 3328 exact checked outputs.
- Tests no longer reach through ns-resolve to the private alias checker. Missing/excess/nil bindings and structured same-node violations are covered.
- Full suite and vendor compile gates on CI.