### PR TITLE
Retire orphan scatter binders after typed lowering migration

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1055,3 +1055,13 @@ artifacts/LinkPlans before rerunning the two-layer chained-gradient and real-wei
 Do not restore the old binder or use the tiny Raster block as evidence those external gates pass.
 The pretrained-rstr checkout inspected alongside it was `3b13ad42e7bf4c98e348cb779c28096848931ba0`;
 no sibling source or dependency was changed by this audit.
+
+The retired scatter invocation boundary is removed: its pipeline marker/accumulator metadata,
+Level Zero-only resident convention, runtime positional binders and handwritten zero-fill source
+had no remaining compiler producer or caller in the source/test/dev/benchmark inventory or the
+inspected pretrained/finetune sources. Current scalar/strided scatter uses the existing typed
+conflict algebra, scheduled KernelBody and ordinary executable binder. Existing tests remain:
+7 typed-scatter tests (55 assertions), plus 3 retained-source/control and OpenCL device tests
+(128 assertions), pass with retired vars unmapped from the REPL. In particular, collision updates
+preserve nonzero destination contents rather than inheriting the old binder's implicit zero-fill.
+This retires an orphan route, not scatter semantics or an independently exercised source oracle.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1065,3 +1065,10 @@ conflict algebra, scheduled KernelBody and ordinary executable binder. Existing 
 (128 assertions), pass with retired vars unmapped from the REPL. In particular, collision updates
 preserve nonzero destination contents rather than inheriting the old binder's implicit zero-fill.
 This retires an orphan route, not scatter semantics or an independently exercised source oracle.
+The retirement includes LinkPlan/ProgramStage certification: old positional descriptors are
+rejected for lacking an executable interface, rather than being certified for a missing binder.
+All retained descriptor effects use the executable ABI; the dead generic extraction tail and its
+emitter-side scalar-type inference import are removed. The focused LinkPlan and ProgramStage
+namespaces pass 9 tests/41 assertions, including rejection on both ZE and OpenCL. A follow-up must
+validate internal scatter accumulator initialization end to end through ordinary typed fill IR;
+do not reintroduce implicit zeroing in a special runtime convention.

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -350,6 +350,13 @@
                 (if (contains? array-params parameter) nil (get scalars parameter)))
               (:all-params descriptor)))))
 
+(defn- step-interface [step]
+  (or (:artifact step)
+      (some-> (:dispatch step) kdispatch/default-alternative)
+      (throw (ex-info "a linkable descriptor step has no executable interface"
+                      {:reason :link-step-interface :phase (:phase step)
+                       :convention (:convention step)}))))
+
 (defn descriptor-pointer-symbols
   "Return the exact set of compiler symbols that the resident descriptor binds as pointers.
 
@@ -358,11 +365,10 @@
   [descriptor]
   (into #{}
         (mapcat (fn [step]
-                  (if (= :scatter (:convention step))
-                    (:arrays step)
-                    (keep (fn [{:keys [kind sym]}]
-                            (when (not= :scalar kind) sym))
-                          (:argument-specs step)))))
+                  (step-interface step)
+                  (keep (fn [{:keys [kind sym]}]
+                          (when (not= :scalar kind) sym))
+                        (:argument-specs step))))
         (:steps descriptor)))
 
 (defn descriptor-allocation-leaves
@@ -386,13 +392,6 @@
          (throw (ex-info "descriptor allocation fields must be unique and ordered"
                          {:reason :link-allocation-fields :symbol sym :fields fields}))))
      leaves)))
-
-(defn- step-interface [step]
-  (or (:artifact step)
-      (some-> (:dispatch step) kdispatch/default-alternative)
-      (throw (ex-info "a linkable descriptor step has no executable interface"
-                      {:reason :link-step-interface :phase (:phase step)
-                       :convention (:convention step)}))))
 
 (defn- merge-access [left right]
   (if (= left right) left
@@ -517,69 +516,6 @@
                              :expected expected :capacity capacity})))))
       {:instance id :step step-index :phase (:phase step)
        :facts (vec (mapcat :facts binding-facts))})))
-
-(defn- scatter-step-facts
-  [nodes instance step-index step]
-  (let [{:keys [id bindings]} instance
-        [out-sym src-sym index-sym :as symbols] (:arrays step)
-        args (instance-arguments instance)
-        n (try (long ((:n-fn step) args))
-               (catch Exception e
-                 (throw (ex-info "link scatter bound did not resolve from its scalar environment"
-                                 {:reason :link-scatter-bound :instance id :step step-index
-                                  :phase (:phase step)}
-                                 e))))
-        _ (when-not (= 3 (count symbols))
-            (throw (ex-info "a linked scatter step requires output, source and index buffers"
-                            {:reason :link-scatter-abi :instance id :step step-index
-                             :arrays symbols})))
-        node-for
-        (fn [symbol]
-          (let [node-id (get bindings symbol ::missing)
-                link-node (get nodes node-id)]
-            (when (= ::missing node-id)
-              (throw (ex-info "link instance omits a scatter buffer binding"
-                              {:reason :link-missing-binding :instance id :symbol symbol
-                               :phase (:phase step)})))
-            (when-not link-node
-              (throw (ex-info "link scatter binding names an absent node"
-                              {:reason :link-absent-node :instance id :symbol symbol
-                               :node node-id :phase (:phase step)})))
-            (when-not (bview/contiguous? (:view link-node))
-              (throw (ex-info "linked scatter bindings require contiguous views"
-                              {:reason :link-noncontiguous-binding :instance id :symbol symbol
-                               :node node-id :phase (:phase step)})))
-            [node-id link-node]))
-        [[out-id out] [src-id src] [index-id index]] (mapv node-for symbols)
-        capacity (fn [link-node]
-                   (quot (get-in link-node [:view :byte-length])
-                         (dtype/bytes-of (get-in link-node [:view :dtype]))))]
-    (when-not (= (dtype/canon (get-in out [:view :dtype]))
-                 (dtype/canon (get-in src [:view :dtype])))
-      (throw (ex-info "linked scatter source and output dtypes differ"
-                      {:reason :link-node-dtype :instance id :step step-index
-                       :output out-id :source src-id
-                       :output-dtype (get-in out [:view :dtype])
-                       :source-dtype (get-in src [:view :dtype])})))
-    (when-not (= :int (dtype/canon (get-in index [:view :dtype])))
-      (throw (ex-info "linked scatter index storage must be int32"
-                      {:reason :link-node-dtype :instance id :step step-index
-                       :index index-id :actual (get-in index [:view :dtype])})))
-    (doseq [[node-id link-node] [[src-id src] [index-id index]]]
-      (when (> n (capacity link-node))
-        (throw (ex-info "linked scatter bound exceeds a source view"
-                        {:reason :link-node-range :instance id :step step-index
-                         :node node-id :expected n :capacity (capacity link-node)}))))
-    {:instance id :step step-index :phase (:phase step)
-     :facts [{:symbol out-sym :node out-id :access :write}
-             {:symbol src-sym :node src-id :access :read}
-             {:symbol index-sym :node index-id :access :read}]}))
-
-(defn- instance-step-facts
-  [nodes values instance step-index step]
-  (if (= :scatter (:convention step))
-    (scatter-step-facts nodes instance step-index step)
-    (abi-step-facts nodes values instance step-index step)))
 
 (defn- canonical-alias-pair [pair]
   (let [pair (set pair)]
@@ -803,7 +739,7 @@
                                  :field field :node node :expected-elements expected-elements
                                  :actual-elements actual-elements})))))))
       (mapv (fn [[step-index step]]
-              (instance-step-facts nodes values instance step-index step))
+              (abi-step-facts nodes values instance step-index step))
             (map-indexed vector (:steps descriptor))))))
 
 (defn- program-value-node!
@@ -988,15 +924,6 @@
       (map-indexed vector (:steps call))))))
 
 (defn- validate-effects! [{:keys [target nodes values instances outputs aliases] :as plan}]
-  (when (and (not (let [target-name (name target)]
-                    (or (= "ze" target-name) (.startsWith target-name "ze:"))))
-             (some #(= :scatter (:convention %))
-                   (mapcat (fn [instance]
-                             (when (link-instance? instance)
-                               (get-in instance [:descriptor :steps])))
-                           instances)))
-    (throw (ex-info "linked scatter execution is not available on this target backend"
-                    {:reason :link-target-convention :target target :convention :scatter})))
   (let [step-facts
         (mapcat #(if (link-instance? %)
                    (validate-instance-bindings! nodes values %)

--- a/src/raster/compiler/ir/program_stage.clj
+++ b/src/raster/compiler/ir/program_stage.clj
@@ -55,16 +55,9 @@
 (defn step-accesses
   "Return `{compiler-symbol :read|:write|:read-write}` for one descriptor step.
 
-   Access comes from the executable ABI, not parameter spelling conventions. Scatter retains its
-   explicit three-buffer contract until it is represented by an ordinary executable ABI."
+   Access comes from the executable ABI, not parameter spelling conventions."
   [step]
-  (if (= :scatter (:convention step))
-    (let [[output source index :as arrays] (:arrays step)]
-      (when-not (and (= 3 (count arrays)) (every? symbol? arrays))
-        (throw (ex-info "program stage scatter requires output, source and index symbols"
-                        {:reason :program-stage-scatter :phase (:phase step) :arrays arrays})))
-      {output :write source :read index :read})
-    (let [interface (kexec/validate! (step-interface step))
+  (let [interface (kexec/validate! (step-interface step))
           slot-groups (kabi/logical-pointer-slot-groups (kexec/abi interface))
           logical-names (mapv :binding slot-groups)
           pointer-specs (filterv #(not= :scalar (:kind %)) (:argument-specs step))
@@ -86,7 +79,7 @@
                                      :symbol symbol :binding binding})))
                   (update accesses symbol merge-access access)))
               {}
-              (map vector symbols slot-groups)))))
+              (map vector symbols slot-groups))))
 
 (defn descriptor-accesses
   "Return the ordered per-step access maps of a resident descriptor."

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -44,7 +44,6 @@
             [raster.compiler.passes.parallel.typed-soac-route :as typed-soac-route]
             [raster.compiler.backend.gpu.entry :as gpu-entry]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
-            [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.gpu.parallel-program-opencl :as parallel-program-opencl]
             [raster.compiler.passes.parallel.compound-detect :as compound-detect]
@@ -2092,29 +2091,10 @@
                            :phase (keyword (str "gpu-step-" i))})
 
                         :else
-                        (let [{:keys [kernel-name arrays scalars n-expr convention output]} step]
-                          {:kernel-name kernel-name
-                           :arrays arrays
-                           ;; :reduce steps carry the resident 1-elem output buffer (sym keyword) so
-                           ;; LinkPlan instantiation wires it like a map output (it lives in :allocs as scratch).
-                           :output (when output (keyword (name output)))
-                           :n-fn (expr->arg-fn all-params scalar-lets n-expr)
-                           ;; Type each scalar arg with the SAME canonical scalar dtype the kernel
-                           ;; DECLARATION uses (par_opencl), so the host arg encoding always matches
-                           ;; the kernel's C param type — single source of truth. A deftm PARAM is in
-                           ;; scalar-types; a HOISTED LOCAL scalar (e.g. `nb (quot in 32)`, not a
-                           ;; param) is typed from its `:raster.type/tag` stamp. The old code only
-                           ;; consulted the param map and DEFAULTED locals to :float — so an int local
-                           ;; like `nb` was declared `int` in the kernel but encoded `:float` on the
-                           ;; host → float-bits into an int slot → garbage index → OOB → device-lost.
-                           :scalar-specs (mapv (fn [s]
-                                                 {:type (c-emit/scalar-parameter-dtype
-                                                         s (:scalar-types gpu-param-types)
-                                                         effective-dtype)
-                                                  :value-fn (expr->arg-fn all-params scalar-lets s)})
-                                               scalars)
-                           :convention convention
-                           :phase (keyword (str "gpu-step-" i))})))
+                        (throw (ex-info "resident extraction has no executable convention"
+                                        {:reason :resident-unsupported-convention
+                                         :convention (:convention step)
+                                         :kernel-name (:kernel-name step)}))))
                     (range) (:steps prog))
        :result-sym (:result prog)
        :compiler-report

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1354,8 +1354,7 @@
      raster.gpu.ze-runtime/invoke-registered-reduction-kernel
      raster.gpu.ze-runtime/invoke-registered-contraction!
      raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
-     raster.compiler.pipeline/invoke-scheduled-executable!
-     raster.gpu.ze-runtime/invoke-registered-scatter-kernel})
+     raster.compiler.pipeline/invoke-scheduled-executable!})
 
 (def ^:private gpu-array-alloc-heads
   '#{double-array float-array int-array long-array byte-array
@@ -1459,26 +1458,6 @@
           (when (and (vector? arguments) (contains? #{:single :none} policy))
             {:dispatch-id dispatch-id :arguments arguments
              :convention :executable :returns sym :result-policy policy})))
-      (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
-      ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
-      ;; accumulator buffer (a zeros-like intermediate), written in-place via atomic +=.
-      ;; The resident bind zeroes it each replay (a zero-fill kernel prepended to the
-      ;; scatter). :arrays is the kernel C-sig order (out src index); the extra scalar
-      ;; (stride) is a :scalar (n stays :n-expr, and n precedes stride in the C-sig — the
-      ;; scatter bind places n before the scalars, unlike the map-void arrays,scalars,n order).
-      ;; stride is optional: emitted 7-wide with a trailing nil, or 6-wide when absent.
-      (when (#{6 7} argc)
-        (let [[_ kname out src index n stride] expr
-              ;; Strip a `(long x)`/`(int x)` cast so the scalar is a bare symbol
-              ;; (scalar-parameter-dtype keys on the name, and the value-fn still evaluates
-              ;; the raw symbol — it is an int stride/index param either way).
-              strip-cast (fn [x] (if (and (seq? x)
-                                          (#{'long 'int 'clojure.core/long 'clojure.core/int} (first x)))
-                                   (second x) x))]
-          {:kernel-name kname :arrays [out src index]
-           :scalars (if stride [(strip-cast stride)] [])
-           :n-expr n :convention :scatter :accumulator out :returns sym}))
-
       (= head 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel)
       ;; SegRed carries VALUES in exact emitter-authored ABI order, including its result and
       ;; bound slots. A nil result is the host-scalar staging protocol and cannot enter a
@@ -2113,16 +2092,12 @@
                            :phase (keyword (str "gpu-step-" i))})
 
                         :else
-                        (let [{:keys [kernel-name arrays scalars n-expr convention output accumulator]} step]
+                        (let [{:keys [kernel-name arrays scalars n-expr convention output]} step]
                           {:kernel-name kernel-name
                            :arrays arrays
                            ;; :reduce steps carry the resident 1-elem output buffer (sym keyword) so
                            ;; LinkPlan instantiation wires it like a map output (it lives in :allocs as scratch).
                            :output (when output (keyword (name output)))
-                           ;; :scatter steps carry the accumulator buffer sym so the linked binder can
-                           ;; zero it (a zero-fill kernel prepended to the atomic-add scatter) each
-                           ;; replay — the zeros-like semantics of scatter-add's output.
-                           :accumulator (when accumulator (keyword (name accumulator)))
                            :n-fn (expr->arg-fn all-params scalar-lets n-expr)
                            ;; Type each scalar arg with the SAME canonical scalar dtype the kernel
                            ;; DECLARATION uses (par_opencl), so the host arg encoding always matches

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1988,7 +1988,6 @@
      :map/:reduce/:map-void/:contract/:executable
                 Select one ABI-compatible KernelArtifact or KernelGraph schedule. Graph-private
                 conversion/layout/split temporaries remain owned by the bound step.
-     :scatter   Expands to zero-fill + scatter behind the same ordered prepared-step boundary.
 
    Optional opts carry descriptor context needed by composition: {:schedule <resolved schedule>
    :roles {compiler-sym -> :constant|...}}. Captured constants make eligible graph transforms a

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1927,7 +1927,7 @@
    DeviceBuffer. Both whole-program binding and composition call this function; convention-specific
    runtime expansion is confined here."
   [device-id step args resolve-buffer schedule roles]
-  (let [{:keys [kernel-name phase convention artifact argument-specs arrays n-fn scalar-specs]}
+  (let [{:keys [kernel-name phase convention artifact argument-specs]}
         step]
     (case convention
       (:map :reduce :map-void :contract :executable)
@@ -1973,42 +1973,6 @@
         (assoc (bind-selected-executable
                 device-id selected ordered-args phase constant-buffer-ids group-count)
                :execution-info execution-info))
-
-      :scatter
-      (do
-        (when (not= :ze (backend-type device-id))
-          (throw (ex-info "resident scatter steps are Level-Zero-only (no OpenCL implementation yet)"
-                          {:backend (backend-type device-id)
-                           :device-id device-id :step kernel-name})))
-        (when (> (count scalar-specs) 1)
-          (throw (ex-info (str "resident scatter step " kernel-name " has "
-                               (count scalar-specs)
-                               " scalars — only a single stride is modeled")
-                          {:kernel kernel-name :scalar-specs scalar-specs})))
-        (let [[out-sym src-sym idx-sym] arrays
-              out-buf (resolve-buffer out-sym)
-              src-buf (resolve-buffer src-sym)
-              idx-buf (resolve-buffer idx-sym)
-              n (long (n-fn args))
-              stride (when (seq scalar-specs)
-                       (long ((:value-fn (first scalar-specs)) args)))
-              ensure-zero! (rt-resolve device-id "ensure-zero-fill-kernel!")
-              specialized-bind! (rt-resolve device-id "bind-registered-map-void-kernel")
-              scatter-bind! (rt-resolve device-id "bind-registered-scatter-kernel!")
-              zero-kernel (ensure-zero! (:dtype out-buf))
-              prepareds (volatile! [])]
-          (try
-            (vswap! prepareds conj
-                    (assoc (specialized-bind! zero-kernel [out-buf] []
-                                              (long (:n-elements out-buf)))
-                           :phase phase))
-            (vswap! prepareds conj
-                    (assoc (scatter-bind! kernel-name [out-buf src-buf idx-buf] n stride)
-                           :phase phase))
-            (->BoundExecutableStep @prepareds {} [])
-            (catch Exception e
-              (destroy-prepared-entry! device-id (->BoundExecutableStep @prepareds {} []))
-              (throw e)))))
 
       (throw (ex-info (str "resident step binder cannot bind a " convention " step ("
                            kernel-name ")")

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -714,7 +714,7 @@
 (defn execution-info
   "Return resident phase admission reports without executing the linked program.
    One entry per bound phase, in phase order; :executable is nil for manual/non-executable phases
-   (including legacy scatter) that do not retain compiler admission evidence.
+   that do not retain compiler admission evidence.
    Entry points describe the bound executable, including any prologue, not measured replay events.
    Equation-first prepared programs do not yet retain this evidence and are explicitly declined."
   [executable]

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1327,16 +1327,6 @@
         (finally (.close arena))))
     (buffer->array ids-buf)))
 
-(defn invoke-registered-scatter-kernel
-  "Invoke a compiled scatter-add kernel. Same interface as ze_runtime."
-  [^String kernel-name output src index n & [stride]]
-  (invoke-registered-map-void-kernel kernel-name
-                                     (if stride [output src index] [output src index])
-                                     (if stride
-                                       [{:type :int :value (int stride)}]
-                                       [])
-                                     n))
-
 (defn invoke-registered-reduce-by-key-kernel
   "Invoke a compiled reduce-by-key kernel. Same interface as ze_runtime."
   [^String kernel-name output keys vals n]

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2449,59 +2449,6 @@
       (.invokeWithArguments ^MethodHandle (:h-launch bound)
                             ^"[Ljava.lang.Object;" (:launch-args bound)))))
 
-(defn ensure-zero-fill-kernel!
-  "Register (idempotently) a zero-fill kernel `out[i]=0` for the given dtype and
-   return its name. Used by the resident scatter step to re-zero the accumulator
-   buffer each replay (scatter-add's output has zeros-like semantics; the atomic
-   `+=` kernel must start from a cleared buffer). C-sig: (out, int n) — matches the
-   (array, _n_bound) layout bind-registered-map-void-kernel expects, so the zero-fill
-   binds through that same path. Idempotency is keyed on the actual kernel-registry
-   (not a side atom) so it survives ns reload."
-  [dtype]
-  (let [dtype (if (= dtype :double) :double :float)
-        ctype (if (= dtype :double) "double" "float")
-        kname (str "zero_fill_" (name dtype))]
-    (when-not (get @kernel-registry kname)
-      (register-kernel! kname
-                        {:source (str "__kernel void " kname
-                                      "(__global " ctype "* out, int n) {\n"
-                                      "  for (int i = get_global_id(0); i < n; i += get_global_size(0))\n"
-                                      "    out[i] = 0;\n}\n")
-                         :array-params ['out]
-                         :scalar-params []
-                         :written-arrays ['out]
-                         :dtype dtype}))
-    kname))
-
-(defn bind-registered-scatter-kernel!
-  "Pre-bind a registered scatter-add kernel over RESIDENT buffers for the replayable
-   program graph. arrays = [out src index] (DeviceBuffer/MemorySegment); the index
-   buffer is int32. Kernel C-sig: (out, src, index, int n [, int stride]) — n precedes
-   stride (NOT the arrays,scalars,n order of a map-void). One work-item per source pair,
-   grid = ceil(n/wg); the atomic `+=` fans overlapping indices in safely. `out` must be
-   pre-zeroed (the resident binder prepends a zero-fill). Returns {:bound :group-count}."
-  ([^String kernel-name arrays n] (bind-registered-scatter-kernel! kernel-name arrays n nil))
-  ([^String kernel-name arrays n stride]
-   (let [{:keys [module workgroup-size]
-          :or {workgroup-size 256}} (ensure-kernel-loaded! kernel-name)
-         kernel-handle (create-kernel-fresh module kernel-name)
-         wg (long workgroup-size)
-         n (long n)
-         seg-of (fn [arr]
-                  (cond
-                    (device-buffer? arr) (:segment ^DeviceBuffer arr)
-                    (instance? MemorySegment arr) arr
-                    :else (throw (ex-info "bind-registered-scatter-kernel! requires resident buffers (DeviceBuffer/MemorySegment)"
-                                          {:arr-type (type arr)}))))
-         dev-segs (mapv seg-of arrays)
-         all-args (vec (concat dev-segs
-                               [{:type :int :value (int n)}]
-                               (when stride [{:type :int :value (int stride)}])))
-         group-count (long (Math/ceil (/ (double n) wg)))]
-     {:bound (bind-kernel! kernel-handle wg all-args (:cmd-list @state))
-      :group-count group-count
-      :kernel-name kernel-name})))
-
 (defn record-graph!
   "Record a FIXED ordered sequence of pre-bound kernels into a regular (replayable) command
   list — a 'command graph'. The per-launch host-append cost (FFI + driver, ~75µs each) is paid
@@ -3233,65 +3180,6 @@
         group-count (long (Math/ceil (/ (double total) wg)))]
     (launch! kernel-handle group-count wg all-args)
     out-buf))
-
-;; ================================================================
-;; Scatter kernel invocation
-;; ================================================================
-
-(defn invoke-registered-scatter-kernel
-  "Pipeline-friendly scatter-add kernel invocation.
-  output[index[i]] += src[i] (atomically).
-
-  kernel-name:  registered scatter kernel
-  output:       JVM array or DeviceBuffer (accumulation target)
-  src:          JVM array or DeviceBuffer (source values)
-  index:        JVM int-array or DeviceBuffer (destination indices)
-  n:            number of source elements
-  stride:       optional stride for strided scatter (nil for unstrided)"
-  [^String kernel-name output src index n & [stride]]
-  (let [{:keys [kernel-handle workgroup-size dtype]
-         :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
-        n (long n)
-        dtype-size (long (get dtype-byte-sizes dtype 4))
-        wg (long (or workgroup-size 256))
-        groups (long (Math/ceil (/ (double n) wg)))
-        ;; Copy arrays to device
-        copy-to (fn [arr tag byte-count]
-                  (if (device-buffer? arr)
-                    (:segment ^DeviceBuffer arr)
-                    (let [seg (ensure-seg kernel-name tag byte-count)
-                          s (MemorySegment/ofArray arr)]
-                      (MemorySegment/copy s 0 seg 0 byte-count)
-                      seg)))
-        ;; Output size is the DESTINATION buffer length (n-dst*stride), NOT the
-        ;; source pair count. For a JVM array the array length is authoritative;
-        ;; the old (* n stride) sized it as n-pairs*stride and overran the output
-        ;; whenever n-pairs > n-dst (the overlapping-index case). For a device
-        ;; buffer copy-to ignores byte-count (it returns the segment directly),
-        ;; so out-elems is unused there.
-        out-elems (if (device-buffer? output) n (alength output))
-        ;; GPU index buffer is int32. scatter-add/gather use (Array long) indices
-        ;; on the CPU; narrow a long-array to int here so the byte copy is coherent
-        ;; (copying n*4 bytes of an 8-byte-per-element long[] reinterprets pairs of
-        ;; longs as ints and silently corrupts the indices).
-        index (if (and (not (device-buffer? index))
-                       (instance? (Class/forName "[J") index))
-                (let [li ^longs index m (alength li) ia (int-array m)]
-                  (dotimes [k m] (aset ia k (int (aget li k))))
-                  ia)
-                index)
-        out-seg (copy-to output :scatter-out (* out-elems dtype-size))
-        src-seg (copy-to src :scatter-src (* n (if stride (* (long stride) dtype-size) dtype-size)))
-        idx-seg (copy-to index :scatter-idx (* n 4))
-        args (if stride
-               [out-seg src-seg idx-seg {:type :int :value (int n)} {:type :int :value (int stride)}]
-               [out-seg src-seg idx-seg {:type :int :value (int n)}])]
-    (launch! kernel-handle groups wg args)
-    ;; Copy back output
-    (when-not (device-buffer? output)
-      (MemorySegment/copy out-seg 0 (MemorySegment/ofArray output) 0
-                          (* (long (alength output)) dtype-size)))
-    output))
 
 ;; ================================================================
 ;; Reduce-by-key kernel invocation

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -272,7 +272,7 @@
            (:reason (ex-data (try (make-plan #{#{:x :out}})
                                   (catch clojure.lang.ExceptionInfo e e))))))))
 
-(deftest scatter-expansion-retains-a-pure-link-contract
+(deftest retired-scatter-descriptors-require-an-executable-interface
   (let [descriptor {:dtype :float
                     :all-params '[out src index n]
                     :array-params '[out src index]
@@ -291,9 +291,12 @@
         instance (link/instance {:id :scatter :descriptor descriptor
                                  :bindings {'out :out 'src :src 'index :index}
                                  :scalars {'n 16}})]
-    (is (link/link-plan? (link/make {:id :scatter :target :ze:0 :nodes nodes
-                                     :instances [instance] :outputs [:out]})))
-    (is (= :link-target-convention
+    (is (= :link-step-interface
+           (:reason (ex-data
+                     (try (link/make {:id :scatter :target :ze:0 :nodes nodes
+                                     :instances [instance] :outputs [:out]})
+                          (catch clojure.lang.ExceptionInfo e e))))))
+    (is (= :link-step-interface
            (:reason (ex-data
                      (try
                        (link/make {:id :scatter-ocl :target :ocl:0

--- a/test/raster/compiler/ir/program_stage_test.clj
+++ b/test/raster/compiler/ir/program_stage_test.clj
@@ -94,6 +94,14 @@
              (link/make {:id :staged-attention :target :ze:0 :nodes nodes
                          :instances instances :outputs [:output]})))))))
 
+(deftest retired-positional-scatter-cannot-manufacture-stage-effects
+  (is (= :program-stage-interface
+         (:reason
+          (ex-data
+           (try (stage/step-accesses {:phase :scatter :convention :scatter
+                                     :arrays '[out source index]})
+                (catch clojure.lang.ExceptionInfo error error)))))))
+
 (deftest staging-fails-loudly-on-ambiguous-or-leaking-effect-contracts
   (let [program (descriptor)]
     (testing "an anchor may not be selected by first/last name-search heuristics"


### PR DESCRIPTION
Stacked on #531.

## Summary
- Remove the old scatter invocation marker and accumulator metadata from resident extraction.
- Remove the Level Zero-only scatter binder, its handwritten zero-fill source, and the orphan ZE/OpenCL positional scatter invokers.
- Typed scalar/strided scatter keeps its conflict certificate, KernelBody emission and common executable binder.
- No semantic operation, test, or independent reference kernel removed. External callers of the retired runtime functions must use the current typed source/public execution route.

## Validation
- Caller audit across source/tests/dev/bench/scripts and inspected pretrained/finetune source found no remaining producer or consumer of the retired functions.
- Existing typed reducing-scatter suite: 7 tests, 55 assertions, green.
- Existing retained-source/control and real OpenCL tests: 3 tests, 128 assertions, green; includes collisions into nonzero output and inactive host branches.
- Retired vars explicitly unmapped from the REPL before validation, so stale definitions cannot mask remaining callers.
- Full suites and CUDA/HIP source fixtures delegated to CI. Independent retirement audit in progress.