### PR TITLE
Require typed complete-write coverage at invocation linking

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1115,8 +1115,14 @@ source compilation **and allocation-free LinkPlan lowering**, not emission alone
 checks cover full/partial overwrite, copy/unspecified storage, malformed facts, aliases, source
 placement, generated names, and value remapping. Existing numerical tests are retained.
 
-Separately, the full typed route namespace on an Intel device exposes remaining unification debt:
-`gemm/split-k-combine-plan` still builds a contraction surface form and calls `contraction-facts`
-and `contract-form->segred`. The source-reparse guard fails with initialization disabled as well;
-its input contains no allocation. Preserve that guard and migrate this compiler-generated
-combine algorithm directly to typed IR in the next slice, rather than weakening the test.
+Compiler-generated scalar matrix and split-K combine algorithms now enter through semantic
+contraction facts, without building and reparsing surface contraction forms. The typed-route
+source-reparse guard remains intact; this is independent of initialization scheduling.
+
+Invocation linking also consumes the retained typed functional write domain. A graph output's
+`:write` role is insufficient to discard zero initialization: the domain must exactly cover
+concrete materialized capacity, have plain layout, and have no graph input sharing its physical
+storage token. The current proof admits single-equation algorithms only; multi-equation graphs
+need an ordered first-touch proof. Unavailable dimensions and unsupported shape expressions
+decline elision, while invalid negative dimensions still fail. This shares the functional-domain
+classification with initialization scheduling, rather than introducing a backend operation list.

--- a/src/raster/compiler/ir/invocation_link.clj
+++ b/src/raster/compiler/ir/invocation_link.clj
@@ -130,17 +130,50 @@
       (contains? roles :output) :write
       :else nil)))
 
+(defn- complete-write?
+  [operation id capacity scalars buffers storage]
+  (when (emitted-equation/emitted-equation? operation)
+    (let [algorithm (:algorithm operation)
+          facts (soac/facts algorithm)
+          destination (get-in facts [:values id])]
+      (when (and (= {:kind :plain} (:representation destination))
+                 (nil? (:logical-layout destination)))
+        (some (fn [equation]
+                (some (fn [[result physical contract]]
+                        (when (and (= id physical) (= :write (:access contract)))
+                          (when-let [shape (soac/dense-functional-result-shape facts equation result)]
+                            (try
+                              (= capacity
+                                 (reduce *' 1 (concrete-shape result {:shape shape}
+                                                              scalars buffers storage)))
+                              (catch clojure.lang.ExceptionInfo e
+                                (if (contains? #{:invocation-link-shape-scalar
+                                                 :invocation-link-shape-extent}
+                                               (:reason (ex-data e)))
+                                  false
+                                  (throw e)))))))
+                      (map vector (nth equation 2) (soac/physical-results facts equation)
+                           (soac/result-storage facts (second equation)))))
+              (soac/equations algorithm))))))
+
 (defn- write-before-read-inputs
-  [parallel-program compiler-values]
+  [parallel-program materialized scalars]
+  (let [program-buffers (:program-buffers materialized)
+        buffers (into {} (map (fn [[id buffer]] [id (:id buffer)])) program-buffers)
+        storage (into {} (map (fn [[_ buffer]] [(:id buffer) buffer])) program-buffers)]
   (into #{}
         (keep (fn [id]
-                (let [first-access
+                (let [[access operation]
                       (some (fn [equation]
                               (when-let [operation (first (:operations equation))]
-                                (graph-buffer-access (:graph operation) id)))
+                                (when-let [access (graph-buffer-access (:graph operation) id)]
+                                  [access operation])))
                             (:equations parallel-program))]
-                  (when (= :write first-access) id))))
-        compiler-values))
+                  (when (and (= :write access)
+                             (complete-write? operation id
+                                              (reduce *' 1 (:shape (get program-buffers id)))
+                                              scalars buffers storage)) id))))
+        (keys program-buffers))))
 
 (defn- add-materialized-inputs
   [state materialized program-values overwrite-inputs]
@@ -258,7 +291,7 @@
         scalars (:program-scalars materialized)
         shape-scalars (merge (invocation-shape-scalars materialized) scalars)
         overwrite-inputs (write-before-read-inputs parallel-program
-                                                   (keys (:program-buffers materialized)))
+                                                   materialized shape-scalars)
         initial (add-materialized-inputs {:buffers {} :loop-scratch {} :storage {}}
                                          materialized (:values parallel-program)
                                          overwrite-inputs)

--- a/src/raster/compiler/ir/invocation_link.clj
+++ b/src/raster/compiler/ir/invocation_link.clj
@@ -135,9 +135,20 @@
   (when (emitted-equation/emitted-equation? operation)
     (let [algorithm (:algorithm operation)
           facts (soac/facts algorithm)
+          equations (soac/equations algorithm)
           destination (get-in facts [:values id])]
-      (when (and (= {:kind :plain} (:representation destination))
-                 (nil? (:logical-layout destination)))
+      ;; A graph's external write permission does not prove its internal first touch.
+      ;; Multi-equation algorithms need an ordered coverage proof before admission.
+      (when (and (= 1 (count equations))
+                 (= {:kind :plain} (:representation destination))
+                 (nil? (:logical-layout destination))
+                 (contains? buffers id)
+                 (not-any? (fn [input]
+                             (and (contains? buffers (:id input))
+                                  (= (get buffers id) (get buffers (:id input)))))
+                           (filter #(contains? #{:input :inout} (:role %))
+                                   (concat (get-in operation [:graph :inputs])
+                                           (get-in operation [:graph :outputs])))))
         (some (fn [equation]
                 (some (fn [[result physical contract]]
                         (when (and (= id physical) (= :write (:access contract)))
@@ -148,13 +159,14 @@
                                                               scalars buffers storage)))
                               (catch clojure.lang.ExceptionInfo e
                                 (if (contains? #{:invocation-link-shape-scalar
-                                                 :invocation-link-shape-extent}
+                                                 :invocation-link-shape-extent
+                                                 :invocation-link-shape-expression}
                                                (:reason (ex-data e)))
                                   false
                                   (throw e)))))))
                       (map vector (nth equation 2) (soac/physical-results facts equation)
                            (soac/result-storage facts (second equation)))))
-              (soac/equations algorithm))))))
+              equations)))))
 
 (defn- write-before-read-inputs
   [parallel-program materialized scalars]

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -960,6 +960,19 @@
   [locals]
   (mapv (fn [{:keys [id dtype init]}] (local-value id dtype init)) locals))
 
+(defn dense-functional-result-shape
+  "Complete logical write domain of a validated functional result, or nil for indexed/effect
+   operations. This is not a physical-capacity or alias proof; callers must establish those
+   separately. Target emission retains this algorithm, so linking can use the same rule."
+  [program-or-facts equation result]
+  (let [f (if (program-form? program-or-facts) (facts program-or-facts) program-or-facts)
+        value (get-in f [:values result])]
+    (when (and (some #{result} (nth equation 2))
+               (contains? '#{map stencil contract segmented-reduce product-reduce
+                             segmented-fold-map scan} (operation-kind equation))
+               (= {:kind :plain} (:representation value)) (nil? (:logical-layout value)))
+      (:shape value))))
+
 (defn result-storage
   "Ordered physical storage contracts for an equation's functional results.
 

--- a/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_initialization.clj
@@ -36,16 +36,13 @@
 (defn- full-overwrite? [facts extent-environment {:keys [destination extent]} equation]
   ;; These functional operations produce their entire validated logical result shape.
   ;; Indexed/guarded effect maps and scatter do not have that guarantee.
-  (and (contains? '#{map stencil contract segmented-reduce product-reduce
-                     segmented-fold-map scan} (dialect/operation-kind equation))
-       (not (contains? (physical-inputs facts equation) destination))
+  (and (not (contains? (physical-inputs facts equation) destination))
        (some (fn [[result storage]]
                (and (= destination (physical-id facts (:destination storage)))
                     (= :write (:access storage))
-                    (plain-storage? (get-in facts [:values result]))
                     (plain-storage? (get-in facts [:values destination]))
                     (extent-proof/same-volume? extent-environment extent
-                                              (get-in facts [:values result :shape]))))
+                                              (dialect/dense-functional-result-shape facts equation result))))
              (map vector (nth equation 2) (dialect/result-storage facts (second equation))))))
 
 (defn- fresh-symbol [used prefix]

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.backend.gpu.kernel-body-compile-fixtures :as fixtures]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.link-plan :as link-plan]
+            [raster.compiler.ir.invocation-link :as invocation-link]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-initialization :as initialization]
@@ -114,6 +115,26 @@
         (is (= :program-link-value-contract (:reason failure)))
         (is (= 8 (:physical-elements failure)))
         (is (= 9 (:logical-elements failure)))))))
+
+(deftest linker-overwrite-proof-uses-typed-domain-not-only-write-permission
+  (let [compiled (equation-first/compile #'fixed-capacity-prefix {:target :cuda:0 :dtype :float})
+        emitted (last (get-in compiled [:emitted :equations]))
+        algorithm (:algorithm (first (:operations emitted)))
+        equation (last (dialect/equations algorithm))
+        destination (first (dialect/physical-results algorithm equation))
+        domain (first (dialect/dense-functional-result-shape algorithm equation
+                                                           (first (nth equation 2))))]
+    (doseq [[capacity extent expected] [[8 4 #{}] [8 8 #{destination}]
+                                       [8 9 #{}] [16 8 #{}] [4 4 #{destination}]]]
+      (is (= expected
+             (#'invocation-link/write-before-read-inputs
+              {:equations [emitted]}
+              {:program-buffers {destination {:id :storage :shape [capacity]}}}
+              {domain {:type :long :value extent}}))))
+    (is (empty? (#'invocation-link/write-before-read-inputs
+                 {:equations [emitted]}
+                 {:program-buffers {destination {:id :storage :shape [8]}}} {}))
+        "an unavailable extent cannot prove complete coverage")))
 
 (deftest allocation-extent-definition-must-dominate-the-allocation
   (let [options {:dtype :float :array-types {'input :float 'output :float}

--- a/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_initialization_test.clj
@@ -134,7 +134,34 @@
     (is (empty? (#'invocation-link/write-before-read-inputs
                  {:equations [emitted]}
                  {:program-buffers {destination {:id :storage :shape [8]}}} {}))
-        "an unavailable extent cannot prove complete coverage")))
+        "an unavailable extent cannot prove complete coverage")
+    (let [operation (first (:operations emitted))
+          prove (fn [op buffers]
+                  (#'invocation-link/complete-write?
+                   op destination 8 {domain {:type :long :value 8}}
+                   buffers {}))]
+      (is (prove operation {destination :storage}))
+      (is (not (prove (update-in operation [:graph :inputs] conj
+                                {:id 'aliased-input :role :input})
+                      {destination :storage 'aliased-input :storage}))
+          "different compiler IDs do not establish physical independence")
+      (is (prove (update-in operation [:graph :inputs] conj
+                            {:id 'independent-input :role :input})
+                 {destination :storage 'independent-input :other-storage}))
+      ;; Exercise the consumer's conservative boundary independently of producer conventions:
+      ;; the emitted IR permits algorithms with more than one equation.
+      (let [equations dialect/equations]
+        (with-redefs [dialect/equations (fn [p] (concat (equations p) (equations p)))]
+          (is (not (prove operation {destination :storage}))
+              "a later dense writer is not an ordered first-touch proof")))
+      (with-redefs [dialect/dense-functional-result-shape (fn [& _] ['(inc n)])]
+        (is (not (prove operation {destination :storage}))
+            "valid but unsupported shape algebra declines the optimization"))
+      (with-redefs [dialect/dense-functional-result-shape (fn [& _] [-1])]
+        (is (= :invocation-link-shape-negative
+               (try (prove operation {destination :storage}) nil
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+            "invalid extents still fail, rather than becoming an optimization decline")))))
 
 (deftest allocation-extent-definition-must-dominate-the-allocation
   (let [options {:dtype :float :array-types {'input :float 'output :float}


### PR DESCRIPTION
## Summary

- Share the TypedSOAC functional dense-result domain between initialization scheduling and invocation linking.
- Require exact concrete physical capacity coverage, rather than treating an emitted graph's write-only ABI permission as a complete-write proof.
- Decline elision for multi-equation algorithms, physical input aliases, unavailable dimensions, and unsupported shape expressions; retain failures for invalid negative dimensions.
- Keep the existing typed initialization maps and source-free lowering path. No backend kernel or operation registry is added.

## Validation

- Initialization/coverage: 19 tests, 121 assertions.
- Public CUDA/HIP source and linking: 12 tests, 142 assertions.
- Local GPU fresh scatter replay: 1 test, 10 assertions.
- Full suite and compile gates delegated to CircleCI.

Stacked on #535. General ordered coverage analysis for multi-equation graphs remains future work; this change declines rather than guessing.
