### PR TITLE
Respect scalar definition order in extent coverage proofs

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1089,6 +1089,9 @@ segmented/product reductions, segmented fold-maps, and scans, with no aliased de
 The shared extent proof follows retained integral scalar SSA and checked Long products, allowing
 equal dimensions with reordered factors without erasing narrowing, floating, or wrapping
 arithmetic. Allocation size must equal result volume: padding still requires initialization.
+Coverage witnesses are consumed in equation order: only incoming scalars are initially available,
+and scalar definitions extend the proof environment after execution. Allocation extent definitions
+must precede their allocation; a later definition cannot justify an earlier fill or elision.
 Write-only permission alone proves nothing for conditional effect stores or sparse updates.
 Allocation cardinality is separate from a destination AbstractValue's logical consumer shape.
 For example, an AD gradient may be allocated with `in*out` elements and later consumed over

--- a/src/raster/compiler/ir/extent_proof.clj
+++ b/src/raster/compiler/ir/extent_proof.clj
@@ -40,10 +40,15 @@
 (defn initial-environment
   "Only incoming scalar values are available before the first equation."
   [program]
-  (let [facts (dialect/facts program)]
+  (let [facts (dialect/facts program)
+        definitions (set (mapcat #(nth % 2) (dialect/equations program)))
+        host-definitions (set (get-in facts [:attributes :source-bindings]))
+        inputs (set (:inputs facts))]
     (into {} (keep (fn [id]
-                     (when-let [proof (opaque-value id (get-in facts [:values id]))]
-                       [id proof]))) (:inputs facts))))
+                     (when (and (not (contains? definitions id))
+                                (or (contains? inputs id) (not (contains? host-definitions id))))
+                       (when-let [proof (opaque-value id (get-in facts [:values id]))]
+                         [id proof])))) (keys (:values facts)))))
 
 (defn advance
   "Extend witnesses after one equation executes. Results become available only here; unknown

--- a/src/raster/compiler/ir/extent_proof.clj
+++ b/src/raster/compiler/ir/extent_proof.clj
@@ -32,15 +32,30 @@
         (try {:dtype :long :product (apply algebra/product (map :product operands))}
              (catch ArithmeticException _ nil))))))
 
-(defn environment
-  "Build product witnesses from typed scalar equations. Unknown integral values are opaque
-   factors; an unproved definition keeps its own SSA identity, never its guessed arithmetic."
+(defn- opaque-value [id value]
+  (when (and (= :tensor (:kind value)) (= [] (:shape value))
+             (integral? (:dtype value)))
+    {:dtype (:dtype value) :product (algebra/monomial id)}))
+
+(defn initial-environment
+  "Only incoming scalar values are available before the first equation."
   [program]
-  (reduce
-   (fn [environment equation]
+  (let [facts (dialect/facts program)]
+    (into {} (keep (fn [id]
+                     (when-let [proof (opaque-value id (get-in facts [:values id]))]
+                       [id proof]))) (:inputs facts))))
+
+(defn advance
+  "Extend witnesses after one equation executes. Results become available only here; unknown
+   integral results retain opaque SSA identity, never guessed arithmetic."
+  [environment facts equation]
+  (let [results (into {} (keep (fn [id]
+                                (when-let [proof (opaque-value id (get-in facts [:values id]))]
+                                  [id proof]))) (nth equation 2))
+        after (merge environment results)]
      (let [{:keys [kind captures lambda]} (dialect/operation-parts equation)]
        (if (not= 'scalar kind)
-         environment
+         after
          (let [{:keys [parameters locals body-results]} (dialect/lambda-parts lambda)
                local-env (merge environment (zipmap parameters (map environment captures)))
                local-env (reduce (fn [env {:keys [id dtype init]}]
@@ -52,22 +67,22 @@
                      (let [proof (expression local-env form)]
                        (if (and proof (= (:dtype (get env id)) (:dtype proof)))
                          (assoc env id proof) env)))
-                   environment (map vector (nth equation 2) body-results))))))
-   (into {} (keep (fn [[id value]]
-                    (when (and (= :tensor (:kind value)) (= [] (:shape value))
-                               (integral? (:dtype value)))
-                      [id {:dtype (:dtype value) :product (algebra/monomial id)}])))
-         (:values (dialect/facts program)))
-   (dialect/equations program)))
+                   after (map vector (nth equation 2) body-results)))))))
+
+(defn environment
+  "Witnesses available after the complete program. For a consumer, use initial-environment
+   and advance only through its predecessors instead."
+  [program]
+  (reduce #(advance %1 (dialect/facts program) %2)
+          (initial-environment program) (dialect/equations program)))
 
 (defn same-volume?
   "Whether allocation extent equals the entire dense result shape. No capacity inequalities."
   [environment extent shape]
   (and (vector? shape)
-   (or (= [extent] shape)
       (try
         (let [allocation (:product (expression environment extent))
               dimensions (map #(-> (expression environment %) :product) shape)]
           (boolean (and allocation (every? some? dimensions)
                         (= allocation (apply algebra/product dimensions)))))
-        (catch ArithmeticException _ false)))))
+        (catch ArithmeticException _ false))))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -3223,6 +3223,15 @@
                                       equations)
               values (reduce-kv #(merge-value %1 %2 %3 shape-equalities)
                                 inferred-values values)
+              allocations (allocation-contracts descriptions array-types scalar-types values
+                                                shape-equalities)
+              ;; An allocation-only public dimension need not appear in a numerical equation.
+              ;; Retain its declared type now; inserting the initializer later makes it an
+              ;; ordinary operation input. Do not infer a missing declaration from its name.
+              values (reduce (fn [values {:keys [extent]}]
+                               (if-let [declared (and (symbol? extent) (get scalar-types extent))]
+                                 (merge-value values extent (tensor-value declared []) shape-equalities)
+                                 values)) values allocations)
               equation-facts
               (into {}
                     (map (fn [description]
@@ -3276,7 +3285,5 @@
                                             :values (set (filter #(contains? values %)
                                                                  (util/free-syms expr)))})
                                          host-descriptions)
-                                   :allocations (allocation-contracts descriptions array-types
-                                                                      scalar-types values
-                                                                      shape-equalities)}})]
+                                   :allocations allocations}})]
           (dialect/make facts equations outputs))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -118,8 +118,13 @@
                 (assoc-in [:equations id] equation-facts)
                 (update :effects conj :memory/write))}))
 
-(defn- allocation-contracts! [facts]
-  (let [allocations (get-in facts [:attributes :allocations] [])]
+(defn- allocation-contracts! [program]
+  (let [facts (dialect/facts program)
+        definitions (into {} (for [equation (dialect/equations program)
+                                   result (nth equation 2)]
+                               [result (get-in facts [:equations (second equation)
+                                                      :provenance :source-binding-id])]))
+        allocations (get-in facts [:attributes :allocations] [])]
     (when-not (and (vector? allocations)
                    (every? #(and (map? %) (dialect/value-id? (:destination %))
                                  (integer? (:source-binding-id %))
@@ -133,6 +138,11 @@
     (doseq [{:keys [destination dtype] :as allocation} allocations
             :let [value (get-in facts [:values destination])]
             :when value]
+      (when (contains? definitions (:extent allocation))
+        (let [definition (get definitions (:extent allocation))]
+          (when-not (and (integer? definition) (< definition (:source-binding-id allocation)))
+            (fail! "allocation extent definition must precede allocation"
+                   {:allocation allocation :definition-site definition}))))
       (when-not (and (= :tensor (:kind value)) (seq (:shape value))
                      (dtype/known? dtype) (= dtype (dtype/canon dtype))
                      (= dtype (:dtype value)))
@@ -164,16 +174,20 @@
   [program]
   (dialect/validate! program)
   (let [original-facts (dialect/facts program)
-        extent-environment (extent-proof/environment program)
         allocations (filter #(and (= :zero (:initialization %))
                                   (contains? (:values original-facts) (:destination %)))
-                            (allocation-contracts! original-facts))
+                            (allocation-contracts! program))
         {:keys [facts equations pending fills elided native]}
         (reduce
-         (fn [{:keys [facts pending] :as state} equation]
+         (fn [{:keys [facts pending available-extents] :as state} equation]
            (let [active (filterv #(touches? facts (:destination %) equation) pending)
                  state (reduce
                         (fn [{:keys [facts] :as state} allocation]
+                          (when-not (extent-proof/same-volume? available-extents
+                                                              (:extent allocation)
+                                                              [(:extent allocation)])
+                            (fail! "initialization extent must be available before its consumer"
+                                   {:allocation allocation :consumer (second equation)}))
                           (let [{:keys [placement native?]}
                                 (initialization-site! facts allocation equation)]
                             (cond
@@ -181,7 +195,7 @@
                                           (update-in [:facts :attributes :native-initialization-providers]
                                                      #(vec (distinct (conj (or % [])
                                                                           (:destination allocation))))))
-                              (full-overwrite? facts extent-environment allocation equation)
+                              (full-overwrite? facts available-extents allocation equation)
                               (update state :elided inc)
                               :else
                               (let [{:keys [equations facts]} (initializer facts allocation placement)]
@@ -190,8 +204,10 @@
                         state active)]
              (-> state
                  (assoc :pending (vec (remove (set active) pending)))
+                 (assoc :available-extents (extent-proof/advance available-extents facts equation))
                  (update :equations conj equation))))
-         {:facts original-facts :equations [] :pending (vec allocations) :fills 0 :elided 0 :native 0}
+         {:facts original-facts :equations [] :pending (vec allocations) :fills 0 :elided 0 :native 0
+          :available-extents (extent-proof/initial-environment program)}
          (dialect/equations program))
         _ (when (seq pending)
             (fail! "live zero storage has no typed initialization site"

--- a/test/raster/compiler/ir/extent_proof_test.clj
+++ b/test/raster/compiler/ir/extent_proof_test.clj
@@ -1,6 +1,8 @@
 (ns raster.compiler.ir.extent-proof-test
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.ir.extent-proof :as proof]))
+            [raster.compiler.ir.extent-proof :as proof]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as dialect]))
 
 (def environment
   {'m {:dtype :long :product {:const 1 :factors ['m]}}
@@ -20,3 +22,20 @@
     (is (not (proof/same-volume? environment 1 nil)))
     (is (not (proof/same-volume? environment 9 [8])))
     (is (proof/same-volume? environment 8 [2 4]))))
+
+(deftest scalar-witnesses-become-available-only-after-their-definition
+  (let [equation '(= product [p]
+                     (scalar {:dtypes [:long]} [m n]
+                             (lambda [x y] (region [] [(* x y)]))))
+        facts (dialect/default-program-facts
+               {:inputs '[m n]
+                :values (zipmap '[m n p] (repeat (av/tensor {:dtype :long :shape []})))
+                :equations {'product (dialect/default-equation-facts {})}})
+        p (dialect/make facts [equation] '[p])
+        before (proof/initial-environment p)
+        after (proof/advance before facts equation)]
+    (is (not (contains? before 'p)))
+    (is (not (proof/same-volume? before 'p '[p])))
+    (is (not (proof/same-volume? before 'p '[m n])))
+    (is (proof/same-volume? after 'p '[m n]))
+    (is (= after (proof/environment p)))))

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -106,6 +106,20 @@
         (is (= 8 (:physical-elements failure)))
         (is (= 9 (:logical-elements failure)))))))
 
+(deftest allocation-extent-definition-must-dominate-the-allocation
+  (let [options {:dtype :float :array-types {'input :float 'output :float}
+                 :scalar-types {'n :long 'width :long}}
+        p (frontend/form->program
+           (frontend/normalize-source (source '(float-array (* n width)) '(* width n)) options)
+           options)
+        allocation (first (get-in (dialect/facts p) [:attributes :allocations]))
+        definition (first (filter #(some #{(:extent allocation)} (nth % 2))
+                                  (dialect/equations p)))]
+    (doseq [site [nil (:source-binding-id allocation) (inc (:source-binding-id allocation))]]
+      (is (= :typed-soac-initialization-contract
+             (reason (with-facts p #(assoc-in % [:equations (second definition)
+                                                 :provenance :source-binding-id] site))))))))
+
 (deftest initialization-contracts-fail-closed
   (let [program (program (source '(float-array 8) 4))]
     (doseq [change [#(update-in % [:attributes :allocations] into

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -56,6 +56,15 @@
       (is (= fills (:initialization-fills stats)))
       (is (= (- 1 fills) (:initialization-full-overwrites stats))))))
 
+(deftest allocation-only-public-extent-is-available-before-the-fill
+  (let [p (frontend/form->program (source '(float-array n) 4)
+                                 {:dtype :float :array-types {'input :float 'output :float}
+                                  :scalar-types {'n :long}})
+        [scheduled stats] (initialization/materialize p)]
+    (is (not (some #{'n} (:inputs (dialect/facts p)))))
+    (is (= 1 (:initialization-fills stats)))
+    (is (some #{'n} (:inputs (dialect/facts scheduled))))))
+
 (deftest total-functional-domains-include-boundaries-and-scan-results
   (doseq [operation ['(raster.par/scan output accumulator (float 0.0) i 8 float
                                       (+ accumulator (aget input i)))


### PR DESCRIPTION
## Summary

Stacked on #534 (which depends on #533). Merge prerequisites first, then rebase after squash.

- Consume scalar extent witnesses in equation order instead of consulting a final whole-program
  environment. Equation results become available only after their definitions.
- Keep unknown integral results opaque; unavailable captures cannot justify product factoring.
- Validate that allocation extent definitions precede their allocations and are available before
  initialization consumers.
- Retain declared public scalar types used only by allocation metadata, without inventing types
  or requiring the not-yet-inserted initializer to make them numerical inputs first.

## Validation

Single capped laptop REPL; no second JVM or cloud dependency:

- Focused extent/initialization tests: 20 tests, 130 assertions, no failures/errors.
- Existing full AD-training residency regression: 1 test, 6 assertions, no failures/errors.
- Before the final allocation-only frontend fix, affected public CUDA/HIP compilation,
  resident contraction ABI and Arc scatter replay: 22 tests, 201 assertions, no failures/errors.
- Six captured real TypedSOAC workloads retain zero redundant fills.

Independent static review completed. Full suites and target compiler gates run on CI.
This is proof/lowering correctness, not a new inference registry or performance claim.
