### PR TITLE
Construct generated matrix and split-K stages from semantic contraction facts

### DIFF
--- a/scripts/ci-install-clojure.sh
+++ b/scripts/ci-install-clojure.sh
@@ -15,7 +15,9 @@ fi
 cli_work=$(mktemp -d -t raster-clojure-install.XXXXXX)
 trap 'rm -rf -- "$cli_work"' EXIT
 cli_archive="$cli_work/clojure-tools.tar.gz"
-curl --fail --show-error --location --retry 3 --retry-delay 2 \
+# A TLS EOF (curl exit 56) is not retried by --retry alone. The download is idempotent,
+# goes to an isolated file, and still must pass the pinned digest before extraction.
+curl --fail --show-error --location --retry 3 --retry-all-errors --retry-delay 2 \
   --connect-timeout 20 --max-time 180 \
   "https://download.clojure.org/install/clojure-tools-${cli_version}.tar.gz" \
   --output "$cli_archive"

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -164,28 +164,22 @@
      (c-emit/c-symbol kernel-name) scheduled target-dialect
      {:parameter-names parameter-names})))
 
-(defn- scalar-contraction-form
+(defn- scalar-contraction-facts
   [variant]
-  (case variant
-    :nn '(raster.par/contract C [[i m] [j n]] [[l k]]
-                               (* (aget A (+ (* i k) l))
-                                  (aget B (+ (* l n) j))))
-    :nt '(raster.par/contract C [[i m] [j n]] [[l k]]
-                               (* (aget A (+ (* i k) l))
-                                  (aget B (+ (* j k) l))))
-    :tn '(raster.par/contract C [[i m] [j n]] [[l k]]
-                               (* (aget A (+ (* l m) i))
-                                  (aget B (+ (* l n) j))))
-    :tt '(raster.par/contract C [[i m] [j n]] [[l k]]
-                               (* (aget A (+ (* l m) i))
-                                  (aget B (+ (* j k) l))))))
+  (let [[a-index b-index]
+        (case variant
+          :nn ['(+ (* i k) l) '(+ (* l n) j)]
+          :nt ['(+ (* i k) l) '(+ (* j k) l)]
+          :tn ['(+ (* l m) i) '(+ (* l n) j)]
+          :tt ['(+ (* l m) i) '(+ (* j k) l)])]
+    (contraction-facts/from-components
+     {:out 'C :free-axes '[[i m] [j n]] :contract-axes '[[l k]] :dtype :float
+      :body (list '* (list 'aget 'A a-index) (list 'aget 'B b-index))})))
 
 (defn- portable-scalar-matrix-plan
   [variant stage-id]
-  (let [form (scalar-contraction-form variant)
-        facts (contraction-facts/contraction-facts form :dtype :float)
-        operation (contract-lower/contract-form->segred
-                   form :id stage-id :dtype :float :facts facts)
+  (let [facts (scalar-contraction-facts variant)
+        operation (contract-lower/contraction-facts->segred facts :id stage-id)
         planned (contraction-schedule/plan-portable-body
                  facts operation {}
                  {:array-types {'A :float 'B :float 'C :float}
@@ -585,12 +579,11 @@
 (defn- split-k-combine-plan
   ([stage-id] (split-k-combine-plan stage-id {'mn :int 'splits :int}))
   ([stage-id scalar-types]
-  (let [form '(raster.par/contract C [[i mn]] [[s splits]]
-                                   (clojure.core/aget
-                                    partials (clojure.core/+ (clojure.core/* s mn) i)))
-        facts (contraction-facts/contraction-facts form :dtype :float)
-        operation (contract-lower/contract-form->segred
-                   form :id stage-id :dtype :float :facts facts)
+  (let [facts (contraction-facts/from-components
+               {:out 'C :free-axes '[[i mn]] :contract-axes '[[s splits]] :dtype :float
+                :body '(clojure.core/aget
+                        partials (clojure.core/+ (clojure.core/* s mn) i))})
+        operation (contract-lower/contraction-facts->segred facts :id stage-id)
         planned (contraction-schedule/plan-portable-body
                  facts operation {}
                  {:array-types {'partials :float 'C :float}

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -26,20 +26,15 @@
   [contract-axes body]
   (contraction-facts/flatten-contract-axes contract-axes body))
 
-(defn contract-form->segred
-  "Parse `(raster.par/contract out [[i mi] …] [[k mk]] body & opts)` → a segmented SegRed.
-   opts: :init (combine init, default 0.0), :combine (default +). :id/:dtype/:grid via
-   kwargs. Supports one or more contracted axes. Pure + device-free (grid stays the passed value,
-   default nil — the device-aware pass fills it)."
-  [form & {:keys [id dtype grid facts] :or {id 0 dtype :double grid nil}}]
-  (let [[_ out free-axes contract-axes] form
-        facts (or facts (contraction-facts/contraction-facts form :dtype dtype))
-        _ (when-not (and (contraction-facts/facts? facts)
-                         (= form (:form facts))
-                         (= dtype (:dtype facts)))
-            (throw (ex-info "contract lowering requires facts derived from the same form"
-                            {:reason :contraction-facts-mismatch
-                             :form form :dtype dtype :facts facts})))
+(defn contraction-facts->segred
+  "Project verified contraction semantics into a segmented schedule without a surface form.
+   The canonical ProductReduction, iteration axes, storage operands and dtype are retained.
+   Pure and device-free; target planning supplies a grid later."
+  [facts & {:keys [id grid] :or {id 0 grid nil}}]
+  (let [_ (when-not (contraction-facts/facts? facts)
+            (throw (ex-info "contract lowering requires verified contraction facts"
+                            {:reason :contraction-facts-mismatch :facts facts})))
+        {:keys [out free-axes contract-axes dtype]} facts
         ;; ZERO free axes is legal: the SegSpace then has only the reduced dim, i.e. exactly the
         ;; 1-D shape (segop/seg-space-1d?) that the full-reduction emitter consumes.
         _ (assert (vector? free-axes) "contract-lower: free-axes must be a vector")
@@ -74,6 +69,16 @@
                     :segmented
                     nil
                     dtype)))
+
+(defn contract-form->segred
+  "Source compatibility entry: parse once, then use the source-free semantic projection."
+  [form & {:keys [id dtype grid facts] :or {id 0 dtype :double grid nil}}]
+  (let [facts (or facts (contraction-facts/contraction-facts form :dtype dtype))]
+    (when-not (and (contraction-facts/facts? facts)
+                   (= form (:form facts)) (= dtype (:dtype facts)))
+      (throw (ex-info "contract lowering requires facts derived from the same form"
+                      {:reason :contraction-facts-mismatch :form form :dtype dtype :facts facts})))
+    (contraction-facts->segred facts :id id :grid grid)))
 
 (defn contraction-facts->segmap
   "Project a zero-reduction contraction's verified facts into its semantic map space.

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -7,6 +7,7 @@
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.core.intel-block-io :as block-io]
             [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-dispatch :as dispatch]
@@ -16,7 +17,8 @@
             [raster.compiler.ir.kernel-precondition :as precondition]
             [raster.compiler.ir.layout-stage :as layout-stage]
             [raster.compiler.ir.matrix-stage :as matrix-stage]
-            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]))
+            [raster.compiler.ir.scheduled-kernel-body :as scheduled-body]
+            [raster.compiler.passes.parallel.contract-lower :as contract-lower]))
 
 (deftest opencl-backend-aliases-share-mixed-matrix-admission
   (let [desc {:device-type :gpu :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
@@ -59,6 +61,19 @@
   [m n k]
   [:a-buffer :b-buffer :c-buffer
    {:type :int :value m} {:type :int :value n} {:type :int :value k}])
+
+(deftest generated-matrix-and-split-k-stages-do-not-roundtrip-through-source
+  (let [forbidden (fn [& _] (throw (ex-info "generated schedule reentered source" {})))]
+    (with-redefs [contraction-facts/contraction-facts forbidden
+                  contraction-facts/surface-form forbidden
+                  contract-lower/contract-form->segred forbidden]
+      (doseq [variant [:nn :nt :tn :tt]]
+        (let [scheduled (emitted variant)]
+          (is (= (cond-> [:f32-scalar :xmx-direct :xmx-split-k]
+                   (contains? #{:nn :nt} variant) (conj :xmx-direct-lhs-tile-cast))
+                 (mapv executable/strategy (:alternatives scheduled))))
+          (doseq [artifact (mapcat executable/artifacts (:alternatives scheduled))]
+            (is (body/kernel-body? (get-in artifact [:attributes :kernel-body])))))))))
 
 (deftest hardware-aware-gemm-selection-is-checked-data
   (let [scheduled (emitted :nn)

--- a/test/raster/compiler/passes/parallel/contract_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_lower_test.clj
@@ -2,7 +2,23 @@
   "W1 step 2a: par/contract FORM → segmented SegRed (IR structure, device-free)."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.passes.parallel.contract-lower :as cl]
+            [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.segop :as segop]))
+
+(deftest semantic-projection-preserves-the-canonical-product-reduction
+  (let [facts (facts/from-components
+               {:out 'C :free-axes '[[i mn]] :contract-axes '[[s splits]] :dtype :float
+                :body '(aget partials (+ (* s mn) i))})
+        operation (cl/contraction-facts->segred facts :id :combine)]
+    (is (nil? (:form facts)))
+    (is (= :combine (:id operation)))
+    (is (= :float (:dtype operation)))
+    (is (identical? (:reduction facts) (:reduction operation)))
+    (is (= #{'partials} (:inputs operation)))
+    (is (= #{'C} (:outputs operation)))
+    (is (= #{'mn 'splits} (:scalars operation)))
+    (is (= [{:name 'i :bound 'mn} {:name 's :bound 'splits}]
+           (get-in operation [:space :dims])))))
 
 (deftest contract-form-to-segred-nn
   (testing "matmul :nn form → segmented SegRed with free segments + reduced contract axis"

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1119,7 +1119,12 @@
     (is (zero? (get-in emitted [:stats :typed-contraction-dispatch-declines
                                 :typed-contraction-dispatch-dynamic-scalar] 0)))
     (is (= 1 (count (:dispatches emitted))))
-    (is (= 1 (count (:kernels emitted))))))
+    ;; A machine with matrix instructions can enumerate multi-kernel alternatives. Every
+    ;; entry point must still come from the retained dispatch, with no missing/extra kernels.
+    (is (seq (:kernels emitted)))
+    (is (= (mapv :kernel-name
+                 (mapcat executable/artifacts (mapcat :alternatives (:dispatches emitted))))
+           (mapv :kernel-name (:kernels emitted))))))
 
 (deftest compatibility-contraction-without-source-or-schedule-fails-loud
   (let [source '(raster.par/contract C [[i 8]] [[l 8]]


### PR DESCRIPTION
## Summary

Stacked on #533; merge that prerequisite first and rebase this single slice after squash.

- Add a source-free ContractionFacts → SegRed projection that retains the canonical
  ProductReduction, axes, operands, and dtype.
- Build compiler-generated scalar GEMM and split-K combine stages directly from semantic
  components, removing their surface-form reconstruction and reparse.
- Preserve the existing source compatibility entry for actual source callers.
- Keep the source-reparse prohibition and verify emitted artifacts account for every selected
  executable alternative rather than assuming a device-independent single alternative.

## Validation

Using the existing capped laptop REPL, without a second JVM:

- Matrix emitter + contraction lowering: 30 tests, 872 assertions, no failures/errors.
- Typed route source-reparse guard: 1 test, 26 assertions, no failures/errors.
- Intel Arc direct and split-K numerical execution: 1 test, 4 assertions, no failures/errors.

Full suites and CUDA/HIP compiler gates remain on CI. This removes compiler duplication;
it does not introduce a new schedule or claim a benchmark speedup/SOTA parity.
