### PR TITLE
Separate kernel dispatch preference from concrete binding admission

### DIFF
--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -162,8 +162,8 @@
                       {:expected (count abi) :actual (count arguments) :abi abi})))
     arguments))
 
-(defn validate-alias-contracts!
-  "Enforce ABI no-write-alias requirements for complete ordered arguments.
+(defn alias-contract-violations
+  "Return ABI no-write-alias violations for complete ordered arguments.
 
   `overlaps?` receives two pointer values and must conservatively report whether their physical
   ranges overlap. Compiler-symbol validation may use equality; runtime call validation supplies
@@ -178,13 +178,18 @@
         stable-inputs (filterv (fn [[slot _]]
                                  (= :no-write-alias (:aliasing slot))) pairs)
         outputs (filterv (fn [[slot _]] (writable? slot)) pairs)]
-    (doseq [[input-slot input] stable-inputs
-            [output-slot output] outputs
-            :when (overlaps? input output)]
-      (throw (ex-info "kernel stable input overlaps a writable output"
-                      {:reason :kernel-abi-no-write-alias
-                       :input-slot input-slot :output-slot output-slot})))
-    arguments))
+    (vec (for [[input-slot input] stable-inputs
+               [output-slot output] outputs
+               :when (overlaps? input output)]
+           {:reason :kernel-abi-no-write-alias
+            :input-slot input-slot :output-slot output-slot}))))
+
+(defn validate-alias-contracts!
+  "Enforce ABI no-write-alias requirements using the same facts as candidate admission."
+  [abi arguments overlaps?]
+  (when-let [violation (first (alias-contract-violations abi arguments overlaps?))]
+    (throw (ex-info "kernel stable input overlaps a writable output" violation)))
+  arguments)
 
 (defn validate-split-binding!
   "Validate the compatibility binder shape `(pointers, user-scalars, implicit-bound)` against an

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -296,3 +296,49 @@
                           (:strategy range)
                           (reduced strategy)))
                       below ranges)))))))))
+
+(defn admit-alternative
+  "Admit a preferred executable against concrete binding facts, without allocating resources.
+
+   `violations` is a pure preflight callback of one executable returning a vector of maps with
+   keyword :reason values; [] means applicable. It must check all binding-dependent obligations
+   relevant to the caller. Callback exceptions propagate, never masquerading as inapplicability.
+   Only automatic selection may fall back, and only to the declared default. Explicit overrides
+   fail if inapplicable. Returns the executable and the attempted strategies for diagnostics.
+   The callback and binding facts are not stored in the serializable dispatch/selector IR."
+  ([dispatch runtime-arguments violations]
+   (admit-alternative dispatch runtime-arguments nil violations))
+  ([dispatch runtime-arguments override violations]
+   (when-not (ifn? violations)
+     (throw (ex-info "kernel dispatch admission requires a preflight callback"
+                     {:reason :kernel-dispatch-admission-callback})))
+   (let [preferred (select-alternative dispatch runtime-arguments override)
+         explicit? (and override (not= :auto override))
+         check (fn [executable]
+                 (let [result (violations executable)]
+                   (when-not (and (vector? result)
+                                  (every? #(and (map? %) (keyword? (:reason %))) result))
+                     (throw (ex-info "kernel dispatch preflight returned malformed violations"
+                                     {:reason :kernel-dispatch-admission-result
+                                      :id (:id dispatch)
+                                      :strategy (alternative-strategy executable)
+                                      :violations result})))
+                   {:strategy (alternative-strategy executable) :violations result}))
+         first-attempt (check preferred)
+         accept (fn [executable attempts]
+                  {:executable executable :attempts attempts})
+         reject (fn [attempts]
+                  (throw (ex-info "kernel dispatch has no applicable selected alternative"
+                                  {:reason :kernel-dispatch-inapplicable
+                                   :id (:id dispatch) :override override
+                                   :attempts attempts})))]
+     (if (empty? (:violations first-attempt))
+       (accept preferred [first-attempt])
+       (if (or explicit? (= (:strategy first-attempt) (:default-strategy dispatch)))
+         (reject [first-attempt])
+         (let [fallback (default-alternative dispatch)
+               fallback-attempt (check fallback)
+               attempts [first-attempt fallback-attempt]]
+           (if (empty? (:violations fallback-attempt))
+             (accept fallback attempts)
+             (reject attempts))))))))

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -71,6 +71,98 @@
                :at-least :subgroup-score-reuse
                :otherwise :reference}}))
 
+(deftest binding-admission-separates-preference-from-applicability
+  (let [arguments [:x :out 512]
+        hazard [{:reason :kernel-graph-writable-alias :left 'x :right 'out}]
+        calls (atom [])
+        preflight (fn [executable]
+                    (swap! calls conj (kexec/strategy executable))
+                    (if (= executable subgroup) hazard []))
+        admission (kdispatch/admit-alternative dispatch arguments preflight)]
+    (is (= reference (:executable admission)))
+    (is (= [:subgroup-score-reuse :reference] @calls))
+    (is (= [{:strategy :subgroup-score-reuse :violations hazard}
+            {:strategy :reference :violations []}]
+           (:attempts admission)))
+    (testing "a cached fixed preference is still subject to admission"
+      (is (= reference
+             (:executable (kdispatch/admit-alternative
+                           (kdispatch/with-selector dispatch
+                             {:kind :fixed-strategy :strategy :subgroup-score-reuse})
+                           arguments :auto preflight)))))
+    (testing "disjoint inputs retain the preferred executable"
+      (is (= subgroup (:executable (kdispatch/admit-alternative
+                                   dispatch arguments (constantly []))))))
+    (testing "an explicit request never silently falls back"
+      (reset! calls [])
+      (let [error (try (kdispatch/admit-alternative dispatch arguments
+                                                   :subgroup-score-reuse preflight)
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= :kernel-dispatch-inapplicable (:reason error)))
+        (is (= [:subgroup-score-reuse] @calls))))
+    (testing "a rejected default is checked only once"
+      (let [calls (atom 0)
+            error (try (kdispatch/admit-alternative
+                        dispatch [:x :out 32]
+                        (fn [_] (swap! calls inc) hazard))
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= 1 @calls))
+        (is (= [{:strategy :reference :violations hazard}] (:attempts error)))))
+    (testing "both rejections remain available to diagnostics"
+      (let [error (try (kdispatch/admit-alternative dispatch arguments (constantly hazard))
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= [:subgroup-score-reuse :reference] (mapv :strategy (:attempts error))))
+        (is (= [hazard hazard] (mapv :violations (:attempts error))))))
+    (testing "preflight failures are not treated as a reason to select another kernel"
+      (let [failure (ex-info "broken preflight" {:reason :unexpected})]
+        (is (identical? failure
+                        (try (kdispatch/admit-alternative dispatch arguments
+                                                        (fn [_] (throw failure)))
+                             (catch Exception e e))))))
+    (testing "a malformed preflight cannot accidentally admit a kernel"
+      (doseq [result [nil false {} [nil] [{}] [{:reason "not-a-keyword"}]]]
+        (is (= :kernel-dispatch-admission-result
+               (try (kdispatch/admit-alternative dispatch arguments (constantly result))
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))))
+
+(deftest admission-reuses-abi-alias-contract-authority
+  (let [leaf (assoc-in subgroup [:abi 0 :aliasing] :no-write-alias)
+        strict (kgraph/make
+                {:inputs [(kgraph/buffer 'x :float 'width :device :input)]
+                 :outputs [(kgraph/buffer 'out :float 'width :device :output)]
+                 :temporaries [] :abi abi :arguments '[x out width]
+                 :scalars [(kgraph/scalar 'width :long)]
+                 :nodes [(kgraph/->ScheduledKernel
+                          :compute leaf
+                          [(kgraph/->ValueUse 'x :read) (kgraph/->ValueUse 'out :write)]
+                          #{'width} [])]
+                 :effects (:effects reference)
+                 :attributes {:strategy :subgroup-score-reuse}})
+        choice (assoc dispatch :alternatives [reference strict])
+        admit (fn [arguments override]
+                (kdispatch/admit-alternative
+                 choice arguments override
+                 #(kabi/alias-contract-violations
+                   (if (= % strict) (:abi leaf) (kexec/abi %)) arguments =)))
+        overlapping [:same :same 512]
+        violations (kabi/alias-contract-violations (:abi leaf) overlapping =)]
+    (is (= reference (:executable (admit overlapping :auto))))
+    (is (= strict (:executable (admit [:left :right 512] :auto))))
+    (is (= 1 (count violations)))
+    (is (= :kernel-abi-no-write-alias (:reason (first violations))))
+    (is (= (first violations)
+           (try (kabi/validate-alias-contracts! (:abi leaf) overlapping =)
+                (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+    (is (= violations
+           (try (admit overlapping :subgroup-score-reuse)
+                (catch clojure.lang.ExceptionInfo e
+                  (get-in (ex-data e) [:attempts 0 :violations])))))
+    (testing "all forbidden pairs are reported, rather than just the first"
+      (let [abi [(kabi/slot 'a :input :float :aliasing :no-write-alias)
+                 (kabi/slot 'b :input :float :aliasing :no-write-alias)
+                 (kabi/slot 'c :output :float)]]
+        (is (= 2 (count (kabi/alias-contract-violations abi [:same :same :same] =))))))))
+
 (deftest forced-and-cached-choices-still-enforce-binding-preconditions
   (let [guarded (assoc subgroup :preconditions [{:expression 'width :op :>= :value 256}])
         choice (assoc dispatch :alternatives [reference guarded])


### PR DESCRIPTION
## Summary
- Add pure binding-admission orchestration after scalar strategy preference. Automatic and cached choices may fall back only to an applicable declared default; explicit overrides fail closed.
- Preserve structured rejection diagnostics and propagate unexpected preflight failures without masking them.
- Extract ABI alias-contract violations as the common authority for validation and admission, including stricter internal node contracts behind an unchanged public graph ABI.

## Validation
- Existing capped REPL: dispatch tests 23 tests / 112 assertions; ABI and KernelCall tests 37 tests / 136 assertions; all pass.
- git diff --check clean. Full suite and target compile gates delegated to CI.

## Boundary
This is the admission prerequisite, not runtime integration or automatic fused-candidate promotion. Concrete graph/node preflight and staged/resident wiring follow. No performance claim or default selector change.