### PR TITLE
Bind distributed certificates to structural local plans

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1088,16 +1088,20 @@ Items 6–8 have checked planning components, not yet one executable numerical a
 `numerical-state` certifies chunk coverage and durable field identity; `numerical-content` tests
 scoped leases and transfer ownership using fake providers; `amr-plan` composes hierarchy, fields,
 regions and routes, but its coarse/fine operator requirements are declarations rather than bodies.
-The distributed certificate currently summarizes optional local plans by ID/operation count, not
-their exact numerical program. Do not treat that summary as a program-equivalence witness.
+The distributed certificate now retains the optional structural local LinkPlan/ExecutionPlan
+contracts instead of only their IDs and operation counts. Equally sized replacements with changed
+operations, scalars, event dependencies, outputs or views invalidate the certificate. Persistent
+compiler values are shared, not serialized or copied; this is not a content hash or snapshot of
+mutable host/device buffers. Explicit compute-step-to-program/shard binding is still required
+before treating the overall plan as an executable numerical workflow.
 
 The next sequence is workload-driven:
 
 1. Admit the existing `raster.ode.pde/heat-rhs-2d!` through direct TypedSOAC scheduling and emission,
-   preserving its multi-store boundaries and offset interior domain. A direct CUDA probe rejects
-   it with `:equation-first-coverage`; the ZE diagnostic reports a scalar route with no SegOps.
-   Existing 1-D RK4 and the direct AD/SGD probe succeed. Do not rewrite the PDE merely to satisfy
-   a narrower matcher, or assume its source comment proves nested-loop lifting already works.
+   preserving its multi-store boundaries and offset interior domain. This local admission now
+   passes CUDA/HIP compile/link and two-grid ZE numerical parity, through counted-store
+   normalization described below. Parallel schedule quality remains unmeasured. Existing 1-D
+   RK4 and the direct AD/SGD probe also succeed; the PDE source was not rewritten for admission.
 2. Bind distributed compute to exact local program entries and shard/view contracts; make numerical
    program drift load-bearing in certification rather than comparing only IDs and counts.
 3. Execute a hardware-free two-shard halo step and compare stitched values with the monolithic

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -988,15 +988,15 @@
            (:halos plan))
      (route-costs plan)
      (:cost-vector simulation)
-     (into {}
-           (map (fn [[device-id local]]
-                  [device-id
-                   {:link-plan (some-> (:link-plan local) :id)
-                    :execution-operations (some-> (:execution-plan local) :operations count)}]))
-           (:device-plans plan)))))
+     ;; A name and an operation count do not identify a local computation. Retain the
+     ;; immutable compiler contracts, including artifacts, scalar bindings, views and event
+     ;; dependencies, so replacing an equally sized program invalidates the witness.
+     ;; This is structural plan verification, not a digest of mutable buffer contents.
+     (:device-plans plan))))
 
 (defn certify
-  "Validate a plan and attach a reproducible coverage, route-cost, and resource witness."
+  "Validate a plan and attach coverage, route-cost, resource and structural local-plan witnesses.
+   Local contracts are compared as compiler values, not portable hashes or buffer snapshots."
   [plan]
   (let [plan (validate! plan)]
     (->CertifiedDistributedPlan plan (derive-certificate plan))))

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -989,14 +989,15 @@
      (route-costs plan)
      (:cost-vector simulation)
      ;; A name and an operation count do not identify a local computation. Retain the
-     ;; immutable compiler contracts, including artifacts, scalar bindings, views and event
+     ;; validated local plan values, including artifacts, scalar bindings, views and event
      ;; dependencies, so replacing an equally sized program invalidates the witness.
      ;; This is structural plan verification, not a digest of mutable buffer contents.
      (:device-plans plan))))
 
 (defn certify
   "Validate a plan and attach coverage, route-cost, resource and structural local-plan witnesses.
-   Local contracts are compared as compiler values, not portable hashes or buffer snapshots."
+   Local contracts are compared as compiler values, not portable hashes or buffer snapshots.
+   Certificates retain their referenced objects but acquire no runtime ownership/arena lease."
   [plan]
   (let [plan (validate! plan)]
     (->CertifiedDistributedPlan plan (derive-certificate plan))))

--- a/test/raster/compiler/ir/distributed_plan_test.clj
+++ b/test/raster/compiler/ir/distributed_plan_test.clj
@@ -2,6 +2,11 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as abstract-value]
             [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.compiler.ir.execution-plan :as execution]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.ir.scan :as scan]))
 
 (defn- two-device-topology
@@ -146,6 +151,64 @@
         error (try (distributed/verify! modified)
                    (catch clojure.lang.ExceptionInfo exception exception))]
     (is (= :distributed-certificate (:reason (ex-data error))))))
+
+(deftest local-plan-witnesses-bind-content-not-names-or-counts
+  (let [queue (execution/compute-queue)
+        ready (execution/->LogicalEvent :ready)
+        done (execution/->LogicalEvent :done)
+        local-execution
+        (execution/validate!
+         (execution/->ExecutionPlan
+          [queue] [ready]
+          [(execution/->ScheduledOperation :step {:kernel :heat :alpha 0.25}
+                                           queue [] done)]
+          [done]))
+        kernel (artifact/make
+                {:kernel-name "plan_witness"
+                 :source "__kernel void plan_witness(__global float* state, long n) {}"
+                 :abi [(abi/slot 'state :output :float) (abi/slot 'n :scalar :long)]
+                 :arguments '[state n]
+                 :launch (launch/spec {:workgroup-size [1] :group-count [(launch/ceil-div 'n 1)]})
+                 :effects {:kind :map :writes '[state]}})
+        descriptor {:dtype :float :all-params '[state n] :array-params '[state]
+                    :scalar-params '[n] :allocs [] :result-sym 'state
+                    :steps [{:phase :map :kernel-name "plan_witness" :convention :map
+                             :artifact kernel
+                             :argument-specs [{:kind :output :sym 'state}
+                                              {:kind :scalar :type :long
+                                               :value-fn (fn [args] (second args))}]}]}
+        local-link (fn [width]
+                     (link-plan/make
+                      {:id :same-local-plan :target :gpu-0
+                       :nodes [(link-plan/node {:id :state :dtype :float :shape [width]
+                                                :device :gpu-0 :role :state})]
+                       :instances [(link-plan/instance {:id :write :descriptor descriptor
+                                                         :bindings {'state :state}
+                                                         :scalars {'n width}})]
+                       :outputs [:state]}))
+        local {:link-plan (local-link 16) :execution-plan local-execution}
+        plan (assoc (training-plan) :device-plans {:gpu-0 local})
+        certified (distributed/certify plan)]
+    (is (= {:gpu-0 local} (get-in certified [:certificate :device-plans])))
+    (is (= certified (distributed/verify! certified)))
+    (doseq [[label changed]
+            [[:scalar (assoc-in local [:execution-plan :operations 0 :operation :alpha] 0.5)]
+             [:operation (assoc-in local [:execution-plan :operations 0 :operation :kernel] :wave)]
+             [:dependency (assoc-in local [:execution-plan :operations 0 :waits] [ready])]
+             [:output (assoc-in local [:execution-plan :outputs] [ready])]
+             [:artifact (assoc-in local [:link-plan :instances 0 :descriptor :steps 0
+                                         :artifact :source]
+                                  "__kernel void plan_witness(__global float* state, long n) { state[0] = 1.0f; }")]
+             [:view (assoc local :link-plan (local-link 8))]]]
+      (testing (name label)
+        (let [modified (assoc-in certified [:plan :device-plans :gpu-0] changed)]
+          (is (= 1 (count (get-in changed [:execution-plan :operations]))))
+          (is (= :same-local-plan (get-in changed [:link-plan :id])))
+          (is (distributed/distributed-plan? (distributed/validate! (:plan modified)))
+              "the replacement is valid on its own, but does not match the old certificate")
+          (is (= :distributed-certificate
+                 (:reason (ex-data (try (distributed/verify! modified)
+                                        (catch clojure.lang.ExceptionInfo e e)))))))))))
 
 (defn- two-device-all-reduce
   []

--- a/test/raster/compiler/ir/distributed_plan_test.clj
+++ b/test/raster/compiler/ir/distributed_plan_test.clj
@@ -152,7 +152,7 @@
                    (catch clojure.lang.ExceptionInfo exception exception))]
     (is (= :distributed-certificate (:reason (ex-data error))))))
 
-(deftest local-plan-witnesses-bind-content-not-names-or-counts
+(deftest local-plan-witnesses-bind-structure-not-names-or-counts
   (let [queue (execution/compute-queue)
         ready (execution/->LogicalEvent :ready)
         done (execution/->LogicalEvent :done)


### PR DESCRIPTION
## Summary

- Bind distributed certificates to validated structural local plans, not just LinkPlan identifiers or operation counts.
- Verify that replacing artifacts, scalar bindings, dependencies, outputs or views invalidates the witness even when names and operation counts stay unchanged.
- Clarify the boundary: in-process structural verification is not a portable content hash, a mutable-buffer snapshot, or an arena ownership lease.

This is the prerequisite for binding distributed compute steps to exact local entry points and shard views; it does not claim numerical distributed execution yet.

## Validation

- Focused distributed-plan tests on the rebased branch: 19 tests, 121 assertions, zero failures/errors.
- Independent review completed; no remaining blockers.
- Full suites and hardware-free target gates run in CI.

Stacked on #541. Retarget/rebase after its squash; do not merge based on checks for an obsolete head.
