### PR TITLE
Report actual admitted resident kernel schedules

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1033,3 +1033,11 @@ the focused 25-update comparison passed 31 assertions; loss went from 2.281172 t
 FP32 and 1.262058 for mixed precision, within the existing per-step relative tolerance. This
 validates the tiny block and selected preference, not a bound-route trace, stationary throughput,
 or real-weight model convergence. Concrete alias admission remains a separate runtime check.
+
+Resident binding now retains a compact admitted-executable report: strategy, precision, entry
+points and admission attempt reason codes, without retaining live arguments or executable source.
+The public compiled/linked `execution-info` query reads that evidence rather than running the
+selector again. The alias-fallback fixture distinguishes preferred and bound strategies; the
+public Arc fusion canary confirms bound fused selection separately from its measured replay.
+Entry points include any prologue and must not be interpreted as replay events. Equation-first
+program reporting remains explicitly unsupported; manual bindings without evidence return nil.

--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -416,6 +416,15 @@
     (println "  steps    :" (count (:steps descriptor)) "resident, by kind:" kinds))
   c)
 
+(defn execution-info
+  "Report the instantiated artifact's admitted resident schedules, without running it.
+   Unlike `ir`, this observes binding-time selection. It is not a replay or timing report."
+  [c]
+  (when-not (compiled? c)
+    (throw (ex-info "execution info requires an instantiated compiled artifact"
+                    {:reason :compiled-execution-info-unbound})))
+  (gpu-link/execution-info (:executable c)))
+
 (defn ir
   "Return the descriptor's resident steps (the artifact's lowered IR) for inspection."
   [c]

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -243,6 +243,18 @@
   [value]
   (instance? BoundExecutableStep value))
 
+(defn execution-info
+  "Describe a currently bound compiler step, without running it or repeating selection.
+   Reports the admitted executable, not timing or proof that a replay has executed. Returns nil
+   for low-level/manual bindings without compiler selection evidence. Missing/closed bindings throw."
+  [sess phase]
+  (let [state @sess]
+    (when (:closed? state)
+      (throw (ex-info "cannot inspect a closed GPU session" {:phase phase})))
+    (when-not (contains? (:prepared state) phase)
+      (throw (ex-info "no prepared phase to inspect" {:phase phase})))
+    (:execution-info (get-in state [:prepared phase]))))
+
 (defn- prepared-bindings
   "Return the ordered backend bindings represented by one prepared session entry. Plain bindings
    from the low-level prepare! API remain valid; compiler steps use BoundExecutableStep because one
@@ -1931,12 +1943,21 @@
                interface logical-or-physical-args
                (rt-resolve device-id "expand-pointer-binding"))
               logical-or-physical-args)
-            selected (if-let [dispatch (:dispatch step)]
-                       (:executable
+            admission (when-let [dispatch (:dispatch step)]
                         (kdispatch/admit-alternative
                          dispatch ordered-args (step-selection-override step schedule)
                          #(executable-alias-violations % ordered-args)))
-                       artifact)
+            selected (if admission (:executable admission) artifact)
+            execution-info
+            {:kind (kexec/kind selected)
+             :strategy (kexec/strategy selected)
+             :precision (:precision (kexec/attributes selected))
+             :entry-points (kexec/entry-points selected)
+             ;; Keep reasons, not live buffer bindings or full executable/source objects.
+             :admission (mapv (fn [{:keys [strategy violations]}]
+                                {:strategy strategy
+                                 :reasons (mapv :reason violations)})
+                              (:attempts admission))}
             constant-buffer-ids
             (when (= :kernel-graph (kexec/kind selected))
               (into #{}
@@ -1947,8 +1968,9 @@
             ;; that needs one group must arrive as an explicit :single SegRed refinement; the
             ;; binder cannot reinterpret an occupancy-capped partial-reduction artifact.
             group-count nil]
-        (bind-selected-executable
-         device-id selected ordered-args phase constant-buffer-ids group-count))
+        (assoc (bind-selected-executable
+                device-id selected ordered-args phase constant-buffer-ids group-count)
+               :execution-info execution-info))
 
       :scatter
       (do

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -250,9 +250,11 @@
   [sess phase]
   (let [state @sess]
     (when (:closed? state)
-      (throw (ex-info "cannot inspect a closed GPU session" {:phase phase})))
+      (throw (ex-info "cannot inspect a closed GPU session"
+                      {:reason :gpu-execution-info-closed :phase phase})))
     (when-not (contains? (:prepared state) phase)
-      (throw (ex-info "no prepared phase to inspect" {:phase phase})))
+      (throw (ex-info "no prepared phase to inspect"
+                      {:reason :gpu-execution-info-missing :phase phase})))
     (:execution-info (get-in state [:prepared phase]))))
 
 (defn- prepared-bindings

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -713,6 +713,8 @@
 
 (defn execution-info
   "Return resident phase admission reports without executing the linked program.
+   One entry per bound phase, in phase order; :executable is nil for manual/non-executable phases
+   (including legacy scatter) that do not retain compiler admission evidence.
    Entry points describe the bound executable, including any prologue, not measured replay events.
    Equation-first prepared programs do not yet retain this evidence and are explicitly declined."
   [executable]

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -711,6 +711,19 @@
       (swap! (:pending-inputs executable) disj node-id)
       executable)))
 
+(defn execution-info
+  "Return resident phase admission reports without executing the linked program.
+   Entry points describe the bound executable, including any prologue, not measured replay events.
+   Equation-first prepared programs do not yet retain this evidence and are explicitly declined."
+  [executable]
+  (let [executable (ensure-live! executable :execution-info)]
+    (when (:prepared-program executable)
+      (throw (ex-info "equation-first execution reporting is not yet available"
+                      {:reason :link-program-execution-info-unsupported})))
+    (mapv (fn [phase]
+            {:phase phase :executable (gpu/execution-info (:session executable) phase)})
+          (:phases executable))))
+
 (defn profile!
   "Profile one replay of an executable instantiated with `{:profile? true}`. Inputs must be ready."
   [executable]

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -330,6 +330,14 @@
                     (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
         (is (false? @opened?) "the selected fallback must meet its own capacity contract")))))
 
+(deftest execution-info-requires-a-live-existing-binding
+  (let [session (atom {:prepared {:manual {}}})]
+    (is (nil? (gpu/execution-info session :manual))
+        "manual bindings must not manufacture compiler evidence")
+    (is (thrown? clojure.lang.ExceptionInfo (gpu/execution-info session :missing)))
+    (swap! session assoc :closed? true)
+    (is (thrown? clojure.lang.ExceptionInfo (gpu/execution-info session :manual)))))
+
 (deftest resident-storage-admission-precedes-backend-binding
   (let [step {:kernel-name "storage-dispatch" :phase :probe :convention :executable
               :dispatch (storage-dispatch)
@@ -346,8 +354,16 @@
          (swap! selected conj (kexec/strategy executable))
          (gpu/->BoundExecutableStep [] {} []))}
       (fn []
-        (bind! :same :same {})
-        (bind! :same :separate {})
+        (let [fallback (gpu/execution-info (bind! :same :same {}) :probe)
+              direct (gpu/execution-info (bind! :same :separate {}) :probe)]
+          (is (= :two-stage (:strategy fallback)))
+          (is (= :direct (:strategy direct)))
+          (is (= [:direct :two-stage] (mapv :strategy (:admission fallback))))
+          (is (seq (get-in fallback [:admission 0 :reasons])))
+          (is (= [] (get-in fallback [:admission 1 :reasons])))
+          (is (= [{:strategy :direct :reasons []}] (:admission direct)))
+          (is (= (kexec/entry-points (kdispatch/default-alternative (storage-dispatch)))
+                 (:entry-points fallback))))
         (is (= [:two-stage :direct] @selected))
         (is (= :kernel-dispatch-inapplicable
                (try (bind! :same :same {:strategy :direct})

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -334,9 +334,13 @@
   (let [session (atom {:prepared {:manual {}}})]
     (is (nil? (gpu/execution-info session :manual))
         "manual bindings must not manufacture compiler evidence")
-    (is (thrown? clojure.lang.ExceptionInfo (gpu/execution-info session :missing)))
+    (is (= :gpu-execution-info-missing
+           (try (gpu/execution-info session :missing)
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
     (swap! session assoc :closed? true)
-    (is (thrown? clojure.lang.ExceptionInfo (gpu/execution-info session :manual)))))
+    (is (= :gpu-execution-info-closed
+           (try (gpu/execution-info session :manual)
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
 
 (deftest resident-storage-admission-precedes-backend-binding
   (let [step {:kernel-name "storage-dispatch" :phase :probe :convention :executable

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -215,6 +215,11 @@
                 (map executable/strategy (:alternatives choice))))
       (let [live (compiled/instantiate! selected {:profile? true})]
         (try
+          (let [bound (mapv :executable (compiled/execution-info live))]
+            (is (= [:xmx-direct-lhs-tile-cast] (mapv :strategy bound)))
+            (is (= [:mixed-f16-f32] (mapv :precision bound)))
+            (is (= [[{:strategy :xmx-direct-lhs-tile-cast :reasons []}]]
+                   (mapv :admission bound))))
           (dotimes [replay 2]
             (when (pos? replay)
               (dotimes [i (alength a)] (aset a i (- (aget a i)))))

--- a/test/raster/gpu/compiled_composition_test.clj
+++ b/test/raster/gpu/compiled_composition_test.clj
@@ -9,6 +9,22 @@
 
 (defn component [_x _w _n])
 
+(deftest execution-info-observes-linked-binding-and-rejects-unavailable-evidence
+  (let [info {:strategy :chosen :entry-points ["chosen_kernel"]}
+        session (atom {:prepared {:phase {:execution-info info}}})
+        live (gpu-link/map->LinkedExecutable
+              {:session session :phases [:phase] :closed? (atom false)})
+        compiled (compiled/map->Compiled {:executable live})]
+    (is (= [{:phase :phase :executable info}] (compiled/execution-info compiled)))
+    (is (= :compiled-execution-info-unbound
+           (try (compiled/execution-info (compiled/map->Prepared {}))
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :link-program-execution-info-unsupported
+           (try (gpu-link/execution-info (assoc live :prepared-program :equation-first))
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (reset! (:closed? live) true)
+    (is (thrown? clojure.lang.ExceptionInfo (compiled/execution-info compiled)))))
+
 (def ^:private kernel
   (artifact/make
    {:kernel-name "compiled_composition_axpy"


### PR DESCRIPTION
## Summary
- Retain compact binding-time selection evidence: executable kind, strategy, precision, entry points and admission reason codes.
- Expose execution-info through the session, LinkedExecutable and public Compiled API without rerunning selection or executing kernels.
- Keep bound entry points distinct from observed replay events; entry points include any prologue. Do not retain source, full executable objects or live bindings in the report.
- Explicitly reject unavailable equation-first reporting; manual bindings return no invented evidence.

## Validation
- Hardware-free lifecycle/resident/staged admission checks: 3 tests, 16 assertions.
- Public wrapper lifecycle and unsupported-path checks: 1 test, 4 assertions.
- Real Arc public fused GEMM-ReLU canary: 1 test, 12 assertions, including actual bound strategy and two correct profiled replays.
- Full suites delegated to CI; independent review in progress.

No selection policy, generated code, precision or allocation ownership changes.