### PR TITLE
Validate public composed GEMM with input fusion and constant-weight replay

### DIFF
--- a/bench/comparison/generated-kernel-protocol.md
+++ b/bench/comparison/generated-kernel-protocol.md
@@ -295,9 +295,13 @@ graph with its explicit typed-input-conversion candidate. This is a **scheduled 
 not a public `deftm` or end-to-end serving benchmark. The default `:residency :all-stages` replays
 weight conversion. `:residency :constant-weights` instead uses ordinary LinkPlan constant roles
 and initialized weight sources to hoist weight-only stages into the one-time prologue. The
-profile records actual replay kernel names separately from the complete compiled graph. The fused candidate remains outside
-automatic selection because physical input/output disjointness and performance admission must
-both be established before promotion.
+profile records actual replay kernel names separately from the complete compiled graph.
+Normal nonbatched Intel NN/NT typed contraction dispatch now enumerates the checked fused
+candidate, including eligible output epilogues. Its analytic selector is unchanged. Explicit
+offline tuning may consider it: alias-inapplicable bindings are recorded without timing, and
+runtime admission rechecks concrete aliases for cached choices. This makes the candidate
+available, not a measured winner. Stationary matched evidence is still required for promotion;
+this scheduled-graph probe still does not measure the public compilation entry end to end.
 
 ```clojure
 ;; Independent rounding and geometry oracle, no timing.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1005,3 +1005,23 @@ are not certified by this fix; backend-wide long arithmetic may pay overflow-che
 cross-target semantic parity and performance remain separate acceptance work.
 Shared-memory pipelines or indexed matrix epilogues should be introduced when those measurements
 or workload requirements justify them. Existing scientific/distributed acceptance gates remain.
+
+The input-conversion follow-up now connects that leaf to the ordinary typed contraction vertical:
+the checked private-cast rewrite preserves the semantic source, scheduled graph and per-node body
+certificates; eligible Intel NN/NT dispatches enumerate the candidate without changing the analytic
+selector. Concrete graph dependencies and public/node ABI alias contracts govern admission before
+graph-private allocation. Automatic or cached preferences may fall back only to the declared
+default; explicit incompatible requests fail. Offline tuning retains source-bound alias rejection
+rows without executing or timing them, excludes them from winners, and requires an applicable
+default. This is alias admission, not a claim of complete scalar/alignment/target applicability.
+
+The public prebound-extent GEMM→ReLU canary exercises lowering, schedule-based recompilation,
+LinkPlan instantiation, constant B and changing A through this route. On the laptop Level Zero
+device, two tiny `[13 32 32]` replays matched 832 outputs exactly and each profiled one generated
+contract kernel; B conversion stayed in the one-time prologue. The non-prebound extent still
+preserves its post-write checked-arithmetic barrier. These are correctness and replay-topology
+results, not stationary throughput or a comparison with an external implementation. Next measure
+the public route across the shape ladder against numerically matched external baselines, retain
+the global-conversion alternative, and continue the resident forward/VJP/update and scientific
+demonstrators. No source-form restriction should become a permanent semantic primitive merely
+to make a benchmark fuse; safe scalar placement needs a proof or guarded schedule.

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -854,29 +854,37 @@
                          :tile tile :vector-width vector-width
                          :requested-splits requested-splits}})
           stage-graph (if (:fuse-lhs-cast? spec)
-                        (or (input-fusion/fuse-lhs-cast stage-graph convert-a-id contract-id)
-                            (throw (ex-info "matrix input cast fusion obligations are not satisfied"
-                                            {:reason :matrix-input-fusion-ineligible :id id})))
-                        stage-graph)
-          emit-spec (assoc spec :strategy strategy)
-          refinement (make-refinement stage-graph source-operation source-graph emit-spec)]
-      (emit-scheduled-stage-graph
-       stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
-                    :prefix prefix :refinement refinement}))))
+                        (input-fusion/fuse-lhs-cast stage-graph convert-a-id contract-id)
+                        stage-graph)]
+      (when stage-graph
+        (let [emit-spec (assoc spec :strategy strategy)
+              refinement (make-refinement stage-graph source-operation source-graph emit-spec)]
+          (emit-scheduled-stage-graph
+           stage-graph {:target-dialect (get spec :target-dialect :opencl-intel)
+                        :prefix prefix :refinement refinement}))))))
+
+(defn- matrix-input-fusion-target? [{:keys [variant target-dialect]}]
+  (and (contains? #{:nn :nt} variant)
+       (= :opencl-intel (or target-dialect :opencl-intel))))
+
+(defn- matrix-input-fusion-alternative [spec]
+  (when (matrix-input-fusion-target? spec)
+    (xmx-graph (assoc spec :split-k? false :fuse-lhs-cast? true
+                     :vector-width (get spec :vector-width 4)
+                     :strategy :xmx-direct-lhs-tile-cast))))
 
 (defn emit-matrix-input-fusion-alternative
   "Emit an explicit Intel direct-matrix candidate with an inlined lhs FP32→FP16 cast.
-   Not included in automatic dispatch: binding requires physical A/C disjointness, which a
-   shape-only selector cannot prove. Retains the ordinary public ABI and original semantic
+   Binding requires physical A/C disjointness; runtime admission checks the concrete ranges.
+   Retains the ordinary public ABI and original semantic
    refinement source. Unsupported layouts/targets fail closed; no implicit fallback."
   [{:keys [variant target-dialect] :as spec}]
-  (when-not (and (contains? #{:nn :nt} variant)
-                 (= :opencl-intel (or target-dialect :opencl-intel)))
+  (when-not (matrix-input-fusion-target? spec)
     (throw (ex-info "matrix input fusion requires Intel direct NN/NT storage"
                     {:reason :matrix-input-fusion-target :variant variant :target target-dialect})))
-  (xmx-graph (assoc spec :split-k? false :fuse-lhs-cast? true
-                   :vector-width (get spec :vector-width 4)
-                   :strategy :xmx-direct-lhs-tile-cast)))
+  (or (matrix-input-fusion-alternative spec)
+      (throw (ex-info "matrix input cast fusion obligations are not satisfied"
+                      {:reason :matrix-input-fusion-ineligible :id (:id spec)}))))
 
 (defn emit-batched-matrix-alternative
   "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.
@@ -1052,6 +1060,7 @@
         split-expression (requested-splits spec)
         xmx-spec (assoc spec :requested-splits split-expression)
         direct (xmx-graph (assoc xmx-spec :split-k? false))
+        fused-input (matrix-input-fusion-alternative xmx-spec)
         split? (not (seq epilogue))
         split (when split? (xmx-graph (assoc xmx-spec :split-k? true)))
         explicit-splits
@@ -1071,7 +1080,8 @@
                   :default :xmx-direct}]
     {:alternatives (cond-> [direct]
                      split (conj split)
-                     (seq explicit-splits) (into explicit-splits))
+                     (seq explicit-splits) (into explicit-splits)
+                     fused-input (conj fused-input))
      :selector selector
      :split-factor-schedules
      (into {} (map (fn [factor] [(split-factor-strategy factor) factor]))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -1396,8 +1396,12 @@
                       (if (:batched? (:schedule mixed))
                         {:xmx-batched (:schedule mixed)}
                         (merge
-                         {:xmx-direct (:schedule mixed)
-                          :xmx-split-k (assoc (:schedule mixed) :split-k? true)}
+                         (cond-> {:xmx-direct (:schedule mixed)
+                                  :xmx-split-k (assoc (:schedule mixed) :split-k? true)}
+                           (some #(= :xmx-direct-lhs-tile-cast (kdispatch/alternative-strategy %))
+                                 (:alternatives mixed))
+                           (assoc :xmx-direct-lhs-tile-cast
+                                  (assoc (:schedule mixed) :input-fusion? true)))
                          (into {}
                                (map (fn [[strategy factor]]
                                       [strategy (assoc (:schedule mixed)

--- a/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
+++ b/src/raster/compiler/passes/parallel/matrix_input_fusion.clj
@@ -93,7 +93,7 @@
                               (assoc-in [:attributes :input-fusion]
                                         {:producer producer :consumer (:operation (get by-id consumer-id))
                                          :physical-precondition :input-output-disjoint
-                                         :selection :explicit-only}))]
+                                         :selection :binding-admission-required}))]
             (graph/validate! candidate)
             (when-not (= (graph/boundary-contract g) (graph/boundary-contract candidate))
               (throw (ex-info "matrix input fusion changed the public boundary"

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -254,8 +254,12 @@
      {:measurement Measurement
       :validation {:passed? true :oracle-hash string :candidate-hash executable-source-hash ...}}
 
+   or {:status :inapplicable :candidate-hash executable-source-hash :violations [...]} from
+   preflight, without a measurement or validation. These rows cannot win; the default must remain
+   applicable for every sample. Runtime admission must recheck cached/transported choices.
+
    Correctness is therefore established before a timing can influence selection. Every result
-   must be stationary and device-event timed. A candidate must improve on the dispatch default by
+   that participates in selection must be stationary and device-event timed. A candidate must improve on the dispatch default by
    more than `improvement-threshold` (default 0.1%) at a sample or the default wins that sample.
    Cache hits do not invoke benchmark-fn."
   [dispatch descriptor runtime-values benchmark-fn

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -63,7 +63,7 @@
 (deftest hardware-aware-gemm-selection-is-checked-data
   (let [scheduled (emitted :nn)
         select #(dispatch/select-alternative scheduled (apply arguments %))]
-    (is (= [:f32-scalar :xmx-direct :xmx-split-k]
+    (is (= [:f32-scalar :xmx-direct :xmx-split-k :xmx-direct-lhs-tile-cast]
            (mapv executable/strategy (:alternatives scheduled))))
     (testing "the matrix-instruction pitch gate is part of the selector, not a runtime binder"
       (is (= :f32-scalar (executable/strategy (select [32 4 4096]))))
@@ -103,7 +103,7 @@
         by-strategy (into {} (map (juxt executable/strategy identity))
                           (:alternatives scheduled))]
     (is (= #{:f32-scalar :xmx-direct :xmx-split-k
-             :xmx-split-k-2 :xmx-split-k-8 :xmx-split-k-32}
+             :xmx-split-k-2 :xmx-split-k-8 :xmx-split-k-32 :xmx-direct-lhs-tile-cast}
            (set (keys by-strategy))))
     (doseq [factor [2 8 32]]
       (let [strategy (gemm/split-factor-strategy factor)
@@ -218,7 +218,8 @@
         temporaries (into {} (map (fn [id] [id {:id [:temporary-buffer id] :alignment 64}]))
                           (keys temporary-specs))
         call (graph-call/make graph (merge buffers temporaries) scalar-values)]
-    (is (= 1 (count alternatives)) "a result transform intentionally disables split-K")
+    (is (= [:xmx-direct :xmx-direct-lhs-tile-cast] (mapv executable/strategy alternatives))
+        "the result transform composes with input fusion but still disables split-K")
     (is (= epilogue (:epilogue stage)))
     (is (= '[bias scale]
            (mapv :name (filter #(= :epilogue (:role %)) (:abi contract)))))

--- a/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/matrix_input_fusion_test.clj
@@ -52,7 +52,7 @@
     (is (= [] (get-in candidate [:nodes 0 :dependencies])))
     (is (= 'A (:lhs stage)))
     (is (= :float (get-in stage [:input-value-regions 'A :accumulator-dtype])))
-    (is (= :explicit-only (get-in candidate [:attributes :input-fusion :selection])))
+    (is (= :binding-admission-required (get-in candidate [:attributes :input-fusion :selection])))
     (is (identical? (get-in original [:nodes 1 :operation])
                     (get-in candidate [:attributes :input-fusion :consumer])))
     (is (= :no-write-alias (get-in artifact [:abi 0 :aliasing])))
@@ -86,12 +86,34 @@
     (is (= [:convert-b :contract] (mapv (comp last :id) (:nodes candidate))))
     (is (= [:b16] (mapv (comp last :id) (:temporaries candidate))))
     (is (= :xmx-direct (get-in ordinary [:selector :default])))
-    (is (not-any? #(= :xmx-direct-lhs-tile-cast (get-in % [:attributes :strategy]))
-                  (:alternatives ordinary)))
+    (is (contains? (set (map executable/strategy (:alternatives ordinary)))
+                   :xmx-direct-lhs-tile-cast))
     (doseq [override [{:variant :tn} {:variant :tt} {:target-dialect :cuda}
                      {:target-dialect :hip}]]
       (is (thrown? clojure.lang.ExceptionInfo
                    (gemm/emit-matrix-input-fusion-alternative (merge spec override)))))))
+
+(deftest normal-enumeration-retains-checked-input-fusion-without-changing-selection
+  (let [spec {:id :enumeration-test :a 'A :b 'B :c 'C :m 16 :n 32 :k 32
+              :fill-workgroups 16
+              :tile (get-in (stage-graph) [:nodes 1 :operation :schedule :tile])}]
+    (doseq [variant [:nn :nt :tn :tt]]
+      (let [result (gemm/emit-matrix-alternatives (assoc spec :variant variant))
+            strategies (set (map executable/strategy (:alternatives result)))]
+        (is (= (contains? #{:nn :nt} variant)
+               (contains? strategies :xmx-direct-lhs-tile-cast)))
+        (is (= :xmx-direct (get-in result [:selector :default])))))
+    (with-redefs [fusion/fuse-lhs-cast (constantly nil)]
+      (is (not (some #(= :xmx-direct-lhs-tile-cast (executable/strategy %))
+                     (:alternatives (gemm/emit-matrix-alternatives (assoc spec :variant :nn))))))
+      (is (= :matrix-input-fusion-ineligible
+             (try (gemm/emit-matrix-input-fusion-alternative (assoc spec :variant :nn))
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+    (let [failure (ex-info "broken fusion pass" {})]
+      (with-redefs [fusion/fuse-lhs-cast (fn [& _] (throw failure))]
+        (is (identical? failure
+                        (try (gemm/emit-matrix-alternatives (assoc spec :variant :nn))
+                             (catch clojure.lang.ExceptionInfo e e))))))))
 
 (deftest fused-leaf-requires-disjoint-physical-input-and-output
   (let [spec {:id :alias-test :a 'A :b 'B :c 'C :m 16 :n 32 :k 32 :variant :nn

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -10,7 +10,9 @@
             [raster.compiler.passes.parallel.contract-route :as contract-route]
             [raster.compiler.pipeline :as pipeline]
             [raster.dl.gpu-grad-parity :as gpu-probe]
-            [raster.gpu.core :as gpu]))
+            [raster.gpu.core :as gpu]
+            [raster.gpu.compiled :as compiled]
+            [raster.perf.production-canary :as canary]))
 
 (def ^:private source
   '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
@@ -187,6 +189,45 @@
            :expected (reference a b m n k)}
           (finally
             (gpu/release-kernel-graph! session handle))))))))
+
+(deftest public-composed-matrix-selects-input-fusion-and-hoists-constant-weights
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "public composed GEMM input fusion")
+    (let [shape [13 32 32]
+          [^floats a b :as arrays] (canary/gemm-arguments shape)
+          ordinary (canary/prepare-gemm :ze:0 arrays shape
+                                       {:variant :relu-prebound :gemm-precision :mixed-f16-f32
+                                        :constants ['B]})
+          choice (get-in ordinary [:descriptor :steps 0 :dispatch])
+          ;; Exercise the public recompilation schedule seam, without manufacturing a measured
+          ;; winner or replacing a Prepared descriptor after its certificate was constructed.
+          selected (compiled/lower
+                    #'canary/gemm-relu-prebound! (into arrays shape)
+                    {:target :ze:0 :dtype :float :gemm-precision :mixed-f16-f32
+                     :constants ['B] :on-non-resident :throw
+                     :schedule {:typed-contraction
+                                {:measured-selectors
+                                 {(:id choice) {:kind :fixed-strategy
+                                                :strategy :xmx-direct-lhs-tile-cast}}}}})]
+      (is (= 1 (count (get-in selected [:descriptor :steps]))))
+      (is (empty? (get-in selected [:descriptor :allocs])))
+      (is (some #{:xmx-direct-lhs-tile-cast}
+                (map executable/strategy (:alternatives choice))))
+      (let [live (compiled/instantiate! selected {:profile? true})]
+        (try
+          (dotimes [replay 2]
+            (when (pos? replay)
+              (dotimes [i (alength a)] (aset a i (- (aget a i)))))
+            (let [result (compiled/profile live)
+                  actual (vec (first (vals (:result result))))
+                  expected (mapv #(max (float 0.0) %)
+                                 (canary/gemm-reference a b shape))
+                  profile (:profile result)]
+              (is (= expected actual) (str "public input-fused replay " replay))
+              (is (= 1 (count profile)) "weight conversion stays in the one-time prologue")
+              (is (= [:xmx-direct-lhs-tile-cast :contract]
+                     (take-last 2 (:phase (first profile)))))))
+          (finally (compiled/close! live)))))))
 
 (deftest long-graph-interface-executes-layout-matrix-and-combine
   (if-not @gpu-probe/gpu-available?

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1199,7 +1199,7 @@
                  (get-in dispatch [:attributes :matrix-graph-decline :reason]))))
         (let [{:keys [abi arguments]} (executable/common-view (kdispatch/default-alternative dispatch))]
           (is (= (if batched? #{:portable-segred :xmx-batched}
-                               #{:portable-segred :xmx-direct :xmx-split-k})
+                               #{:portable-segred :xmx-direct :xmx-split-k :xmx-direct-lhs-tile-cast})
                  (set (map kdispatch/alternative-strategy (:alternatives dispatch)))))
           (doseq [[dimensions expected]
                   (cond-> [[{'m 16 'n 32 'k 32} (if batched? :xmx-batched :xmx-direct)]
@@ -1258,7 +1258,7 @@
                  (kdispatch/alternative-strategy
                   (kdispatch/select-alternative dispatch
                                                 [:a :b :c m n k])))]
-    (is (= [:portable-segred :xmx-direct :xmx-split-k] strategies))
+    (is (= [:portable-segred :xmx-direct :xmx-split-k :xmx-direct-lhs-tile-cast] strategies))
     (is (apply = (map :abi (:alternatives dispatch))))
     (is (apply = (map :arguments (:alternatives dispatch))))
     (is (= '[A B C m n k] (:arguments (first (:alternatives dispatch)))))
@@ -1289,15 +1289,11 @@
             (is (= :scheduled-graph-refinement-source (:reason (ex-data exception))))))))
     (testing "input fusion retains the exact typed source and rewritten stage graph"
       (let [source-graph (:source direct-refinement)
-            candidate (gpu-gemm/emit-matrix-input-fusion-alternative
-                       {:id :typed-input-fusion :a 'A :b 'B :c 'C :m 'm :n 'n :k 'k
-                        :variant :nn :tile (get-in direct-graph [:attributes :tile])
-                        :source-operation operation :source-graph source-graph
-                        :external-interface (select-keys source-graph [:abi :arguments :effects])})
+            candidate (kdispatch/alternative dispatch :xmx-direct-lhs-tile-cast)
             refinement (get-in candidate [:attributes :scheduled-graph-refinement])
             stages (graph-refinement/scheduled-graph refinement)]
         (is (identical? operation (graph-refinement/source-operation refinement)))
-        (is (= source-graph (:source refinement)))
+        (is (identical? source-graph (:source refinement)))
         (is (= [:convert-b :contract] (mapv (comp last :id) (:nodes stages))))
         (is (kernel-graph/dataflow-equivalent? stages candidate))
         (doseq [[stage-node emitted-node] (map vector (:nodes stages) (:nodes candidate))]
@@ -1409,7 +1405,7 @@
                      algorithm operation :dtype :float :desc descriptor
                      :precision :mixed-f16-f32 :split-factors [2 8])]
         (is (= #{:portable-segred :xmx-direct :xmx-split-k
-                 :xmx-split-k-2 :xmx-split-k-8}
+                 :xmx-split-k-2 :xmx-split-k-8 :xmx-direct-lhs-tile-cast}
                (set (map kdispatch/alternative-strategy (:alternatives tunable)))))
         (is (= 8 (get-in tunable [:attributes :candidate-schedules
                                   :xmx-split-k-8 :split-factor])))))
@@ -1764,7 +1760,7 @@
         matrix-graph (kdispatch/alternative scheduled :xmx-direct)
         contract-artifact (-> matrix-graph :nodes last :operation)
         body (get-in contract-artifact [:attributes :kernel-body])]
-    (is (= [:portable-segred :xmx-direct]
+    (is (= [:portable-segred :xmx-direct :xmx-direct-lhs-tile-cast]
            (mapv kdispatch/alternative-strategy (:alternatives scheduled)))
         "split-K waits until its final combine can own the result transform")
     (is (= '[A B C bias scale m n k] (:arguments matrix-graph)))


### PR DESCRIPTION
## Summary
- Exercise public deftm GEMM followed by a ReLU map using the prebound-extent form, not a hand-assembled scheduled graph.
- Recompile via the public schedule option to select the normally enumerated input-fused candidate, without fabricating a measured winner or mutating a certified Prepared descriptor.
- Instantiate through LinkPlan with B constant, change A between two profiled replays, and verify one replay kernel and exact outputs.

## Validation
- Real laptop Level Zero GPU: one focused test, 9 assertions, 832 exact output values; passed.
- One descriptor step, no descriptor scratch allocations, one replay kernel with weight conversion hoisted.
- Uses existing visible Level Zero test gating on device-free CI. No timing assertion or speedup claim.
- The dynamic composed form without the prebound extent still has two descriptor steps; this is an existing distinct normalization/fusion gap, not claimed solved here.

Stacked on #527. Full CI gates must pass before merge.