### PR TITLE
Exclude binding-inapplicable candidates from offline kernel tuning

### DIFF
--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1600,6 +1600,23 @@
     (let [{:keys [buffers]} (kexec/graph-bindings executable runtime-arguments)]
       (kgcall/binding-alias-violations executable buffers kcall/pointer-overlaps?))))
 
+(defn kernel-executable-alias-violations
+  "Query concrete alias compatibility of an executable's ABI-ordered session keys/views.
+   Resolves live allocation contracts without creating sub-buffers, recording or allocating.
+   Returns structured violations; invalid/missing bindings throw. This is alias preflight only,
+   not proof of scalar, capacity, alignment or target applicability."
+  [sess executable arguments]
+  (let [executable (kexec/validate! executable)
+        abi (kexec/abi executable)
+        _ (when (:closed? @sess)
+            (throw (ex-info "cannot preflight a closed GPU session" {})))
+        _ (kabi/validate-arguments! abi arguments)
+        values (mapv (fn [slot argument]
+                       (if (= :scalar (:kind slot)) argument
+                           (:view (resolve-resident-binding sess argument))))
+                     abi arguments)]
+    (executable-alias-violations executable values)))
+
 (defn- staged-pointer-plan
   "Validate and group ABI pointer values by object identity before any allocation.
 

--- a/src/raster/gpu/dispatch_benchmark.clj
+++ b/src/raster/gpu/dispatch_benchmark.clj
@@ -97,7 +97,9 @@
 
    The context contains :session, :dispatch, :executable, :runtime-value, :case, and after the
    validation replay, :outputs. The driver supplies :candidate-hash itself, so a callback cannot
-   accidentally validate one source and bless another."
+   accidentally validate one source and bless another. Alias-inapplicable bindings return
+   {:status :inapplicable :candidate-hash ... :violations [...]} before binding or timing;
+   malformed bindings and other failures still throw."
   [session dispatch executable runtime-value case-fn & {:keys [measurement]}]
   (let [dispatch (kdispatch/validate! dispatch)
         strategy (kdispatch/alternative-strategy executable)
@@ -115,7 +117,11 @@
     (when (seq reserved)
       (throw (ex-info "dispatch benchmark measurement options contain driver-owned fields"
                       {:runtime-value runtime-value :reserved reserved})))
-    (let [key [::candidate runtime-value (kdispatch/alternative-strategy executable) (random-uuid)]
+    (if-let [violations (seq (gpu/kernel-executable-alias-violations
+                             session executable (:arguments case)))]
+      {:status :inapplicable :violations (vec violations)
+       :candidate-hash (:source-hash (tuning/executable-signature executable))}
+      (let [key [::candidate runtime-value (kdispatch/alternative-strategy executable) (random-uuid)]
           started (System/nanoTime)
           handle (gpu/bind-kernel-executable! session key executable (:arguments case)
                                               {:profile? true
@@ -140,7 +146,7 @@
                               session handle (mapcat identity opts))]
           {:measurement measured :validation validation})
         (finally
-          (gpu/release-kernel-graph! session handle))))))
+          (gpu/release-kernel-graph! session handle)))))))
 
 (defn tune-dispatch!
   "Tune an emitted KernelDispatch through resident validation and device-event measurement.

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -14,7 +14,7 @@
   (:import [java.nio.charset StandardCharsets]
            [java.security MessageDigest]))
 
-(def tuning-version 3)
+(def tuning-version 4)
 
 (defrecord DispatchTuning
            [key identity selector measurements])
@@ -147,7 +147,7 @@
   [:min-ns :median-ns :p75-ns :mean-ns :cv :stationary? :n :warmup-iterations
    :budget-ms :cold-warm :timing-source :compile-ms :hashes])
 
-(defn- validate-benchmark-result!
+(defn- validate-measured-result!
   [executable runtime-value result]
   (let [{:keys [measurement validation]} result
         signature (executable-signature executable)]
@@ -182,6 +182,28 @@
      :validation (select-keys validation
                               [:passed? :oracle-hash :candidate-hash :max-error :rtol :atol])}))
 
+(defn- validate-benchmark-result!
+  [executable runtime-value result]
+  (if (= :inapplicable (:status result))
+    (let [signature (executable-signature executable)
+          {:keys [violations candidate-hash]} result]
+      (when-not (and (= candidate-hash (:source-hash signature))
+                     (vector? violations) (seq violations)
+                     (every? #(and (map? %) (keyword? (:reason %))) violations)
+                     (not (contains? result :measurement))
+                     (not (contains? result :validation)))
+        (throw (ex-info "inapplicable dispatch candidate requires source-bound preflight violations"
+                        {:reason :dispatch-tuning-inapplicable-result
+                         :strategy (:strategy signature) :runtime-value runtime-value
+                         :result result})))
+      {:runtime-value runtime-value :strategy (:strategy signature)
+       :status :inapplicable :candidate-hash candidate-hash :violations violations})
+    (do
+      (when (contains? result :status)
+        (throw (ex-info "unknown dispatch benchmark result status"
+                        {:reason :dispatch-tuning-result-status :status (:status result)})))
+      (validate-measured-result! executable runtime-value result))))
+
 (defn- winner-at
   [rows default-strategy improvement-threshold]
   (let [by-strategy (into {} (map (juxt :strategy identity)) rows)
@@ -189,7 +211,14 @@
                         (throw (ex-info "dispatch measurements omit the default strategy"
                                         {:default-strategy default-strategy
                                          :strategies (set (keys by-strategy))})))
-        best-row (apply min-key #(get-in % [:measurement :min-ns]) rows)
+        _ (when (= :inapplicable (:status default-row))
+            (throw (ex-info "dispatch tuning requires an applicable default strategy"
+                            {:reason :dispatch-tuning-default-inapplicable
+                             :default-strategy default-strategy
+                             :runtime-value (:runtime-value default-row)
+                             :violations (:violations default-row)})))
+        applicable (filterv #(not= :inapplicable (:status %)) rows)
+        best-row (apply min-key #(get-in % [:measurement :min-ns]) applicable)
         default-cost (double (get-in default-row [:measurement :min-ns]))
         best-cost (double (get-in best-row [:measurement :min-ns]))]
     (if (< best-cost (* default-cost (- 1.0 (double improvement-threshold))))
@@ -264,7 +293,9 @@
 
   This is the schedule mode for compile-time axes such as stage depth and shared-memory layout:
   they do not require manufacturing a runtime ABI scalar. The same oracle, stationary device-event,
-  source-hash, device, numerical and layout gates used by sampled tuning remain mandatory."
+  source-hash, device, numerical and layout gates used by sampled tuning remain mandatory.
+  Source-bound :inapplicable results retain their preflight diagnostics but cannot win; the
+  declared default must remain applicable. Runtime binding must recheck transported choices."
   [dispatch descriptor benchmark-fn
    & {:keys [numerical-mode layout improvement-threshold force?]
       :or {improvement-threshold 0.001 force? false}}]

--- a/test/raster/gpu/dispatch_benchmark_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_test.clj
@@ -1,6 +1,7 @@
 (ns raster.gpu.dispatch-benchmark-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -14,6 +15,15 @@
             [raster.gpu.measurement :as measurement]
             [raster.gpu.tuning-cache :as cache])
   (:import [java.nio.file Files]))
+
+(defn- test-session []
+  (let [keys [:x :out :values-resident :out-resident]]
+    (atom {:session-id :benchmark-test
+           :buffers (zipmap keys (repeat {:dtype :float :n-elements 2048 :byte-size 8192}))
+           :allocations (into {} (map (fn [key]
+                                       [key (bview/allocation
+                                             {:id [:benchmark-test key] :byte-size 8192
+                                              :memory-space :device :ownership :borrowed})])) keys)})))
 
 (def ^:private abi
   [(kabi/slot 'x :input :float :role :operand)
@@ -44,6 +54,34 @@
     :selector {:kind :runtime-scalar-threshold
                :argument 'width :threshold 256
                :at-least :subgroup :otherwise :reference}}))
+
+(deftest alias-inapplicability-does-not-bind-run-or-measure
+  (let [strict (assoc-in reference [:abi 0 :aliasing] :no-write-alias)
+        dispatch (kdispatch/make
+                  {:id "alias-benchmark" :alternatives [strict]
+                   :default-strategy :reference
+                   :selector {:kind :fixed-strategy :strategy :reference}})
+        session (test-session)
+        fail (fn [& _] (throw (AssertionError. "inapplicable candidate reached execution")))
+        run (fn [arguments]
+              (benchmark/benchmark-candidate!
+               session dispatch strict :fixed
+               (constantly {:arguments arguments :before-run! fail :validate! fail})))]
+    (with-redefs [gpu/bind-kernel-executable! fail
+                  gpu/run-kernel-graph! fail
+                  gpu/measure-bound-kernel-graph! fail
+                  gpu/release-kernel-graph! fail]
+      (let [result (run [:x :x {:type :long :value 128}])]
+        (is (= :inapplicable (:status result)))
+        (is (= [:kernel-abi-no-write-alias] (mapv :reason (:violations result))))
+        (is (= (:source-hash (tuning/executable-signature strict)) (:candidate-hash result)))
+        (is (not (contains? result :measurement)))
+        (is (not (contains? result :validation))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No buffer"
+                           (run [:missing :out {:type :long :value 128}])))
+      (let [left (gpu/buffer-view session :x {:shape [128]})
+            overlap (gpu/buffer-view session :x {:byte-offset 256 :shape [128]})]
+        (is (= :inapplicable (:status (run [left overlap {:type :long :value 128}]))))))))
 
 (def ^:private descriptor
   {:device-id :ze:0 :vendor "Intel" :arch "test" :driver-version "test-driver"
@@ -86,7 +124,7 @@
                       gpu/release-kernel-graph!
                       (fn [_ handle] (swap! actions conj [:release (:candidate handle)]))]
           (benchmark/benchmark-candidate!
-           (atom {}) dispatch reference 128
+           (test-session) dispatch reference 128
            (fn [_]
              {:arguments [:x :out {:type :long :value 128}]
               :before-run! #(swap! actions conj [:restore (:runtime-value %)])
@@ -128,7 +166,7 @@
                                                :compile-ms compile-ms :hashes hashes))
                       gpu/release-kernel-graph! (fn [& _])]
           (benchmark/benchmark-candidate!
-           :session graph-dispatch graph 1025
+           (test-session) graph-dispatch graph 1025
            (fn [_]
              {:arguments [:values-resident :out-resident n]
               :validate! (fn [{:keys [outputs executable]}]
@@ -152,7 +190,7 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"failed its oracle"
            (benchmark/benchmark-candidate!
-            (atom {}) dispatch reference 128
+            (test-session) dispatch reference 128
             (fn [_]
               {:arguments [:x :out {:type :long :value 128}]
                :validate! (constantly {:passed? false :oracle-hash "host-reference-v1"})}))))
@@ -167,7 +205,7 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"require :before-run!"
          (benchmark/benchmark-candidate!
-          (atom {}) stateful-dispatch stateful 128
+          (test-session) stateful-dispatch stateful 128
           (fn [_]
             {:arguments [:x :out {:type :long :value 128}]
              :validate! (constantly {:passed? true :oracle-hash "oracle"})}))))))
@@ -196,7 +234,7 @@
                     gpu/release-kernel-graph! (fn [& _] (swap! releases inc))]
         (let [result
               (benchmark/tune-dispatch!
-               (atom {}) dispatch descriptor [768 128 256]
+               (test-session) dispatch descriptor [768 128 256]
                (fn [runtime-value]
                  {:arguments [:x :out {:type :long :value runtime-value}]
                   :validate! (constantly {:passed? true
@@ -210,7 +248,7 @@
           (is (= 6 @binds @releases))
           (testing "cached result bypasses resident execution"
             (let [cached (benchmark/tune-dispatch!
-                          (atom {}) dispatch descriptor [128 256 768]
+                          (test-session) dispatch descriptor [128 256 768]
                           (fn [_] (throw (ex-info "must not construct a case" {})))
                           :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
                           :layout {:input :row-major :output :row-major})]

--- a/test/raster/gpu/dispatch_tuning_test.clj
+++ b/test/raster/gpu/dispatch_tuning_test.clj
@@ -86,6 +86,55 @@
   (.toFile (Files/createTempDirectory "raster-dispatch-tuning-"
                                       (make-array java.nio.file.attribute.FileAttribute 0))))
 
+(defn- inapplicable-result [executable]
+  {:status :inapplicable
+   :candidate-hash (:source-hash (tuning/executable-signature executable))
+   :violations [{:reason :kernel-abi-no-write-alias}]})
+
+(deftest inapplicable-candidates-are-retained-but-never-win
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (let [result (tuning/tune!
+                  dispatch descriptor [128 512]
+                  (fn [executable width]
+                    (if (and (= executable subgroup) (= width 128))
+                      (inapplicable-result executable)
+                      (validated-result executable (if (= executable reference) 100 10))))
+                  :numerical-mode numerical-mode :layout layout)
+          fixed (tuning/tune-fixed!
+                 fixed-dispatch descriptor
+                 #(if (= % subgroup) (inapplicable-result %) (validated-result % 100))
+                 :numerical-mode numerical-mode :layout layout)]
+      (is (= 4 (count (:measurements result))))
+      (is (= 1 (count (filter #(= :inapplicable (:status %)) (:measurements result)))))
+      (is (= {:kind :runtime-scalar-ranges :argument 'width :below :reference
+              :ranges [{:at-least 512 :strategy :subgroup}]}
+             (:selector result)))
+      (is (= {:kind :fixed-strategy :strategy :reference} (:selector fixed)))
+      (is (= fixed
+             (tuning/tune-fixed!
+              fixed-dispatch descriptor (fn [_] (throw (AssertionError. "cache miss")))
+              :numerical-mode numerical-mode :layout layout)))
+      (is (= :dispatch-tuning-default-inapplicable
+             (try (tuning/tune-fixed!
+                   fixed-dispatch descriptor
+                   #(if (= % reference) (inapplicable-result %) (validated-result % 10))
+                   :force? true :numerical-mode numerical-mode :layout layout)
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+
+(deftest rejection-rows-cannot-forge-or-hide-measurements
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (doseq [bad [(assoc (inapplicable-result subgroup) :candidate-hash "wrong")
+                 (assoc (inapplicable-result subgroup) :violations [])
+                 (assoc (inapplicable-result subgroup) :violations [{}])
+                 (assoc (inapplicable-result subgroup) :measurement nil)
+                 (assoc (inapplicable-result subgroup) :validation {:passed? true})]]
+      (is (= :dispatch-tuning-inapplicable-result
+             (try (tuning/tune-fixed!
+                   fixed-dispatch descriptor
+                   #(if (= % subgroup) bad (validated-result % 100))
+                   :force? true :numerical-mode numerical-mode :layout layout)
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+
 (deftest static-schedule-axis-produces-a-fixed-measured-selector
   (binding [cache/*cache-root* (temporary-cache-root)]
     (let [calls (atom [])


### PR DESCRIPTION
## Summary
- Add pure session-key/view alias preflight, resolving live allocation contracts without materializing sub-buffers.
- Benchmark driver returns source-bound inapplicable diagnostics before binding, restore, oracle execution or timing.
- Sampled and fixed tuning retain rejection rows but exclude them from winners; an applicable default is mandatory. Invalid rejection rows and unexpected failures throw.
- Bump tuning cache schema to version 4. Transported selectors still undergo runtime binding admission.

## Validation
- Existing capped REPL: 42 dispatch/tuning/benchmark tests, 202 assertions, all green.
- Driver tests prove rejected candidates never reach binding, execution, measurement or cleanup; missing bindings are errors, not skipped rows.
- Tests cover sampled/fixed rejection, cache reload, unavailable default, wrong source hashes and malformed rows.
- Full suite and target gates on CI; read-only review requested.

## Boundary
Stacked on #525. This is alias applicability only; scalar, capacity, alignment and target failures are not silently converted into skip rows. No new candidate enumeration or default promotion in this slice.