### PR TITLE
Preflight concrete alias contracts before staged and resident dispatch binding

### DIFF
--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -155,7 +155,9 @@
     (catch UnsupportedOperationException _
       (identical? left right))))
 
-(defn- pointer-overlaps?
+(defn pointer-overlaps?
+  "Compare the concrete pointer representations accepted by KernelCall, including views and
+   native segment ranges. Shared by validation and pre-allocation dispatch admission."
   [left right]
   (let [left-view (resident-view left)
         right-view (resident-view right)

--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -4,7 +4,8 @@
    KernelGraph owns stable buffers, node uses and dependencies. KernelGraphCall supplies one
    resident value for every graph buffer and turns each emitted node into a checked KernelCall.
    Driver allocation, registration, recording and events remain runtime concerns."
-  (:require [raster.compiler.ir.kernel-artifact :as kart]
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph :as kgraph]
@@ -76,6 +77,52 @@
                      :kernel-graph-alias-dependency
                      "kernel graph omits a dependency introduced by overlapping resident views")
                     violation)))
+  bindings)
+
+(defn binding-alias-violations
+  "Check graph hazards and public/node ABI alias contracts before private allocation.
+   Requires complete public bindings. Each private graph buffer denotes a fresh disjoint
+   allocation; repeated references to that same private buffer still alias. The supplied overlap
+   predicate compares only real public pointer values. Scalar, extent and alignment checks are
+   separate obligations, not inferred from an empty alias result."
+  [graph bindings overlaps?]
+  (let [graph (executable/validate! graph)
+        hazards (external-alias-violations graph bindings overlaps?)
+        public (set (keys bindings))
+        private (set (map :id (:temporaries graph)))
+        ;; Compare graph identities, resolving only public identities to physical values. This
+        ;; avoids inventing fake resident pointers or conflating unknown storage with disjointness.
+        alias? (fn [left right]
+                 (cond
+                   (and (contains? public left) (contains? public right))
+                   (overlaps? (get bindings left) (get bindings right))
+                   (and (contains? private left) (contains? private right)) (= left right)
+                   (or (and (contains? public left) (contains? private right))
+                       (and (contains? private left) (contains? public right))) false
+                   :else (throw (ex-info "alias contract names an undeclared graph buffer"
+                                         {:reason :kernel-graph-alias-buffer
+                                          :left left :right right}))))
+        contracts (fn [abi arguments]
+                    (kabi/alias-contract-violations abi arguments alias?))]
+    (into (into hazards (contracts (:abi graph) (:arguments graph)))
+          (mapcat (fn [{:keys [id operation]}]
+                    (map #(assoc % :node id)
+                         (contracts (:abi operation) (:arguments operation)))))
+          (:nodes graph))))
+
+(defn validate-binding-aliases!
+  "Enforce graph and node ABI alias contracts before graph-private allocation."
+  [graph bindings overlaps?]
+  (when-let [violation (first (binding-alias-violations graph bindings overlaps?))]
+    (throw (ex-info
+            (case (:reason violation)
+              :kernel-graph-writable-alias
+              "one kernel cannot bind overlapping writable graph buffer views"
+              :kernel-graph-alias-dependency
+              "kernel graph omits a dependency introduced by overlapping resident views"
+              :kernel-abi-no-write-alias
+              "kernel stable input overlaps a writable output")
+            violation)))
   bindings)
 
 (defn direct-scalar-range-preconditions

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1425,7 +1425,7 @@
                                    buffer-keys)
            _ (doseq [[id {:keys [view]}] external-bindings]
                (validate-external-view! (get graph-buffer-by-id id) view scalar-values))
-           _ (kgcall/validate-external-aliases! graph (update-vals external-bindings :view) bview/overlaps?)
+           _ (kgcall/validate-binding-aliases! graph (update-vals external-bindings :view) bview/overlaps?)
            _ (release-graph-events! sess graph-key)
            temporary-specs (kgcall/temporary-specs graph scalar-values)
            temporary-buffers (alloc-buffers-transactional temporary-specs device-id)
@@ -1589,6 +1589,17 @@
            (bind-kernel-graph! sess executable-key executable buffers scalar-values
                                (select-keys options [:profile?]))))))))
 
+(defn- executable-alias-violations
+  "Pure storage admission; ordinary scalar, capacity, alignment and backend checks still apply."
+  [executable runtime-arguments]
+  (case (kexec/kind executable)
+    :kernel-artifact
+    (kabi/alias-contract-violations (kexec/abi executable) runtime-arguments
+                                   kcall/pointer-overlaps?)
+    :kernel-graph
+    (let [{:keys [buffers]} (kexec/graph-bindings executable runtime-arguments)]
+      (kgcall/binding-alias-violations executable buffers kcall/pointer-overlaps?))))
+
 (defn- staged-pointer-plan
   "Validate and group ABI pointer values by object identity before any allocation.
 
@@ -1690,8 +1701,16 @@
         dispatch (kdispatch/validate! dispatch)
         common (kdispatch/default-alternative dispatch)
         typed-arguments (kexec/typed-runtime-arguments common runtime-arguments)
-        executable (kdispatch/select-alternative dispatch typed-arguments)
-        {:keys [groups arguments]} (staged-pointer-plan device-id executable typed-arguments)
+        ;; Validate the shared input representation before asking whether any schedule can use
+        ;; these bindings. This pass groups identities but does not allocate or open a session.
+        common-plan (staged-pointer-plan device-id common typed-arguments)
+        executable (:executable
+                    (kdispatch/admit-alternative
+                     dispatch typed-arguments
+                     #(executable-alias-violations % typed-arguments)))
+        {:keys [groups arguments]} (if (identical? common executable)
+                                    common-plan
+                                    (staged-pointer-plan device-id executable typed-arguments))
         result-pairs (filterv (fn [[slot _]] (= :result (:role slot)))
                               (map vector (kexec/abi executable) typed-arguments))]
     (when (and (= :single result-policy) (> (count result-pairs) 1))
@@ -1827,6 +1846,7 @@
       :kernel-graph
       (let [{:keys [buffers scalar-values]}
             (kexec/graph-bindings executable runtime-arguments)
+            _ (kgcall/validate-binding-aliases! executable buffers kcall/pointer-overlaps?)
             extent-values (into {} (map (fn [[id buffer]]
                                           [(list 'extent id) (:n-elements buffer)])) buffers)
             _ (doseq [buffer-spec (concat (:inputs executable) (:outputs executable))
@@ -1893,8 +1913,10 @@
                (rt-resolve device-id "expand-pointer-binding"))
               logical-or-physical-args)
             selected (if-let [dispatch (:dispatch step)]
-                       (kdispatch/select-alternative
-                        dispatch ordered-args (step-selection-override step schedule))
+                       (:executable
+                        (kdispatch/admit-alternative
+                         dispatch ordered-args (step-selection-override step schedule)
+                         #(executable-alias-violations % ordered-args)))
                        artifact)
             constant-buffer-ids
             (when (= :kernel-graph (kexec/kind selected))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1643,7 +1643,19 @@
               (vswap! groups conj {:key key :value value :dtype actual-dtype
                                    :elements elements :resident? resident?
                                    :indexes [index] :read? read? :write? write?}))))))
-    (when (= :kernel-graph (kexec/kind executable))
+    (let [groups @groups
+          key-by-index (reduce (fn [result {:keys [key indexes]}]
+                                 (reduce #(assoc %1 %2 key) result indexes))
+                               {} groups)]
+      {:groups groups
+       :arguments (mapv (fn [index [slot value]]
+                          (if (= :scalar (:kind slot)) value (get key-by-index index)))
+                        (range) (map vector (kexec/abi executable) typed-arguments))})))
+
+(defn- validate-staged-graph-capacities!
+  "Check the selected graph's extents, not the unselected default schedule's extents."
+  [executable typed-arguments]
+  (when (= :kernel-graph (kexec/kind executable))
       (let [{:keys [buffers scalar-values]} (kexec/graph-bindings executable typed-arguments)
             capacity-of (fn [value]
                           (if (dtype/dtype-for-jvm-array value)
@@ -1669,15 +1681,7 @@
             (throw (ex-info "staged graph buffer extent exceeds its supplied capacity"
                             {:reason :staged-graph-buffer-capacity
                              :buffer id :elements elements :resolved expected-elements
-                             :capacity actual-elements :graph-buffer graph-buffer}))))))
-    (let [groups @groups
-          key-by-index (reduce (fn [result {:keys [key indexes]}]
-                                 (reduce #(assoc %1 %2 key) result indexes))
-                               {} groups)]
-      {:groups groups
-       :arguments (mapv (fn [index [slot value]]
-                          (if (= :scalar (:kind slot)) value (get key-by-index index)))
-                        (range) (map vector (kexec/abi executable) typed-arguments))})))
+                             :capacity actual-elements :graph-buffer graph-buffer})))))))
 
 (declare run-kernel-graph!)
 
@@ -1703,14 +1707,12 @@
         typed-arguments (kexec/typed-runtime-arguments common runtime-arguments)
         ;; Validate the shared input representation before asking whether any schedule can use
         ;; these bindings. This pass groups identities but does not allocate or open a session.
-        common-plan (staged-pointer-plan device-id common typed-arguments)
+        {:keys [groups arguments]} (staged-pointer-plan device-id common typed-arguments)
         executable (:executable
                     (kdispatch/admit-alternative
                      dispatch typed-arguments
                      #(executable-alias-violations % typed-arguments)))
-        {:keys [groups arguments]} (if (identical? common executable)
-                                    common-plan
-                                    (staged-pointer-plan device-id executable typed-arguments))
+        _ (validate-staged-graph-capacities! executable typed-arguments)
         result-pairs (filterv (fn [[slot _]] (= :result (:role slot)))
                               (map vector (kexec/abi executable) typed-arguments))]
     (when (and (= :single result-policy) (> (count result-pairs) 1))

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -8,6 +8,7 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-tuning :as tuning]
@@ -231,6 +232,110 @@
                 (kgraph/->ValueUse 'out :write)] #{'width} [:stage-one])]
       :effects (:effects reference)
       :attributes {:strategy :two-stage}})))
+
+(defn- direct-graph []
+  (kgraph/make
+   {:inputs [(kgraph/buffer 'x :float 'width :device :input)]
+    :outputs [(kgraph/buffer 'out :float 'width :device :output)]
+    :temporaries [] :abi abi :arguments '[x out width]
+    :scalars [(kgraph/scalar 'width :long)]
+    :nodes [(kgraph/->ScheduledKernel
+             :direct (assoc-in subgroup [:abi 0 :aliasing] :no-write-alias)
+             [(kgraph/->ValueUse 'x :read) (kgraph/->ValueUse 'out :write)] #{'width} [])]
+    :effects (:effects reference) :attributes {:strategy :direct}}))
+
+(defn- storage-dispatch []
+  (kdispatch/make
+   {:id "storage-dispatch" :alternatives [(staged-graph) (direct-graph)]
+    :default-strategy :two-stage
+    :selector {:kind :fixed-strategy :strategy :direct}}))
+
+(deftest graph-storage-admission-includes-internal-abi-and-physical-ranges
+  (let [allocation (bview/allocation {:id :admission :byte-size 64 :memory-space :device
+                                     :ownership :borrowed})
+        left (bview/view allocation {:id :left :dtype :float :shape [8]})
+        overlap (bview/view allocation {:id :overlap :byte-offset 16 :dtype :float :shape [8]})
+        right (bview/view allocation {:id :right :byte-offset 32 :dtype :float :shape [8]})
+        check #(kgcall/binding-alias-violations %1 {'x left 'out %2} kcall/pointer-overlaps?)]
+    (is (empty? (check (staged-graph) overlap))
+        "the ordered copy stage snapshots the overlapping source")
+    (is (empty? (check (direct-graph) right)))
+    (let [violations (check (direct-graph) overlap)]
+      (is (= #{:kernel-graph-writable-alias :kernel-abi-no-write-alias}
+             (set (map :reason violations))))
+      (is (every? #(= :direct (:node %)) violations)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exactly every public"
+                         (kgcall/binding-alias-violations (direct-graph) {'x left}
+                                                         kcall/pointer-overlaps?)))))
+
+(deftest staged-storage-admission-precedes-session-and-preserves-snapshot-fallback
+  (let [selected (atom [])
+        input (float-array 3)
+        separate (float-array 3)]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" (constantly (storage-dispatch))
+           "device-buffer?" (constantly false)))
+       #'gpu/with-gpu-session* (fn [_ body] (body (atom {:device-id :probe})))
+       #'gpu/alloc! (fn [& _])
+       #'gpu/bind-kernel-executable!
+       (fn [_ _ executable _] (swap! selected conj (kexec/strategy executable)) :handle)
+       #'gpu/run-kernel-graph! (fn [& _])
+       #'gpu/download-range! (fn [& _])}
+      (fn []
+        (gpu/invoke-staged-executable! :probe "storage-dispatch" [input input 3])
+        (gpu/invoke-staged-executable! :probe "storage-dispatch" [input separate 3])
+        (is (= [:two-stage :direct] @selected))))
+    (testing "a rejected sole default cannot open a session"
+      (with-redefs-fn
+        {#'raster.gpu.core/rt-resolve
+         (fn [_ function-name]
+           (case function-name
+             "kernel-dispatch-registry-entry"
+             (constantly (kdispatch/make
+                          {:id "strict-only" :alternatives [(direct-graph)]
+                           :default-strategy :direct
+                           :selector {:kind :fixed-strategy :strategy :direct}}))
+             "device-buffer?" (constantly false)))
+         #'gpu/with-gpu-session* (fn [& _] (throw (AssertionError. "opened session")))}
+        #(is (= :kernel-dispatch-inapplicable
+                (try (gpu/invoke-staged-executable! :probe "strict-only" [input input 3])
+                     (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))))
+
+(deftest resident-storage-admission-precedes-backend-binding
+  (let [step {:kernel-name "storage-dispatch" :phase :probe :convention :executable
+              :dispatch (storage-dispatch)
+              :strategy-selection {:path [:strategy] :mapping {:direct :direct} :default :auto}
+              :argument-specs [{:kind :input :sym 'x} {:kind :output :sym 'out}
+                               {:kind :scalar :type :long :value-fn (constantly 3)}]}
+        selected (atom [])
+        bind! (fn [input output schedule]
+                (gpu/bind-step! (atom {:device-id :probe :buffers {'x input 'out output}})
+                                step {} identity {:schedule schedule}))]
+    (with-redefs-fn
+      {#'raster.gpu.core/bind-selected-executable
+       (fn [_ executable & _]
+         (swap! selected conj (kexec/strategy executable))
+         (gpu/->BoundExecutableStep [] {} []))}
+      (fn []
+        (bind! :same :same {})
+        (bind! :same :separate {})
+        (is (= [:two-stage :direct] @selected))
+        (is (= :kernel-dispatch-inapplicable
+               (try (bind! :same :same {:strategy :direct})
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+        (is (= [:two-stage :direct] @selected)
+            "explicit rejection did not enter the backend binder")
+        (testing "distinct resident wrappers retain their physical range facts"
+          (let [segment (java.lang.foreign.MemorySegment/ofArray (float-array 16))
+                buffer (fn [offset] {:segment (.asSlice segment offset 32)
+                                     :dtype :float :n-elements 8 :byte-size 32})]
+            (reset! selected [])
+            (bind! (buffer 0) (buffer 16) {})
+            (bind! (buffer 0) (buffer 32) {})
+            (is (= [:two-stage :direct] @selected))))))))
 
 (deftest graph-node-compilation-requirements-invalidate-tuning
   (let [graph (staged-graph)

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -304,6 +304,32 @@
                 (try (gpu/invoke-staged-executable! :probe "strict-only" [input input 3])
                      (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))))
 
+(deftest staged-admission-does-not-impose-an-unselected-default-extent
+  (let [choice (update (storage-dispatch) :alternatives
+                       (fn [[snapshot direct]]
+                         [(assoc-in snapshot [:inputs 0 :elements] 4) direct]))
+        input (float-array 3)
+        opened? (atom false)]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" (constantly choice)
+           "device-buffer?" (constantly false)))
+       #'gpu/with-gpu-session*
+       (fn [& _] (reset! opened? true) (throw (ex-info "past preflight" {:reason :past-preflight})))}
+      (fn []
+        (is (= :past-preflight
+               (try (gpu/invoke-staged-executable! :probe "storage-dispatch"
+                                                  [input (float-array 3) 3])
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+        (is @opened?)
+        (reset! opened? false)
+        (is (= :staged-graph-buffer-capacity
+               (try (gpu/invoke-staged-executable! :probe "storage-dispatch" [input input 3])
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+        (is (false? @opened?) "the selected fallback must meet its own capacity contract")))))
+
 (deftest resident-storage-admission-precedes-backend-binding
   (let [step {:kernel-name "storage-dispatch" :phase :probe :convention :executable
               :dispatch (storage-dispatch)

--- a/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
@@ -3,6 +3,8 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-call :as call]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.kernel-graph :as graph]
@@ -114,6 +116,19 @@
                           fused {'A :shared-ac 'B :weights 'C :shared-ac} =))))
     (is (= [] (graph-call/external-alias-violations
                fused {'A :activation 'B :weights 'C :result} =)))
+    (let [choice (dispatch/make
+                  {:id "matrix-storage-admission" :alternatives [ordinary fused]
+                   :default-strategy (executable/strategy ordinary)
+                   :selector {:kind :fixed-strategy :strategy (executable/strategy fused)}})
+          admit (fn [buffers override]
+                  (dispatch/admit-alternative
+                   choice (mapv buffers (:arguments ordinary)) override
+                   #(graph-call/binding-alias-violations % buffers =)))]
+      (is (= ordinary (:executable (admit {'A :same 'B :weights 'C :same} :auto))))
+      (is (= fused (:executable (admit {'A :input 'B :weights 'C :output} :auto))))
+      (is (= :kernel-dispatch-inapplicable
+             (try (admit {'A :same 'B :weights 'C :same} (executable/strategy fused))
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
     (is (= 3 (count (calls ordinary true))) "global conversion snapshots A before C is written")
     (is (= 2 (count (calls fused false))))
     (is (= :kernel-abi-no-write-alias


### PR DESCRIPTION
## Summary
- Share graph access/dependency and public/node ABI alias checks before graph-private allocation. Private storage is fresh and disjoint except for repeated references to the same private buffer.
- Apply binding-aware admission in staged and resident descriptor dispatch: cached/automatic incompatible choices fall back only to the declared default; explicit incompatible requests fail closed.
- Reuse existing concrete BufferView and native segment overlap semantics. Validate shared pointer representations once, then enforce only the selected graph capacity contracts.

## Validation
- Capped existing REPL: 43 tests / 216 assertions across dispatch, graph calls, buffer views and actual emitted matrix fusion graphs; all pass.
- Real Level Zero constant-weight smoke: 3328 exact output elements checked, both staged and fused candidates pass.
- Read-only review identified default-extent narrowing; fixed and regression tested.
- git diff --check clean; full suite and vendor compile gates on CI.

## Scope
This admits storage alias compatibility, not every possible target/scalar/capacity/alignment failure. Those checks remain enforced normally and are not caught as fallback signals. Resident external sub-buffer materialization still precedes descriptor selection; graph-private allocations and backend kernel binding follow admission. No new candidate enumeration, automatic performance promotion or tuning winner claim.