### PR TITLE
Bind distributed compute to logical shards through existing LinkPlans

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1092,8 +1092,35 @@ The distributed certificate now retains the optional structural local LinkPlan/E
 contracts instead of only their IDs and operation counts. Equally sized replacements with changed
 operations, scalars, event dependencies, outputs or views invalidate the certificate. Persistent
 compiler values are shared, not serialized or copied; this is not a content hash or snapshot of
-mutable host/device buffers. Explicit compute-step-to-program/shard binding is still required
-before treating the overall plan as an executable numerical workflow.
+mutable host/device buffers. The next structural binding relates named local entries and global
+shards without introducing another ABI or memory representation:
+
+```clojure
+{:device-plans
+ {:gpu-0
+  {:entries {:stencil {:link-plan local-plan}}
+   :steps {:advance-0
+           {:entry :stencil
+            :bindings {:tile-in  {:value :u-now  :shard :tile-0}
+                       :tile-out {:value :u-next :shard :tile-0}}}}}}}
+```
+
+`distributed-plan/compute-bindings` returns validated entries, logical bindings, actual ABI-derived
+accesses and physical leaf views, plus explicit unbound analytical compute steps. Shard identities
+are qualified by their global value; exact local shape and the existing AbstractValue storage
+contract must match. Public inputs/state/results and unsourced constants cannot disappear from
+the binding. Sourced constants and private scratch may remain local. Repeated bindings of the
+same resident shard must agree on allocation identity, range and ordered field packing.
+Distinct shards cannot overlap physical ranges on one device without an explicit relation;
+disjoint subviews remain legal. Declared global memory-space constraints must hold for every
+physical leaf. Entry access facts are derived once per report, not once per invocation.
+
+This is not yet distributed execution: device-scoped allocation sharing, transfer realization,
+submission/completion and ownership still need a numerical vertical. Separately instantiated
+LinkPlans currently namespace their owned allocations per executable. Matching structural views
+does not change that behavior or prove cross-entry zero-copy replay. Whole-shard binding also
+does not stand in for a future explicit halo-subregion mapping. Optional flat ExecutionPlans remain
+analytical; arbitrary event DAGs cannot be asserted as the realization of a named LinkPlan entry.
 
 The next sequence is workload-driven:
 

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1114,6 +1114,9 @@ same resident shard must agree on allocation identity, range and ordered field p
 Distinct shards cannot overlap physical ranges on one device without an explicit relation;
 disjoint subviews remain legal. Declared global memory-space constraints must hold for every
 physical leaf. Entry access facts are derived once per report, not once per invocation.
+Bound leaves cannot alias private entry storage until an alias-aware access proof exists.
+Private-private storage and unused entries remain entry-scoped; only bound shard storage gains
+device-scoped identity. Unknown device-local keys are rejected rather than silently ignored.
 
 This is not yet distributed execution: device-scoped allocation sharing, transfer realization,
 submission/completion and ownership still need a numerical vertical. Separately instantiated

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -44,6 +44,17 @@
     (when-not (= (count bindings) (count (distinct (vals bindings))))
       (fail! "one compute call gives one shard distinct local identities"
              :distributed-compute-duplicate-shard {:bindings bindings}))
+    ;; LinkPlan validates declared aliases locally, but logical ABI access facts do not
+    ;; propagate through them. Do not hide private mutations behind a bound read-only value.
+    (let [bound-nodes (into #{} (mapcat #(map :node (:leaves (get-in plan [:values %]))))
+                            supplied)]
+      (doseq [bound-node bound-nodes
+              [private-node node] (:nodes plan)
+              :when (not (contains? bound-nodes private-node))]
+        (when (view/overlaps? (get-in plan [:nodes bound-node :view]) (:view node))
+          (fail! "bound shard storage cannot alias private entry storage without an access proof"
+                 :distributed-compute-private-alias
+                 {:bound-node bound-node :private-node private-node}))))
     (into {}
           (map (fn [[id reference]]
                  (when-not (and (map? reference) (= #{:value :shard} (set (keys reference))))
@@ -88,6 +99,10 @@
         bound
         (reduce-kv
          (fn [bound device local]
+           (when-not (set/subset? (set (keys local))
+                                  #{:entries :steps :link-plan :execution-plan :attributes})
+             (fail! "unknown device-local compute contract keys"
+                    :distributed-compute-device-keys {:device device :keys (set (keys local))}))
            (let [entries (get local :entries {}) calls (get local :steps {})]
              (when-not (and (map? entries) (map? calls))
                (fail! "device compute entries and calls must be maps"

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -1,0 +1,140 @@
+(ns raster.compiler.ir.distributed-compute
+  "Structural compute bindings, reusing LinkPlan ABI and physical view contracts.
+   This namespace creates no runtime resources or distributed executor."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.buffer-view :as view]
+            [raster.compiler.ir.link-plan :as link]
+            [raster.compiler.ir.validate :refer [fail!]]))
+
+(defn- required-values [plan accesses]
+  (into (set (link/output-value-ids plan))
+        (keep (fn [[id value]]
+                (let [nodes (map #(get-in plan [:nodes (:node %)]) (:leaves value))
+                      role (:role (first nodes))]
+                  (when (and (contains? accesses id)
+                             (or (contains? #{:input :state} role)
+                                 (and (= :constant role) (not-every? :source nodes))))
+                    id))))
+        (:values plan)))
+
+(defn- entry-facts [device id entry]
+  (when-not (and (some? id) (map? entry) (= #{:link-plan} (set (keys entry))))
+    (fail! "a named compute entry owns one LinkPlan"
+           :distributed-compute-entry {:device device :entry id}))
+  (let [plan (:link-plan entry)
+        accesses (link/value-accesses plan)]
+    (when-not (= device (:target plan))
+      (fail! "compute entry target differs from its mesh device"
+             :distributed-compute-entry-device {:device device :entry id}))
+    {:link-plan plan :accesses accesses :required (required-values plan accesses)}))
+
+(defn- bind-values [{plan :link-plan :keys [accesses required]} device globals shards bindings]
+  (when-not (map? bindings)
+    (fail! "compute bindings must map local values to qualified shard references"
+           :distributed-compute-bindings {:bindings bindings}))
+  (let [supplied (set (keys bindings))
+        available (set/union (set (keys accesses)) (set (link/output-value-ids plan)))]
+    (when-not (set/subset? required supplied)
+      (fail! "compute binding omits a public local value"
+             :distributed-compute-missing-values {:missing (set/difference required supplied)}))
+    (when-not (set/subset? supplied available)
+      (fail! "compute binding names an absent or unused local value"
+             :distributed-compute-local-value {:unknown (set/difference supplied available)}))
+    (when-not (= (count bindings) (count (distinct (vals bindings))))
+      (fail! "one compute call gives one shard distinct local identities"
+             :distributed-compute-duplicate-shard {:bindings bindings}))
+    (into {}
+          (map (fn [[id reference]]
+                 (when-not (and (map? reference) (= #{:value :shard} (set (keys reference))))
+                   (fail! "shard identity must be qualified by its global value"
+                          :distributed-compute-shard-reference {:reference reference}))
+                 (let [{:keys [value shard]} reference
+                       global (get globals value)
+                       candidate (first (filter #(= shard (:id %)) (get shards value)))
+                       local (get-in plan [:values id])
+                       leaves (mapv (fn [{:keys [name node]}]
+                                      {:name name :view (get-in plan [:nodes node :view])})
+                                    (:leaves local))]
+                   (when-not (and global candidate)
+                     (fail! "compute binding names an absent value shard"
+                            :distributed-compute-shard {:reference reference}))
+                   (when-not (= device (:device candidate))
+                     (fail! "compute binding names a shard on another device"
+                            :distributed-compute-shard-device {:device device :shard candidate}))
+                   (when-not (and (= (:shape candidate) (get-in local [:abstract :shape]))
+                                  (av/storage-contract-compatible? global (:abstract local)))
+                     (fail! "local value does not realize the shard's logical storage contract"
+                            :distributed-compute-value-contract
+                            {:reference reference :local (:abstract local)
+                             :global global :shape (:shape candidate)}))
+                   (when (and (:memory-space global)
+                              (not-every? #(= (:memory-space global)
+                                              (get-in % [:view :allocation :memory-space])) leaves))
+                     (fail! "local storage violates the global value's memory-space constraint"
+                            :distributed-compute-memory-space {:reference reference}))
+                   [id {:value value :shard shard :access (get accesses id)
+                        :physical-layout (:physical-layout local)
+                        :leaves leaves}]))
+               bindings))))
+
+(defn bindings
+  "Derive bindings after the enclosing DistributedPlan validates its DAG and shards.
+   Unbound analytical compute is explicit. Fully bound compute is not a distributed executor:
+   device-scoped allocation, transfer realization, events and arena ownership remain runtime
+   obligations. Whole-shard shapes are required; halo subregions need an explicit view relation."
+  [{:keys [device-plans steps values shards]}]
+  (let [step-by-id (into {} (map (juxt :id identity)) steps)
+        bound
+        (reduce-kv
+         (fn [bound device local]
+           (let [entries (get local :entries {}) calls (get local :steps {})]
+             (when-not (and (map? entries) (map? calls))
+               (fail! "device compute entries and calls must be maps"
+                      :distributed-compute-entries {:device device}))
+             (when (and (or (seq entries) (seq calls))
+                        (or (:link-plan local) (:execution-plan local)))
+               (fail! "analytical plans cannot also declare named compute entries"
+                      :distributed-compute-mixed-plans {:device device}))
+             (let [entries (into {} (map (fn [[id entry]]
+                                          [id (entry-facts device id entry)])) entries)]
+             (reduce-kv
+              (fn [bound id call]
+                (when-not (and (map? call) (= #{:entry :bindings} (set (keys call))))
+                  (fail! "compute call requires a named entry and logical bindings"
+                         :distributed-compute-call {:step id :call call}))
+                (let [entry (:entry call) step (get step-by-id id)
+                      plan (get-in entries [entry :link-plan])]
+                  (when-not (and (= :compute (:kind step)) (= device (:device step)))
+                    (fail! "local call does not name a compute step on this device"
+                           :distributed-compute-step {:device device :step id}))
+                  (when-not plan
+                    (fail! "compute call names an absent local entry"
+                           :distributed-compute-entry {:device device :entry entry}))
+                  (assoc bound id {:entry entry :link-plan plan
+                                   :values (bind-values (get entries entry) device values shards
+                                                        (:bindings call))})))
+              bound calls))))
+         {} device-plans)
+        realized (volatile! {})]
+    ;; Distinct entry points cannot silently assign one resident shard different storage.
+    ;; IDs of views may differ; allocation identity, ranges and ordered field packing may not.
+    (doseq [[id entry] bound
+            [_ {:keys [value shard physical-layout leaves]}] (:values entry)]
+      (let [key [(:device (get step-by-id id)) value shard]
+            realization {:physical-layout physical-layout
+                         :leaves (mapv #(update % :view dissoc :id) leaves)}]
+        (when (and (contains? @realized key)
+                   (not= (:realization (get @realized key)) realization))
+          (fail! "compute entries disagree on a resident shard's physical realization"
+                 :distributed-compute-shard-storage {:step id :shard key}))
+        (doseq [[other-key other] @realized
+                :when (and (not= key other-key) (= (first key) (first other-key)))
+                left leaves right (:leaves other)]
+          (when (view/overlaps? (:view left) (:view right))
+            (fail! "distinct distributed shards cannot alias physical storage without a relation"
+                   :distributed-compute-shard-alias {:shard key :other other-key})))
+        (vswap! realized assoc key {:realization realization :leaves leaves})))
+    {:bindings bound
+     :unbound (mapv :id (filter #(and (= :compute (:kind %))
+                                     (not (contains? bound (:id %)))) steps))}))

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -12,6 +12,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.abstract-value :as abstract-value]
+            [raster.compiler.ir.distributed-compute :as compute]
             [raster.compiler.ir.execution-plan :as execution-plan]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.ir.scan :as scan]
@@ -814,7 +815,7 @@
 
 (declare simulate)
 
-(defn validate!
+(defn- validate-structure!
   "Validate and return a DistributedPlan without realizing any runtime resource."
   [plan]
   (when-not (distributed-plan? plan)
@@ -853,6 +854,19 @@
       (fail! "distributed plan attributes must be a map"
              :distributed-plan-attributes {:attributes attributes})))
   plan)
+
+(defn validate!
+  "Validate distributed structure and local compute bindings without realizing resources."
+  [plan]
+  (compute/bindings (validate-structure! plan))
+  plan)
+
+(defn compute-bindings
+  "Validate and resolve named local compute entries and qualified shard bindings.
+   Returns `{:bindings {step-id ...} :unbound [compute-step-id ...]}`. This is a
+   structural compiler contract, not a runtime executor or allocation/transfer proof."
+  [plan]
+  (compute/bindings (validate-structure! plan)))
 
 (defn plan
   [{:keys [id mesh topology values shards collective-groups collectives

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -923,12 +923,14 @@
                 (range (min 3 (:trip-count step))))))
       (map-indexed vector (:steps call))))))
 
+(defn- instance-access-facts [{:keys [nodes values instances]}]
+  (mapcat #(if (link-instance? %)
+             (validate-instance-bindings! nodes values %)
+             (validate-program-instance-bindings! nodes values %))
+          instances))
+
 (defn- validate-effects! [{:keys [target nodes values instances outputs aliases] :as plan}]
-  (let [step-facts
-        (mapcat #(if (link-instance? %)
-                   (validate-instance-bindings! nodes values %)
-                   (validate-program-instance-bindings! nodes values %))
-                instances)
+  (let [step-facts (instance-access-facts plan)
         initialized (volatile! (into #{}
                                      (keep (fn [[id {:keys [role source]}]]
                                              ;; Ownership answers who releases storage, not whether
@@ -992,6 +994,22 @@
   "Validate a LinkPlan without allocating storage, registering kernels, or contacting a driver."
   [plan]
   (-> plan validate-plan-structure! validate-allocations-and-aliases! validate-effects!))
+
+(defn value-accesses
+  "Return conservative logical-value accesses from the validated executable ABI.
+
+   Uses the same bound step facts as ownership validation, not node role guesses. Ordered
+   physical fields are joined into their owning LinkValue, independently of packing/dtype.
+   This summarizes reads/writes; it does not prove full initialization, disjoint ranges,
+   external ownership or completion. Unused values are absent."
+  [plan]
+  (let [plan (validate! plan)
+        node-values (into {} (mapcat (fn [[id value]]
+                                      (map (fn [leaf] [(:node leaf) id]) (:leaves value)))
+                                    (:values plan)))]
+    (reduce (fn [accesses {:keys [node access]}]
+              (update accesses (get node-values node) merge-access access))
+            {} (mapcat :facts (instance-access-facts plan)))))
 
 (defn make
   "Construct and purely validate a LinkPlan.

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -230,6 +230,44 @@
       (is (empty? (:unbound (distributed/compute-bindings plan))))
       (is (= 1 @calls)))))
 
+(deftest bound-shards-cannot-hide-private-aliases
+  (let [local (local-link-plan)
+        scratch (-> (get-in local [:nodes :x-node])
+                    (assoc :id :private-node :role :scratch)
+                    (assoc-in [:view :id] :private-node))
+        local (-> local
+                  (assoc-in [:nodes :private-node] scratch)
+                  (assoc-in [:values :private]
+                            (link/value {:id :private :abstract (local-abstract [2 3])
+                                         :leaves [{:name :value :node :private-node}]}))
+                  (assoc :aliases #{#{:x-node :private-node}})
+                  (update :instances conj
+                          (link/instance {:id :private-write :descriptor copy-descriptor
+                                          :bindings {'x :local-y 'weights :local-weights
+                                                     'y :private}
+                                          :scalars {'n 6}})))]
+    (is (link/link-plan? (link/validate! local)))
+    (is (= {:local-x :read :local-weights :read :local-y :read-write :private :write}
+           (link/value-accesses local)))
+    (is (= :distributed-compute-private-alias
+           (failure-reason #(make-plan {:link-plan local}))))
+    (testing "private scratch can occupy a disjoint range in the same allocation"
+      (is (distributed/distributed-plan?
+           (make-plan {:link-plan
+                       (-> local
+                           (assoc :aliases #{})
+                           (assoc-in [:nodes :x-node :view :allocation :byte-size] 48)
+                           (assoc-in [:nodes :private-node :view :allocation :byte-size] 48)
+                           (assoc-in [:nodes :private-node :view :byte-offset] 24))}))))))
+
+(deftest misspelled-local-contract-keys-do-not-silently-declare-analytical-compute
+  (let [base (device-plans (local-link-plan))
+        misspelled (-> base
+                       (assoc-in [:gpu-0 :step] (get-in base [:gpu-0 :steps]))
+                       (update :gpu-0 dissoc :steps))]
+    (is (= :distributed-compute-device-keys
+           (failure-reason #(make-plan {:device-plans misspelled}))))))
+
 (deftest entry-step-value-and-shard-references-fail-closed
   (let [base (device-plans (local-link-plan))]
     (doseq [[label plans]

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -1,0 +1,300 @@
+(ns raster.compiler.ir.distributed-compute-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.link-plan :as link]))
+
+(def ^:private copy-kernel
+  (artifact/make
+   {:kernel-name "distributed_copy"
+    :source (str "__kernel void distributed_copy(__global const float* x, "
+                 "__global const float* weights, __global float* y, long n) {}")
+    :abi [(abi/slot 'x :input :float)
+          (abi/slot 'weights :input :float)
+          (abi/slot 'y :output :float)
+          (abi/slot 'n :scalar :long)]
+    :arguments '[x weights y n]
+    :launch (launch/spec {:workgroup-size [8]
+                          :group-count [(launch/ceil-div 'n 8)]})
+    :effects {:kind :map :reads '[x weights] :writes '[y]}}))
+
+(def ^:private copy-descriptor
+  {:dtype :float
+   :all-params '[x weights n]
+   :array-params '[x weights]
+   :scalar-params '[n]
+   :array-roles {'x :input 'weights :constant}
+   :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 2)))}]
+   :steps [{:phase :copy :kernel-name "distributed_copy" :convention :map
+            :artifact copy-kernel
+            :argument-specs [{:kind :input :sym 'x}
+                             {:kind :input :sym 'weights}
+                             {:kind :output :sym 'y}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 2)))}]}]
+   :result-sym 'y})
+
+(defn- local-abstract
+  ([shape] (local-abstract :float shape))
+  ([dtype shape]
+   (av/tensor {:dtype dtype :shape shape :representation {:kind :plain}})))
+
+(defn- local-link-plan
+  ([] (local-link-plan {}))
+  ([opts]
+   (let [{:keys [x-shape x-dtype target]
+          :or {x-shape [2 3] x-dtype :float target :gpu-0}} opts
+         weights-source (if (contains? opts :weights-source)
+                          (:weights-source opts)
+                          (float-array 6))
+         node (fn [id role source]
+                (link/node {:id id :dtype :float :shape [6] :device target :role role
+                            :source source}))
+         x (node :x-node :input nil)
+         weights (node :weights-node :constant weights-source)
+         y (node :y-node :output nil)]
+     (link/make
+      {:id :local-copy :target target :nodes [x weights y]
+       :values [(link/value {:id :local-x :abstract (local-abstract x-dtype x-shape)
+                             :leaves [{:name :value :node :x-node}]})
+                (link/value {:id :local-weights :abstract (local-abstract [2 3])
+                             :leaves [{:name :value :node :weights-node}]})
+                (link/value {:id :local-y :abstract (local-abstract [2 3])
+                             :leaves [{:name :value :node :y-node}]})]
+       :instances [(link/instance {:id :copy :descriptor copy-descriptor
+                                   :bindings {'x :local-x
+                                              'weights :local-weights
+                                              'y :local-y}
+                                   :scalars {'n 6}})]
+       :outputs [:y-node]}))))
+
+(defn- topology []
+  (distributed/topology
+   [(distributed/device {:id :gpu-0 :memory-capacity-bytes 1048576})
+    (distributed/device {:id :gpu-1 :memory-capacity-bytes 1048576})]
+   []))
+
+(defn- global-value []
+  (av/tensor {:dtype :float :shape [2 3]
+              :representation {:kind :plain}
+              :sharding {:kind :replicated :devices [:gpu-0 :gpu-1]}
+              :ownership :owned}))
+
+(defn- shards [value prefix]
+  [(distributed/shard {:id (keyword (str (name prefix) "-0"))
+                       :value value :device :gpu-0 :offsets [0 0]
+                       :shape [2 3] :ownership :replica})
+   (distributed/shard {:id (keyword (str (name prefix) "-1"))
+                       :value value :device :gpu-1 :offsets [0 0]
+                       :shape [2 3] :ownership :replica})])
+
+(defn- device-plans
+  ([link-plan] (device-plans link-plan {}))
+  ([link-plan bindings]
+   {:gpu-0
+    {:entries {:copy {:link-plan link-plan}}
+     :steps {:copy-0
+             {:entry :copy
+              :bindings (merge {:local-x {:value :x :shard :x-0}
+                                :local-y {:value :y :shard :y-0}}
+                               bindings)}}}}))
+
+(defn- plan-map
+  ([] (plan-map {}))
+  ([opts]
+   (let [link-plan (or (:link-plan opts) (local-link-plan))
+         values (or (:values opts)
+                    {:x (global-value) :weights (global-value) :y (global-value)})
+         shard-map (or (:shards opts)
+                       {:x (shards :x :x)
+                        :weights (shards :weights :weights)
+                        :y (shards :y :y)})
+         steps (or (:steps opts)
+                   [(distributed/compute-step
+                     {:id :copy-0 :device :gpu-0 :duration-ns 10})
+                    (distributed/compute-step
+                     {:id :analytical-only :device :gpu-1 :duration-ns 20
+                      :dependencies [:copy-0]})])]
+     {:id :distributed-copy
+      :mesh (distributed/mesh [{:name :data :size 2}] [:gpu-0 :gpu-1])
+      :topology (topology)
+      :values values :shards shard-map
+      :device-plans (or (:device-plans opts) (device-plans link-plan))
+      :steps steps :outputs [:analytical-only]})))
+
+(defn- make-plan
+  ([] (distributed/plan (plan-map)))
+  ([overrides] (distributed/plan (plan-map overrides))))
+
+(defn- failure-reason [thunk]
+  (:reason (ex-data (try (thunk) (catch clojure.lang.ExceptionInfo error error)))))
+
+(deftest compute-bindings-retain-exact-link-values-and-derived-accesses
+  (let [plan (make-plan)
+        report (distributed/compute-bindings plan)
+        binding (get-in report [:bindings :copy-0])]
+    (is (= [:analytical-only] (:unbound report)))
+    (is (= :copy (:entry binding)))
+    (is (= :local-copy (get-in binding [:link-plan :id])))
+    (is (= {:local-x :read :local-y :write}
+           (update-vals (:values binding) :access)))
+    (is (= {:value :x :shard :x-0}
+           (select-keys (get-in binding [:values :local-x]) [:value :shard])))
+    (is (= :x-node
+           (get-in binding [:values :local-x :leaves 0 :view :id])))
+    (is (= [6]
+           (get-in binding [:values :local-x :leaves 0 :view :shape])))))
+
+(deftest bindings-are-qualified-by-global-value-and-exact-shard-shape
+  (testing "same-volume transposition is not a shard-shape proof"
+    (is (= :distributed-compute-value-contract
+         (failure-reason
+          #(make-plan {:link-plan (local-link-plan {:x-shape [3 2]})})))))
+  (testing "storage dtype must agree with the global value"
+    (is (= :distributed-compute-value-contract
+         (failure-reason
+          #(make-plan {:values (assoc (:values (plan-map)) :x
+                                      (assoc (global-value) :dtype :double))})))))
+  (testing "a shard on another device cannot satisfy the local compute binding"
+    (let [plans (device-plans (local-link-plan))
+          plans (assoc-in plans [:gpu-0 :steps :copy-0 :bindings :local-x :shard] :x-1)]
+      (is (= :distributed-compute-shard-device
+             (failure-reason #(make-plan {:device-plans plans})))))))
+
+(deftest repeated-shards-require-one-structural-physical-realization
+  (let [local (local-link-plan)
+        base (plan-map)
+        plans (-> (device-plans local)
+                  (assoc-in [:gpu-0 :entries :again] {:link-plan local})
+                  (assoc-in [:gpu-0 :steps :analytical-only]
+                            (assoc (get-in (device-plans local) [:gpu-0 :steps :copy-0])
+                                   :entry :again)))
+        plan (assoc base :device-plans plans
+                    :steps (mapv #(assoc % :device :gpu-0) (:steps base)))]
+    (is (empty? (:unbound (distributed/compute-bindings (distributed/plan plan)))))
+    (is (= :distributed-compute-shard-storage
+           (failure-reason
+            #(distributed/plan
+              (assoc-in plan [:device-plans :gpu-0 :entries :again :link-plan
+                              :nodes :x-node :view :allocation :id] :different-allocation)))))
+    (is (= :distributed-compute-entry-device
+           (failure-reason
+            #(make-plan {:device-plans (device-plans (local-link-plan {:target :gpu-1}))}))))))
+
+(deftest distinct-shards-cannot-alias-across-entries
+  (let [local (assoc-in (local-link-plan)
+                        [:nodes :x-node :view :allocation :byte-size] 48)
+        base (plan-map)
+        plans (-> (device-plans local)
+                  (assoc-in [:gpu-0 :entries :again] {:link-plan local})
+                  (assoc-in [:gpu-0 :steps :analytical-only]
+                            {:entry :again
+                             :bindings {:local-x {:value :weights :shard :weights-0}
+                                        :local-y {:value :y :shard :y-0}}}))
+        plan (assoc base :device-plans plans
+                    :steps (mapv #(assoc % :device :gpu-0) (:steps base)))]
+    (is (= :distributed-compute-shard-alias
+           (failure-reason #(distributed/plan plan))))
+    (testing "disjoint ranges of the same allocation remain distinct legal shards"
+      (is (distributed/distributed-plan?
+           (distributed/plan
+            (assoc-in plan [:device-plans :gpu-0 :entries :again :link-plan
+                           :nodes :x-node :view :byte-offset] 24)))))))
+
+(deftest declared-global-memory-space-constrains-physical-leaves
+  (let [local (local-link-plan)
+        actual (get-in local [:nodes :x-node :view :allocation :memory-space])
+        base (plan-map {:link-plan local})]
+    (is (distributed/distributed-plan? (distributed/plan base)))
+    (is (distributed/distributed-plan?
+         (distributed/plan (assoc-in base [:values :x :memory-space] actual))))
+    (is (= :distributed-compute-memory-space
+           (failure-reason
+            #(distributed/plan
+              (assoc-in base [:values :x :memory-space]
+                        (if (= actual :host) :device :host))))))))
+
+(deftest shared-entry-access-facts-are-derived-once-per-report
+  (let [base (plan-map)
+        call (get-in base [:device-plans :gpu-0 :steps :copy-0])
+        plan (distributed/plan
+              (-> base
+                  (assoc-in [:device-plans :gpu-0 :steps :analytical-only] call)
+                  (update :steps #(mapv (fn [step] (assoc step :device :gpu-0)) %))))
+        calls (atom 0)
+        original link/value-accesses]
+    (with-redefs [link/value-accesses (fn [local] (swap! calls inc) (original local))]
+      (is (empty? (:unbound (distributed/compute-bindings plan))))
+      (is (= 1 @calls)))))
+
+(deftest entry-step-value-and-shard-references-fail-closed
+  (let [base (device-plans (local-link-plan))]
+    (doseq [[label plans]
+            [[:entry (assoc-in base [:gpu-0 :steps :copy-0 :entry] :missing)]
+             [:step (-> base
+                        (assoc-in [:gpu-0 :steps :missing]
+                                  (get-in base [:gpu-0 :steps :copy-0]))
+                        (update-in [:gpu-0 :steps] dissoc :copy-0))]
+             [:local-value
+              (-> base
+                  (assoc-in [:gpu-0 :steps :copy-0 :bindings :missing]
+                            (get-in base [:gpu-0 :steps :copy-0 :bindings :local-x]))
+                  (update-in [:gpu-0 :steps :copy-0 :bindings] dissoc :local-x))]
+             [:global-value
+              (assoc-in base [:gpu-0 :steps :copy-0 :bindings :local-x :value] :missing)]
+             [:shard
+              (assoc-in base [:gpu-0 :steps :copy-0 :bindings :local-x :shard] :missing)]]]
+      (testing (name label)
+        (is (keyword? (failure-reason #(make-plan {:device-plans plans}))))))))
+
+(deftest required-boundary-values-and-duplicate-shards-are-checked
+  (let [base (device-plans (local-link-plan))]
+    (testing "an input cannot disappear from distributed dataflow"
+      (is (keyword?
+           (failure-reason
+            #(make-plan {:device-plans
+                         (update-in base [:gpu-0 :steps :copy-0 :bindings]
+                                    dissoc :local-x)})))))
+    (testing "two local values cannot claim one qualified shard"
+      (is (keyword?
+           (failure-reason
+            #(make-plan {:device-plans
+                         (assoc-in base [:gpu-0 :steps :copy-0 :bindings :local-y]
+                                   {:value :x :shard :x-0})})))))
+    (testing "a sourced constant is local unless deliberately exposed"
+      (is (distributed/distributed-plan? (make-plan)))
+      (let [plans (device-plans
+                   (local-link-plan)
+                   {:local-weights {:value :weights :shard :weights-0}})]
+        (is (= :read
+               (get-in (distributed/compute-bindings
+                        (make-plan {:device-plans plans}))
+                       [:bindings :copy-0 :values :local-weights :access])))))
+    (testing "an unsourced constant is a required distributed input"
+      (let [link-plan (local-link-plan {:weights-source nil})]
+        (is (keyword? (failure-reason #(make-plan {:link-plan link-plan}))))
+        (is (distributed/distributed-plan?
+             (make-plan
+              {:link-plan link-plan
+               :device-plans
+               (device-plans link-plan
+                             {:local-weights {:value :weights :shard :weights-0}})})))))))
+
+(deftest certificate-detects-compute-binding-mutation
+  (let [plan (make-plan)
+        certified (distributed/certify plan)
+        ;; The swap remains a valid plan because x and y have identical storage contracts, but it
+        ;; changes which global shard is read and written by the certified local executable.
+        modified (-> certified
+                     (assoc-in [:plan :device-plans :gpu-0 :steps :copy-0
+                                :bindings :local-x]
+                               {:value :y :shard :y-0})
+                     (assoc-in [:plan :device-plans :gpu-0 :steps :copy-0
+                                :bindings :local-y]
+                               {:value :x :shard :x-0}))]
+    (is (distributed/distributed-plan? (distributed/validate! (:plan modified))))
+    (is (= :distributed-certificate
+           (failure-reason #(distributed/verify! modified))))))

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -77,6 +77,24 @@
                   (instance :layer-1 :hidden :w1 :out)]
       :outputs [:out]})))
 
+(deftest logical-value-accesses-come-from-bound-kernel-effects
+  (let [plan (valid-plan)]
+    (is (= {:x :read :w0 :read :w1 :read :hidden :read-write :out :write}
+           (link/value-accesses plan)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (link/value-accesses (assoc plan :instances (vec (reverse (:instances plan)))))))
+    (let [plan (link/make
+                {:id :logical-names :target (:target plan) :nodes (:nodes plan)
+                 :values (mapv (fn [[id value]] (assoc value :id [:logical id])) (:values plan))
+                 :instances (mapv (fn [instance]
+                                    (update instance :bindings
+                                            #(into {} (map (fn [[symbol id]] [symbol [:logical id]])) %)))
+                                  (:instances plan))
+                 :outputs (:outputs plan)})]
+      (is (= {[:logical :x] :read [:logical :w0] :read [:logical :w1] :read
+              [:logical :hidden] :read-write [:logical :out] :write}
+             (link/value-accesses plan))))))
+
 (deftest data-valued-descriptor-instances-compose-through-stable-node-identities
   (let [plan (valid-plan)]
     (is (link/link-plan? plan))


### PR DESCRIPTION
## Summary

- Derive logical LinkValue accesses from the existing validated executable ABI; reuse the same effect facts as LinkPlan validation.
- Relate named local LinkPlan entries to distributed compute steps and qualified global value/shard identities, without introducing another ABI or storage representation.
- Validate complete public boundaries, exact shard shapes and storage contracts, target and memory-space constraints, repeated physical realizations and cross-entry shard aliasing. Disjoint views remain legal.
- Keep analytical/unbound compute explicit. This is a structural binding contract, not distributed execution, a lifetime lease, or proof of zero-copy cross-entry replay.

## Validation

- Distributed binding, plan, LinkPlan, AMR and KV transfer tests: 53 tests, 247 assertions, zero failures/errors.
- Final focused rerun including disjoint private scratch: 11 tests, 38 assertions, zero failures/errors.
- Review regressions cover overlapping distinct shards, disjoint subviews, memory-space mismatches and once-per-entry access derivation.
- Follow-up review rejects a real sequential private scratch write aliasing a bound read-only input, while preserving disjoint private ranges; misspelled local schema keys fail closed.
- Full suite and source compiler gates delegated to CircleCI.

Stacked on #542. Next acceptance is numerical shard/halo execution and checkpoint continuation, not further structural-only proof claims.
