### PR TITLE
Enumerate checked input-fused GEMM candidates through the typed compiler

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -295,9 +295,13 @@ graph with its explicit typed-input-conversion candidate. This is a **scheduled 
 not a public `deftm` or end-to-end serving benchmark. The default `:residency :all-stages` replays
 weight conversion. `:residency :constant-weights` instead uses ordinary LinkPlan constant roles
 and initialized weight sources to hoist weight-only stages into the one-time prologue. The
-profile records actual replay kernel names separately from the complete compiled graph. The fused candidate remains outside
-automatic selection because physical input/output disjointness and performance admission must
-both be established before promotion.
+profile records actual replay kernel names separately from the complete compiled graph.
+Normal nonbatched Intel NN/NT typed contraction dispatch now enumerates the checked fused
+candidate, including eligible output epilogues. Its analytic selector is unchanged. Explicit
+offline tuning may consider it: alias-inapplicable bindings are recorded without timing, and
+runtime admission rechecks concrete aliases for cached choices. This makes the candidate
+available, not a measured winner. Stationary matched evidence is still required for promotion;
+this scheduled-graph probe still does not measure the public compilation entry end to end.
 
 ```clojure
 ;; Independent rounding and geometry oracle, no timing.

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -854,29 +854,37 @@
                          :tile tile :vector-width vector-width
                          :requested-splits requested-splits}})
           stage-graph (if (:fuse-lhs-cast? spec)
-                        (or (input-fusion/fuse-lhs-cast stage-graph convert-a-id contract-id)
-                            (throw (ex-info "matrix input cast fusion obligations are not satisfied"
-                                            {:reason :matrix-input-fusion-ineligible :id id})))
-                        stage-graph)
-          emit-spec (assoc spec :strategy strategy)
-          refinement (make-refinement stage-graph source-operation source-graph emit-spec)]
-      (emit-scheduled-stage-graph
-       stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
-                    :prefix prefix :refinement refinement}))))
+                        (input-fusion/fuse-lhs-cast stage-graph convert-a-id contract-id)
+                        stage-graph)]
+      (when stage-graph
+        (let [emit-spec (assoc spec :strategy strategy)
+              refinement (make-refinement stage-graph source-operation source-graph emit-spec)]
+          (emit-scheduled-stage-graph
+           stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
+                        :prefix prefix :refinement refinement}))))))
+
+(defn- matrix-input-fusion-target? [{:keys [variant target-dialect]}]
+  (and (contains? #{:nn :nt} variant)
+       (= :opencl-intel (or target-dialect :opencl-intel))))
+
+(defn- matrix-input-fusion-alternative [spec]
+  (when (matrix-input-fusion-target? spec)
+    (xmx-graph (assoc spec :split-k? false :fuse-lhs-cast? true
+                     :vector-width (get spec :vector-width 4)
+                     :strategy :xmx-direct-lhs-tile-cast))))
 
 (defn emit-matrix-input-fusion-alternative
   "Emit an explicit Intel direct-matrix candidate with an inlined lhs FP32→FP16 cast.
-   Not included in automatic dispatch: binding requires physical A/C disjointness, which a
-   shape-only selector cannot prove. Retains the ordinary public ABI and original semantic
+   Binding requires physical A/C disjointness; runtime admission checks the concrete ranges.
+   Retains the ordinary public ABI and original semantic
    refinement source. Unsupported layouts/targets fail closed; no implicit fallback."
   [{:keys [variant target-dialect] :as spec}]
-  (when-not (and (contains? #{:nn :nt} variant)
-                 (= :opencl-intel (or target-dialect :opencl-intel)))
+  (when-not (matrix-input-fusion-target? spec)
     (throw (ex-info "matrix input fusion requires Intel direct NN/NT storage"
                     {:reason :matrix-input-fusion-target :variant variant :target target-dialect})))
-  (xmx-graph (assoc spec :split-k? false :fuse-lhs-cast? true
-                   :vector-width (get spec :vector-width 4)
-                   :strategy :xmx-direct-lhs-tile-cast)))
+  (or (matrix-input-fusion-alternative spec)
+      (throw (ex-info "matrix input cast fusion obligations are not satisfied"
+                      {:reason :matrix-input-fusion-ineligible :id (:id spec)}))))
 
 (defn emit-batched-matrix-alternative
   "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.
@@ -1052,6 +1060,7 @@
         split-expression (requested-splits spec)
         xmx-spec (assoc spec :requested-splits split-expression)
         direct (xmx-graph (assoc xmx-spec :split-k? false))
+        fused-input (matrix-input-fusion-alternative xmx-spec)
         split? (not (seq epilogue))
         split (when split? (xmx-graph (assoc xmx-spec :split-k? true)))
         explicit-splits
@@ -1071,7 +1080,8 @@
                   :default :xmx-direct}]
     {:alternatives (cond-> [direct]
                      split (conj split)
-                     (seq explicit-splits) (into explicit-splits))
+                     (seq explicit-splits) (into explicit-splits)
+                     fused-input (conj fused-input))
      :selector selector
      :split-factor-schedules
      (into {} (map (fn [factor] [(split-factor-strategy factor) factor]))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1396,8 +1396,12 @@
                       (if (:batched? (:schedule mixed))
                         {:xmx-batched (:schedule mixed)}
                         (merge
-                         {:xmx-direct (:schedule mixed)
-                          :xmx-split-k (assoc (:schedule mixed) :split-k? true)}
+                         (cond-> {:xmx-direct (:schedule mixed)
+                                  :xmx-split-k (assoc (:schedule mixed) :split-k? true)}
+                           (some #(= :xmx-direct-lhs-tile-cast (kdispatch/alternative-strategy %))
+                                 (:alternatives mixed))
+                           (assoc :xmx-direct-lhs-tile-cast
+                                  (assoc (:schedule mixed) :input-fusion? true)))
                          (into {}
                                (map (fn [[strategy factor]]
                                       [strategy (assoc (:schedule mixed)

--- a/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
+++ b/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
@@ -93,7 +93,7 @@
                               (assoc-in [:attributes :input-fusion]
                                         {:producer producer :consumer (:operation (get by-id consumer-id))
                                          :physical-precondition :input-output-disjoint
-                                         :selection :explicit-only}))]
+                                         :selection :binding-admission-required}))]
             (graph/validate! candidate)
             (when-not (= (graph/boundary-contract g) (graph/boundary-contract candidate))
               (throw (ex-info "matrix input fusion changed the public boundary"

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -254,8 +254,12 @@
      {:measurement Measurement
       :validation {:passed? true :oracle-hash string :candidate-hash executable-source-hash ...}}
 
+   or {:status :inapplicable :candidate-hash executable-source-hash :violations [...]} from
+   preflight, without a measurement or validation. These rows cannot win; the default must remain
+   applicable for every sample. Runtime admission must recheck cached/transported choices.
+
    Correctness is therefore established before a timing can influence selection. Every result
-   must be stationary and device-event timed. A candidate must improve on the dispatch default by
+   that participates in selection must be stationary and device-event timed. A candidate must improve on the dispatch default by
    more than `improvement-threshold` (default 0.1%) at a sample or the default wins that sample.
    Cache hits do not invoke benchmark-fn."
   [dispatch descriptor runtime-values benchmark-fn

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -63,7 +63,7 @@
 (deftest hardware-aware-gemm-selection-is-checked-data
   (let [scheduled (emitted :nn)
         select #(dispatch/select-alternative scheduled (apply arguments %))]
-    (is (= [:f32-scalar :xmx-direct :xmx-split-k]
+    (is (= [:f32-scalar :xmx-direct :xmx-split-k :xmx-direct-lhs-tile-cast]
            (mapv executable/strategy (:alternatives scheduled))))
     (testing "the matrix-instruction pitch gate is part of the selector, not a runtime binder"
       (is (= :f32-scalar (executable/strategy (select [32 4 4096]))))
@@ -103,7 +103,7 @@
         by-strategy (into {} (map (juxt executable/strategy identity))
                           (:alternatives scheduled))]
     (is (= #{:f32-scalar :xmx-direct :xmx-split-k
-             :xmx-split-k-2 :xmx-split-k-8 :xmx-split-k-32}
+             :xmx-split-k-2 :xmx-split-k-8 :xmx-split-k-32 :xmx-direct-lhs-tile-cast}
            (set (keys by-strategy))))
     (doseq [factor [2 8 32]]
       (let [strategy (gemm/split-factor-strategy factor)
@@ -218,7 +218,8 @@
         temporaries (into {} (map (fn [id] [id {:id [:temporary-buffer id] :alignment 64}]))
                           (keys temporary-specs))
         call (graph-call/make graph (merge buffers temporaries) scalar-values)]
-    (is (= 1 (count alternatives)) "a result transform intentionally disables split-K")
+    (is (= [:xmx-direct :xmx-direct-lhs-tile-cast] (mapv executable/strategy alternatives))
+        "the result transform composes with input fusion but still disables split-K")
     (is (= epilogue (:epilogue stage)))
     (is (= '[bias scale]
            (mapv :name (filter #(= :epilogue (:role %)) (:abi contract)))))

--- a/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
@@ -52,7 +52,7 @@
     (is (= [] (get-in candidate [:nodes 0 :dependencies])))
     (is (= 'A (:lhs stage)))
     (is (= :float (get-in stage [:input-value-regions 'A :accumulator-dtype])))
-    (is (= :explicit-only (get-in candidate [:attributes :input-fusion :selection])))
+    (is (= :binding-admission-required (get-in candidate [:attributes :input-fusion :selection])))
     (is (identical? (get-in original [:nodes 1 :operation])
                     (get-in candidate [:attributes :input-fusion :consumer])))
     (is (= :no-write-alias (get-in artifact [:abi 0 :aliasing])))
@@ -86,12 +86,34 @@
     (is (= [:convert-b :contract] (mapv (comp last :id) (:nodes candidate))))
     (is (= [:b16] (mapv (comp last :id) (:temporaries candidate))))
     (is (= :xmx-direct (get-in ordinary [:selector :default])))
-    (is (not-any? #(= :xmx-direct-lhs-tile-cast (get-in % [:attributes :strategy]))
-                  (:alternatives ordinary)))
+    (is (contains? (set (map executable/strategy (:alternatives ordinary)))
+                   :xmx-direct-lhs-tile-cast))
     (doseq [override [{:variant :tn} {:variant :tt} {:target-dialect :cuda}
                      {:target-dialect :hip}]]
       (is (thrown? clojure.lang.ExceptionInfo
                    (gemm/emit-matrix-input-fusion-alternative (merge spec override)))))))
+
+(deftest normal-enumeration-retains-checked-input-fusion-without-changing-selection
+  (let [spec {:id :enumeration-test :a 'A :b 'B :c 'C :m 16 :n 32 :k 32
+              :fill-workgroups 16
+              :tile (get-in (stage-graph) [:nodes 1 :operation :schedule :tile])}]
+    (doseq [variant [:nn :nt :tn :tt]]
+      (let [result (gemm/emit-matrix-alternatives (assoc spec :variant variant))
+            strategies (set (map executable/strategy (:alternatives result)))]
+        (is (= (contains? #{:nn :nt} variant)
+               (contains? strategies :xmx-direct-lhs-tile-cast)))
+        (is (= :xmx-direct (get-in result [:selector :default])))))
+    (with-redefs [fusion/fuse-lhs-cast (constantly nil)]
+      (is (not (some #(= :xmx-direct-lhs-tile-cast (executable/strategy %))
+                     (:alternatives (gemm/emit-matrix-alternatives (assoc spec :variant :nn))))))
+      (is (= :matrix-input-fusion-ineligible
+             (try (gemm/emit-matrix-input-fusion-alternative (assoc spec :variant :nn))
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+    (let [failure (ex-info "broken fusion pass" {})]
+      (with-redefs [fusion/fuse-lhs-cast (fn [& _] (throw failure))]
+        (is (identical? failure
+                        (try (gemm/emit-matrix-alternatives (assoc spec :variant :nn))
+                             (catch clojure.lang.ExceptionInfo e e))))))))
 
 (deftest fused-leaf-requires-disjoint-physical-input-and-output
   (let [spec {:id :alias-test :a 'A :b 'B :c 'C :m 16 :n 32 :k 32 :variant :nn

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1199,7 +1199,7 @@
                  (get-in dispatch [:attributes :matrix-graph-decline :reason]))))
         (let [{:keys [abi arguments]} (executable/common-view (kdispatch/default-alternative dispatch))]
           (is (= (if batched? #{:portable-segred :xmx-batched}
-                               #{:portable-segred :xmx-direct :xmx-split-k})
+                               #{:portable-segred :xmx-direct :xmx-split-k :xmx-direct-lhs-tile-cast})
                  (set (map kdispatch/alternative-strategy (:alternatives dispatch)))))
           (doseq [[dimensions expected]
                   (cond-> [[{'m 16 'n 32 'k 32} (if batched? :xmx-batched :xmx-direct)]
@@ -1258,7 +1258,7 @@
                  (kdispatch/alternative-strategy
                   (kdispatch/select-alternative dispatch
                                                 [:a :b :c m n k])))]
-    (is (= [:portable-segred :xmx-direct :xmx-split-k] strategies))
+    (is (= [:portable-segred :xmx-direct :xmx-split-k :xmx-direct-lhs-tile-cast] strategies))
     (is (apply = (map :abi (:alternatives dispatch))))
     (is (apply = (map :arguments (:alternatives dispatch))))
     (is (= '[A B C m n k] (:arguments (first (:alternatives dispatch)))))
@@ -1289,15 +1289,11 @@
             (is (= :scheduled-graph-refinement-source (:reason (ex-data exception))))))))
     (testing "input fusion retains the exact typed source and rewritten stage graph"
       (let [source-graph (:source direct-refinement)
-            candidate (gpu-gemm/emit-matrix-input-fusion-alternative
-                       {:id :typed-input-fusion :a 'A :b 'B :c 'C :m 'm :n 'n :k 'k
-                        :variant :nn :tile (get-in direct-graph [:attributes :tile])
-                        :source-operation operation :source-graph source-graph
-                        :external-interface (select-keys source-graph [:abi :arguments :effects])})
+            candidate (kdispatch/alternative dispatch :xmx-direct-lhs-tile-cast)
             refinement (get-in candidate [:attributes :scheduled-graph-refinement])
             stages (graph-refinement/scheduled-graph refinement)]
         (is (identical? operation (graph-refinement/source-operation refinement)))
-        (is (= source-graph (:source refinement)))
+        (is (identical? source-graph (:source refinement)))
         (is (= [:convert-b :contract] (mapv (comp last :id) (:nodes stages))))
         (is (kernel-graph/dataflow-equivalent? stages candidate))
         (doseq [[stage-node emitted-node] (map vector (:nodes stages) (:nodes candidate))]
@@ -1409,7 +1405,7 @@
                      algorithm operation :dtype :float :desc descriptor
                      :precision :mixed-f16-f32 :split-factors [2 8])]
         (is (= #{:portable-segred :xmx-direct :xmx-split-k
-                 :xmx-split-k-2 :xmx-split-k-8}
+                 :xmx-split-k-2 :xmx-split-k-8 :xmx-direct-lhs-tile-cast}
                (set (map kdispatch/alternative-strategy (:alternatives tunable)))))
         (is (= 8 (get-in tunable [:attributes :candidate-schedules
                                   :xmx-split-k-8 :split-factor])))))
@@ -1764,7 +1760,7 @@
         matrix-graph (kdispatch/alternative scheduled :xmx-direct)
         contract-artifact (-> matrix-graph :nodes last :operation)
         body (get-in contract-artifact [:attributes :kernel-body])]
-    (is (= [:portable-segred :xmx-direct]
+    (is (= [:portable-segred :xmx-direct :xmx-direct-lhs-tile-cast]
            (mapv kdispatch/alternative-strategy (:alternatives scheduled)))
         "split-K waits until its final combine can own the result transform")
     (is (= '[A B C bias scale m n k] (:arguments matrix-graph)))


### PR DESCRIPTION
## Summary
- Normal Intel NN/NT matrix alternatives now include the existing checked input-cast fusion candidate. Analytic selectors and default strategies remain unchanged.
- The existing semantic transform controls eligibility; an ordinary decline withholds the candidate, while unexpected compiler failures propagate. Explicit unsupported requests still fail.
- Preserve typed graph refinement/source identities and composed output epilogues; expose the candidate schedule in typed dispatch metadata.
- Update benchmarking documentation and the sampled tuning rejection-result contract.

## Validation
- Focused existing REPL: 13 directly affected test vars / 213 assertions pass (GEMM selection, split factors, epilogues, typed routes, ABI ordering, long shapes, transpose eligibility, fusion/alias contracts).
- Enumerated fused candidate retains identical TypedSOAC source and exact scheduled-stage certificates.
- The broad GEMM namespace hit the REPL timeout; switched to focused vars. Full namespace/suite and vendor gates belong to CI. No full-suite pass claimed.
- No performance promotion or SOTA claim; matched stationary baseline evidence remains outstanding.

Stacked on #526, which supplies tuner applicability handling over #525 runtime admission.