### PR TITLE
Schedule fresh resident zeros through typed SOAC maps

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1084,12 +1084,17 @@ Explicit compound allocation lengths use the same scalar SSA normalization as la
 at the original allocation site; the public invocation plan therefore sees a scalar dimension,
 not a reconstructed arithmetic expression. Value remapping preserves the allocation contracts.
 
-The first overwrite-elision proof is deliberately narrow: an unconditional dense map over exactly
-the allocated extent, with no aliased destination read. Write-only permission is not a full-domain
-coverage proof for conditional stores, padded contractions, or sparse updates. Unsupported extent,
-dtype, placement, alias, and observable-host-use contracts fail closed. Broader coverage proofs
-for contractions/effect maps remain performance work; this change does not claim optimal fill
-elision or improve the matrix schedule selector.
+Overwrite elision uses complete logical result shapes for functional maps, stencils, contractions,
+segmented/product reductions, segmented fold-maps, and scans, with no aliased destination read.
+The shared extent proof follows retained integral scalar SSA and checked Long products, allowing
+equal dimensions with reordered factors without erasing narrowing, floating, or wrapping
+arithmetic. Allocation size must equal result volume: padding still requires initialization.
+Write-only permission alone proves nothing for conditional effect stores or sparse updates.
+Unsupported extent, dtype, placement, alias, and observable-host-use contracts fail closed.
+General effect-map dense-image proofs remain work; this does not change the matrix selector.
+Storage first consumed by retained host bindings keeps the native allocation provider and host
+writes; GPU staging uploads that state. Such host buffer accesses still disqualify straight-line
+resident extraction. Observations between fused constituents cannot use this exemption.
 
 Validation covers ordinary and strided public scatter, holes, collisions, changed inputs, and
 two replays on Arc; both stages are ordinary KernelBody kernels. CUDA/HIP checks cover public

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1072,3 +1072,33 @@ emitter-side scalar-type inference import are removed. The focused LinkPlan and 
 namespaces pass 9 tests/41 assertions, including rejection on both ZE and OpenCL. A follow-up must
 validate internal scatter accumulator initialization end to end through ordinary typed fill IR;
 do not reintroduce implicit zeroing in a special runtime convention.
+
+## Fresh-storage initialization through the typed vertical
+
+Resident allocation does not itself implement Clojure's fresh-array zero semantics, and allocating
+once is not enough for repeated execution. The frontend now retains allocation initialization,
+element type, extent, and source order in TypedSOAC facts using the shared allocator descriptor.
+GPU scheduling materializes required zeros as ordinary typed maps after fusion and before
+ownership certification. Native fresh-array execution keeps its native initialization provider.
+Explicit compound allocation lengths use the same scalar SSA normalization as launch extents,
+at the original allocation site; the public invocation plan therefore sees a scalar dimension,
+not a reconstructed arithmetic expression. Value remapping preserves the allocation contracts.
+
+The first overwrite-elision proof is deliberately narrow: an unconditional dense map over exactly
+the allocated extent, with no aliased destination read. Write-only permission is not a full-domain
+coverage proof for conditional stores, padded contractions, or sparse updates. Unsupported extent,
+dtype, placement, alias, and observable-host-use contracts fail closed. Broader coverage proofs
+for contractions/effect maps remain performance work; this change does not claim optimal fill
+elision or improve the matrix schedule selector.
+
+Validation covers ordinary and strided public scatter, holes, collisions, changed inputs, and
+two replays on Arc; both stages are ordinary KernelBody kernels. CUDA/HIP checks cover public
+source compilation **and allocation-free LinkPlan lowering**, not emission alone. Focused pure
+checks cover full/partial overwrite, copy/unspecified storage, malformed facts, aliases, source
+placement, generated names, and value remapping. Existing numerical tests are retained.
+
+Separately, the full typed route namespace on an Intel device exposes remaining unification debt:
+`gemm/split-k-combine-plan` still builds a contraction surface form and calls `contraction-facts`
+and `contract-form->segred`. The source-reparse guard fails with initialization disabled as well;
+its input contains no allocation. Preserve that guard and migrate this compiler-generated
+combine algorithm directly to typed IR in the next slice, rather than weakening the test.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1090,6 +1090,13 @@ The shared extent proof follows retained integral scalar SSA and checked Long pr
 equal dimensions with reordered factors without erasing narrowing, floating, or wrapping
 arithmetic. Allocation size must equal result volume: padding still requires initialization.
 Write-only permission alone proves nothing for conditional effect stores or sparse updates.
+Allocation cardinality is separate from a destination AbstractValue's logical consumer shape.
+For example, an AD gradient may be allocated with `in*out` elements and later consumed over
+`alength(weights)`. These remain independent symbolic identities: the initializer covers the
+constructor extent, while concrete invocation/LinkPlan validation checks logical demand against
+capacity. Known undersized allocations fail statically; neither symbolic equality nor extra
+capacity is a license to elide a fill. Plain representation and absent logical layout remain
+mandatory for this initialization route.
 Unsupported extent, dtype, placement, alias, and observable-host-use contracts fail closed.
 General effect-map dense-image proofs remain work; this does not change the matrix selector.
 Storage first consumed by retained host bindings keeps the native allocation provider and host

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1095,6 +1095,9 @@ General effect-map dense-image proofs remain work; this does not change the matr
 Storage first consumed by retained host bindings keeps the native allocation provider and host
 writes; GPU staging uploads that state. Such host buffer accesses still disqualify straight-line
 resident extraction. Observations between fused constituents cannot use this exemption.
+The native-provider obligation is retained as semantic data and survives value remapping.
+Source-independent SOAC promotion and invocation linking reject it until an explicit content
+provider exists; an ABI `:write` role cannot silently discharge that obligation.
 
 Validation covers ordinary and strided public scatter, holes, collisions, changed inputs, and
 two replays on Arc; both stages are ordinary KernelBody kernels. CUDA/HIP checks cover public

--- a/src/raster/compiler/ir/extent_proof.clj
+++ b/src/raster/compiler/ir/extent_proof.clj
@@ -1,0 +1,73 @@
+(ns raster.compiler.ir.extent-proof
+  "Conservative product equality over retained integral scalar SSA.
+
+   This is a proof, not an expression rewrite: scalar evaluation order and overflow checks
+   stay in the program. Narrowing casts, floating arithmetic and unchecked products remain
+   opaque. Only successful checked Long multiplication admits mathematical factorization."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.index-algebra :as algebra]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(defn- integral? [t] (contains? #{:byte :short :int :long} t))
+
+(defn- expression [environment form]
+  (cond
+    (symbol? form) (get environment form)
+    (and (integer? form) (<= 0 form Long/MAX_VALUE))
+    {:dtype :long :product (algebra/monomial form)}
+    (seq? form)
+    (let [op (descriptor/semantic-op form)
+          operands (mapv #(expression environment %) (descriptor/call-args form))]
+      (cond
+        (and (descriptor/cast-op? op) (= 1 (count operands)))
+        (let [operand (first operands)
+              target (some-> (descriptor/cast-result-tag op) dtype/dtype-for-scalar-tag)]
+          (when (and (integral? (:dtype operand)) (integral? target)
+                     (<= (dtype/bytes-of (:dtype operand)) (dtype/bytes-of target)))
+            (assoc operand :dtype target)))
+        ;; Raster's Integer multiplication wraps; its Long specialization is checked.
+        (and (descriptor/multiplication-op? op) (seq operands)
+             (every? #(and (= :long (:dtype %)) (:product %)) operands))
+        (try {:dtype :long :product (apply algebra/product (map :product operands))}
+             (catch ArithmeticException _ nil))))))
+
+(defn environment
+  "Build product witnesses from typed scalar equations. Unknown integral values are opaque
+   factors; an unproved definition keeps its own SSA identity, never its guessed arithmetic."
+  [program]
+  (reduce
+   (fn [environment equation]
+     (let [{:keys [kind captures lambda]} (dialect/operation-parts equation)]
+       (if (not= 'scalar kind)
+         environment
+         (let [{:keys [parameters locals body-results]} (dialect/lambda-parts lambda)
+               local-env (merge environment (zipmap parameters (map environment captures)))
+               local-env (reduce (fn [env {:keys [id dtype init]}]
+                                   (assoc env id
+                                          (when-let [proof (expression env init)]
+                                            (when (= dtype (:dtype proof)) proof))))
+                                 local-env locals)]
+           (reduce (fn [env [id form]]
+                     (let [proof (expression local-env form)]
+                       (if (and proof (= (:dtype (get env id)) (:dtype proof)))
+                         (assoc env id proof) env)))
+                   environment (map vector (nth equation 2) body-results))))))
+   (into {} (keep (fn [[id value]]
+                    (when (and (= :tensor (:kind value)) (= [] (:shape value))
+                               (integral? (:dtype value)))
+                      [id {:dtype (:dtype value) :product (algebra/monomial id)}])))
+         (:values (dialect/facts program)))
+   (dialect/equations program)))
+
+(defn same-volume?
+  "Whether allocation extent equals the entire dense result shape. No capacity inequalities."
+  [environment extent shape]
+  (and (vector? shape)
+   (or (= [extent] shape)
+      (try
+        (let [allocation (:product (expression environment extent))
+              dimensions (map #(-> (expression environment %) :product) shape)]
+          (boolean (and allocation (every? some? dimensions)
+                        (= allocation (apply algebra/product dimensions)))))
+        (catch ArithmeticException _ false)))))

--- a/src/raster/compiler/ir/invocation_link.clj
+++ b/src/raster/compiler/ir/invocation_link.clj
@@ -242,6 +242,11 @@
   [materialized parallel-program target evaluate-host]
   (let [materialized (materialization/validate! materialized)
         parallel-program (emitted-program/validate! parallel-program)
+        _ (when-let [providers (seq (get-in parallel-program
+                                           [:attributes :native-initialization-providers]))]
+            (fail! :invocation-link-native-initialization
+                   "source-independent linking requires an explicit native-content provider"
+                   {:destinations (vec providers)}))
         invocation-plan (:plan materialized)
         invocation-id (:id invocation-plan)
         _ (when-not (= (set (:program-inputs invocation-plan))

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -2085,7 +2085,19 @@
                               :equations equation-facts)
                  (seq (get-in source-facts [:attributes :host-read-values]))
                  (update-in [:attributes :host-read-values]
-                            #(vec (distinct (map rename %)))))]
+                            #(vec (distinct (map rename %))))
+                 (seq (get-in source-facts [:attributes :allocations]))
+                 (update-in [:attributes :allocations]
+                            #(mapv (fn [allocation]
+                                     (-> allocation
+                                         (update :destination rename)
+                                         (update :extent (fn [extent]
+                                                           (if (value-id? extent)
+                                                             (rename extent)
+                                                             (util/subst-syms value-map extent)))))) %))
+                 (seq (get-in source-facts [:attributes :host-read-sites]))
+                 (update-in [:attributes :host-read-sites]
+                            #(mapv (fn [site] (update site :values (fn [ids] (set (map rename ids))))) %)))]
     (make facts' equation-forms (mapv rename (outputs program)))))
 
 (defn default-equation-facts

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -2086,6 +2086,9 @@
                  (seq (get-in source-facts [:attributes :host-read-values]))
                  (update-in [:attributes :host-read-values]
                             #(vec (distinct (map rename %))))
+                 (seq (get-in source-facts [:attributes :native-initialization-providers]))
+                 (update-in [:attributes :native-initialization-providers]
+                            #(vec (distinct (map rename %))))
                  (seq (get-in source-facts [:attributes :allocations]))
                  (update-in [:attributes :allocations]
                             #(mapv (fn [allocation]

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -359,6 +359,10 @@
     (fail! :structured-control-soac-promotion
            "loop-free promotion requires an analyzed :typed-soac ParallelProgram"
            {:dialect (:dialect parallel-program)}))
+  (when-let [providers (seq (get-in parallel-program [:attributes :native-initialization-providers]))]
+    (fail! :structured-control-native-initialization
+           "source-independent promotion cannot discard native allocation and host writes"
+           {:destinations (vec providers)}))
   (let [parallel-program (hoist-host-invocation-equations parallel-program)
         public-parameters (vec (or public-parameters active-params))
         _ (when-not (seq public-parameters)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1918,7 +1918,21 @@
                              (assoc-in state [:local-scalar-types symbol] scalar-dtype)
                              state)
                      scalar-aliases (:scalar-aliases state)
-                     extent (parallel-extent expression)
+                     parallel-extent (parallel-extent expression)
+                     allocation-extent (allocation-length expression)
+                     ;; Normalize explicit allocation lengths at their original evaluation site,
+                     ;; using the same scalar SSA mechanism as launch extents. Source-shaped
+                     ;; one-argument allocators retain their exemplar (not a substituted size).
+                     explicit-allocation-extent
+                     (when (and allocation-extent
+                                (= allocation-extent (last (descriptor/call-args expression))))
+                       allocation-extent)
+                     extent (or parallel-extent explicit-allocation-extent)
+                     replace-extent (fn [expression extent]
+                                      (if parallel-extent
+                                        (replace-parallel-extent expression extent)
+                                        (with-meta (apply list (concat (butlast expression) [extent]))
+                                          (meta expression))))
                      ;; `(alength y)` over a local allocation is the allocation's declared
                      ;; length; follow renamed allocations to their length as well.
                      resolve-length (fn resolve-length [extent seen]
@@ -1950,7 +1964,7 @@
                    ;; count remains an executable scalar equation with a distinct dimension id.
                    (dialect/extent? canonical-extent)
                    (update state :normalized conj
-                           [symbol (replace-parallel-extent expression canonical-extent)])
+                           [symbol (replace-extent expression canonical-extent)])
 
                    (provably-pure-scalar? canonical-extent)
                    (if-let [extent-id (get compound-extents canonical-extent)]
@@ -1958,7 +1972,7 @@
                      ;; redundant scalar work, this exposes equal launch geometry to the
                      ;; general horizontal-fusion rule (for example two same-shaped views).
                      (update state :normalized conj
-                             [symbol (replace-parallel-extent expression extent-id)])
+                             [symbol (replace-extent expression extent-id)])
                      (let [extent-dtype (or (retained-scalar-dtype canonical-extent local-scalar-types)
                                             :long)
                            extent-tag (dtype/scalar-tag-for-dtype extent-dtype)
@@ -1973,7 +1987,7 @@
                            (assoc-in [:compound-extents canonical-extent] extent-id)
                            (update :normalized into
                                    [[extent-id canonical-extent]
-                                    [symbol (replace-parallel-extent expression extent-id)]]))))
+                                    [symbol (replace-extent expression extent-id)]]))))
 
                    :else
                    (update state :normalized conj [symbol expression]))))
@@ -3056,6 +3070,27 @@
                                                              values)]
     (form->program* source options)))
 
+(defn- allocation-contracts
+  "Allocation leaves the equation spine as host scaffolding, but initialization is semantic.
+   Supported constructor arity and positive scalar-kind evidence distinguish a length from a
+   copy input; (float-array n 7), for example, must never become a zero-initialization fact."
+  [descriptions array-types scalar-types values shape-equalities]
+  (binding [*declared-kinds*
+            {:arrays (set (keys array-types))
+             :scalars (into (set (keys scalar-types))
+                            (keep (fn [[id value]] (when (= [] (:shape value)) id)))
+                            values)}]
+    (into []
+          (keep (fn [{:keys [kind id sym expr]}]
+                  (when (= :scalar kind)
+                    (when-let [extent (allocation-length expr)]
+                      {:destination sym :source-binding-id id
+                       :extent (canonical-extent shape-equalities values extent)
+                       :initialization (descriptor/allocation-initialization
+                                        (descriptor/semantic-op expr))
+                       :dtype (:dtype (get values sym))}))))
+          descriptions)))
+
 (defn- form->program*
   [source {:keys [dtype array-types scalar-types values shape-equalities]
            :or {dtype :double array-types {} scalar-types {} values {} shape-equalities {}}}]
@@ -3226,6 +3261,16 @@
                       :effects total-effects
                       :provenance {:front-end :analyzed-source}
                       :attributes {:source-dialect :closed-clojure
+                                   :source-bindings (mapv first pairs)
                                    :host-binding-ids host-binding-ids
-                                   :host-read-values host-read-values}})]
+                                   :host-read-values host-read-values
+                                   :host-read-sites
+                                   (mapv (fn [{:keys [id expr]}]
+                                           {:source-binding-id id
+                                            :values (set (filter #(contains? values %)
+                                                                 (util/free-syms expr)))})
+                                         host-descriptions)
+                                   :allocations (allocation-contracts descriptions array-types
+                                                                      scalar-types values
+                                                                      shape-equalities)}})]
           (dialect/make facts equations outputs))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1842,6 +1842,7 @@
     (if (and (seq? source) (contains? #{'let 'let*} (first source)))
       (let [[head bindings & body] source
             pairs (vec (partition 2 bindings))
+            occupied-symbols (set (filter symbol? (tree-seq coll? seq source)))
             {:keys [normalized]}
             (reduce
              (fn [{:keys [compound-extents allocation-lengths scalar-aliases pure-scalar-ids
@@ -1976,8 +1977,13 @@
                      (let [extent-dtype (or (retained-scalar-dtype canonical-extent local-scalar-types)
                                             :long)
                            extent-tag (dtype/scalar-tag-for-dtype extent-dtype)
+                           extent-base (str "rstr_extent_" ordinal)
                            extent-id (with-meta
-                                       (clojure.core/symbol (str "rstr_extent_" ordinal))
+                                       (first (remove occupied-symbols
+                                                      (cons (clojure.core/symbol extent-base)
+                                                            (map #(clojure.core/symbol
+                                                                   (str extent-base "_" %))
+                                                                 (range)))))
                                        {:tag extent-tag :raster.type/tag extent-tag
                                         ;; This SSA value is introduced by the frontend as the
                                         ;; canonical identity of compound launch/storage algebra.

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -30,6 +30,9 @@
       (some #(= destination (physical-id facts (:destination %)))
             (dialect/result-storage facts (second equation)))))
 
+(defn- plain-storage? [value]
+  (and (= {:kind :plain} (:representation value)) (nil? (:logical-layout value))))
+
 (defn- full-overwrite? [facts extent-environment {:keys [destination extent]} equation]
   ;; These functional operations produce their entire validated logical result shape.
   ;; Indexed/guarded effect maps and scatter do not have that guarantee.
@@ -39,6 +42,8 @@
        (some (fn [[result storage]]
                (and (= destination (physical-id facts (:destination storage)))
                     (= :write (:access storage))
+                    (plain-storage? (get-in facts [:values result]))
+                    (plain-storage? (get-in facts [:values destination]))
                     (extent-proof/same-volume? extent-environment extent
                                               (get-in facts [:values result :shape]))))
              (map vector (nth equation 2) (dialect/result-storage facts (second equation))))))
@@ -113,7 +118,7 @@
                 (assoc-in [:equations id] equation-facts)
                 (update :effects conj :memory/write))}))
 
-(defn- allocation-contracts! [facts]
+(defn- allocation-contracts! [facts extent-environment]
   (let [allocations (get-in facts [:attributes :allocations] [])]
     (when-not (and (vector? allocations)
                    (every? #(and (map? %) (dialect/value-id? (:destination %))
@@ -136,7 +141,14 @@
       (when (and (= :zero (:initialization allocation))
                  (not (integral-extent? facts (:extent allocation))))
         (fail! "zero allocation requires a canonical integral scalar extent"
-               {:allocation allocation})))
+               {:allocation allocation}))
+      (when (and (= :zero (:initialization allocation))
+                 (not (and (plain-storage? value)
+                           (or (= [(list 'unknown-dimension destination)] (:shape value))
+                               (extent-proof/same-volume? extent-environment
+                                                         (:extent allocation) (:shape value))))))
+        (fail! "fresh zero allocation requires matching plain dense storage"
+               {:allocation allocation :value value})))
     allocations))
 
 (defn materialize
@@ -149,7 +161,7 @@
         extent-environment (extent-proof/environment program)
         allocations (filter #(and (= :zero (:initialization %))
                                   (contains? (:values original-facts) (:destination %)))
-                            (allocation-contracts! original-facts))
+                            (allocation-contracts! original-facts extent-environment))
         {:keys [facts equations pending fills elided native]}
         (reduce
          (fn [{:keys [facts pending] :as state} equation]

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -171,7 +171,10 @@
                           (let [{:keys [placement native?]}
                                 (initialization-site! facts allocation equation)]
                             (cond
-                              native? (update state :native inc)
+                              native? (-> state (update :native inc)
+                                          (update-in [:facts :attributes :native-initialization-providers]
+                                                     #(vec (distinct (conj (or % [])
+                                                                          (:destination allocation))))))
                               (full-overwrite? facts extent-environment allocation equation)
                               (update state :elided inc)
                               :else

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -1,0 +1,164 @@
+(ns raster.compiler.passes.parallel.typed-soac-initialization
+  "Schedule fresh-storage initialization as ordinary typed equations.
+
+   Allocation contracts come from the frontend, not an allocator registry here. This pass is
+   for resident execution, where allocation itself does not implement the language's zeros and
+   a replay must reestablish them. Native fresh-array execution needs no such schedule."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(defn- fail! [message data]
+  (throw (ex-info message (assoc data :reason :typed-soac-initialization-contract))))
+
+(defn- physical-id [facts value]
+  (let [aliases (into {} (mapcat :aliases) (vals (:equations facts)))]
+    (loop [id value seen #{}]
+      (if-let [target (let [target (get aliases id)] (when (not= target id) target))]
+        (do (when (contains? seen id)
+              (fail! "initialization encountered a cyclic physical alias" {:value id}))
+            (recur target (conj seen id)))
+        id))))
+
+(defn- physical-inputs [facts equation]
+  (set (map #(physical-id facts %) (dialect/operation-inputs equation))))
+
+(defn- touches? [facts destination equation]
+  (or (contains? (physical-inputs facts equation) destination)
+      (some #(= destination (physical-id facts (:destination %)))
+            (dialect/result-storage facts (second equation)))))
+
+(defn- full-overwrite? [facts {:keys [destination extent]} equation]
+  ;; Only an unconditional dense map with the exact allocation domain is a coverage proof.
+  ;; A write-only effect map or contraction can leave holes or padding untouched.
+  (and (= 'map (dialect/operation-kind equation))
+       (= extent (get-in (dialect/operation-parts equation) [:attributes :extent]))
+       (not (contains? (physical-inputs facts equation) destination))
+       (some #(and (= destination (physical-id facts (:destination %))) (= :write (:access %)))
+             (dialect/result-storage facts (second equation)))))
+
+(defn- fresh-symbol [used prefix]
+  (first (remove used (map #(symbol (str prefix %)) (range)))))
+
+(defn- initialization-site! [facts {:keys [destination source-binding-id] :as allocation} consumer]
+  (let [consumer-facts (get-in facts [:equations (second consumer)])
+        placements (or (seq (keys (get-in consumer-facts [:attributes :fusion/constituents])))
+                       [(get-in consumer-facts [:provenance :source-binding-id])])]
+    (when-not (every? integer? placements)
+      (fail! "initialization requires an ordered analyzed-source consumer"
+             {:allocation allocation :consumer (second consumer) :placements placements}))
+    (let [placement (apply max placements)]
+      (when-not (< source-binding-id placement)
+        (fail! "initialization consumer must follow allocation"
+               {:allocation allocation :consumer (second consumer) :placement placement}))
+      (doseq [read (get-in facts [:attributes :host-read-sites])
+              :when (and (contains? (:values read) destination)
+                         (< source-binding-id (:source-binding-id read) placement))]
+        (fail! "a host observation precedes the first resident initialization site"
+               {:allocation allocation :host-read read :placement placement}))
+      placement)))
+
+(defn- integral-extent? [facts extent]
+  (or (and (integer? extent) (not (neg? extent)))
+      (let [value (get-in facts [:values extent])]
+        (and (dialect/value-id? extent) (= :tensor (:kind value))
+             (= [] (:shape value)) (contains? #{:int :long} (:dtype value))))))
+
+(defn- initializer [facts {:keys [destination extent dtype source-binding-id] :as allocation}
+                    placement]
+  (when-not (integral-extent? facts extent)
+    (fail! "resident initialization requires a typed allocation extent and scalar element type"
+           {:allocation allocation}))
+  (let [scalar-tag (try (dtype/scalar-tag-for-dtype dtype)
+                       (catch clojure.lang.ExceptionInfo e
+                         (fail! "resident initialization requires a scalar-emittable element type"
+                                {:allocation allocation :cause (ex-data e)})))
+        used (set/union (set (keys (:values facts))) (set (keys (:equations facts)))
+                        (set (get-in facts [:attributes :source-bindings])))
+        result (fresh-symbol used "rstr_initialized_")
+        id (fresh-symbol (conj used result) "rstr_initialization_equation_")
+        index (fresh-symbol (conj used result) "rstr_zero_index_")
+        equation (list '= id [result]
+                       (list 'map {:index index :extent extent} [] []
+                             (dialect/lambda-form [] []
+                                                  [(list (symbol "clojure.core" (name scalar-tag)) 0)])))
+        equation-facts
+        (-> (dialect/default-equation-facts
+             {:source-binding-id placement :allocation-source-binding-id source-binding-id})
+            (assoc :effects #{:memory/write} :aliases {result destination})
+            (assoc :attributes {:initialization :zero
+                                :result-storage [{:destination destination :access :write
+                                                  :host-return :effect}]}))]
+    {:equations [equation]
+     :facts (-> facts
+                (assoc-in [:values result]
+                          (av/tensor {:dtype dtype :shape [extent]
+                                      :representation {:kind :plain}}))
+                (assoc-in [:equations id] equation-facts)
+                (update :effects conj :memory/write))}))
+
+(defn- allocation-contracts! [facts]
+  (let [allocations (get-in facts [:attributes :allocations] [])]
+    (when-not (and (vector? allocations)
+                   (every? #(and (map? %) (dialect/value-id? (:destination %))
+                                 (integer? (:source-binding-id %))
+                                 (not (neg? (:source-binding-id %)))
+                                 (contains? #{:zero :copy :unspecified} (:initialization %)))
+                           allocations)
+                   (= (count allocations) (count (distinct (map :destination allocations))))
+                   (= (count allocations) (count (distinct (map :source-binding-id allocations)))))
+      (fail! "allocation facts must identify distinct ordered storage contracts"
+             {:allocations allocations}))
+    (doseq [{:keys [destination dtype] :as allocation} allocations
+            :let [value (get-in facts [:values destination])]
+            :when value]
+      (when-not (and (= :tensor (:kind value)) (seq (:shape value))
+                     (dtype/known? dtype) (= dtype (dtype/canon dtype))
+                     (= dtype (:dtype value)))
+        (fail! "allocation and destination must agree on the retained element type"
+               {:allocation allocation :value value}))
+      (when (and (= :zero (:initialization allocation))
+                 (not (integral-extent? facts (:extent allocation))))
+        (fail! "zero allocation requires a canonical integral scalar extent"
+               {:allocation allocation})))
+    allocations))
+
+(defn materialize
+  "Return [program stats], inserting zero maps before the first physical use of fresh storage.
+   Unspecified/copy allocations retain their own contracts. Elision needs exact dense coverage,
+   never merely an ABI :write permission. Run after fusion and before ownership certification."
+  [program]
+  (dialect/validate! program)
+  (let [original-facts (dialect/facts program)
+        allocations (filter #(and (= :zero (:initialization %))
+                                  (contains? (:values original-facts) (:destination %)))
+                            (allocation-contracts! original-facts))
+        {:keys [facts equations pending fills elided]}
+        (reduce
+         (fn [{:keys [facts pending] :as state} equation]
+           (let [active (filterv #(touches? facts (:destination %) equation) pending)
+                 state (reduce
+                        (fn [{:keys [facts] :as state} allocation]
+                          (let [placement (initialization-site! facts allocation equation)]
+                            (if (full-overwrite? facts allocation equation)
+                              (update state :elided inc)
+                              (let [{:keys [equations facts]} (initializer facts allocation placement)]
+                                (-> state (assoc :facts facts)
+                                    (update :equations into equations) (update :fills inc))))))
+                        state active)]
+             (-> state
+                 (assoc :pending (vec (remove (set active) pending)))
+                 (update :equations conj equation))))
+         {:facts original-facts :equations [] :pending (vec allocations) :fills 0 :elided 0}
+         (dialect/equations program))
+        _ (when (seq pending)
+            (fail! "live zero storage has no typed initialization site"
+                   {:allocations pending}))
+        definitions (set (mapcat #(nth % 2) equations))
+        references (set (mapcat #(into (dialect/operation-inputs %)
+                                      (filter dialect/value-id? (dialect/operation-extents %)))
+                               equations))
+        facts (assoc facts :inputs (vec (sort-by pr-str (set/difference references definitions))))]
+    [(dialect/make facts equations (dialect/outputs program))
+     {:initialization-fills fills :initialization-full-overwrites elided}]))

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -118,7 +118,7 @@
                 (assoc-in [:equations id] equation-facts)
                 (update :effects conj :memory/write))}))
 
-(defn- allocation-contracts! [facts extent-environment]
+(defn- allocation-contracts! [facts]
   (let [allocations (get-in facts [:attributes :allocations] [])]
     (when-not (and (vector? allocations)
                    (every? #(and (map? %) (dialect/value-id? (:destination %))
@@ -143,11 +143,17 @@
         (fail! "zero allocation requires a canonical integral scalar extent"
                {:allocation allocation}))
       (when (and (= :zero (:initialization allocation))
-                 (not (and (plain-storage? value)
-                           (or (= [(list 'unknown-dimension destination)] (:shape value))
-                               (extent-proof/same-volume? extent-environment
-                                                         (:extent allocation) (:shape value))))))
-        (fail! "fresh zero allocation requires matching plain dense storage"
+                 (not (plain-storage? value)))
+        (fail! "fresh zero allocation requires plain dense storage"
+               {:allocation allocation :value value}))
+      ;; AbstractValue shape can be a consumer's logical access domain, not the allocator's
+      ;; physical capacity (e.g. an AD gradient consumed over alength(weights)). The constructor
+      ;; extent is authoritative for initialization. Never guess a symbolic equality here;
+      ;; concrete graph/LinkPlan binding checks access capacity. Reject a known short allocation.
+      (when (and (= :zero (:initialization allocation))
+                 (integer? (:extent allocation)) (every? integer? (:shape value))
+                 (> (reduce *' 1 (:shape value)) (:extent allocation)))
+        (fail! "fresh zero allocation is smaller than its logical access domain"
                {:allocation allocation :value value})))
     allocations))
 
@@ -161,7 +167,7 @@
         extent-environment (extent-proof/environment program)
         allocations (filter #(and (= :zero (:initialization %))
                                   (contains? (:values original-facts) (:destination %)))
-                            (allocation-contracts! original-facts extent-environment))
+                            (allocation-contracts! original-facts))
         {:keys [facts equations pending fills elided native]}
         (reduce
          (fn [{:keys [facts pending] :as state} equation]

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -7,6 +7,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.extent-proof :as extent-proof]
             [raster.compiler.ir.soac-dialect :as dialect]))
 
 (defn- fail! [message data]
@@ -29,14 +30,18 @@
       (some #(= destination (physical-id facts (:destination %)))
             (dialect/result-storage facts (second equation)))))
 
-(defn- full-overwrite? [facts {:keys [destination extent]} equation]
-  ;; Only an unconditional dense map with the exact allocation domain is a coverage proof.
-  ;; A write-only effect map or contraction can leave holes or padding untouched.
-  (and (= 'map (dialect/operation-kind equation))
-       (= extent (get-in (dialect/operation-parts equation) [:attributes :extent]))
+(defn- full-overwrite? [facts extent-environment {:keys [destination extent]} equation]
+  ;; These functional operations produce their entire validated logical result shape.
+  ;; Indexed/guarded effect maps and scatter do not have that guarantee.
+  (and (contains? '#{map stencil contract segmented-reduce product-reduce
+                     segmented-fold-map scan} (dialect/operation-kind equation))
        (not (contains? (physical-inputs facts equation) destination))
-       (some #(and (= destination (physical-id facts (:destination %))) (= :write (:access %)))
-             (dialect/result-storage facts (second equation)))))
+       (some (fn [[result storage]]
+               (and (= destination (physical-id facts (:destination storage)))
+                    (= :write (:access storage))
+                    (extent-proof/same-volume? extent-environment extent
+                                              (get-in facts [:values result :shape]))))
+             (map vector (nth equation 2) (dialect/result-storage facts (second equation))))))
 
 (defn- fresh-symbol [used prefix]
   (first (remove used (map #(symbol (str prefix %)) (range)))))
@@ -48,16 +53,26 @@
     (when-not (every? integer? placements)
       (fail! "initialization requires an ordered analyzed-source consumer"
              {:allocation allocation :consumer (second consumer) :placements placements}))
-    (let [placement (apply max placements)]
+    (let [placement (apply max placements)
+          reads (filter #(and (some (fn [value] (= destination (physical-id facts value)))
+                                   (:values %))
+                              (< source-binding-id (:source-binding-id %) placement))
+                        (get-in facts [:attributes :host-read-sites]))
+          host-sites (set (get-in facts [:attributes :host-binding-ids]))
+          native? (and (seq reads)
+                       (every? #(and (contains? host-sites (:source-binding-id %))
+                                     (< (:source-binding-id %) (apply min placements))) reads))]
       (when-not (< source-binding-id placement)
         (fail! "initialization consumer must follow allocation"
                {:allocation allocation :consumer (second consumer) :placement placement}))
-      (doseq [read (get-in facts [:attributes :host-read-sites])
-              :when (and (contains? (:values read) destination)
-                         (< source-binding-id (:source-binding-id read) placement))]
+      (doseq [read reads :when (not native?)]
         (fail! "a host observation precedes the first resident initialization site"
                {:allocation allocation :host-read read :placement placement}))
-      placement)))
+      ;; Host-controlled consumers retain the native allocator and its initial contents.
+      ;; Resident extraction rejects these buffer-reading host bindings; staging uploads the
+      ;; resulting host array. A later fill would erase the host's writes. An observation
+      ;; between fused constituents is not a native-first use and still fails closed.
+      {:placement placement :native? (boolean native?)})))
 
 (defn- integral-extent? [facts extent]
   (or (and (integer? extent) (not (neg? extent)))
@@ -131,18 +146,23 @@
   [program]
   (dialect/validate! program)
   (let [original-facts (dialect/facts program)
+        extent-environment (extent-proof/environment program)
         allocations (filter #(and (= :zero (:initialization %))
                                   (contains? (:values original-facts) (:destination %)))
                             (allocation-contracts! original-facts))
-        {:keys [facts equations pending fills elided]}
+        {:keys [facts equations pending fills elided native]}
         (reduce
          (fn [{:keys [facts pending] :as state} equation]
            (let [active (filterv #(touches? facts (:destination %) equation) pending)
                  state (reduce
                         (fn [{:keys [facts] :as state} allocation]
-                          (let [placement (initialization-site! facts allocation equation)]
-                            (if (full-overwrite? facts allocation equation)
+                          (let [{:keys [placement native?]}
+                                (initialization-site! facts allocation equation)]
+                            (cond
+                              native? (update state :native inc)
+                              (full-overwrite? facts extent-environment allocation equation)
                               (update state :elided inc)
+                              :else
                               (let [{:keys [equations facts]} (initializer facts allocation placement)]
                                 (-> state (assoc :facts facts)
                                     (update :equations into equations) (update :fills inc))))))
@@ -150,7 +170,7 @@
              (-> state
                  (assoc :pending (vec (remove (set active) pending)))
                  (update :equations conj equation))))
-         {:facts original-facts :equations [] :pending (vec allocations) :fills 0 :elided 0}
+         {:facts original-facts :equations [] :pending (vec allocations) :fills 0 :elided 0 :native 0}
          (dialect/equations program))
         _ (when (seq pending)
             (fail! "live zero storage has no typed initialization site"
@@ -161,4 +181,5 @@
                                equations))
         facts (assoc facts :inputs (vec (sort-by pr-str (set/difference references definitions))))]
     [(dialect/make facts equations (dialect/outputs program))
-     {:initialization-fills fills :initialization-full-overwrites elided}]))
+     {:initialization-fills fills :initialization-full-overwrites elided
+      :initialization-native-providers native}]))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -11,6 +11,7 @@
             [raster.compiler.passes.parallel.effect-source :as effect-source]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-initialization :as initialization]
             [raster.compiler.passes.parallel.typed-soac-projection :as projection]
             [raster.compiler.passes.parallel.typed-soac-resident :as resident]
             [raster.compiler.passes.parallel.typed-soac-ownership :as ownership]
@@ -622,7 +623,8 @@
    (attempt form dtype {}))
   ([form dtype array-types]
    (attempt form dtype array-types {}))
-  ([form dtype array-types {:keys [resident-reductions? scalar-types values abstract-machine]
+  ([form dtype array-types {:keys [resident-reductions? resident-initialization?
+                                 scalar-types values abstract-machine]
                             :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (let [form (frontend/normalize-source form {:array-types array-types
@@ -640,6 +642,10 @@
                    (if resident-reductions?
                      (resident/realize typed-result)
                      [typed-result {:resident-reductions 0 :inlined-scalars 0}])
+                   [typed-result initialization-stats]
+                   (if resident-initialization?
+                     (initialization/materialize typed-result)
+                     [typed-result {}])
                    [typed-result ownership-stats] (ownership/prove typed-result)]
                (if (not-any? #(contains? #{:map :scatter :effect-map :stencil :reduce
                                            :segmented-reduce :contract :product-reduce
@@ -652,7 +658,7 @@
                    {:declined decline}
                    (let [{:keys [source realized]} (realize-source form typed-result)]
                      {:program (envelope typed-result source realized)
-                      :stats (merge typed-stats resident-stats ownership-stats
+                      :stats (merge typed-stats resident-stats initialization-stats ownership-stats
                                     {:route :typed-soac :typed-validated true
                                      :front-end :analyzed-source})}))))))
          (catch clojure.lang.ExceptionInfo exception

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -795,6 +795,7 @@
       (let [typed (typed-soac-route/attempt
                    source (:dtype opts) (:array-types opts)
                    {:resident-reductions? (true? (:resident-reductions? opts))
+                    :resident-initialization? (device/gpu-target? (:target-device opts))
                     :scalar-types (:scalar-types opts)
                     :values (:values opts)
                     :abstract-machine abstract-machine})]

--- a/test/raster/compiler/ir/extent_proof_test.clj
+++ b/test/raster/compiler/ir/extent_proof_test.clj
@@ -1,0 +1,22 @@
+(ns raster.compiler.ir.extent-proof-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.extent-proof :as proof]))
+
+(def environment
+  {'m {:dtype :long :product {:const 1 :factors ['m]}}
+   'n {:dtype :long :product {:const 1 :factors ['n]}}
+   'i {:dtype :int :product {:const 1 :factors ['i]}}})
+
+(deftest extent-equality-is-a-proof-not-cast-stripping
+  (doseq [extent ['(* m n) '(* n m) '(* (long m) n) '(* m (* n 1))]]
+    (is (proof/same-volume? environment extent '[m n])))
+  (doseq [extent ['(* m n 2) '(* (int m) n) '(* (float m) n)
+                  '(unchecked-multiply m n) '(raster.numeric/* i i)
+                  '(* m unknown) '(* -1 m) '(* 9223372036854775807 2)]]
+    (is (not (proof/same-volume? environment extent '[m n]))))
+  (testing "opaque wrapping products cannot equal their mathematical expansion"
+    (is (not (proof/same-volume? environment '(raster.numeric/* i i) '[i i]))))
+  (testing "unknown/missing shapes and padding do not prove full coverage"
+    (is (not (proof/same-volume? environment 1 nil)))
+    (is (not (proof/same-volume? environment 9 [8])))
+    (is (proof/same-volume? environment 8 [2 4]))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -18,6 +18,29 @@
           total (raster.par/reduce acc 0.0 j n (+ acc (clojure.core/aget y j)))]
          total))
 
+(deftest physical-allocation-initialization-survives-host-scaffolding
+  (let [contracts
+        (fn [allocation]
+          (let [source (list 'let* ['output allocation
+                                   'written '(raster.par/map! output i n nil (aget input i))]
+                             'written)
+                program (frontend/form->program
+                         source {:dtype :double :array-types {'input :float 'output :float}
+                                 :scalar-types {'n :long}})]
+            (is (some? program))
+            (get-in (dialect/facts program) [:attributes :allocations])))]
+    (doseq [[allocation initialization]
+            [['(clojure.core/float-array n) :zero]
+             ['(raster.math/zeros-like input n) :zero]
+             ['(raster.math/alloc-like input n) :unspecified]
+             ['(clojure.core/aclone input) :copy]]]
+      (is (= [{:destination 'output :source-binding-id 0
+               :extent 'n
+               :initialization initialization :dtype :float}]
+             (contracts allocation))))
+    (is (empty? (contracts '(clojure.core/float-array n 7))))
+    (is (empty? (contracts '(clojure.core/float-array [1.0 2.0]))))))
+
 (deftest returned-buffer-identity-is-normalized-before-access-contracts
   (let [source '(let* [r (raster.par/contract C [[i 4]] [] (clojure.core/aget A i))
                        alias r

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_device_test.clj
@@ -1,0 +1,28 @@
+(ns raster.compiler.passes.parallel.typed-soac-initialization-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-compile-fixtures :as fixtures]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.compiled :as compiled]))
+
+(deftest public-fresh-scatter-reestablishes-zeros-on-every-replay
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "public typed allocation initialization")
+    (doseq [[function values dimensions expected]
+            [[#'fixtures/public-c-family-scatter [1 2 3] [3] [3.0 0.0 3.0]]
+             [#'fixtures/public-c-family-strided-scatter [1 2 3 4 5 6] [3 2]
+              [4.0 6.0 0.0 0.0 5.0 6.0]]]]
+      (let [input (float-array values)
+            prepared (compiled/lower function
+                                     (into [input (int-array [0 0 2])] dimensions)
+                                     {:target :ze:0 :dtype :float :on-non-resident :throw})
+            live (compiled/instantiate! prepared {:profile? true})]
+        (try
+          (is (= [:map-void :map-void] (mapv :convention (compiled/ir prepared))))
+          (doseq [sign [1.0 -1.0]]
+            (dotimes [i (alength input)] (aset-float input i (* sign (nth values i))))
+            (let [result (compiled/profile live)]
+              (is (= (mapv #(* sign %) expected)
+                     (vec (get-in result [:result :output]))))
+              (is (= 2 (count (:profile result)))
+                  "the zero map is part of every replay, not an allocation-time upload")))
+          (finally (compiled/close! live)))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -1,0 +1,122 @@
+(ns raster.compiler.passes.parallel.typed-soac-initialization-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-compile-fixtures :as fixtures]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.link-plan :as link-plan]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-initialization :as initialization]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(defn- source [allocation extent]
+  (list 'let* ['output allocation
+               'written (list 'raster.par/map! 'output 'i extent nil '(aget input i))]
+        'written))
+
+(defn- program [source]
+  (frontend/form->program source {:dtype :double :array-types {'input :float 'output :float}}))
+
+(deftest zero-initialization-needs-full-coverage-not-write-permission
+  (doseq [[extent fills elided] [[4 1 0] [8 0 1]]]
+    (let [source (source '(float-array 8) extent)
+          [scheduled stats] (initialization/materialize (program source))]
+      (is (= fills (:initialization-fills stats)))
+      (is (= elided (:initialization-full-overwrites stats)))
+      (is (= (inc fills) (count (dialect/equations scheduled))))
+      (when (pos? fills)
+        (let [fill (first (dialect/equations scheduled))
+              result (first (nth fill 2))
+              facts (dialect/facts scheduled)
+              realized (#'route/realize-source source scheduled)
+              pairs (mapv vec (partition 2 (second (:source realized))))]
+          (is (= 'map (dialect/operation-kind fill)))
+          (is (= :float (get-in facts [:values result :dtype])))
+          (is (= [8] (get-in facts [:values result :shape])))
+          (is (= '[output (float-array 8)] (first pairs)) "allocation survives placement")
+          (is (= 3 (count pairs)) "fill precedes the prefix write")
+          (is (= scheduled (first (initialization/materialize scheduled))) "idempotent"))))))
+
+(deftest unspecified-and-copy-storage-do-not-acquire-zero-fills
+  (doseq [allocation ['(raster.math/alloc-like input 8) '(aclone input)]]
+    (let [program (program (source allocation 4))
+          [scheduled stats] (initialization/materialize program)]
+      (is (= program scheduled))
+      (is (zero? (:initialization-fills stats))))))
+
+(defn- with-facts [program f]
+  (dialect/make (f (dialect/facts program))
+                (dialect/equations program) (dialect/outputs program)))
+
+(defn- reason [program]
+  (try (initialization/materialize program) nil
+       (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+
+(deftest initialization-contracts-fail-closed
+  (let [program (program (source '(float-array 8) 4))]
+    (doseq [change [#(update-in % [:attributes :allocations] into
+                               (get-in % [:attributes :allocations]))
+                    #(assoc-in % [:attributes :allocations 0 :dtype] :double)
+                    #(assoc-in % [:attributes :allocations 0 :initialization] :invented)
+                    #(assoc-in % [:attributes :allocations 0 :extent] -1)
+                    #(assoc-in % [:attributes :allocations 0 :extent] 'input)
+                    #(assoc-in % [:attributes :allocations 0 :extent] '(do (mutate!) 8))
+                    #(assoc-in % [:attributes :allocations 0 :source-binding-id] nil)
+                    #(update-in % [:equations 1 :provenance] dissoc :source-binding-id)
+                    #(assoc-in % [:attributes :allocations 0 :source-binding-id] 2)]]
+      (is (= :typed-soac-initialization-contract (reason (with-facts program change)))))))
+
+(deftest generated-initializers-avoid-host-symbols
+  (let [program (with-facts (program (source '(float-array 8) 4))
+                  #(update-in % [:attributes :source-bindings] conj
+                              'rstr_initialized_0 'rstr_initialization_equation_0))
+        [scheduled] (initialization/materialize program)
+        fill (first (dialect/equations scheduled))]
+    (is (not= 'rstr_initialized_0 (first (nth fill 2))))
+    (is (not= 'rstr_initialization_equation_0 (second fill)))))
+
+(deftest aliases-cannot-turn-a-read-into-an-overwrite-proof
+  (let [program (with-facts (program (source '(float-array 8) 8))
+                  #(update-in % [:equations 1 :aliases] assoc 'input 'middle 'middle 'output))
+        [_ stats] (initialization/materialize program)]
+    (is (= 1 (:initialization-fills stats)))
+    (is (zero? (:initialization-full-overwrites stats)))
+    (is (= :typed-soac-initialization-contract
+           (reason (with-facts program #(assoc-in % [:equations 1 :aliases 'middle] 'input)))))))
+
+(deftest host-observations-prevent-late-initialization-and-elision
+  (doseq [extent [4 8]]
+    (let [program (with-facts (program (source '(float-array 8) extent))
+                    #(-> %
+                         (assoc-in [:equations 1 :provenance :source-binding-id] 2)
+                         (assoc-in [:attributes :host-read-sites]
+                                   [{:source-binding-id 1 :values #{'output}}])))]
+      (is (= :typed-soac-initialization-contract (reason program))))))
+
+(deftest public-initialization-cross-compiles-without-a-device
+  (doseq [target [:cuda:0 :hip:0]
+          [function arguments] [[#'fixtures/public-c-family-scatter
+                                 [(float-array [1 2 3]) (int-array [0 0 2]) 3]]
+                                [#'fixtures/public-c-family-strided-scatter
+                                 [(float-array [1 2 3 4 5 6]) (int-array [0 0 2]) 3 2]]]]
+    (let [compilation (equation-first/compile function {:target target :dtype :float})
+          plan (equation-first/lower compilation arguments)]
+      (is (= [:kernel-body :kernel-body]
+             (mapv #(get-in % [:attributes :emission-route]) (:kernels compilation))))
+      (is (link-plan/link-plan? plan))
+      (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
+
+(deftest allocation-facts-compose-with-value-remapping
+  (let [original (frontend/form->program
+                  (source '(float-array n) 'n)
+                  {:dtype :float :array-types {'input :float 'output :float}
+                   :scalar-types {'n :long}})
+        original (with-facts original
+                   #(assoc-in % [:attributes :host-read-sites]
+                              [{:source-binding-id 2 :values #{'output}}]))
+        remapped (dialect/remap-values original {'output 'storage 'n 'length})
+        [scheduled stats] (initialization/materialize remapped)]
+    (is (= 'storage (get-in (dialect/facts scheduled) [:attributes :allocations 0 :destination])))
+    (is (= 'length (get-in (dialect/facts scheduled) [:attributes :allocations 0 :extent])))
+    (is (= #{'storage} (get-in (dialect/facts scheduled) [:attributes :host-read-sites 0 :values])))
+    (is (= '[output written] (get-in (dialect/facts scheduled) [:attributes :source-bindings])))
+    (is (= 1 (:initialization-full-overwrites stats)))))

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.typed-soac-initialization-test
   (:require [clojure.test :refer [deftest is]]
+            [raster.core :refer [deftm]]
             [raster.compiler.backend.gpu.kernel-body-compile-fixtures :as fixtures]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.link-plan :as link-plan]
@@ -74,6 +75,36 @@
 (defn- reason [program]
   (try (initialization/materialize program) nil
        (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+
+(deftest logical-prefix-shape-is-not-the-allocation-capacity
+  (doseq [domain [4 'm]]
+    (let [p (frontend/form->program (source '(float-array 8) domain)
+                                   {:dtype :float :array-types {'input :float 'output :float}
+                                    :scalar-types {'m :long}})
+          p (with-facts p #(assoc-in % [:values 'output :shape] [domain]))
+          [scheduled stats] (initialization/materialize p)]
+      (is (= 1 (:initialization-fills stats)))
+      (is (= 8 (get-in (dialect/operation-parts (first (dialect/equations scheduled)))
+                       [:attributes :extent])))
+      (is (= [domain] (get-in (dialect/facts scheduled) [:values 'output :shape]))))))
+
+(deftm fixed-capacity-prefix
+  [input :- (Array float) domain :- Long] :- (Array float)
+  (let [output (float-array 8)]
+    (raster.par/map! output i domain float (raster.arrays/aget input i))))
+
+(deftest symbolic-logical-demand-is-checked-against-concrete-capacity
+  (doseq [target [:cuda:0 :hip:0]]
+    (let [compiled (equation-first/compile #'fixed-capacity-prefix {:target target :dtype :float})]
+      (doseq [n [4 8]]
+        (let [plan (equation-first/lower compiled [(float-array n) n])]
+          (is (link-plan/link-plan? plan))
+          (is (= 0 (get-in plan [:attributes :driver-allocations])))))
+      (let [failure (try (equation-first/lower compiled [(float-array 9) 9]) nil
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= :program-link-value-contract (:reason failure)))
+        (is (= 8 (:physical-elements failure)))
+        (is (= 9 (:logical-elements failure)))))))
 
 (deftest initialization-contracts-fail-closed
   (let [program (program (source '(float-array 8) 4))]

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-initialization :as initialization]
+            [raster.compiler.passes.parallel.structured-control-route :as structured]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
 
 (defn- source [allocation extent]
@@ -152,6 +153,22 @@
                                 {0 {} 2 {}}))))
         "a host observation between fused constituents cannot become native-first")))
 
+(deftest write-permission-cannot-drop-a-native-provider-during-promotion
+  (let [source '(let* [output (float-array 8)
+                       seeded (do (aset output 7 (float 7.0)) nil)
+                       written (raster.par/map! output i 4 nil (aget input i))] written)
+        [scheduled] (initialization/materialize (program source))
+        equation (last (dialect/equations scheduled))]
+    (is (= :write (:access (first (dialect/result-storage scheduled (second equation))))))
+    (is (= ['output] (get-in (dialect/facts scheduled)
+                            [:attributes :native-initialization-providers])))
+    (is (= scheduled (first (initialization/materialize scheduled))))
+    (is (= ['renamed] (get-in (dialect/facts (dialect/remap-values scheduled {'output 'renamed}))
+                             [:attributes :native-initialization-providers])))
+    (is (= :structured-control-native-initialization
+           (try (structured/promote-soac-program (route/program-envelope scheduled) {}) nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+
 (deftest public-initialization-cross-compiles-without-a-device
   (doseq [target [:cuda:0 :hip:0]
           [function arguments] [[#'fixtures/public-c-family-scatter
@@ -163,6 +180,12 @@
       (is (= [:kernel-body :kernel-body]
              (mapv #(get-in % [:attributes :emission-route]) (:kernels compilation))))
       (is (link-plan/link-plan? plan))
+      (is (= :invocation-link-native-initialization
+             (try (equation-first/lower
+                   (assoc-in compilation [:emitted :attributes :native-initialization-providers]
+                             ['native-storage]) arguments)
+                  nil
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
       (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
 
 (deftest allocation-facts-compose-with-value-remapping

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -120,3 +120,23 @@
     (is (= #{'storage} (get-in (dialect/facts scheduled) [:attributes :host-read-sites 0 :values])))
     (is (= '[output written] (get-in (dialect/facts scheduled) [:attributes :source-bindings])))
     (is (= 1 (:initialization-full-overwrites stats)))))
+
+(deftest allocation-extent-normalization-is-hygienic-and-precedes-allocation
+  (let [source '(let* [output (float-array (* n width))
+                       written (raster.par/map! output i (* n width) nil
+                                               (+ (aget input i) rstr_extent_0))]
+                 written)
+        normalized (frontend/normalize-source
+                    source {:array-types {'input :float 'output :float}
+                            :scalar-types {'n :long 'width :long 'rstr_extent_0 :long}})
+        [[extent expression] [output allocation] [_ consumer]]
+        (partition 2 (second normalized))]
+    (is (not= 'rstr_extent_0 extent))
+    (is (= '(* n width) expression))
+    (is (= 'output output))
+    (is (= (list 'float-array extent) allocation))
+    (is (= extent (nth consumer 3)))
+    (is (= '(+ (aget input i) rstr_extent_0) (last consumer)))
+    (is (= normalized (frontend/normalize-source
+                      normalized {:array-types {'input :float 'output :float}
+                                  :scalar-types {'n :long 'width :long 'rstr_extent_0 :long}})))))

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -43,6 +43,29 @@
       (is (= program scheduled))
       (is (zero? (:initialization-fills stats))))))
 
+(deftest full-domain-proof-follows-scalar-ssa-products
+  (doseq [[allocation fills] [['(* (long n) width) 0] ['(* n width 2) 1]]]
+    (let [options {:dtype :float :array-types {'input :float 'output :float}
+                   :scalar-types {'n :long 'width :long}}
+          source (source (list 'float-array allocation) '(* width n))
+          normalized (frontend/normalize-source source options)
+          p (frontend/form->program normalized options)
+          [_ stats] (initialization/materialize p)]
+      (is (= fills (:initialization-fills stats)))
+      (is (= (- 1 fills) (:initialization-full-overwrites stats))))))
+
+(deftest total-functional-domains-include-boundaries-and-scan-results
+  (doseq [operation ['(raster.par/scan output accumulator (float 0.0) i 8 float
+                                      (+ accumulator (aget input i)))
+                     '(raster.par/stencil! output [input] 1 :dirichlet float i 8
+                                          (+ (aget input (- i 1)) (aget input (+ i 1))))]
+          allocation [8 9]]
+    (let [p (frontend/form->program
+             (list 'let* ['output (list 'float-array allocation) 'written operation] 'written)
+             {:dtype :float :array-types {'input :float 'output :float}})
+          [_ stats] (initialization/materialize p)]
+      (is (= (if (= allocation 8) 0 1) (:initialization-fills stats))))))
+
 (defn- with-facts [program f]
   (dialect/make (f (dialect/facts program))
                 (dialect/equations program) (dialect/outputs program)))
@@ -91,6 +114,30 @@
                          (assoc-in [:attributes :host-read-sites]
                                    [{:source-binding-id 1 :values #{'output}}])))]
       (is (= :typed-soac-initialization-contract (reason program))))))
+
+(deftest host-first-storage-keeps-native-initialization-and-host-writes
+  (let [source '(let* [output (float-array 8)
+                       seeded (do (aset output 0 (float 7.0)) nil)
+                       written (raster.par/map! output i 8 nil
+                                               (+ (aget output i) (aget input i)))] written)
+        p (program source)
+        [scheduled stats] (initialization/materialize p)
+        realized (:source (#'route/realize-source source scheduled))
+        run (eval (list 'fn ['input] realized))]
+    (is (= 1 (:initialization-native-providers stats)))
+    (is (zero? (:initialization-fills stats)))
+    (is (zero? (:initialization-full-overwrites stats)))
+    (is (= (take 4 (second source)) (take 4 (second realized)))
+        "native allocation and host mutation precede the GPU stage unchanged")
+    (is (= [7.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0]
+           (vec (run (float-array (range 8))))))
+    (is (= [7.0 -1.0 -2.0 -3.0 -4.0 -5.0 -6.0 -7.0]
+           (vec (run (float-array (map - (range 8)))))))
+    (is (= :typed-soac-initialization-contract
+           (reason (with-facts p
+                     #(assoc-in % [:equations 2 :attributes :fusion/constituents]
+                                {0 {} 2 {}}))))
+        "a host observation between fused constituents cannot become native-first")))
 
 (deftest public-initialization-cross-compiles-without-a-device
   (doseq [target [:cuda:0 :hip:0]

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -83,10 +83,23 @@
                     #(assoc-in % [:attributes :allocations 0 :extent] -1)
                     #(assoc-in % [:attributes :allocations 0 :extent] 'input)
                     #(assoc-in % [:attributes :allocations 0 :extent] '(do (mutate!) 8))
+                    #(assoc-in % [:values 'output :shape] [9])
                     #(assoc-in % [:attributes :allocations 0 :source-binding-id] nil)
                     #(update-in % [:equations 1 :provenance] dissoc :source-binding-id)
                     #(assoc-in % [:attributes :allocations 0 :source-binding-id] 2)]]
       (is (= :typed-soac-initialization-contract (reason (with-facts program change)))))))
+
+(deftest logical-volume-does-not-prove-physical-layout-coverage
+  (let [p (program (source '(float-array 8) 8))]
+    (doseq [[facet value] [[:representation {:kind :strided :stride 2}]
+                           [:logical-layout {:strides [2]}]]]
+      (let [changed (with-facts p
+                      #(update % :values
+                               (fn [values]
+                                 (into {} (map (fn [[id av]]
+                                                 [id (if (seq (:shape av))
+                                                       (assoc av facet value) av)])) values))))]
+        (is (= :typed-soac-initialization-contract (reason changed)))))))
 
 (deftest generated-initializers-avoid-host-symbols
   (let [program (with-facts (program (source '(float-array 8) 4))


### PR DESCRIPTION
## Summary

- Retain fresh-allocation initialization, dtype, extent and source-order contracts in TypedSOAC, using the shared allocator descriptor.
- Materialize GPU zeros as ordinary typed maps after fusion and before ownership certification. Replay resets sparse accumulators; no special runtime convention or handwritten fill kernel.
- Elide only exact dense-map full overwrites without aliased destination reads. Validate malformed contracts, ordering, host observations, generated identities and value remapping.
- Normalize explicit compound allocation lengths through the existing scalar extent mechanism at the allocation site, so public CUDA/HIP invocation lowering sees canonical dimensions.

## Validation

- Affected dialect/frontend/initialization/device namespaces: 79 tests, 394 assertions, no failures/errors.
- Final helper cleanup rerun: 9 initialization tests, 59 assertions, no failures/errors.
- Real Intel Arc ordinary and strided scatter: changed inputs, collisions, holes, two replays each, exactly two replay kernels.
- CUDA/HIP: both public fixtures emit two KernelBody kernels and lower allocation-free LinkPlans without target hardware. Vendor compiler gates run in CI.
- No full laptop suite; CI runs full shards and CPU OpenCL gates.

## Explicit remaining debt

The broader typed route namespace has one Intel-device-sensitive source-reparse guard error: `gemm/split-k-combine-plan` still reconstructs its compiler-generated contraction through source. This test has no allocations and reproduces with the new initialization pass disabled. The guard is unchanged; migration of that remaining generated combine path is the next unification slice.

This is correctness/unification work, not a performance promotion. Full-coverage proofs for conditional effect maps and contractions remain follow-up work; write-only ABI access is deliberately not sufficient to omit initialization.
