### PR TITLE
Retire orphan reduce-by-key runtime and handwritten OpenCL routes

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1075,6 +1075,14 @@ do not reintroduce implicit zeroing in a special runtime convention.
 
 ## Fresh-storage initialization through the typed vertical
 
+The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also
+retired after an exact-symbol and dynamic-dispatch reachability audit. Production reduce-by-key
+already enters the typed reducing-scatter conflict contract, scheduled SegMap/KernelBody, and
+generic map-void invocation; the public combinator and CPU semantics are unchanged. The direct
+OpenCL source generator remains test-only oracle debt, and the retained Vulkan scaffold is not
+changed by this retirement. Neither old source generator validates arbitrary reduction operators;
+they must not become production routes without the typed conflict contract.
+
 Resident allocation does not itself implement Clojure's fresh-array zero semantics, and allocating
 once is not enough for repeated execution. The frontend now retains allocation initialization,
 element type, extent, and source order in TypedSOAC facts using the shared allocator descriptor.

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1078,10 +1078,12 @@ do not reintroduce implicit zeroing in a special runtime convention.
 The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also
 retired after an exact-symbol and dynamic-dispatch reachability audit. Production reduce-by-key
 already enters the typed reducing-scatter conflict contract, scheduled SegMap/KernelBody, and
-generic map-void invocation; the public combinator and CPU semantics are unchanged. The direct
-OpenCL source generator remains test-only oracle debt, and the retained Vulkan scaffold is not
-changed by this retirement. Neither old source generator validates arbitrary reduction operators;
-they must not become production routes without the typed conflict contract.
+generic map-void invocation; the public combinator and CPU semantics are unchanged. The test-only
+handwritten OpenCL source generator is retired separately: it accepted arbitrary operators but
+always emitted addition. Its source assertions now exercise the existing public typed dispatch
+test, which also asserts KernelBody emission and no longer skips on namespace-loading failures.
+The retained Vulkan scaffold is unchanged; its analogous operator-validation gap must be closed
+through the typed conflict contract before any future production activation.
 
 Resident allocation does not itself implement Clojure's fresh-array zero semantics, and allocating
 once is not enough for repeated execution. The frontend now retains allocation initialization,

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -318,48 +318,6 @@
      :active-ids? true}))
 
 ;; ================================================================
-;; Reduce-by-key kernel generator
-;; ================================================================
-
-(defn generate-par-reduce-by-key-kernel
-  "Generate an OpenCL C kernel from a raster.par/reduce-by-key form.
-  Segmented reduction: output[keys[i]] op= values[i] using atomics.
-
-  Returns {:kernel-name str :source str :array-params [syms]
-           :scalar-params [{:name sym :type kw} ...] :dtype kw}."
-  [form & {:keys [dtype kernel-name-prefix]
-           :or {dtype :float kernel-name-prefix "par_reduce_by_key"}}]
-  (let [info (par/extract-par-reduce-by-key-info form)
-        {:keys [out keys vals]} info
-        kernel-name (str kernel-name-prefix "_" (gensym ""))
-        ctype (get codegen/opencl-type-map dtype "float")
-        out-c (ce/c-symbol out)
-        keys-c (ce/c-symbol keys)
-        vals-c (ce/c-symbol vals)
-        needs-float-atomic? (contains? #{:float :double} dtype)
-        ;; Only + is supported for atomic reduce-by-key (most common case)
-        source (str (codegen/extension-pragmas dtype)
-                    "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
-                    (when needs-float-atomic? ce/opencl-atomic-add-float-helper)
-                    "__kernel void " kernel-name
-                    "(__global " ctype "* " out-c
-                    ", __global const int* restrict " keys-c
-                    ", __global const " ctype "* restrict " vals-c
-                    ", int _n_bound) {\n"
-                    "    for (int i = get_global_id(0); i < _n_bound; i += get_global_size(0)) {\n"
-                    "        int k = " keys-c "[i];\n"
-                    (if needs-float-atomic?
-                      (str "        atomic_add_float(&" out-c "[k], " vals-c "[i]);\n")
-                      (str "        atomic_add(&" out-c "[k], " vals-c "[i]);\n"))
-                    "    }\n"
-                    "}\n")]
-    {:kernel-name kernel-name
-     :source source
-     :array-params [out keys vals]
-     :scalar-params [{:name 'n :type :int}]
-     :dtype dtype}))
-
-;; ================================================================
 ;; Compound kernel codegen
 ;; ================================================================
 

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1327,11 +1327,6 @@
         (finally (.close arena))))
     (buffer->array ids-buf)))
 
-(defn invoke-registered-reduce-by-key-kernel
-  "Invoke a compiled reduce-by-key kernel. Same interface as ze_runtime."
-  [^String kernel-name output keys vals n]
-  (invoke-registered-map-void-kernel kernel-name [output keys vals] [] n))
-
 ;; ================================================================
 ;; Lifecycle
 ;; ================================================================

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -3182,44 +3182,6 @@
     out-buf))
 
 ;; ================================================================
-;; Reduce-by-key kernel invocation
-;; ================================================================
-
-(defn invoke-registered-reduce-by-key-kernel
-  "Pipeline-friendly reduce-by-key kernel invocation.
-  output[keys[i]] += vals[i] (atomically).
-
-  kernel-name:  registered reduce-by-key kernel
-  output:       JVM array or DeviceBuffer (accumulation target)
-  keys:         JVM int-array or DeviceBuffer (key indices)
-  vals:         JVM array or DeviceBuffer (values to accumulate)
-  n:            number of elements"
-  [^String kernel-name output keys vals n]
-  (let [{:keys [kernel-handle workgroup-size dtype]
-         :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
-        n (long n)
-        dtype-size (long (get dtype-byte-sizes dtype 4))
-        wg (long (or workgroup-size 256))
-        groups (long (Math/ceil (/ (double n) wg)))
-        copy-to (fn [arr tag byte-count]
-                  (if (device-buffer? arr)
-                    (:segment ^DeviceBuffer arr)
-                    (let [seg (ensure-seg kernel-name tag byte-count)
-                          s (MemorySegment/ofArray arr)]
-                      (MemorySegment/copy s 0 seg 0 byte-count)
-                      seg)))
-        out-seg (copy-to output :rbk-out (* (long (if (device-buffer? output) n (alength output))) dtype-size))
-        keys-seg (copy-to keys :rbk-keys (* n 4))
-        vals-seg (copy-to vals :rbk-vals (* n dtype-size))
-        args [out-seg keys-seg vals-seg {:type :int :value (int n)}]]
-    (launch! kernel-handle groups wg args)
-    ;; Copy back output
-    (when-not (device-buffer? output)
-      (MemorySegment/copy out-seg 0 (MemorySegment/ofArray output) 0
-                          (* (long (alength output)) dtype-size)))
-    output))
-
-;; ================================================================
 ;; Cleanup
 ;; ================================================================
 

--- a/test/raster/par_test.clj
+++ b/test/raster/par_test.clj
@@ -444,16 +444,6 @@
       (is (clojure.string/includes? (:source kernel) "stride"))
       (is (true? (:strided? kernel))))))
 
-(deftest reduce-by-key-kernel-source-generation
-  (testing "Reduce-by-key kernel generates valid OpenCL C source"
-    (require '[raster.compiler.backend.gpu.par-opencl :as pocl])
-    (let [gen (resolve 'raster.compiler.backend.gpu.par-opencl/generate-par-reduce-by-key-kernel)
-          form '(raster.par/reduce-by-key out keys vals 100 +)
-          kernel (gen form :dtype :float)]
-      (is (string? (:source kernel)))
-      (is (clojure.string/includes? (:source kernel) "__kernel void"))
-      (is (clojure.string/includes? (:source kernel) "atomic_add_float")))))
-
 ;; ================================================================
 ;; Opencl-pass dispatch tests (verify pipeline integration)
 ;; ================================================================
@@ -531,8 +521,7 @@
 
 (deftest opencl-pass-reduce-by-key-dispatch
   (testing "opencl-pass dispatches reduce-by-key to GPU kernel"
-    (try (require '[raster.compiler.backend.gpu.par-opencl :as pocl]) (catch Exception _))
-    (when-let [pass (resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)]
+    (let [pass (requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)]
       (let [form '(raster.par/reduce-by-key out keys vals 1000 +)
             result (pass form :device-id :ze:0 :dtype :float :min-elements 0)
             kernel (first (:kernels result))]
@@ -540,6 +529,9 @@
         (is (= 1 (get-in result [:stats :segop-relowered])))
         (is (= :reducing-scatter (get-in kernel [:effects :kind])))
         (is (= :reduce (get-in kernel [:effects :write-conflict])))
+        (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+        (is (string? (:source kernel)))
+        (is (clojure.string/includes? (:source kernel) "__kernel void"))
         (is (some? (get-in kernel [:provenance :scheduled-operation])))
         (is (clojure.string/includes? (:source kernel) "atomic_add_float"))
         (is (= 'out (last (:form result))))))))


### PR DESCRIPTION
## Summary

- Remove the unused OpenCL and Level Zero reduce-by-key invocation shortcuts; production already uses the typed reducing-scatter contract and generic executable invocation.
- Remove the test-only handwritten OpenCL reduce-by-key generator, which accepted arbitrary operators but always emitted addition.
- Move its source checks onto the existing public typed-dispatch test, assert KernelBody emission, and replace silent namespace-resolution skipping with required resolution.
- Preserve the public combinator, JVM semantics, typed conflict/ABI tests, and Vulkan scaffold.

## Validation

- Exact-symbol and dynamic-dispatch audit found no runtime/compiler/sibling consumers of retired entry points.
- Typed reducing scatter and public scatter: 10 tests, 58 assertions.
- Retained reduce-by-key semantics and public dispatch: 6 tests, 24 assertions; assertion count preserved while removing the duplicate source-only test.
- Removed Vars were explicitly unmapped in the capped REPL before validation.
- Full suite and hardware-free compiler gates run in CircleCI.

Stacked on #536. This retires orphan routes; it does not claim new performance or broaden reduction semantics.
