### PR TITLE
Normalize counted store loops through TypedSOAC; execute 2D heat directly

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1127,6 +1127,21 @@ must still fail target checks rather than narrow. Raw store-loop normalization c
 use one typed Long scalar extent `max(0, long(bound))` and the existing effect-region analysis,
 with sequential order retained until a dependence proof permits parallel scheduling.
 
+The source normalization now uses that existing effect-map boundary: a closed raw `dotimes`
+store region keeps every body form, performs the Long conversion at its original site, and
+clamps negative counts through an ordinary typed scalar conditional. Unknown/effectful or
+mutable-array-derived bounds remain outside this normalization. No new operation registry or
+semantic loop dialect is introduced. An explicit returned destination observes its latest write
+even when the loop itself returns nil. Effect result shapes project the physical destination's
+extent, and that projection participates in ordinary SSA remapping.
+
+The existing `heat-rhs-2d!` now compiles and links through the direct CUDA/HIP boundary without
+driver allocation. A local Level Zero numerical regression compares all cells against the CPU
+for 2×3 (empty interior) and 5×7 grids with nonzero initial destination contents. This establishes
+local execution correctness, not a competitive parallel stencil schedule, distributed execution,
+or a performance result. The next distributed seam remains exact local-program/shard binding,
+followed by numerical halo execution and real-byte durable restore.
+
 ## Fresh-storage initialization through the typed vertical
 
 The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1142,6 +1142,29 @@ local execution correctness, not a competitive parallel stencil schedule, distri
 or a performance result. The next distributed seam remains exact local-program/shard binding,
 followed by numerical halo execution and real-byte durable restore.
 
+The counted-loop migration also exposes `softmax-rows!` as an end-to-end scalar-sharing
+regression. Pure, destination, and offset maps now project a complete typed lexical `let`
+spine into ordered TypedSOAC locals instead of embedding it in one expression for later
+substitution. Missing local type evidence declines admission rather than inventing a consumer
+type. This preserves each intermediate once through SegMap and KernelBody. On the existing
+softmax exponential polynomial, the generated kernel dropped from 25,599 scalar computes and
+3,379,887 source bytes to 24 computes and 2,259 bytes. CUDA/HIP source-size ratchets and local
+Level Zero numerical parity cover this case; these are not throughput or SOTA benchmark claims.
+The shared inliner likewise retains actual argument types and once-only evaluation (including
+unused checked conversions), and never flattens initializer bindings into loop/recur parameters.
+
+Coverage accounting distinguishes newly admitted sequential store work from formerly parallel
+work becoming serialized. The migration's new sequential regions include host loops previously
+outside typed coverage; they do not establish a competitive schedule. The serialization ratchet
+remains in force, with deliberate baseline changes requiring an audit of the previous workload
+route and preservation of existing independent regions.
+The refreshed 236-var baseline admits 23 such regions: 19 previously scalar programs,
+previously compatible `softmax-rows!`, and three partially typed programs (`maxpool2d-bwd!`,
+`mean-pool`, `dense-into!`) whose old typed kernels covered initialization/copy/final scaling
+while the counted loops remained host work. Their existing independent kernels are retained.
+The resulting route counts are 132 typed, 47 scalar, 14 compatible, and 43 errors; the 43 errors
+remain visible debt rather than being excluded from the corpus.
+
 ## Fresh-storage initialization through the typed vertical
 
 The analogous OpenCL/Level Zero `invoke-registered-reduce-by-key-kernel` shortcuts are also

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1323,10 +1323,14 @@
 
 (defn- emit-scalar-operations
   [operations context depth]
-  (reduce (fn [[source ctx] operation]
-            (let [[next-source next-context] (emit-scalar-operation operation ctx depth)]
-              [(str source next-source) next-context]))
-          ["" context] operations))
+  (let [[fragments context]
+        (reduce (fn [[fragments ctx] operation]
+                  (let [[source next-context] (emit-scalar-operation operation ctx depth)]
+                    [(conj fragments source) next-context]))
+                [[] context] operations)]
+    ;; Appending immutable prefixes copies all preceding source for every SSA op.
+    ;; Join once, preserving the exact operation/context order.
+    [(apply str fragments) context]))
 
 (defn- scalar-storage-map
   [kernel-body]

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -755,8 +755,10 @@
                  ;; ANF flattening: if a typed-macro expansion returns (let* [...] body),
                  ;; splice the inner bindings into the parent let and use the body as
                  ;; the init. This keeps the IR flat for fusion and bytecode compilation.
+                 ;; Never splice into a loop: each binding is also a recur parameter.
                  [extra-binds rewritten-init]
-                 (if (and (seq? rewritten-init) (= 'let* (first rewritten-init)))
+                 (if (and (form/let-head? let-sym)
+                          (seq? rewritten-init) (= 'let* (first rewritten-init)))
                    (let [[_ inner-bindings & inner-body] rewritten-init
                          ;; CC10 fix: splice intermediate effectful forms as bindings
                          ;; so they are not silently dropped

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -2000,7 +2000,7 @@
             (let [id (rename dimension)]
               (if (symbol? id) id (list 'value id)))
 
-            (and (seq? dimension) (contains? #{'value 'unknown-dimension} (first dimension))
+            (and (seq? dimension) (contains? #{'value 'extent 'unknown-dimension} (first dimension))
                  (= 2 (count dimension))
                  (contains? value-map (second dimension)))
             (list (first dimension) (rename (second dimension)))

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -233,9 +233,13 @@
                                   body-with-lets (if (seq all-lets)
                                                    (list 'let* (vec (mapcat identity all-lets)) body)
                                                    body)
-                                  flat-idx (gensym "flat_idx__")
-                                  flat-body (list 'let* [i-sym (list 'clojure.core/quot flat-idx cols-expr)
-                                                         j-sym (list 'clojure.core/rem flat-idx cols-expr)]
+                                  ;; These coordinates are generated from the Long counted
+                                  ;; domain, not inferred from the stored element's dtype.
+                                  flat-idx (with-meta (gensym "flat_idx__") {:raster.type/tag 'long})
+                                  row-id (vary-meta i-sym assoc :raster.type/tag 'long)
+                                  col-id (vary-meta j-sym assoc :raster.type/tag 'long)
+                                  flat-body (list 'let* [row-id (list 'clojure.core/quot flat-idx cols-expr)
+                                                         col-id (list 'clojure.core/rem flat-idx cols-expr)]
                                                   body-with-lets)]
                               {:out-sym out-sym
                                :index-sym flat-idx

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -6,6 +6,7 @@
    this pass performs no source-level type or function inference."
   (:require [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.numeric-constant :as numeric-constant]
             [raster.compiler.core.scalar-conversion :as scalar-conversion]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
@@ -212,9 +213,11 @@
                     (let [type (canon-type actual)]
                       {:operations [] :result expression :type type
                        :range (known-range expression type)})
-                    (decline! :unbound-scalar
-                              "scalar expression references an undeclared value"
-                              {:expression expression :environment (set (keys env))}))
+                    (if-let [constant (numeric-constant/value expression)]
+                      (lower-value (:value constant) expected env)
+                      (decline! :unbound-scalar
+                                "scalar expression references an undeclared value"
+                                {:expression expression :environment (set (keys env))})))
 
                   (descriptor/aget-call? expression)
                   (let [array (descriptor/aget-array-sym expression)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2508,15 +2508,6 @@
                 (dialect/lambda-form (vec (concat parameters capture-parameters))
                                      local-forms writes)))))
 
-(defn- effect-expressions
-  "Every expression an effect evaluates, descending into store loops."
-  [effect]
-  (if-let [region (:region effect)]
-    (concat (map :init (:locals region)) (mapcat effect-expressions (:effects region)))
-  (if-let [{:keys [effects] :as loop} (:loop effect)]
-    (concat (source-loop-expressions loop) (mapcat effect-expressions effects))
-    [(:index effect) (:predicate effect) (:value effect)])))
-
 (defn- effect-map-equation
   [{:keys [id index extent iteration-order locals inputs scalars results result-storage effects
            result-dtypes]}]

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -2481,10 +2481,10 @@
         values (mapv (fn [cast body] (if cast (list cast body) body)) casts bodies)
         destinations (mapv :destination result-storage)
         semantic-inputs (into (set inputs) destinations)
-        all-expressions (vec (concat (map :init locals) write-indices predicates values))
-        [pointwise stable]
-        ((juxt filter remove) #(pointwise-input? all-expressions % index) semantic-inputs)
-        arrays (vec (sort-by pr-str pointwise))
+        ;; Indexed updates do not assert that a captured buffer's capacity equals the
+        ;; update domain. Preserve indexed reads and the buffer's own shape contract.
+        stable semantic-inputs
+        arrays []
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
@@ -2521,13 +2521,14 @@
   [{:keys [id index extent iteration-order locals inputs scalars results result-storage effects
            result-dtypes]}]
   (let [destinations (mapv :destination result-storage)
+        destination-dtypes (zipmap destinations result-dtypes)
         destination-set (set destinations)
-        all-expressions (vec (concat (map :init locals)
-                                     (mapcat effect-expressions effects)))
         semantic-inputs (set/difference (set inputs) destination-set)
-        [pointwise stable]
-        ((juxt filter remove) #(pointwise-input? all-expressions % index) semantic-inputs)
-        arrays (vec (sort-by pr-str pointwise))
+        ;; An effect traversal need not cover the complete physical input. Keep explicit
+        ;; indexed reads instead of giving a pointwise capture the traversal's shape: e.g.
+        ;; a clamped counted loop may read a prefix of an already-shaped producer.
+        stable semantic-inputs
+        arrays []
         captures (vec (sort-by pr-str (distinct (concat stable scalars))))
         element-parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
@@ -2572,7 +2573,11 @@
                 (list 'effect-loop attributes (transform extent) lambda)))
             (list 'effect (get destination-substitutions out)
                   effect-conflict (transform index) (transform predicate)
-                  (transform (if cast (list cast value) value))))))
+                  ;; Primitive aset converts to the destination element type. Preserve any
+                  ;; source conversion inside that store conversion, rather than asking the
+                  ;; target emitter to infer or silently coerce a mismatched scalar value.
+                  (transform (list (dtype/scalar-tag-for-dtype (get destination-dtypes out))
+                                   (if cast (list cast value) value)))))))
         effect-forms (mapv effect-form effects)]
     (list '= id results
           (list 'effect-map

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1831,6 +1831,31 @@
             (with-meta (apply list (assoc (vec expression) position id)) (meta expression))]))))
    [state expression] inputs))
 
+(defn- normalize-counted-store-loop
+  "Express a closed source store loop through the existing effect-map boundary.
+   This spelling grants no parallelism: write-region analysis still proves its order.
+   Preserve dotimes' single Long conversion and empty nonpositive domain."
+  [expression]
+  (if (and (seq? expression)
+           (contains? '#{dotimes clojure.core/dotimes} (first expression))
+           (not (contains? util/*shadowing-locals* (first expression)))
+           (vector? (second expression))
+           (= 2 (count (second expression)))
+           (symbol? (first (second expression))))
+    (let [[idx bound] (second expression)
+          body (list* 'do (nnext expression))]
+      (if (and (provably-pure-scalar? bound)
+               ;; Reading mutable storage cannot be shared with a later extent equation.
+               (empty? (par/collect-aget-arrays bound))
+               (store-region body idx))
+        (with-meta
+          (list 'raster.par/map-void! idx
+                (list 'clojure.core/long bound)
+                body)
+          (meta expression))
+        expression))
+    expression))
+
 (defn- normalize-source*
   [source scalar-types]
   ;; Direct backend entry may see source before the ordinary pipeline's SSA cleanup. Clojure
@@ -1866,6 +1891,19 @@
                                           (normalize-fixed-scalar-inputs state expression
                                                                          [[2 :int] [3 :long]])
                                           [state expression])
+                     counted-expression (normalize-counted-store-loop expression)
+                     [state expression] (if (= expression counted-expression)
+                                          [state expression]
+                                          (let [[state counted] (normalize-fixed-scalar-inputs
+                                                                 state counted-expression [[2 :long]])
+                                                count-id (nth counted 2)
+                                                extent (with-meta
+                                                         (list 'if (list 'clojure.core/< count-id 0)
+                                                               0 count-id)
+                                                         {:tag 'long :raster.type/tag 'long})]
+                                            (normalize-fixed-scalar-inputs
+                                             state (apply list (assoc (vec counted) 2 extent))
+                                             [[2 :long]])))
                      local-scalar-types (:local-scalar-types state)
                      expression (->> expression
                                      (canonicalize-strided-indexed-operation ordinal)
@@ -2824,13 +2862,11 @@
         destination-results
         (into {}
               (mapcat (fn [description]
-                        (keep (fn [[result {:keys [destination host-return]}]]
-                                ;; Effect-only operations expose their destinations through the
-                                ;; reconstructed host form, not as numerical TypedSOAC results.
-                                ;; Only value-returning storage contracts may rewrite a terminal
-                                ;; physical destination to its logical SSA result.
-                                (when (= :buffer host-return)
-                                  [destination result]))
+                        (map (fn [[result {:keys [destination]}]]
+                               ;; The operation itself may return nil, but an explicit later
+                               ;; read/return of its destination observes the latest stored value.
+                               ;; Do not confuse the loop's host return with the buffer's identity.
+                               [destination result])
                               (map vector (:results description)
                                    (:result-storage description)))))
               descriptions)
@@ -2901,7 +2937,8 @@
 (defn- ordinary-equation-values
   [equation default-dtype array-types scalar-types known-values]
   (let [[_ _ results] equation
-        {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
+        {:keys [kind attributes arrays captures destinations]} (dialect/operation-parts equation)
+        result-destinations (zipmap results destinations)
         extent (:extent attributes)
         dimension-ids (set (filter dialect/value-id? (dialect/operation-extents equation)))
         dimension-value
@@ -2969,7 +3006,10 @@
                                          segmented-fold-map
                                          (dialect/segmented-fold-map-result-shape attributes)
                                          scan (dialect/scan-result-shape attributes)
-                                         (scatter effect-map) [(list 'unknown-dimension id)]
+                                         scatter [(list 'unknown-dimension id)]
+                                         ;; An effect updates existing storage, not a dense
+                                         ;; tensor whose length is the iteration count.
+                                         effect-map [(list 'extent (get result-destinations id))]
                                          (dialect/extent-shape extent)))])
                    results result-dtypes)))))
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -152,6 +152,17 @@
                  (every? :dtype locals))
         locals))))
 
+(defn- typed-map-region
+  "Preserve a map's typed lexical spine instead of expanding shared expressions."
+  [expression]
+  (if (and (seq? expression) (form/let-head? (first expression)))
+    (let [[_ bindings & results] expression
+          locals (typed-region-locals bindings)]
+      (when (and (= 1 (count results)) (some? locals)
+                 (every? (comp simple-symbol? :id) locals))
+        {:locals locals :body (first results)}))
+    {:locals [] :body expression}))
+
 (defn- substitute-store
   [substitutions store]
   (reduce (fn [store field]
@@ -1213,11 +1224,14 @@
           elem-type (dtype/canon (or elem-type
                                      (dtype/dtype-for-scalar-tag cast)
                                      default-dtype))
-          io (extract-io body idx [symbol])]
-      (merge {:kind :map :id id :sym symbol :results [symbol]
-              :index idx :extent bound :locals [] :casts [cast] :bodies [body]
-              :pure? true :elem-type elem-type}
-             io))
+          io (extract-io body idx [symbol])
+          region (typed-map-region body)]
+      (when region
+        (merge {:kind :map :id id :sym symbol :results [symbol]
+                :index idx :extent bound :locals (:locals region)
+                :casts [cast] :bodies [(:body region)]
+                :pure? true :elem-type elem-type}
+               io)))
 
     (par/par-map-form? expression)
     (let [{:keys [out idx bound cast body elem-type offset]}
@@ -1231,15 +1245,17 @@
                                      (when (symbol? out) (get array-types out))
                                      default-dtype))
           write-index (when offset (list 'clojure.core/+ offset idx))
-          io (extract-io (if offset (list 'do write-index body) body) idx [out])]
+          io (extract-io (if offset (list 'do write-index body) body) idx [out])
+          region (typed-map-region body)]
       ;; A binder with the same spelling as the caller-owned destination needs distinct value/view
       ;; identity before it can be SSA. Every other offset map is an injective partial write:
       ;; destination[base+i] is a typed unique scatter, not a map carrying an emitter-only offset.
       ;; The destination is read/write because elements outside the slice remain observable.
-      (when-not (= symbol out)
+      (when (and region (not= symbol out))
         (if offset
           (merge {:kind :scatter :id id :sym symbol :results [symbol]
-                  :index idx :extent bound :locals [] :casts [cast] :bodies [body]
+                  :index idx :extent bound :locals (:locals region)
+                  :casts [cast] :bodies [(:body region)]
                   :write-indices [write-index] :predicates [1] :conflict :unique
                   :result-storage [{:destination out :access :read-write
                                     :host-return :buffer}]
@@ -1247,7 +1263,8 @@
                   :source-operation :raster.par/map-offset}
                  io)
           (merge {:kind :map :id id :sym symbol :results [symbol]
-                  :index idx :extent bound :locals [] :casts [cast] :bodies [body]
+                  :index idx :extent bound :locals (:locals region)
+                  :casts [cast] :bodies [(:body region)]
                   :result-storage [{:destination out
                                     :access (if (contains? (:inputs io) out) :read-write :write)
                                     :host-return :buffer}]

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -129,11 +129,12 @@
     (symbol (namespace impl-sym) n)))
 
 (defn- needs-arg-lift?
-  "Evaluate expression arguments once before substitution, even when unused.
+  "Evaluate nonconstant expression arguments once before substitution, even when unused.
    Casts are expressions too: checked conversion may throw, and its operand may
-   have effects. Later simplification can remove bindings proven unnecessary."
+   have effects. Only the shared checked constant evaluator may prove a call safe
+   to substitute directly; a failing conversion never supplies that evidence."
   [arg]
-  (coll? arg))
+  (and (coll? arg) (nil? (constant/value arg))))
 
 (defn- check-inline-arity! [callee params args call]
   (when (not= (count params) (count args))

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -45,13 +45,15 @@
    inlinable, as are bare value-type constructor tails (see value-ctor-call?)
    and branch forms (if / case*) whose whole body is a single value expression
    the inliner substitutes into the call site (e.g. predicate/lookup helpers like
-   chunk-block, block-solid?). Other bare function calls are not — they need
-   let* wrapping for the inliner to decompose."
+   chunk-block, block-solid?), symbols and literal values. Other bare function calls
+   are not — they need let* wrapping for the inliner to decompose."
   [body]
-  (and (seq? body)
-       (or (contains? #{:binding :scope :do :invk :par :branch}
-                      (:kind (form/form-info body)))
-           (value-ctor-call? body))))
+  (or (symbol? body) (number? body) (string? body) (keyword? body)
+      (nil? body) (boolean? body) (char? body)
+      (and (seq? body)
+           (or (contains? #{:binding :scope :do :invk :par :branch}
+                          (:kind (form/form-info body)))
+               (value-ctor-call? body)))))
 
 (def ^:private prim-or-array-tags
   "Tags that are safe for inlining even when body has scoped forms.
@@ -126,21 +128,39 @@
         n (if-let [i (str/index-of n "_m_")] (subs n 0 i) n)]
     (symbol (namespace impl-sym) n)))
 
-(def ^:private trivial-cast?
-  "Cast/coercion calls that are cheap to duplicate — single arg, no allocation."
-  #{'long 'double 'float 'int 'byte 'short 'char
-    'unchecked-long 'unchecked-double 'unchecked-float 'unchecked-int
-    'clojure.core/long 'clojure.core/double 'clojure.core/float 'clojure.core/int
-    'clojure.core/byte 'clojure.core/short 'clojure.core/char})
-
 (defn- needs-arg-lift?
-  "True if arg is a non-trivial expression that should be lifted to a let binding
-   before parameter substitution. Prevents duplication when callee params appear
-   multiple times (e.g. inside par/pmap bodies where CSE can't reach)."
+  "Evaluate expression arguments once before substitution, even when unused.
+   Casts are expressions too: checked conversion may throw, and its operand may
+   have effects. Later simplification can remove bindings proven unnecessary."
   [arg]
-  (and (seq? arg)
-       (let [head (first arg)]
-         (not (trivial-cast? head)))))
+  (coll? arg))
+
+(defn- check-inline-arity! [callee params args call]
+  (when (not= (count params) (count args))
+    (throw (ex-info
+            (str "Arity mismatch inlining `" callee "`: it takes "
+                 (count params) " arg(s) but the call passes " (count args)
+                 ". A deftm has no variadic or multi-arity form.")
+            {:callee callee :expected-arity (count params) :actual-arity (count args)
+             :params (vec params) :args (vec args) :form call}))))
+
+(defn- argument-substitution
+  "Build a call-by-value substitution, emitting argument bindings in source order."
+  [params args tags emit!]
+  (into {}
+        (map-indexed
+         (fn [i p]
+           (let [a (nth args i)
+                 t (when tags (nth tags i nil))
+                 typed? (and t (not (arg-subst-skip-tags t)) (symbol? a)
+                             (not (.contains (str t) "IFn__")))]
+             (if (or typed? (needs-arg-lift? a))
+               (let [id (with-meta (gensym (str "arg_" (name p) "_"))
+                                  (if typed? {:tag t} (meta a)))]
+                 (emit! [id a])
+                 [p id])
+               [p a])))
+         params)))
 
 (defn- safe-to-inline?
   "Check if a resolved deftm body is safe to inline.
@@ -1062,9 +1082,11 @@
                              single-use? (<= (get sym-uses ftm-sym 0) 1)]
                          (when (and (= (count params) (count args))
                                     (or inline? single-use?))
-                           (subst-syms (zipmap params args) body))))]
+                           (let [subst (argument-substitution
+                                        params args nil #(swap! result-pairs conj %))]
+                             {:body (subst-syms subst body)}))))]
                  (if beta-result
-                   (do (swap! result-pairs conj [sym beta-result])
+                   (do (swap! result-pairs conj [sym (:body beta-result)])
                        (reset! any-inlined? true))
        ;; Check for (nth <vg-sym> N) — resolve to element symbol
                    (let [nth-resolved
@@ -1099,20 +1121,7 @@
                  ;; no overload resolves, the call is left symbolic, and reverse-AD
                  ;; reports "No AD template for <callee>".) A deftm call with the wrong
                  ;; number of args is always a bug — say so, at the call.
-                                 _ (when (not= (count params) (count args))
-                                     (throw (ex-info
-                                             (str "Arity mismatch inlining `" head "`: it takes "
-                                                  (count params) " arg(s) " (pr-str (vec params))
-                                                  " but the call passes " (count args) " "
-                                                  (pr-str (vec args))
-                                                  ". Fix the call site — a deftm has no variadic or "
-                                                  "multi-arity form, so this call can never dispatch.")
-                                             {:callee head
-                                              :expected-arity (count params)
-                                              :actual-arity (count args)
-                                              :params (vec params)
-                                              :args (vec args)
-                                              :form init})))
+                                 _ (check-inline-arity! head params args init)
                  ;; Handle multi-form bodies: wrap in (do ...) if more than one form
                                  body-form (if (> (count walked-body) 1)
                                              (list* 'do walked-body)
@@ -1125,35 +1134,9 @@
                  ;; 2. Non-trivial call expressions: prevents duplication when the param
                  ;;    appears multiple times in the callee body (e.g. inside par/pmap
                  ;;    where CSE can't extract the duplicate afterward)
-                                 skip-tags arg-subst-skip-tags
                                  param-subst
-                                 (into {}
-                                       (map-indexed
-                                        (fn [i p]
-                                          (let [a (nth args i)
-                                                t (when tags (nth tags i nil))]
-                                            (cond
-                              ;; Record/value type — emit typed binding
-                                              (and t (not (skip-tags t))
-                                                   (not (and t (.contains (str t) "IFn__")))
-                                                   (symbol? a))
-                                              (let [typed-sym (with-meta (gensym (str (name p) "_"))
-                                                                {:tag t})]
-                                                (swap! result-pairs conj [typed-sym a])
-                                                [p typed-sym])
-
-                              ;; Non-trivial call arg — lift to prevent duplication
-                                              (needs-arg-lift? a)
-                                              (let [lifted-sym (with-meta (gensym (str "arg_" (name p) "_"))
-                                                                 (meta a))]
-                                                (swap! result-pairs conj [lifted-sym a])
-                                                [p lifted-sym])
-
-                              ;; Simple arg (symbol, constant, trivial cast)
-                                              :else
-                                              [p a]))))
-                                       callee-params)
-                                 body-head (first body-form)]
+                                 (argument-substitution callee-params args tags
+                                                        #(swap! result-pairs conj %))]
                              (if (form/binding-form? body-form)
                                (let [[_ inner-bindings & inner-body] body-form
                                      inner-pairs (partition 2 inner-bindings)
@@ -1298,7 +1281,7 @@
   ([form] (inline-invk form {}))
   ([form {:keys [preserve-templates?] :as policy}]
    (cond
-     (and (seq? form) (= '.invk (first form)) (>= (count form) 3))
+     (and (seq? form) (= '.invk (first form)) (>= (count form) 2))
      (let [impl-sym (second form)
            rkey (recursion-key impl-sym)
            ;; Keep an op symbolic for reverse-AD only if it has a REVERSE rule
@@ -1312,6 +1295,7 @@
                         (try-resolve-deftm impl-sym))]
        (if deftm-info
          (let [{:keys [params walked-body]} deftm-info
+               _ (check-inline-arity! impl-sym params (drop 2 form) form)
                body-form (first walked-body)
                safe? (safe-to-inline? deftm-info)
                ;; size policy: large straight-line callees become calls (wasm path);
@@ -1326,36 +1310,14 @@
                    new-args (map #(inline-invk % policy) args)]
                (util/make-invk impl-sym new-args (meta form)))
              ;; Simple body -- safe to inline
-             (let [args (vec (drop 2 form))
+             (let [args (mapv #(inline-invk % policy) (drop 2 form))
                    {:keys [tags]} deftm-info
                    callee-params (mapv #(with-meta (if (symbol? %) % (symbol (name %))) nil) params)
-                   skip-tags arg-subst-skip-tags
                    ;; ANF lifting + typed bindings — same logic as inline-one-pass
                    lifted-bindings (atom [])
                    param-subst
-                   (into {}
-                         (map-indexed
-                          (fn [i p]
-                            (let [a (nth args i nil)
-                                  t (when tags (nth tags i nil))]
-                              (cond
-                                (and t (not (skip-tags t))
-                                     (not (and t (.contains (str t) "IFn__")))
-                                     (symbol? a))
-                                (let [typed-sym (with-meta (gensym (str (name p) "_"))
-                                                  {:tag t})]
-                                  (swap! lifted-bindings conj typed-sym a)
-                                  [p typed-sym])
-
-                                (needs-arg-lift? a)
-                                (let [lifted-sym (with-meta (gensym (str "arg_" (name p) "_"))
-                                                   (meta a))]
-                                  (swap! lifted-bindings conj lifted-sym a)
-                                  [p lifted-sym])
-
-                                :else
-                                [p a]))))
-                         callee-params)
+                   (argument-substitution callee-params args tags
+                                          #(swap! lifted-bindings into %))
                    inlined (subst-syms param-subst body-form)
                    ;; mark this callee as on the inline stack while re-processing its
                    ;; body, so a recursive self-call inside stays a call (terminates)
@@ -1379,11 +1341,14 @@
            r (apply list head new-bindings new-body)]
        (if-let [m (meta form)] (with-meta r m) r))
 
-     ;; Scope-introducing forms -- recurse into body only (not binding vector)
+     ;; Scope initializers and outer operands are values, but binder names and par
+     ;; layout are structural. Reuse the shared decomposition without hoisting anything.
      (and (seq? form) (form/scope-form? form))
-     (let [[head binding & body] form
-           r (apply list head binding (map #(inline-invk % policy) body))]
-       (if-let [m (meta form)] (with-meta r m) r))
+     (if-let [{:keys [scopes outer rebuild]} (form/scope-info form)]
+       (let [transform #(mapv (fn [expression] (inline-invk expression policy)) %)]
+         (rebuild (mapv #(-> % (update :inits transform) (update :body transform)) scopes)
+                  (transform outer)))
+       form)
 
      ;; do block -- recurse into all expressions
      (and (seq? form) (= 'do (first form)))

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -146,7 +146,7 @@
 
 (defn- argument-substitution
   "Build a call-by-value substitution, emitting argument bindings in source order."
-  [params args tags emit!]
+  [params args tags source-env emit!]
   (into {}
         (map-indexed
          (fn [i p]
@@ -155,8 +155,14 @@
                  typed? (and t (not (arg-subst-skip-tags t)) (symbol? a)
                              (not (.contains (str t) "IFn__")))]
              (if (or typed? (needs-arg-lift? a))
-               (let [id (with-meta (gensym (str "arg_" (name p) "_"))
-                                  (if typed? {:tag t} (meta a)))]
+               ;; A new binder must retain the argument's actual source type. The formal
+               ;; parameter may widen it; stamping that consumer type here loses precision
+               ;; boundaries. Use the same metadata/environment authority as call resolution.
+               (let [source-tag (when-not typed? (inf/infer-arg-tag a source-env))
+                     id (with-meta (gensym (str "arg_" (name p) "_"))
+                                   (if typed? {:tag t}
+                                       (cond-> (meta a)
+                                         source-tag (assoc :raster.type/tag source-tag))))]
                  (emit! [id a])
                  [p id])
                [p a])))
@@ -1083,7 +1089,7 @@
                          (when (and (= (count params) (count args))
                                     (or inline? single-use?))
                            (let [subst (argument-substitution
-                                        params args nil #(swap! result-pairs conj %))]
+                                        params args nil @type-env #(swap! result-pairs conj %))]
                              {:body (subst-syms subst body)}))))]
                  (if beta-result
                    (do (swap! result-pairs conj [sym (:body beta-result)])
@@ -1135,7 +1141,7 @@
                  ;;    appears multiple times in the callee body (e.g. inside par/pmap
                  ;;    where CSE can't extract the duplicate afterward)
                                  param-subst
-                                 (argument-substitution callee-params args tags
+                                 (argument-substitution callee-params args tags @type-env
                                                         #(swap! result-pairs conj %))]
                              (if (form/binding-form? body-form)
                                (let [[_ inner-bindings & inner-body] body-form
@@ -1316,7 +1322,7 @@
                    ;; ANF lifting + typed bindings — same logic as inline-one-pass
                    lifted-bindings (atom [])
                    param-subst
-                   (argument-substitution callee-params args tags
+                   (argument-substitution callee-params args tags *param-env*
                                           #(swap! lifted-bindings into %))
                    inlined (subst-syms param-subst body-form)
                    ;; mark this callee as on the inline stack while re-processing its

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -9,6 +9,15 @@
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
+(deftest scalar-source-assembly-preserves-context-order
+  (with-redefs-fn {#'opencl/emit-scalar-operation
+                  (fn [operation context depth]
+                    [(str depth ":" context ":" operation ";") (inc context)])}
+    (fn []
+      (is (= ["" 7] (#'opencl/emit-scalar-operations [] 7 2)))
+      (is (= ["2:7:a;2:8:b;2:9:c;" 10]
+             (#'opencl/emit-scalar-operations ["a" "b" "c"] 7 2))))))
+
 (defn- scalar-kernel-body []
   (let [group 'query-row
         lane 'lane

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -16,6 +16,13 @@
 ;; classify-form
 ;; ================================================================
 
+(deftest loop-initializer-lets-do-not-add-recur-parameters
+  (let [walked (wb '(loop* [i 0 acc (let* [seed (+ i 2)] seed)]
+                     (if (< i 3) (recur (inc i) (+ acc i)) acc)))]
+    (is (= ['i 'acc] (vec (take-nth 2 (second walked)))))
+    (is (= 'let* (first (nth (second walked) 3))))
+    (is (= 5 (eval walked)))))
+
 (deftest operand-return-contract-is-carried-into-following-bindings
   (doseq [init ['(raster.par/contract out [[i n]] [[j n]] 1.0)
                 '(raster.par/reduce-by-key out keys values n +)]]

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -380,6 +380,15 @@
       (is (= :none (get-in compilation [:stats :fallback])))
       (is (= 0 (get-in linked [:attributes :driver-allocations]))))))
 
+(deftest counted-softmax-initializers-use-the-public-c-family-boundary
+  (doseq [target [cuda-target hip-target]]
+    (let [compilation (equation-first/compile #'attention/softmax-rows!
+                                            {:target target :dtype :float})
+          plan (equation-first/lower compilation [(float-array 6) 2 3])]
+      (is (= 4 (count (:kernels compilation))))
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
+
 (deftest counted-mixed-precision-stores-use-explicit-destination-conversion
   (doseq [target [cuda-target hip-target]]
     (let [compilation (equation-first/compile #'array-ops/reduce-axis-backward

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -386,6 +386,8 @@
                                             {:target target :dtype :float})
           plan (equation-first/lower compilation [(float-array 6) 2 3])]
       (is (= 4 (count (:kernels compilation))))
+      (is (every? #(< (count (:source %)) 32768) (:kernels compilation))
+          "the polynomial's shared scalar spine must not expand into megabytes of source")
       (is (= :none (get-in compilation [:stats :fallback])))
       (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
 

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -14,6 +14,7 @@
             [raster.core :refer [deftm]]
             [raster.dl.attention :as attention]
             [raster.numeric]
+            [raster.ode.pde :as pde]
             [raster.par]
             [raster.runtime.hardware :as hardware]))
 
@@ -377,6 +378,18 @@
       (is (= [module-target] (mapv :target (:kernels compilation))))
       (is (= :none (get-in compilation [:stats :fallback])))
       (is (= 0 (get-in linked [:attributes :driver-allocations]))))))
+
+(deftest heat-2d-counted-stores-use-the-public-c-family-boundary
+  (doseq [[target module-target] [[cuda-target :cuda-c] [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile #'pde/heat-rhs-2d!
+                                            {:target target :dtype :double})
+          plan (equation-first/lower compilation
+                                     [(double-array 35) (double-array 35)
+                                      5 7 0.25 4.0 9.0])]
+      (is (seq (:kernels compilation)))
+      (is (every? #(= module-target (:target %)) (:kernels compilation)))
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
 
 (deftest emitted-program-rejects-a-mixed-target-module
   (let [compilation (equation-first/compile

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -13,6 +13,7 @@
             [raster.gpu.parallel-program :as program-runtime]
             [raster.core :refer [deftm]]
             [raster.dl.attention :as attention]
+            [raster.dl.array-ops :as array-ops]
             [raster.numeric]
             [raster.ode.pde :as pde]
             [raster.par]
@@ -378,6 +379,13 @@
       (is (= [module-target] (mapv :target (:kernels compilation))))
       (is (= :none (get-in compilation [:stats :fallback])))
       (is (= 0 (get-in linked [:attributes :driver-allocations]))))))
+
+(deftest counted-mixed-precision-stores-use-explicit-destination-conversion
+  (doseq [target [cuda-target hip-target]]
+    (let [compilation (equation-first/compile #'array-ops/reduce-axis-backward
+                                            {:target target :dtype :float})]
+      (is (seq (:kernels compilation)))
+      (is (= :none (get-in compilation [:stats :fallback]))))))
 
 (deftest heat-2d-counted-stores-use-the-public-c-family-boundary
   (doseq [[target module-target] [[cuda-target :cuda-c] [hip-target :hip-cpp]]]

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -13,6 +13,7 @@
             [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.dl.gpu-grad-parity :as gp]
+            [raster.dl.attention :as attention]
             [raster.gpu.link :as gpu-link]
             [raster.linalg.contract :as contract]
             [raster.ode.pde :as pde]))
@@ -129,6 +130,22 @@
                           (format "CPU=%.15g GPU=%.15g" (double expected) actual)))
                     (finally
                       (gpu-link/close! executable))))))))
+
+(deftest softmax-counted-initializers-execute-through-the-direct-vertical
+  (when-gpu "softmax-counted-initializers"
+    (let [values [1000.0 1001.0 999.0 -1000.0 -999.0 -1001.0]
+          expected (float-array values)
+          _ (attention/softmax-rows! expected 2 3)
+          compilation (equation-first/compile #'attention/softmax-rows!
+                                              {:target :ze:0 :dtype :float})
+          plan (equation-first/lower compilation [(float-array values) 2 3])
+          executable (gpu-link/instantiate! plan)]
+      (try
+        (gpu-link/run! executable)
+        (let [actual (gpu-link/download executable (first (:outputs plan)))]
+          (doseq [i (range 6)]
+            (is (< (Math/abs (- (aget expected i) (aget ^floats actual i))) 1.0e-4))))
+        (finally (gpu-link/close! executable))))))
 
 (deftest heat-2d-counted-stores-execute-through-the-direct-vertical
   (when-gpu "heat-2d-counted-store-execution"

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -133,7 +133,7 @@
 
 (deftest softmax-counted-initializers-execute-through-the-direct-vertical
   (when-gpu "softmax-counted-initializers"
-    (let [values [1000.0 1001.0 999.0 -1000.0 -999.0 -1001.0]
+    (let [values [1000.0 1001.0 999.0 -1000.0 -998.0 -1001.0]
           expected (float-array values)
           _ (attention/softmax-rows! expected 2 3)
           compilation (equation-first/compile #'attention/softmax-rows!

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -130,6 +130,26 @@
                     (finally
                       (gpu-link/close! executable))))))))
 
+(deftest heat-2d-counted-stores-execute-through-the-direct-vertical
+  (when-gpu "heat-2d-counted-store-execution"
+    (doseq [[nx ny] [[2 3] [5 7]]]
+      (let [n (* nx ny)
+            input (double-array (map #(Math/sin (double %)) (range n)))
+            expected (double-array (repeat n -99.0))
+            output (double-array (repeat n -99.0))
+            _ (pde/heat-rhs-2d! expected input nx ny 0.25 4.0 9.0)
+            compilation (equation-first/compile #'pde/heat-rhs-2d!
+                                                {:target :ze:0 :dtype :double})
+            plan (equation-first/lower compilation [output input nx ny 0.25 4.0 9.0])
+            executable (gpu-link/instantiate! plan)]
+        (try
+          (gpu-link/run! executable)
+          (let [actual (gpu-link/download executable (first (:outputs plan)))]
+            (doseq [i (range n)]
+              (is (< (Math/abs (- (aget expected i) (aget ^doubles actual i))) 1.0e-10)
+                  (str [nx ny] " cell " i))))
+          (finally (gpu-link/close! executable)))))))
+
 (deftest symbolic-dense-contraction-uses-one-correct-kernel-body-test
   (let [left (float-array [1 2 3 4 5 6])
         right (float-array [7 8 9 10 11 12])

--- a/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
+++ b/test/raster/compiler/passes/parallel/scalar_region_body_test.clj
@@ -19,6 +19,18 @@
       :lower-index (fn [expression scope] (index/lower expression (conj scope 'i) decline!))
       :decline! decline!})))
 
+(deftest static-numeric-constants-use-shared-evidence
+  (let [lower (:lower (lowerer))
+        result (lower 'java.lang.Float/NEGATIVE_INFINITY :float {})]
+    (is (= :float (:type result)))
+    (is (= Float/NEGATIVE_INFINITY (get-in result [:result :value])))
+    (is (= 'Float/NEGATIVE_INFINITY
+           (:result (lower 'Float/NEGATIVE_INFINITY :float
+                           {'Float/NEGATIVE_INFINITY :float})))
+        "declared locals take precedence over static constant lookup")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"undeclared value"
+                         (lower 'Float/UNKNOWN :float {})))))
+
 (deftest java-round-keeps-overload-separate-from-consumer-type
   (let [lower (:lower (lowerer))
         widened (lower '(Math/round (aget x i)) :long {'i :int})

--- a/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
@@ -477,10 +477,7 @@
                 z (raster.par/pmap j n float
                                    (clojure.core/+ (clojure.core/aget y j)
                                                    (clojure.core/aget b j)))
-                _effect (dotimes [k n]
-                          (clojure.core/aset
-                           acc 0 (clojure.core/+ (clojure.core/aget acc 0)
-                                                 (clojure.core/aget y k))))]
+                _effect (clojure.core/prn y)]
                z)
         options {:dtype :float :target-device :ocl:0
                  :array-types {'x :float 'b :float 'acc :float}

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.typed-soac-frontend-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.par]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.soac :as legacy-soac]
             [raster.compiler.ir.axis-map :as axis-map]
@@ -11,6 +12,50 @@
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(deftest counted-store-loops-use-the-existing-effect-dialect
+  (let [source '(let* [result (dotimes [i n]
+                               (aset out i 1.0)
+                               (aset scratch i 2.0))] result)
+        options {:dtype :double :array-types {'out :double 'scratch :double}
+                 :scalar-types {'n :long}}
+        normalized (frontend/normalize-source source options)
+        bindings (second normalized)
+        program (frontend/form->program normalized options)
+        run (fn [form n]
+              (let [out (double-array 3) scratch (double-array 3)
+                    f (eval (list 'fn '[n out scratch] form))]
+                (try
+                  [(f n out scratch) (vec out) (vec scratch)]
+                  (catch Exception e [(class e) (vec out) (vec scratch)]))))]
+    (is (some? program))
+    (is (= 'long (:tag (meta (first bindings)))))
+    (is (= 'raster.par/map-void! (first (last bindings))))
+    (is (= normalized (frontend/normalize-source normalized options)))
+    (doseq [n [Long/MIN_VALUE -1 0 1 3 2147483648 Long/MAX_VALUE]]
+      (is (= (run source n) (run normalized n)) (str "count " n)))))
+
+(deftest counted-conflicting-stores-retain-order-and-explicit-buffer-return
+  (let [options {:dtype :double :array-types {'out :double} :scalar-types {'n :long}}
+        source '(let* [r (dotimes [i n] (aset out 0 (double i)))] out)
+        program (frontend/form->program (frontend/normalize-source source options) options)
+        equation (last (dialect/equations program))
+        result (first (nth equation 2))
+        renamed (dialect/remap-values program {'out [:argument 0] result [:result 0]})]
+    (is (= 'effect-map (dialect/operation-kind equation)))
+    (is (= :sequential (:iteration-order (:attributes (dialect/operation-parts equation)))))
+    (is (= [result] (dialect/outputs program)))
+    (is (= '[(extent out)] (get-in (dialect/facts program) [:values result :shape])))
+    (is (= '[(extent [:argument 0])]
+           (get-in (dialect/facts renamed) [:values [:result 0] :shape])))
+    (is (= [[:argument 0]]
+           (dialect/physical-results renamed (last (dialect/equations renamed)))))))
+
+(deftest unknown-or-mutable-counts-are-not-normalized
+  (doseq [bound ['(next-count!) '(aget counts 0)]]
+    (let [source (list 'let* ['r (list 'dotimes ['i bound] '(aset out i 1.0))] 'r)]
+      (is (= source (frontend/normalize-source source
+                                              {:array-types {'out :double 'counts :long}}))))))
 
 (def ^:private source
   '(let* [^long n (clojure.core/alength x)

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -13,6 +13,27 @@
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
 
+(deftest map-let-spines-become-typed-locals
+  (let [body '(let* [^float p1 (* (aget x i) (aget x i))
+                    ^float p2 (* p1 p1)
+                    ^float p3 (* p2 p2)] p3)
+        source (list 'let* ['y (list 'raster.par/pmap 'i 'n 'float body)] 'y)
+        program (frontend/form->program source
+                                        {:dtype :float :array-types {'x :float}
+                                         :scalar-types {'n :long}})
+        parts (dialect/operation-parts (first (dialect/equations program)))
+        region (dialect/lambda-parts (:lambda parts))]
+    (is (some? program))
+    (is (= 3 (count (:locals region))))
+    (is (= '[p1 p2 p3] (mapv :id (:locals region))))))
+
+(deftest map-let-spines-require-complete-scalar-type-evidence
+  (doseq [body ['(let* [p (* x x)] p)
+                '(let* [^float p (* x x) ^float p (* p p)] p)
+                '(let* [^float p (* x x)] (observe! p) p)
+                '(let* [^floats p x] p)]]
+    (is (nil? (#'frontend/typed-map-region body)))))
+
 (deftest counted-store-loops-use-the-existing-effect-dialect
   (let [source '(let* [result (dotimes [i n]
                                (aset out i 1.0)

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -51,6 +51,17 @@
     (is (= [[:argument 0]]
            (dialect/physical-results renamed (last (dialect/equations renamed)))))))
 
+(deftest counted-stores-preserve-source-rounding-before-destination-conversion
+  (let [options {:dtype :double :array-types {'out :double 'x :double}
+                 :scalar-types {'n :long}}
+        source '(let* [r (dotimes [i n] (aset out 0 (float (aget x i))))] out)
+        program (frontend/form->program (frontend/normalize-source source options) options)]
+    (is (some? program))
+    (is (some #(and (seq? %) (= 'double (first %))
+                    (seq? (second %)) (= 'float (first (second %))))
+              (tree-seq coll? seq (last (dialect/equations program))))
+        "widen the source-rounded float; do not replace its cast with a double cast")))
+
 (deftest unknown-or-mutable-counts-are-not-normalized
   (doseq [bound ['(next-count!) '(aget counts 0)]]
     (let [source (list 'let* ['r (list 'dotimes ['i bound] '(aset out i 1.0))] 'r)]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -9,9 +9,20 @@
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.core.util :as util]
+            [raster.compiler.passes.parallel.patterns :as patterns]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(deftest generated-row-major-coordinates-carry-their-domain-type
+  (let [matched (patterns/match-nested-dotimes-row-major-map
+                 '(dotimes [i rows]
+                    (dotimes [j cols]
+                      (aset out (+ (* i cols) j) 1.0))))
+        locals (take-nth 2 (second (:value-expr matched)))]
+    (is (some? matched))
+    (is (= ['long 'long] (mapv #(get (meta %) :raster.type/tag) locals)))
+    (is (some? (#'frontend/typed-map-region (:value-expr matched))))))
 
 (deftest map-let-spines-become-typed-locals
   (let [body '(let* [^float p1 (* (aget x i) (aget x i))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -300,8 +300,9 @@
                (first (:body-results (dialect/lambda-parts (:lambda operation)))))]
     (is (= 'scatter (:kind operation)))
     (is (= :unique (get-in operation [:attributes :conflict])))
-    (is (= '[indices src out] (dialect/operation-inputs equation)))
-    (is (= {:destination-index '%element0 :predicate 1 :value '%element1} write))
+    (is (= '[indices out src] (dialect/operation-inputs equation)))
+    (is (= {:destination-index '(clojure.core/aget %capture0 i) :predicate 1
+            :value '(clojure.core/aget %capture2 i)} write))
     (is (= [{:destination 'out :access :read-write :host-return :effect}]
            (get-in (dialect/facts program) [:equations 0 :attributes :result-storage])))
     (is (= :analyzed-source
@@ -326,7 +327,7 @@
     (is (= 'scatter (:kind operation)))
     (is (= :unique (get-in operation [:attributes :conflict])))
     (is (= '(clojure.core/+ %capture0 i) (:destination-index write)))
-    (is (= '[src base out] (dialect/operation-inputs equation)))
+    (is (= '[base out src] (dialect/operation-inputs equation)))
     (is (= [{:destination 'out :access :read-write :host-return :buffer}]
            (dialect/result-storage program (second equation))))))
 

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -942,8 +942,8 @@
         kernel (first (:kernels emitted))]
     (is (= :typed-soac (:dialect program)))
     (is (:typed-validated stats))
-    (is (= [] (:outputs program))
-        "the effect binder keeps its host nil semantics")
+    (is (= [[:effect-map 0 0] [:effect-map 0 1]] (:outputs program))
+        "the source explicitly returns both updated destinations, not the effect's nil binder")
     (is (= [[:effect-map 0 0] [:effect-map 0 1]]
            (dialect/outputs algorithm)))
     (is (= ['a 'b]
@@ -1931,16 +1931,34 @@
     (is (some #{'cols} binders) (pr-str source))
     (is (some #{'_eff} binders) "the host loop itself is retained as written")))
 
+(deftest counted-indexed-updates-preserve-an-existing-producer-shape
+  (let [source '(let* [y (raster.par/pmap i n float (* 2.0 (aget x i)))
+                      z (raster.par/pmap j n float (+ 1.0 (aget y j)))
+                      effect (dotimes [k n]
+                               (aset acc 0 (+ (aget acc 0) (aget y k))))]
+                     z)
+        routed (route/attempt source :float {'x :float 'acc :float}
+                              {:scalar-types {'n :long}})
+        program (:program routed)
+        run (fn [form]
+              (let [acc (float-array [0.0])
+                    f (eval (list 'fn '[^floats x ^floats acc ^long n] form))
+                    result (f (float-array [1.0 2.0 3.0 4.0]) acc 4)]
+                [(vec result) (vec acc)]))]
+    (is (nil? (:declined routed)))
+    (is (= '[n] (get-in program [:values 'y :shape])))
+    (is (= 1 (count (filter #{'y} (take-nth 2 (second (:source program)))))))
+    (when program
+      (is (= [[3.0 5.0 7.0 9.0] [20.0]] (run source) (run (:source program)))))))
+
 (deftest a-producer-the-host-reads-is-not-fused-away
-  ;; `y` has one typed consumer (`z`) and one host reader (the loop). Counting only typed uses
+  ;; `y` has one typed consumer (`z`) and one opaque host reader. Counting only typed uses
   ;; would inline `y` into `z` and then resurrect its source binding for the host: the producer
   ;; would run twice. Host reads are uses, so `y` stays its own equation.
   (let [routed (route/attempt
                 '(let* [y (raster.par/pmap i n float (clojure.core/* 2.0 (clojure.core/aget x i)))
                         z (raster.par/pmap j n float (clojure.core/+ 1.0 (clojure.core/aget y j)))
-                        _eff (dotimes [k n]
-                               (clojure.core/aset acc 0 (clojure.core/+ (clojure.core/aget acc 0)
-                                                                         (clojure.core/aget y k))))]
+                        _eff (clojure.core/prn y)]
                        z)
                 :float {'x :float 'acc :float} {:scalar-types {'n :long}})
         program (:program routed)

--- a/test/raster/compiler/passes/scalar/inline_test.clj
+++ b/test/raster/compiler/passes/scalar/inline_test.clj
@@ -33,6 +33,85 @@
     (doseq [index [-1 2 'n '(long n) '(int 4294967296) '(float 1)]]
       (is (nil? (#'inline/known-vg-element elements 'vg index))))))
 
+(deftest leaf-bodies-are-inlinable
+  (doseq [body ['x 'java.lang.Float/NEGATIVE_INFINITY 42 1.5 nil true]]
+    (is (#'inline/inlinable-body? body))))
+
+(deftest inlining-preserves-unused-checked-arguments
+  (with-redefs-fn {#'inline/try-resolve-deftm
+                  (fn [_] {:params ['x] :tags ['int] :walked-body [42]})}
+    (fn []
+      (let [inlined (#'inline/inline-invk '(.invk example/constant (int 4294967296)))]
+        (is (thrown? ArithmeticException (eval inlined))
+            "an unused checked argument still throws before entering the callee"))
+      (let [inlined (#'inline/inline-invk
+                    '(.invk example/constant (int (do (swap! calls inc) 3))))]
+        (is (= [42 1] (eval (list 'let ['calls '(atom 0)]
+                                 [inlined '(deref calls)]))))))))
+
+(deftest direct-inline-arity-is-checked-before-substitution
+  (with-redefs-fn {#'inline/try-resolve-deftm
+                  (fn [_] {:params ['x] :tags ['long] :walked-body [42]})}
+    (fn []
+      (doseq [call ['(.invk example/constant)
+                   '(.invk example/constant 1 (swap! calls inc))]]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Arity mismatch"
+                             (#'inline/inline-invk call)))))))
+
+(deftest unused-collection-arguments-still-evaluate-their-elements
+  (with-redefs-fn {#'inline/try-resolve-deftm
+                  (fn [_] {:params ['x] :walked-body [42]})}
+    (fn []
+      (doseq [argument ['[(swap! calls inc)] '{:key (swap! calls inc)}
+                       '#{(swap! calls inc)}]]
+        (let [inlined (#'inline/inline-invk (list '.invk 'example/constant argument))]
+          (is (= [42 1] (eval (list 'let ['calls '(atom 0)]
+                                   [inlined '(deref calls)])))))))))
+
+(deftest local-function-inlining-preserves-call-by-value
+  (doseq [body [nil false 42 '(+ x x)]
+          argument ['(int (do (swap! calls inc) 3))]]
+    (let [source (list 'let* ['f (list 'ftm ['x] body)
+                             'result (list 'f argument)] 'result)
+          inlined (:form (#'inline/inline-one-pass source))
+          ;; The local function declaration remains for later DCE; use a host fn
+          ;; solely to execute this intermediate compiler form.
+          executable (clojure.walk/postwalk
+                      #(if (and (seq? %) (= 'ftm (first %)))
+                         (cons 'fn (rest %)) %) inlined)]
+      (is (= [(if (seq? body) 6 body) 1]
+             (eval (list 'let ['calls '(atom 0)] [executable '(deref calls)])))))))
+
+(deftest binding-inline-accepts-constant-leaves
+  (with-redefs-fn {#'inline/try-resolve-deftm
+                  (fn [& _] {:params ['x] :tags ['long] :walked-body [42]})}
+    (fn []
+      (let [inlined (:form (#'inline/inline-one-pass
+                           '(let* [result (example/constant (int 4294967296))] result)))]
+        (is (thrown? ArithmeticException (eval inlined)))))))
+
+(deftest nested-argument-calls-are-expanded-before-lifting
+  (with-redefs-fn {#'inline/try-resolve-deftm
+                  (fn [_] {:params ['x] :tags ['long] :walked-body ['x]})}
+    (fn []
+      (let [inlined (#'inline/inline-invk
+                    '(.invk example/identity (.invk example/identity (+ 1 2))))]
+        (is (not-any? #(and (seq? %) (= '.invk (first %)))
+                      (tree-seq coll? seq inlined)))
+        (is (= 3 (eval inlined)))))))
+
+(deftest inlining-visits-loop-initializers-without-changing-binders
+  (with-redefs-fn {#'inline/try-resolve-deftm
+                  (fn [_] {:params ['x] :tags ['long] :walked-body ['x]})}
+    (fn []
+      (let [inlined (#'inline/inline-invk
+                    '(loop* [i 0 acc (.invk example/identity (long (+ i 2)))]
+                       (if (< i 3) (recur (inc i) (+ acc i)) acc)))]
+        (is (= ['i 'acc] (vec (take-nth 2 (second inlined)))))
+        (is (not-any? #(and (seq? %) (= '.invk (first %)))
+                      (tree-seq coll? seq inlined)))
+        (is (= 5 (eval inlined)))))))
+
 ;; Monomorphic callee taking THREE args (mirrors the concrete-float finetune.train/gblock,
 ;; which takes 38 and was called with 37).
 (deftm arity-callee

--- a/test/raster/compiler/passes/scalar/inline_test.clj
+++ b/test/raster/compiler/passes/scalar/inline_test.clj
@@ -33,6 +33,16 @@
     (doseq [index [-1 2 'n '(long n) '(int 4294967296) '(float 1)]]
       (is (nil? (#'inline/known-vg-element elements 'vg index))))))
 
+(deftest lifted-arguments-retain-source-types-not-formal-consumer-types
+  (doseq [[argument environment] [['(float 1.0) {}]
+                                 ['(clojure.core/aget a 0) {'a 'floats}]]]
+    (let [bindings (atom [])
+          substitution (#'inline/argument-substitution
+                        ['x] [argument] ['double] environment #(swap! bindings conj %))
+          id (get substitution 'x)]
+      (is (= 'float (:raster.type/tag (meta id))))
+      (is (= [[id argument]] @bindings)))))
+
 (deftest leaf-bodies-are-inlinable
   (doseq [body ['x 'java.lang.Float/NEGATIVE_INFINITY 42 1.5 nil true]]
     (is (#'inline/inlinable-body? body))))

--- a/test/raster/compiler/passes/scalar/inline_test.clj
+++ b/test/raster/compiler/passes/scalar/inline_test.clj
@@ -34,7 +34,7 @@
       (is (nil? (#'inline/known-vg-element elements 'vg index))))))
 
 (deftest lifted-arguments-retain-source-types-not-formal-consumer-types
-  (doseq [[argument environment] [['(float 1.0) {}]
+  (doseq [[argument environment] [['(float (aget a 0)) {'a 'doubles}]
                                  ['(clojure.core/aget a 0) {'a 'floats}]]]
     (let [bindings (atom [])
           substitution (#'inline/argument-substitution
@@ -42,6 +42,12 @@
           id (get substitution 'x)]
       (is (= 'float (:raster.type/tag (meta id))))
       (is (= [[id argument]] @bindings)))))
+
+(deftest checked-constant-evidence-avoids-unnecessary-argument-bindings
+  (doseq [argument ['(float 0.0) '(float 1.0) '(long 4)]]
+    (is (false? (#'inline/needs-arg-lift? argument))))
+  (doseq [argument ['(int 4294967296) '(float (observe!))]]
+    (is (#'inline/needs-arg-lift? argument))))
 
 (deftest leaf-bodies-are-inlinable
   (doseq [body ['x 'java.lang.Float/NEGATIVE_INFINITY 42 1.5 nil true]]

--- a/test/raster/compiler/review_regression_test.clj
+++ b/test/raster/compiler/review_regression_test.clj
@@ -7,6 +7,7 @@
             [raster.numeric :as n]
             [raster.arrays :refer [aget aset alength]]
             [raster.compiler.core.inference :as inf]
+            [raster.compiler.core.walker :as walker]
             [raster.ad.reverse :as rev]))
 
 ;; ================================================================
@@ -102,13 +103,15 @@
 ;; ================================================================
 
 (deftest cc10-anf-flatten-preserves-effects
-  (testing "walker.clj ANF flatten splices intermediate effects as bindings"
-    (let [src (slurp "src/raster/compiler/core/walker.clj")
-          ;; Must use butlast/last pattern, not just (last inner-body)
-          idx (.indexOf src "ANF flattening")
-          section (subs src idx (min (+ idx 800) (count src)))]
-      (is (.contains section "butlast")
-          "ANF flattening must use butlast to preserve intermediate forms"))))
+  (testing "ANF flattening preserves intermediate effects in their original order"
+    (let [walked (walker/walk-body
+                  '(let* [result (let* [value 7]
+                                   (println "first") (println "second") value)] result)
+                  {:type-env {}})
+          result (atom nil)
+          output (with-out-str (reset! result (eval walked)))]
+      (is (= 7 @result))
+      (is (= "first\nsecond\n" output)))))
 
 ;; ================================================================
 ;; CC5/CC4: dotimes AD backward must not double-invoke mapcat

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -2,10 +2,10 @@
  :dtype :float,
  :summary
  {:total 236,
-  :typed-soac 104,
+  :typed-soac 132,
   :error 43,
-  :scalar 73,
-  :compatibility 16},
+  :scalar 47,
+  :compatibility 14},
  :vars
  [{:var raster.dl.array-ops/argmax-rows!,
    :route :typed-soac,
@@ -23,20 +23,22 @@
    :route :error,
    :error :kernel-body-store-dtype}
   {:var raster.dl.array-ops/blit-slab!,
-   :route :scalar,
-   :typed-validated false,
+   :route :typed-soac,
+   :typed-validated true,
    :declines []}
   {:var raster.dl.array-ops/broadcast-add,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.array-ops/broadcast-add-dh,
    :route :error,
    :error :kernel-body-store-dtype}
   {:var raster.dl.array-ops/broadcast-add-dt,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/broadcast-kv-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -48,23 +50,27 @@
   {:var raster.dl.array-ops/dot-rows-dW,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_273037 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_2695334 = (loop"}
   {:var raster.dl.array-ops/dot-rows-dh,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.array-ops/flat-embed-d-space-emb,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/flat-embed-d-state-emb,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/flat-embed-d-values,
    :route :scalar,
    :typed-validated false,
@@ -72,15 +78,18 @@
   {:var raster.dl.array-ops/flat-embed-dWe,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/flat-embed-dbe,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/flat-embed-op,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.array-ops/gather,
    :route :typed-soac,
    :typed-validated true,
@@ -112,7 +121,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_277628 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_2701741 = (if (clo"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -120,11 +129,13 @@
   {:var raster.dl.array-ops/reduce-axis,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.array-ops/reduce-axis-backward,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.array-ops/scale-clamp-exp,
    :route :typed-soac,
    :typed-validated true,
@@ -154,9 +165,10 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.array-ops/scatter-strided-2d,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.array-ops/segment-div,
    :route :scalar,
    :typed-validated false,
@@ -174,9 +186,10 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.array-ops/slice-strided-2d,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.array-ops/sum-kv-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -237,13 +250,12 @@
   {:var raster.dl.attention/causal-attn-with-cache!,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
   {:var raster.dl.attention/causal-multi-head-attention,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.attention/causal-multi-head-attention-cached!,
    :route :scalar,
    :typed-validated false,
@@ -275,7 +287,8 @@
    :route :scalar,
    :typed-validated false,
    :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   [{:reason :sequential-effect-continuation,
+     :kind :typed-soac-declined}]}
   {:var raster.dl.attention/causal-single-head-attention,
    :route :error,
    :error
@@ -350,9 +363,10 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.attention/rope-pos-partial!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.attention/rope-pos-rows-buf!,
    :route :typed-soac,
    :typed-validated true,
@@ -391,18 +405,19 @@
    :declines
    [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.attention/sinusoidal-embedding,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.attention/softmax-rows!,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 2}}
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_290419 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_2716216 = (loop"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -416,8 +431,8 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.diffusion/forward-noise-backward,
-   :route :scalar,
-   :typed-validated false,
+   :route :typed-soac,
+   :typed-validated true,
    :declines []}
   {:var raster.dl.diffusion/linear-beta-schedule,
    :route :typed-soac,
@@ -434,17 +449,19 @@
   {:var raster.dl.loss/cross-entropy-loss-backward,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :sequential-effect-continuation,
+     :kind :typed-soac-declined}]}
   {:var raster.dl.loss/huber-loss,
    :route :error,
-   :error :illegal-op-remains}
+   :error :scalar-reduction-requires-typed-graph}
   {:var raster.dl.loss/huber-loss-backward,
    :route :typed-soac,
    :typed-validated true,
    :declines []}
   {:var raster.dl.loss/l1-loss,
    :route :error,
-   :error :illegal-op-remains}
+   :error :scalar-reduction-requires-typed-graph}
   {:var raster.dl.loss/l1-loss-backward,
    :route :error,
    :error :kernel-body-opencl-intrinsic}
@@ -454,7 +471,7 @@
    :declines []}
   {:var raster.dl.loss/mse-loss,
    :route :error,
-   :error :illegal-op-remains}
+   :error :scalar-reduction-requires-typed-graph}
   {:var raster.dl.nn/add-bias-rows!,
    :route :typed-soac,
    :typed-validated true,
@@ -462,23 +479,27 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129649 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_2532423 = (if (clo"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/batch-norm-backward-dgamma,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/batch-norm-backward-dx,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/batch-norm-jvp-dx,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/col2im-1d,
    :route :error,
    :error
@@ -540,19 +561,19 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/embedding,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/embedding-backward,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/geglu,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/gelu,
    :route :typed-soac,
    :typed-validated true,
@@ -634,30 +655,34 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/layer-norm,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/layer-norm!,
    :route :typed-soac,
    :typed-validated true,
    :declines [],
    :effect-orders {:independent 1}}
   {:var raster.dl.nn/layer-norm-backward-dbeta,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/layer-norm-backward-dgamma,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/layer-norm-backward-dx,
    :route :error,
    :error
    "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(sums = (loop* [i 0 s"}
   {:var raster.dl.nn/layer-norm-jvp-dx,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/leaky-relu,
    :route :typed-soac,
    :typed-validated true,
@@ -673,73 +698,52 @@
   {:var raster.dl.nn/linear,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/linear!,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/linear-dW,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
-  {:var raster.dl.nn/linear-db,
-   :route :scalar,
-   :typed-validated false,
    :declines []}
+  {:var raster.dl.nn/linear-db,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/linear-dx,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/linear-nb,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/matmul,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/matmul!,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/matmul-dA,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/matmul-dA!,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/matmul-dB,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/matmul-dB!,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/maxpool2d,
    :route :scalar,
    :typed-validated false,
@@ -751,11 +755,13 @@
   {:var raster.dl.nn/maxpool2d-bwd!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/mean-pool,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/residual-add,
    :route :typed-soac,
    :typed-validated true,
@@ -800,9 +806,10 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/rms-norm-jvp-dx,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/sigmoid,
    :route :typed-soac,
    :typed-validated true,
@@ -828,9 +835,10 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/skip-layer-norm,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/softmax-1d,
    :route :compatibility,
    :typed-validated false,
@@ -843,9 +851,7 @@
   {:var raster.dl.nn/swiglu,
    :route :typed-soac,
    :typed-validated true,
-   :declines
-   [{:reason :typed-contraction-dispatch-dynamic-scalar,
-     :kind :typed-contraction-dispatch-declines}]}
+   :declines []}
   {:var raster.dl.nn/tanh-act,
    :route :typed-soac,
    :typed-validated true,
@@ -855,13 +861,15 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/transpose-2d,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/transpose-2d!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.nn/xavier-init,
    :route :error,
    :error
@@ -877,7 +885,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_287811 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_2714668 = (if (.in"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -942,16 +950,16 @@
   {:var raster.nn/dense-into!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_301217 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_2725484 = \\\"Kai"}
   {:var raster.nn/loss-fn,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.nn/predict-fn,
    :route :typed-soac,
    :typed-validated true,
@@ -968,7 +976,7 @@
    :route :compatibility,
    :typed-validated false,
    :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   [{:reason :typed-soac-unknown-value, :kind :typed-soac-declined}]}
   {:var raster.nn/softmax-backward,
    :route :error,
    :error :parallel-program-parameter-role-conflict}
@@ -976,7 +984,7 @@
    :route :compatibility,
    :typed-validated false,
    :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   [{:reason :typed-soac-unknown-value, :kind :typed-soac-declined}]}
   {:var raster.nn/softmax-cross-entropy-backward,
    :route :typed-soac,
    :typed-validated true,
@@ -984,7 +992,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_308082 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_2732733 = \\\"Xav"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}
@@ -993,9 +1001,10 @@
    :typed-validated true,
    :declines []}
   {:var raster.ode.pde/heat-rhs-2d!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines [],
+   :effect-orders {:sequential 3}}
   {:var raster.ode.pde/solve-fixed-step,
    :route :error,
    :error
@@ -1003,4 +1012,4 @@
   {:var raster.ode.pde/wave-rhs-1d!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_32"}]}
+   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_27"}]}


### PR DESCRIPTION
## Summary

- Normalize closed raw counted store loops into the existing TypedSOAC effect-map boundary, retaining every body form, nil return, checked Long conversion and empty negative domains. Unknown/effectful and mutable-array-derived bounds remain unchanged.
- Preserve physical destination shape and an explicitly returned destination after nil-valued effects. Remap extent projections with their SSA destination IDs.
- Compile and link the existing 2-D heat RHS through CUDA/HIP, and compare actual Level Zero execution with CPU values on empty-interior and non-square grids.
- Preserve indexed input storage shapes independently of counted traversal extents and retain explicit source/destination precision conversions.
- Preserve call-by-value and argument type evidence during leaf inlining, including loop initializers; share argument binding and arity checks rather than adding per-operator exceptions.
- Keep map `let` spines as TypedSOAC locals. This fixes the softmax polynomial's exponential source expansion: 25,599 scalar computes / 3,379,887 bytes become 24 computes / 2,259 bytes. Source assembly also no longer repeatedly copies every preceding prefix.

No new semantic IR or operation registry. Existing ownership analysis decides independence versus sequential scheduling. This is local compiler correctness coverage, not a competitive stencil benchmark or distributed solver claim.

## Validation

- Frontend and C-family suites: 71 tests, 424 assertions, green before the final remap regression.
- Final frontend and dialect suites: 73 tests, 354 assertions, green.
- Final CUDA/HIP heat compile/link and local GPU numerical tests: 2 tests, 49 assertions, green.
- Independent review caught and fixed missing extent-projection SSA remapping; final review has no blockers.
- One capped REPL; full suite and hardware-free compiler gates delegated to CI.
- Review-fix frontend/inliner suite: 74 tests, 335 assertions, green. CUDA/HIP softmax source-size checks and local GPU numerical parity: 2 tests, 14 assertions, green.
- An earlier softmax native compilation attempt timed out before preserving the scalar spine; the corrected generated kernel completed the device test. These are correctness and source-size results, not runtime throughput benchmarks.
- Final frontend/route/segmented regressions: 136 tests, 981 assertions, green; asymmetric two-row softmax device parity: 6 assertions, green.
- Corpus audit: 236 programs, 132 typed / 47 scalar / 14 compatible / 43 errors. No route downgrades remain. Baseline explicitly admits 23 new sequential regions (19 formerly scalar, softmax formerly compatible, three partially typed programs with previously host loops); existing independent kernels and the serialization ratchet remain intact.

Base includes squash-merged #540. Next campaign seam: bind distributed compute to exact local programs and shard views, then numerical halo parity and durable byte restore.
