### PR TITLE
Preserve Long counted domains in effect-map CPU expansion

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1259,13 +1259,15 @@ steps, parallel legs cannot claim the same directed link, and the certificate re
 semantic operation and its schedule. This makes ring/tree/native implementations replaceable while
 the dependency DAG and topology simulator account for their actual bytes and routes.
 
-Axis-partitioned scientific values now use the same machinery for nonperiodic halo exchange. A
+Axis-partitioned scientific values now use the same machinery for halo exchange. A
 semantic `HaloExchange` names the value, partition axis, halo width, and boundary policy. Scheduling
 derives adjacent owned shard faces, exact source rectangles, dtype-sized byte counts, and both
 directed routes; those facts are retained on transfer steps and in the distributed certificate.
-The first contract intentionally supports nonperiodic one-axis partitions. Periodic boundaries,
-multidimensional decomposition, and overlap lifetimes still need explicit semantics rather than
-being smuggled through generic transfer attributes.
+The contract supports nonperiodic and periodic one-axis partitions, including wrap-edge schedules
+and target-local ghost rectangles. Combining destinations retain a certified associative algebra
+and owned-face rectangles. General multidimensional decomposition and overlap lifetimes still need
+explicit semantics rather than being smuggled through generic transfer attributes. Region and cost
+certification alone does not establish numerical pack/transport/unpack or stencil execution.
 
 Block-structured adaptive meshes now have an explicit outer `AMRWorkloadPlan`. A certified
 `RefinementHierarchy` retains rectangular patch identity, level coordinates, per-axis ratios,

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1111,6 +1111,13 @@ The next sequence is workload-driven:
 This keeps cloud hardware, native fabrics and object storage out of the development hot loop.
 It does not replace the external training acceptance or measured kernel-comparison work.
 
+The first loop-admission prerequisite fixes an existing unsound dense-map match: a multi-form
+`dotimes` body beginning with `do` could select that `do`'s last store and drop its earlier stores
+and all sibling forms. Dense matching now requires one accounted-for body; unproved ordered
+effects remain intact. The numerical regression checks every destination. This closes an effect
+preservation bug, not the broader 2-D heat admission gap; that still needs a complete typed
+iteration-domain and cross-iteration write/read proof.
+
 ## Fresh-storage initialization through the typed vertical
 
 The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1081,6 +1081,36 @@ namespaces pass 9 tests/41 assertions, including rejection on both ZE and OpenCL
 validate internal scatter accumulator initialization end to end through ordinary typed fill IR;
 do not reintroduce implicit zeroing in a special runtime convention.
 
+## Distributed numerical acceptance checkpoint (2026-09-13)
+
+Items 6–8 have checked planning components, not yet one executable numerical acceptance:
+`distributed-plan` simulates topology, dependencies, collective/halo schedules and analytic costs;
+`numerical-state` certifies chunk coverage and durable field identity; `numerical-content` tests
+scoped leases and transfer ownership using fake providers; `amr-plan` composes hierarchy, fields,
+regions and routes, but its coarse/fine operator requirements are declarations rather than bodies.
+The distributed certificate currently summarizes optional local plans by ID/operation count, not
+their exact numerical program. Do not treat that summary as a program-equivalence witness.
+
+The next sequence is workload-driven:
+
+1. Admit the existing `raster.ode.pde/heat-rhs-2d!` through direct TypedSOAC scheduling and emission,
+   preserving its multi-store boundaries and offset interior domain. A direct CUDA probe rejects
+   it with `:equation-first-coverage`; the ZE diagnostic reports a scalar route with no SegOps.
+   Existing 1-D RK4 and the direct AD/SGD probe succeed. Do not rewrite the PDE merely to satisfy
+   a narrower matcher, or assume its source comment proves nested-loop lifting already works.
+2. Bind distributed compute to exact local program entries and shard/view contracts; make numerical
+   program drift load-bearing in certification rather than comparing only IDs and counts.
+3. Execute a hardware-free two-shard halo step and compare stitched values with the monolithic
+   numerical oracle, alongside the certified region/byte/cost checks.
+4. Checkpoint actual addressed bytes through a local immutable file/mmap provider, close/reopen,
+   restore, continue, and compare with uninterrupted execution; test branch reuse of unchanged chunks.
+5. Grow that seam into conservative 2-D shallow water and typed prolongation/restriction, then
+   subcycling/reflux. Existing Dirichlet heat decay tests are not mass conservation, lake-at-rest,
+   convergence-rate oracles, or numerical AMR acceptance.
+
+This keeps cloud hardware, native fabrics and object storage out of the development hot loop.
+It does not replace the external training acceptance or measured kernel-comparison work.
+
 ## Fresh-storage initialization through the typed vertical
 
 The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1118,6 +1118,15 @@ effects remain intact. The numerical regression checks every destination. This c
 preservation bug, not the broader 2-D heat admission gap; that still needs a complete typed
 iteration-domain and cross-iteration write/read proof.
 
+The next counted-domain prerequisite aligns `map-void!` and its compiler CPU expansion with
+their documented `dotimes` semantics: evaluate the bound once as Long, execute no iterations for
+nonpositive counts, and return nil. Explicit user narrowing casts remain executable. The former
+implicit Int coercion could not faithfully represent a source Long-count loop. This changes no
+kernel ABI and does not admit GPU launches beyond a target's index limits; unsupported domains
+must still fail target checks rather than narrow. Raw store-loop normalization can subsequently
+use one typed Long scalar extent `max(0, long(bound))` and the existing effect-region analysis,
+with sequential order retained until a dependence proof permits parallel scheduling.
+
 ## Fresh-storage initialization through the typed vertical
 
 The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -260,7 +260,7 @@
   [form]
   (let [[_ i-sym bound-expr body-expr] form
         n-sym (gensym "n__")]
-    (list 'let* [n-sym (list 'int bound-expr)]
+    (list 'let* [n-sym (list 'long bound-expr)]
           (list 'dotimes [i-sym n-sym]
                 body-expr)
           nil)))

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -41,7 +41,7 @@
   [form idx-sym]
   (when (and (seq? form)
              (contains? aset-syms (first form))
-             (>= (count form) 4))
+             (= (count form) 4))
     (let [[_ out idx-expr val-expr] form]
       (when (and (symbol? out)
                  (idx-matches? idx-expr idx-sym))
@@ -152,8 +152,8 @@
 
 (defn match-dotimes-map-loop
   "Match a dotimes loop that writes one element with aset.
-	Handles direct dotimes, do wrappers, and outer let wrappers that only bind
-	temporary bound expressions.
+	Handles direct dotimes and output-returning do wrappers. Outer let wrappers
+	are handled by loop-lift's structural recursion, preserving all bindings and effects.
 	Returns {:out-sym :index-sym :bound-expr :cast-fn :value-expr} or nil."
   [form]
   (when (seq? form)
@@ -192,24 +192,7 @@
           (= 1 (count non-string-forms))
           (match-dotimes-map-loop (first non-string-forms))))
 
-      (form/binding-form? form)
-      (let [[_ bindings-vec & body-exprs] form
-            binding-pairs (partition 2 bindings-vec)]
-        (when (<= 1 (count body-exprs) 2)
-          (let [inner (first body-exprs)
-                subst-map (into {}
-                                (map (fn [[sym val-expr]]
-                                       (if (and (seq? val-expr)
-                                                (contains? #{'int 'long 'clojure.core/int 'clojure.core/long}
-                                                           (first val-expr))
-                                                (= 2 (count val-expr)))
-                                         [sym (second val-expr)]
-                                         [sym val-expr]))
-                                     binding-pairs))]
-            (when-let [info (match-dotimes-map-loop inner)]
-              (let [bound (:bound-expr info)
-                    resolved-bound (get subst-map bound bound)]
-                (assoc info :bound-expr resolved-bound)))))))))
+      :else nil)))
 
 (defn match-nested-dotimes-row-major-map
   "Match a nested dotimes row-major write that can be flattened to 1D.
@@ -237,7 +220,7 @@
                                         {:aset-form candidate :let-bindings []}))]
                   (when aset-result
                     (let [{:keys [aset-form let-bindings]} aset-result]
-                      (when (and (seq? aset-form) (>= (count aset-form) 4))
+                      (when (and (seq? aset-form) (= (count aset-form) 4))
                         (let [[_ out-sym idx-expr val-expr] aset-form]
                           (when (and (symbol? out-sym)
                                      (row-major-linear-index? idx-expr i-sym j-sym cols-expr))
@@ -452,7 +435,7 @@
                                                    (contains? aset-syms (first candidate)))
                                           {:aset-form candidate :let-bindings []}))]
                     (when-let [{:keys [aset-form]} aset-result]
-                      (when (and (seq? aset-form) (>= (count aset-form) 4))
+                      (when (and (seq? aset-form) (= (count aset-form) 4))
                         (let [[_ out-sym write-idx read-expr] aset-form]
                           (when (and (symbol? out-sym)
                                      (column-major-linear-index? write-idx i-sym j-sym rows-expr)

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -162,11 +162,9 @@
       (let [[_ bindings & body-forms] form]
         (when (and (vector? bindings) (= 2 (count bindings)))
           (let [[idx-sym bound-expr] bindings
-                raw-body (if (= 1 (count body-forms))
-                           (first body-forms)
-                           (when (and (seq? (first body-forms))
-                                      (= 'do (first (first body-forms))))
-                             (last (rest (first body-forms)))))
+                ;; A dense-map witness accounts for one store, not an arbitrary suffix of
+                ;; an effect sequence. Multi-form bodies need the ordered effect-map route.
+                raw-body (when (= 1 (count body-forms)) (first body-forms))
                 aset-result (when raw-body
                               (or (when-let [info (match-aset-write raw-body idx-sym)]
                                     {:info info})

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -530,10 +530,11 @@
   side effects (aset, atomic-add!, etc.). Expands to dotimes on CPU.
 
   Form: (raster.par/map-void! idx bound body)
-  Semantics: for idx in 0..bound: body (for side effects)"
+  Semantics: for idx in 0..bound: body (for side effects). Like dotimes, evaluates
+  the bound once as a Long; nonpositive counts execute no iterations."
   [idx-sym bound-expr body-expr]
   (let [n-sym (gensym "n__")]
-    `(let [~n-sym (int ~bound-expr)]
+    `(let [~n-sym (long ~bound-expr)]
        (dotimes [~idx-sym ~n-sym]
          ~body-expr)
        nil)))

--- a/test/raster/compiler/passes/parallel/loop_lift_test.clj
+++ b/test/raster/compiler/passes/parallel/loop_lift_test.clj
@@ -60,12 +60,34 @@
                       x)
           {:keys [form stats]} (loop-lift/lift-parallel-forms form)]
       (is (= 1 (:maps-detected stats)))
-      ;; Bound should be the original 'bound', not 'n_'
+      ;; Preserve the narrowing cast and its binding scope instead of substituting raw bound.
       (let [bindings (second form)
-            [_ expr] (take 2 bindings)]
-        (when (and (seq? expr) (= 'raster.par/map! (first expr)))
-          (let [[_ _out _idx bound-expr _cast _body] expr]
-            (is (= 'bound bound-expr))))))))
+            [_ expr] (take 2 bindings)
+            map-form (nth expr 2)]
+        (is (= '[n_ (int bound)] (second expr)))
+        (is (= 'raster.par/map! (first map-form)))
+        (is (= 'n_ (nth map-form 3)))))))
+
+(deftest lifting-preserves-wrapper-bindings-and-sibling-stores
+  (let [source '(let* [n_ (int n) side (aset scratch 0 7.0)]
+                 (dotimes [i n_] (aset out i 1.0))
+                 (aset tail 0 9.0))
+        lifted (loop-lift/lift-parallel-forms source)
+        execute (eval (list 'fn '[scratch out tail n]
+                            (ir.par/expand-par-forms (:form lifted))))
+        scratch (double-array 1) out (double-array 3) tail (double-array 1)]
+    (is (= 1 (get-in lifted [:stats :maps-detected])))
+    (is (= (second source) (second (:form lifted))))
+    (is (= 9.0 (execute scratch out tail 3)))
+    (is (= [7.0] (vec scratch)))
+    (is (= [1.0 1.0 1.0] (vec out)))
+    (is (= [9.0] (vec tail)))))
+
+(deftest dense-store-witnesses-require-exact-aset-arity
+  (is (nil? (patterns/match-aset-write '(aset out i j 1.0) 'i)))
+  (is (nil? (patterns/match-nested-dotimes-row-major-map
+             '(dotimes [i rows]
+                (dotimes [j cols] (aset out (+ (* i cols) j) 0 1.0)))))))
 
 (deftest allow-same-index-self-read-map
   (testing "dotimes reading output at same index (SGD pattern) IS detected as parallel"

--- a/test/raster/compiler/passes/parallel/loop_lift_test.clj
+++ b/test/raster/compiler/passes/parallel/loop_lift_test.clj
@@ -36,6 +36,22 @@
           {:keys [stats]} (loop-lift/lift-parallel-forms form)]
       (is (= 1 (:maps-detected stats))))))
 
+(deftest dense-map-matching-does-not-discard-sibling-effects
+  (let [loop '(dotimes [i n]
+                (do (aset scratch i 7.0) (aset out i 1.0))
+                (aset tail i 9.0))
+        source (list 'let* ['written loop] 'written)
+        lifted (loop-lift/lift-parallel-forms source)
+        execute (eval (list 'fn '[scratch out tail n] (:form lifted)))
+        scratch (double-array 3) out (double-array 3) tail (double-array 3)]
+    (is (nil? (patterns/match-dotimes-map-loop loop)))
+    (is (zero? (get-in lifted [:stats :maps-detected])))
+    (is (= source (:form lifted)))
+    (execute scratch out tail 3)
+    (is (= [7.0 7.0 7.0] (vec scratch)))
+    (is (= [1.0 1.0 1.0] (vec out)))
+    (is (= [9.0 9.0 9.0] (vec tail)))))
+
 (deftest detect-let-wrapped-dotimes
   (testing "let-wrapped dotimes (with int bound) is detected"
     (let [form '(let* [x (let [n_ (int bound)]

--- a/test/raster/par_test.clj
+++ b/test/raster/par_test.clj
@@ -11,16 +11,18 @@
 
 (deftest map-void-counts-match-dotimes-without-implicit-narrowing
   (let [stop (ex-info "first iteration" {:probe :counted-domain})
-        run (fn [head bound]
+        run (fn [head bound & [explicit-int?]]
               (let [evaluations (atom 0)
                     body '(throw stop)
+                    bound-expression (list 'do '(swap! evaluations inc)
+                                           (if explicit-int? '(int bound) 'bound))
                     expression (case head
-                                 :dotimes (list 'dotimes ['i '(do (swap! evaluations inc) bound)] body)
+                                 :dotimes (list 'dotimes ['i bound-expression] body)
                                  :macro (list 'raster.par/map-void! 'i
-                                              '(do (swap! evaluations inc) bound) body)
+                                              bound-expression body)
                                  :ir (ir.par/expand-par-map-void!
                                       (list 'raster.par/map-void! 'i
-                                            '(do (swap! evaluations inc) bound) body)))
+                                            bound-expression body)))
                     execute (eval (list 'fn '[bound evaluations stop] expression))
                     result (try (execute bound evaluations stop)
                                 (catch Throwable e
@@ -32,7 +34,10 @@
         (is (= expected (run :macro bound)))
         (is (= expected (run :ir bound)))
         (is (= 1 (second expected)))))
-    (is (= :first-iteration (first (run :macro 2147483648))))))
+    (is (= :first-iteration (first (run :macro 2147483648))))
+    (doseq [head [:macro :ir]]
+      (is (= (run :dotimes 2147483648 true) (run head 2147483648 true))
+          "an explicit narrowing cast still executes and rejects overflow before the body"))))
 
 (deftest par-map-form-detection
   (testing "par-map-form? identifies parallel map forms"

--- a/test/raster/par_test.clj
+++ b/test/raster/par_test.clj
@@ -9,6 +9,31 @@
 ;; Parallel form structure tests
 ;; ================================================================
 
+(deftest map-void-counts-match-dotimes-without-implicit-narrowing
+  (let [stop (ex-info "first iteration" {:probe :counted-domain})
+        run (fn [head bound]
+              (let [evaluations (atom 0)
+                    body '(throw stop)
+                    expression (case head
+                                 :dotimes (list 'dotimes ['i '(do (swap! evaluations inc) bound)] body)
+                                 :macro (list 'raster.par/map-void! 'i
+                                              '(do (swap! evaluations inc) bound) body)
+                                 :ir (ir.par/expand-par-map-void!
+                                      (list 'raster.par/map-void! 'i
+                                            '(do (swap! evaluations inc) bound) body)))
+                    execute (eval (list 'fn '[bound evaluations stop] expression))
+                    result (try (execute bound evaluations stop)
+                                (catch Throwable e
+                                  (if (identical? stop e) :first-iteration (class e))))]
+                [result @evaluations]))]
+    (doseq [bound [0 -1 Long/MIN_VALUE 1 3 2147483648 Long/MAX_VALUE
+                   (inc (bigint Long/MAX_VALUE))]]
+      (let [expected (run :dotimes bound)]
+        (is (= expected (run :macro bound)))
+        (is (= expected (run :ir bound)))
+        (is (= 1 (second expected)))))
+    (is (= :first-iteration (first (run :macro 2147483648))))))
+
 (deftest par-map-form-detection
   (testing "par-map-form? identifies parallel map forms"
     (is (ir.par/par-map-form? '(raster.par/map! out i 10 double (+ (aget a i) 1.0))))


### PR DESCRIPTION
## Summary

Align the CPU macro and compiler fallback expansion of `map-void!` with its documented `dotimes` semantics: Long count, evaluated once, empty for nonpositive counts, and nil return. Remove only the implicit Int narrowing; explicit user casts still execute.

This is a prerequisite for faithfully normalizing source store loops into the existing typed effect-map route. No new IR or ABI is introduced, and GPU index/launch limits are unchanged.

## Validation

- Parallel combinator, typed scatter, and loop tests: 82 tests, 300 assertions before two extra explicit-cast assertions.
- Final count-contract test: 1 test, 27 assertions, including Long endpoints, out-of-Int counts, Long overflow, evaluate-once, and explicit narrowing.
- Public CUDA/HIP source and linking: 12 tests, 142 assertions.
- Large positive count tests throw on the first iteration, so they do not execute large loops.
- Independent review approved the host semantic change; full suite delegated to CircleCI.

Stacked on #539. Broader 2-D PDE loop admission is still outstanding.
