### PR TITLE
Verify mixed training uses its admitted matrix routes

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1041,3 +1041,17 @@ selector again. The alias-fallback fixture distinguishes preferred and bound str
 public Arc fusion canary confirms bound fused selection separately from its measured replay.
 Entry points include any prologue and must not be interpreted as replay events. Equation-first
 program reporting remains explicitly unsupported; manual bindings without evidence return nil.
+
+The training acceptance also compares the successfully replayed program's bound phase reports
+against each selected matrix step, so runtime fallback cannot silently satisfy mixed coverage.
+The numerical trajectory and tolerances are unchanged.
+
+External training remains a separate acceptance item. A source audit of finetune-rstr
+`9e9ba5d62f3822f056e01c37231d7eaa7c84947c` found that `finetune.train/bind-layer!`,
+`forward-pass!` and `backward-pass!` still depend on the retired `gpu/bind-program!` and
+`gpu/run-program!` APIs. Its released Raster dependency is 0.2.287, with a sibling override for
+development. Migrate shared forward/VJP adapter state and output views onto public compiled
+artifacts/LinkPlans before rerunning the two-layer chained-gradient and real-weight stack gates.
+Do not restore the old binder or use the tiny Raster block as evidence those external gates pass.
+The pretrained-rstr checkout inspected alongside it was `3b13ad42e7bf4c98e348cb779c28096848931ba0`;
+no sibling source or dependency was changed by this audit.

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -40,6 +40,7 @@
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]
+            [raster.gpu.link :as link]
             [raster.gpu.descriptor-fixture :as fixture]))
 
 ;; ── the twin block (concrete float, LoRA delta inline) ──────────────────────────
@@ -328,7 +329,7 @@
   [prog args]
   (into []
         (keep
-         (fn [step]
+         (fn [[step-index step]]
            (let [schedules (get-in step [:dispatch :attributes :candidate-schedules])]
              (when (some #(= :matrix (:family %)) (vals schedules))
                (let [choice (:dispatch step)
@@ -340,15 +341,16 @@
                      selected (dispatch/select-alternative choice runtime-arguments)
                      strategy (executable/strategy selected)
                      schedule (get schedules strategy)]
-                 {:variant (:variant schedule)
+                 {:step-index step-index
+                  :variant (:variant schedule)
                   :family (:family schedule)
                   :strategy strategy
                   :precision (:precision (executable/attributes selected))})))))
-        (:steps prog)))
+        (map-indexed vector (:steps prog))))
 
 (defn- run-trajectory!
   "n-steps of the resident train step under `prog`'s GEMM policy in a fresh session.
-   Returns the host loss trajectory [loss(state_0) … loss(state_n)]."
+   Returns host losses [loss(state_0) … loss(state_n)] and the bound phase execution reports."
   [prog cfg st0 lr n-steps]
   (let [st (clone-adapters st0)
         args (train-args cfg st lr)
@@ -363,7 +365,7 @@
                             (repeat :constant))))]
         (loop [k 0 losses [(host-loss cfg st)]]
           (if (= k n-steps)
-            losses
+            {:losses losses :execution-info (link/execution-info (:executable program))}
             (do (fixture/run! program args)
                 (recur (inc k)
                        (conj losses
@@ -397,8 +399,17 @@
                              (= :mixed-f16-f32 (:precision %))) dims)
                 (str "mixed training must analytically select matrix execution, not merely enumerate it: "
                      (pr-str dims))))
-          (let [l32 (run-trajectory! p32 cfg st0 lr n-steps)
-                l16 (run-trajectory! p16 cfg st0 lr n-steps)]
+          (let [{l32 :losses} (run-trajectory! p32 cfg st0 lr n-steps)
+                {l16 :losses bound :execution-info} (run-trajectory! p16 cfg st0 lr n-steps)]
+            (testing "the replayed training program bound every selected mixed matrix schedule"
+              ;; This fixture lowers one descriptor instance. Link reports exactly one entry per
+              ;; descriptor step, in order, including nil evidence for unsupported/manual phases.
+              (is (= (count (:steps p16)) (count bound)))
+              (is (= (mapv #(select-keys % [:strategy :precision]) dims)
+                     (mapv (fn [{:keys [step-index]}]
+                             (select-keys (get-in bound [step-index :executable])
+                                          [:strategy :precision]))
+                           dims))))
             (println "  [mixed-precision bwd] f32-scalar loss:"
                      (mapv #(format "%.6f" %) (take 3 l32)) "…"
                      (mapv #(format "%.6f" %) (take-last 2 l32)))


### PR DESCRIPTION
Stacked on #530.

## Summary
- Inspect retained bound phase reports after the existing 25-update Gemma LoRA forward/reverse-AD/SGD trajectory.
- Match strategy and precision for each selected matrix step, preventing silent runtime fallback from satisfying mixed-precision coverage.
- Reuse the existing trajectory; no extra training loop or relaxed numerical tolerance.
- Record pinned external finetune migration debt: its real-weight gates still depend on retired resident program APIs; no sibling modifications.

## Validation
- Focused real Arc test: 1 test, 33 assertions, zero failures/errors.
- All 56 matrix choices agree with actual bound strategy/precision after replay.
- FP32 final loss 1.261994; mixed 1.262058, unchanged from the prior run.
- Independent review confirmed one-descriptor step/phase ordering and fallback coverage.
- Full suites delegated to CI.