### PR TITLE
Validate compiled continuation from real mapped numerical checkpoints

### DIFF
--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1095,9 +1095,19 @@ device availability. The composition exposed and fixed ANF result-type loss: exi
 initializer metadata now survives onto new bindings, including structurally equal rewrites.
 No function/type inference registry or census exemption was added.
 
+Local checkpoint continuation is now exercised with actual files and scoped mmap leases. A
+certified manifest carries an SHA-256 address and explicit little-endian raw-f64 format; reopening
+checks payload length and digest before consuming bytes, and a corruption negative control fails.
+The device acceptance advances two compiled steps, downloads directly into the mapped file, closes
+the original session and mapping, opens a read-only lease, uploads directly into a fresh session,
+closes the lease after synchronous transfer, and advances two more steps to the unpartitioned
+reference. Temporary payloads are 448 bytes and deleted in `finally`. This is a local-file provider
+fixture, not a production storage adapter, serialized manifest migration test, crash-consistent
+publication protocol, asynchronous restore, or distributed checkpoint.
+
 Still required: bind padded ghost storage explicitly to the global owned-shard contract, realize
-the distributed compute/transfer DAG with device-scoped allocation and ownership, then checkpoint
-real bytes and continue the same numerical evolution after reopening. The two-worker acceptance
+the distributed compute/transfer DAG with device-scoped allocation and ownership, then carry the
+local checkpoint acceptance through distributed publication and restore. The two-worker acceptance
 must not be counted as evidence those cross-entry and multi-device runtime obligations are done.
 
 Items 6–8 have checked planning components, but not yet multi-device numerical execution:

--- a/design/compiler-unification-campaign.md
+++ b/design/compiler-unification-campaign.md
@@ -1104,6 +1104,8 @@ closes the lease after synchronous transfer, and advances two more steps to the 
 reference. Temporary payloads are 448 bytes and deleted in `finally`. This is a local-file provider
 fixture, not a production storage adapter, serialized manifest migration test, crash-consistent
 publication protocol, asynchronous restore, or distributed checkpoint.
+A read-only mapping is not an immutable snapshot against another process writing the backing file;
+a production provider must pin an immutable version or hold an appropriate storage snapshot lease.
 
 Still required: bind padded ghost storage explicitly to the global owned-shard contract, realize
 the distributed compute/transfer DAG with device-scoped allocation and ownership, then carry the

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -1468,14 +1468,14 @@
           ;; Inlining an effectful call can expose its typed result reference (e.g. an
           ;; array returned after stores). Carry that existing evidence onto the ANF
           ;; binder; do not reconstruct a function/type registry or infer from syntax.
-          new-bindings (vec (mapcat (fn [[sym init]]
+          new-bindings (with-meta (vec (mapcat (fn [[sym init]]
                                      [(if (and (symbol? sym)
                                                (nil? (:raster.type/tag (meta sym))))
                                         (if-let [tag (:raster.type/tag (meta init))]
                                           (vary-meta sym assoc :raster.type/tag tag)
                                           sym)
                                         sym)
-                                      init]) all-pairs))]
+                                      init]) all-pairs)) (meta bindings-vec))]
       ;; Clojure equality ignores metadata: returning `form` on structural equality
       ;; would discard a type-only repair. Retain the enclosing metadata as well.
       (with-meta (list* (if (= new-bindings (vec bindings-vec)) (first form) 'let*)

--- a/test/raster/compiler/distributed_numerical_test.clj
+++ b/test/raster/compiler/distributed_numerical_test.clj
@@ -165,8 +165,16 @@
           (with-open [channel (FileChannel/open path (into-array OpenOption [StandardOpenOption/WRITE]))]
             (.write channel (ByteBuffer/wrap (byte-array [(byte 127)])) 0))
           (is (= :checkpoint-digest
-                 (:reason (ex-data (try (open-checkpoint-lease path certified)
-                                       (catch clojure.lang.ExceptionInfo error error))))))))
+                 (:reason (ex-data (try
+                                     (with-open [unexpected (open-checkpoint-lease path certified)] nil)
+                                     (catch clojure.lang.ExceptionInfo error error)))))))
+        (testing "a truncated payload fails its extent contract before restoration"
+          (with-open [channel (FileChannel/open path (into-array OpenOption [StandardOpenOption/WRITE]))]
+            (.truncate channel (dec byte-count)))
+          (is (= :checkpoint-size
+                 (:reason (ex-data (try
+                                     (with-open [unexpected (open-checkpoint-lease path certified)] nil)
+                                     (catch clojure.lang.ExceptionInfo error error))))))))
       (finally (Files/deleteIfExists path)))))
 
 (defn- whole-field-executable [initial]

--- a/test/raster/compiler/distributed_numerical_test.clj
+++ b/test/raster/compiler/distributed_numerical_test.clj
@@ -8,9 +8,18 @@
             [raster.compiler.equation-first :as equation]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.compiler.ir.numerical-state :as state]
+            [raster.runtime.numerical-content :as content]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]
-            [raster.gpu.link :as link]))
+            [raster.gpu.link :as link])
+  (:import [java.lang.foreign Arena MemorySegment ValueLayout]
+           [java.nio ByteBuffer ByteOrder]
+           [java.nio.channels FileChannel FileChannel$MapMode]
+           [java.nio.file Files OpenOption StandardOpenOption]
+           [java.nio.file.attribute FileAttribute]
+           [java.security MessageDigest]
+           [java.util HexFormat]))
 
 (deftm heat-step!
   [out :- (Array double), u :- (Array double), rhs :- (Array double),
@@ -66,22 +75,165 @@
                :dst-element (* (inc target-row) width)
                :elements (quot bytes Double/BYTES)})) (:steps halo))))
 
-(defn- reference [initial]
-  (loop [u (aclone ^doubles initial) step 0]
-    (if (= step iterations) u
-        (recur (heat-step! (double-array (alength u)) u (double-array (alength u))
-                          8 width dt)
-               (inc step)))))
-
-(defn- owned-values [shards arrays]
-  (vec (mapcat (fn [{:keys [id shape]}]
-                 (take (* (first shape) width) (drop width (seq (get arrays id))))) shards)))
+(defn- reference
+  ([initial] (reference initial iterations))
+  ([initial nsteps]
+   (loop [u (aclone ^doubles initial) step 0]
+     (if (= step nsteps) u
+         (recur (heat-step! (double-array (alength u)) u (double-array (alength u))
+                           8 width dt)
+                (inc step))))))
 
 (defn- max-error [expected actual]
   (when-not (= (count expected) (count actual))
     (throw (ex-info "numerical output extent differs from the reference"
                     {:expected (count expected) :actual (count actual)})))
   (reduce max 0.0 (map #(Math/abs (- (double %1) (double %2))) expected actual)))
+
+(defn- payload-address [^ByteBuffer bytes]
+  (let [digest (MessageDigest/getInstance "SHA-256")]
+    (.update digest (.duplicate bytes))
+    (state/content-address :sha-256 (.formatHex (HexFormat/of) (.digest digest)))))
+
+(defn- checkpoint-manifest [address byte-count]
+  (state/certify
+   (state/manifest
+    {:id :heat/step-2 :logical-coordinate {:step 2 :time-seconds (* 2 dt)}
+     :fields [(state/field
+               {:id :u :value (av/tensor {:dtype :double :shape [8 width]})
+                :chunk-shape [8 width]
+                :chunks [(state/chunk
+                           {:id :field :offsets [0 0] :shape [8 width]
+                            :logical-byte-length byte-count :stored-byte-length byte-count
+                            :content address
+                            :storage {:format :raw-f64 :byte-order :little-endian}})]})]
+     :numerical-contract {:mode :ieee :determinism :reproducible-order
+                          :compatibility-id "heat-euler:f64:dirichlet:dt=0.01"}
+     :provenance {:program-fingerprint "raster-numerical-acceptance/heat-step-v1"}})))
+
+(defn- open-checkpoint-lease [path certified]
+  ;; A real local-file realization fixture, not a production store/provider implementation.
+  ;; Verify actual bytes against the certified identity before numerical code consumes them.
+  (let [certified (state/verify! certified)
+        chunk (get-in certified [:manifest :fields 0 :chunks 0])
+        address (:content chunk)
+        arena (Arena/ofConfined)]
+    (try
+      (with-open [channel (FileChannel/open path (into-array OpenOption [StandardOpenOption/READ]))]
+        (when-not (= (:stored-byte-length chunk) (.size channel))
+          (throw (ex-info "checkpoint payload extent differs" {:reason :checkpoint-size})))
+        (let [segment (.map channel FileChannel$MapMode/READ_ONLY 0 (.size channel) arena)]
+          (when-not (= address (payload-address (.asByteBuffer segment)))
+            (throw (ex-info "checkpoint payload does not match its content address"
+                            {:reason :checkpoint-digest})))
+          (content/local-content-lease
+           {:content address
+            :placement (content/content-placement {:provider-id :local-test :tier-id :file
+                                                    :content address})
+            :segment segment :byte-length (.byteSize segment) :release-fn #(.close arena)})))
+      (catch Throwable error
+        (.close arena)
+        (throw error)))))
+
+(deftest real-mapped-checkpoint-resumes-the-same-numerical-evolution
+  (let [initial (:initial (problem))
+        checkpoint (reference initial 2)
+        byte-count (* Double/BYTES (alength ^doubles checkpoint))
+        bytes (doto (ByteBuffer/allocate byte-count) (.order ByteOrder/LITTLE_ENDIAN))
+        path (Files/createTempFile "raster-heat-checkpoint-" ".bin" (make-array FileAttribute 0))]
+    (try
+      (doseq [v checkpoint] (.putDouble bytes v))
+      (.flip bytes)
+      (let [certified (checkpoint-manifest (payload-address bytes) byte-count)]
+        (with-open [channel (FileChannel/open path (into-array OpenOption [StandardOpenOption/WRITE]))]
+          (while (.hasRemaining bytes) (.write channel bytes))
+          (.force channel true))
+        ;; Mapping is reopened after the writer closes. The scoped segment, not the original
+        ;; checkpoint array, supplies the restored numerical state.
+        (let [lease (open-checkpoint-lease path certified)
+              segment (content/lease-segment lease)
+              restored (try
+                         (is (.isReadOnly ^MemorySegment segment))
+                         (.toArray ^MemorySegment segment
+                                   (.withOrder ValueLayout/JAVA_DOUBLE_UNALIGNED ByteOrder/LITTLE_ENDIAN))
+                         (finally (.close lease)))]
+          (is (content/lease-closed? lease))
+          (is (false? (.isAlive (.scope ^MemorySegment segment))))
+          (is (= (vec checkpoint) (vec restored)))
+          (is (< (max-error (reference initial) (reference restored 2)) 1.0e-12)))
+        (testing "structural certification cannot disguise corrupt payload bytes"
+          (with-open [channel (FileChannel/open path (into-array OpenOption [StandardOpenOption/WRITE]))]
+            (.write channel (ByteBuffer/wrap (byte-array [(byte 127)])) 0))
+          (is (= :checkpoint-digest
+                 (:reason (ex-data (try (open-checkpoint-lease path certified)
+                                       (catch clojure.lang.ExceptionInfo error error))))))))
+      (finally (Files/deleteIfExists path)))))
+
+(defn- whole-field-executable [initial]
+  (let [n (alength ^doubles initial)
+        plan (equation/lower @compiled-step
+                             [(double-array n) initial (double-array n) 8 width dt])]
+    (link/instantiate! plan)))
+
+(defn- source-node [executable source]
+  (or (first (keep (fn [[id node]] (when (identical? source (:source node)) id))
+                   (get-in executable [:plan :nodes])))
+      (throw (ex-info "source boundary missing from lowered plan" {}))))
+
+(defn- advance-device! [executable input steps]
+  (let [output (first (get-in executable [:plan :outputs]))]
+    (dotimes [_ steps]
+      (link/run! executable)
+      (gpu/copy-range! (:session executable) (link/node-view executable output)
+                       (link/node-view executable input) {:elements (* 8 width)}))
+    output))
+
+(deftest mapped-checkpoint-restores-into-a-new-compiled-device-session
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "mapped-checkpoint-device-continuation")
+    (let [initial (:initial (problem))
+          n (* 8 width) byte-count (* n Double/BYTES)
+          path (Files/createTempFile "raster-device-checkpoint-" ".bin" (make-array FileAttribute 0))]
+      (try
+        ;; The raw payload has a declared endian contract. This fixture performs no endian
+        ;; conversion while transferring native f64 device buffers.
+        (when-not (= ByteOrder/LITTLE_ENDIAN (ByteOrder/nativeOrder))
+          (throw (ex-info "raw f64 checkpoint transfer needs explicit endian conversion" {})))
+        (let [certified
+              (with-open [executable (whole-field-executable initial)]
+                (let [output (advance-device! executable (source-node executable initial) 2)]
+                  (with-open [arena (Arena/ofConfined)
+                              channel (FileChannel/open path
+                                                        (into-array OpenOption
+                                                                    [StandardOpenOption/READ
+                                                                     StandardOpenOption/WRITE]))]
+                    (.position channel (dec byte-count))
+                    (.write channel (ByteBuffer/wrap (byte-array [0])))
+                    (let [segment (.map channel FileChannel$MapMode/READ_WRITE 0 byte-count arena)]
+                      (gpu/download-range! (:session executable) (link/node-view executable output)
+                                           segment {:elements n})
+                      (.force segment)
+                      (checkpoint-manifest (payload-address (.asByteBuffer segment)) byte-count)))))
+              empty-state (double-array n)]
+          ;; The old executable/session and mapped writer are closed before a fresh execution
+          ;; is initialized directly from the read-only mapping. No intermediate restore array.
+          (with-open [executable (whole-field-executable empty-state)
+                      lease (open-checkpoint-lease path certified)]
+            (let [input (source-node executable empty-state)]
+              (gpu/upload-range! (:session executable) (link/node-view executable input)
+                                 (content/lease-segment lease) {:elements n})
+              ;; Upload is synchronous: closing here is safe and proves replay does not depend
+              ;; on a still-live mapped arena. Async ownership is covered by separate contracts.
+              (.close lease)
+              (is (content/lease-closed? lease))
+              (let [output (advance-device! executable input 2)
+                    actual (link/download executable output)]
+                (is (< (max-error (reference initial) actual) 1.0e-10))))))
+        (finally (Files/deleteIfExists path))))))
+
+(defn- owned-values [shards arrays]
+  (vec (mapcat (fn [{:keys [id shape]}]
+                 (take (* (first shape) width) (drop width (seq (get arrays id))))) shards)))
 
 (defn- host-run [problem exchange?]
   (loop [inputs (local-inputs problem) step 0]

--- a/test/raster/compiler/passes/scalar/inline_test.clj
+++ b/test/raster/compiler/passes/scalar/inline_test.clj
@@ -29,13 +29,15 @@
 (deftest anf-bindings-carry-existing-result-types-without-reinference
   (let [result (with-meta 'rhs {:raster.type/tag 'doubles})
         effect (with-meta 'effect {:raster.effect/effectful true})
-        source (with-meta (list 'let* [effect result] result) {:source-marker :kept})
+        source (with-meta (list 'let* (with-meta [effect result] {:bindings-marker :kept}) result)
+                 {:source-marker :kept})
         flattened (inline/flatten-nested-lets source)
         binder (first (second flattened))]
     (is (= source flattened) "metadata-only propagation must survive structural equality")
     (is (= 'doubles (:raster.type/tag (meta binder))))
     (is (:raster.effect/effectful (meta binder)))
     (is (= {:source-marker :kept} (meta flattened)))
+    (is (= {:bindings-marker :kept} (meta (second flattened))))
     (is (nil? (:tag (meta binder))) "compiler type evidence is not a JVM primitive hint")
     (let [already-typed (with-meta 'value {:raster.type/tag 'double})
           init (with-meta 'input {:raster.type/tag 'float})


### PR DESCRIPTION
## Summary

- Validate numerical checkpoint/resume with actual 448-byte files, certified content identities, explicit little-endian f64 storage, and scoped read-only mmap leases.
- Reopen after the writer closes; verify payload length and SHA-256 before use. Reject a corrupted byte.
- Execute two compiled device steps, export directly into a mapped file, close the old session, restore the mapping directly into a fresh session, close the lease after synchronous upload, and execute two more steps against the uninterrupted reference.
- Keep temporary-file cleanup in finally. Preserve binding-vector metadata as requested by the ANF review.

## Validation

- Numerical tests: 5 tests, 18 assertions, all passing, including real GPU halo and checkpoint continuation.
- Inliner, numerical manifest and content-lease contracts: 25 tests, 117 assertions, all passing.
- Full CI delegated to CircleCI.

## Boundaries

This is a local-file realization fixture, not a new production storage implementation. It does not prove serialized manifest compatibility, crash-consistent publication, asynchronous restore, multi-host transfer, or distributed checkpoint coordination. These remain explicit campaign obligations. Stacked on #544.
