### PR TITLE
Validate AD training through direct equation-first LinkPlans

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1056,6 +1056,14 @@ Do not restore the old binder or use the tiny Raster block as evidence those ext
 The pretrained-rstr checkout inspected alongside it was `3b13ad42e7bf4c98e348cb779c28096848931ba0`;
 no sibling source or dependency was changed by this audit.
 
+The existing small `mse ∘ linear-nb` AD/SGD acceptance now executes through the direct equation-first
+compile/lower/LinkPlan boundary. Its legacy descriptor compilation assertion remains a compatibility
+check, but numerical validation uses two resident updates with CPU parity, per-replay state progress,
+and an unchanged host initialization array. Direct lowering reports zero driver allocations; device
+allocation starts only at LinkPlan instantiation. This replaces the old numerical descriptor run,
+rather than adding another model-sized training loop. It is a reusable compiler capability check,
+not external real-model training validation or a performance result.
+
 The retired scatter invocation boundary is removed: its pipeline marker/accumulator metadata,
 Level Zero-only resident convention, runtime positional binders and handwritten zero-fill source
 had no remaining compiler producer or caller in the source/test/dev/benchmark inventory or the

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -8,18 +8,21 @@
    what makes gradient computation run on device.
 
    The full mse∘linear-nb train step returning updated weights is checked for resident
-   compilation and, on a device, numerical agreement with the CPU update.
+   compilation and, through the direct equation-first LinkPlan, repeated numerical agreement
+   with CPU updates over resident mutable weights.
 
    Device checks use Level Zero. Schedule selection retains precision and index-width legality;
    residency is not a claim that an XMX candidate was selected. Skips visibly without a GPU."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.pipeline :as pl]
+            [raster.compiler.equation-first :as equation-first]
             [raster.dl.array-ops :as ops]
             [raster.dl.attention :as attn]
             [raster.arrays :as ra]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.dl.nn :as nn]
             [raster.gpu.core :as gpu]
+            [raster.gpu.link :as gpu-link]
             [raster.gpu.descriptor-fixture :as fixture]))
 
 ;; Availability + skip routing use the shared HONEST probe (raster.dl.gpu-grad-parity):
@@ -353,21 +356,35 @@
             "mse∘linear train step must extract fully resident (matmuls + fused loss + SGD)")
         (when p
           (is (seq (:steps p)) "resident descriptor carries kernel steps"))))
-    (testing "a small AD/SGD update executes numerically, not only as a resident descriptor"
-      (if-not @gp/gpu-available?
-        (gp/gpu-skip! "gpu-ad-full-train-step-execution")
-        (let [batch 2 in-f 3 out-f 2 lr 0.01
-              weights (rnd (* in-f out-f) 31)
-              initial-weights (vec weights)
-              input (rnd (* batch in-f) 32)
-              target (rnd (* batch out-f) 33)
-              expected (@train (aclone weights) input target batch in-f out-f lr)
-              {:keys [out]} (run-resident train
-                                         [weights input target batch in-f out-f lr])]
-          (is (= (* in-f out-f) (count out) (count expected)))
-          (is (< (rel-err out expected) 1e-3)
-              "the GPU update matches the complete CPU AD and SGD composition")
-          (is (not= initial-weights (vec expected))
-              "the fixture performs a nontrivial weight update")
-          (is (not= initial-weights (vec out))
-              "the GPU cannot satisfy the check by returning unchanged weights"))))))
+    (let [compilation (equation-first/compile train {:target :ze:0 :dtype :float})
+          batch 2 in-f 3 out-f 2 lr 0.01
+          weights (rnd (* in-f out-f) 31)
+          initial-weights (vec weights)
+          input (rnd (* batch in-f) 32)
+          target (rnd (* batch out-f) 33)
+          plan (equation-first/lower compilation
+                                     [weights input target batch in-f out-f lr])]
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 0 (get-in plan [:attributes :driver-allocations])))
+      (testing "direct AD/SGD updates replay over resident weights without host reupload"
+        (if-not @gp/gpu-available?
+          (gp/gpu-skip! "gpu-ad-full-train-step-execution")
+          (let [expected (aclone weights)
+                previous (volatile! initial-weights)
+                live (gpu-link/instantiate! plan)]
+            (try
+              (dotimes [_ 2]
+                (@train expected input target batch in-f out-f lr)
+                (gpu-link/run! live)
+                (let [out (gpu-link/download live (first (:outputs plan)))]
+                  (is (= (* in-f out-f) (count out) (count expected)))
+                  (is (< (rel-err out expected) 1e-3)
+                      "each resident replay matches the complete CPU AD and SGD composition")
+                  (is (not= initial-weights (vec expected))
+                      "the fixture performs a nontrivial weight update")
+                  (is (not= @previous (vec out))
+                      "each GPU replay advances weights rather than returning the prior update")
+                  (vreset! previous (vec out))))
+              (is (= initial-weights (vec weights))
+                  "the host initialization array is not the evolving resident state")
+              (finally (gpu-link/close! live)))))))))


### PR DESCRIPTION
## Summary

Move the existing small AD/SGD numerical acceptance from the resident descriptor runner to the direct equation-first compile/lower/LinkPlan API. Retain the existing descriptor compilation assertion as compatibility coverage.

The same executable now performs two resident updates, checked against CPU AD/SGD after each replay. Each result must advance from the previous device state, while the original host weights remain unchanged. Compilation/lowering also run without a GPU and assert no fallback and zero driver allocations.

This is compiler capability validation, not external real-model training acceptance or a performance claim.

## Validation

- Existing AD acceptance: 1 test, 13 assertions, all green on the local Arc device.
- Independent resource-lifetime and test-coverage review found no blockers.
- Exploratory direct CUDA compilation/lowering also succeeded (seven typed equations, zero driver allocations).
- Full suite and vendor compile gates delegated to CircleCI.

Stacked on #537. No production code or numerical tolerance changes.
