### PR TITLE
Bind explicit dense distributed domains from resolved invocation shapes

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -19,7 +19,7 @@ single-owned placement. The new spelling describes the full local materializatio
  [{:kind :owned :value :u :shard :left :local-offsets [1 0]}
   {:kind :replica :transfer :receive-right-face}
   {:kind :boundary :region {:offsets [0 0] :shape [1 7]}
-   :producer :initialize-left-boundary}]}
+   :provider {:step :initialize-left-boundary :local-value :boundary-out}}]}
 ```
 
 The example's identifiers are schematic. Replica geometry comes from the referenced scheduled
@@ -48,7 +48,8 @@ For every local materialization:
 
 ## Identity and endpoint resolution
 
-An owned realization remains keyed by `[device global-value shard-id]`. An incoming replica is
+An owned realization remains keyed by `[device global-value shard-id]`, comparing its derived
+owned subviews rather than the entire padded base. An incoming replica is
 keyed by `[target-device transfer-step-id]`, not by its source's owned-shard key. Source and target
 therefore may have different allocations, while repeated references to one materialization must
 agree on its actual views. Transfer identity also distinguishes refreshed replicas across unrolled
@@ -58,6 +59,9 @@ Resolve transfer endpoints through these placement identities. Avoid a second ha
 of ABI arguments or duplicate source/destination rectangle declarations. If the source owned
 realization cannot be identified uniquely, or the target replica is absent, lowering must refuse
 execution even when the topology-only plan remains useful for simulation.
+Combining halo transfers must use their certified reduction over the derived owned target face;
+they must never be silently implemented as a copy. The initial copy-mode vertical rejects these
+until its runtime can execute the stated reduction.
 
 ## Readiness is separate from geometry
 

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -34,6 +34,10 @@ flat `[n]` arrays: do not infer a two-dimensional domain from scalar parameter n
 confuse the acceptance test's separately constructed rectangular view with the compiled ABI view.
 Composite/packed layouts keep their existing whole-shard route until their physical layout has a
 certified region projection. Do not add per-quantization addressing knowledge to memory planning.
+Enforce this restriction in validation: one plain dense injective leaf, equal element volume, and
+no unresolved logical layout. Coordinate-disjoint regions are not physically disjoint for arbitrary
+zero/overlapping strides. A boundary provider must resolve an exact local value and producing
+region, with ABI-derived write evidence and physical subview correspondence, not merely a step ID.
 
 For every local materialization:
 
@@ -59,7 +63,8 @@ Resolve transfer endpoints through these placement identities. Avoid a second ha
 of ABI arguments or duplicate source/destination rectangle declarations. If the source owned
 realization cannot be identified uniquely, or the target replica is absent, lowering must refuse
 execution even when the topology-only plan remains useful for simulation.
-Combining halo transfers must use their certified reduction over the derived owned target face;
+Only copy-mode halos create replica placements. Combining halo transfers must use their certified
+reduction over the derived owned target face in global coordinates, not an absent ghost replica;
 they must never be silently implemented as a copy. The initial copy-mode vertical rejects these
 until its runtime can execute the stated reduction.
 
@@ -69,7 +74,9 @@ Before an executable plan can allocate resources, prove:
 
 1. Every compute step has a local executable binding, and every transfer has exact projected views.
 2. Every read has an initialized owned region, completed incoming transfer, or completed boundary
-   producer. Initial host data is evidence only until an intervening write invalidates it.
+   producer. Initial host data is evidence only until an overlapping physical write invalidates it;
+   disjoint regional writes do not invalidate one another. Whole-buffer ABI effects remain
+   conservative unless a narrower physical write region is actually proven.
 3. Producers precede consumers through the DAG's actual dependencies/events. Vector order and
    analytical duration estimates alone are not completion events.
 4. Writes and overlapping transfer ranges cannot race; refreshed replicas invalidate old readiness.

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -1,0 +1,93 @@
+# Distributed materialization and execution boundary
+
+Status: reviewed implementation plan, not an implemented execution contract.
+
+The current whole-shard binding deliberately requires one local LinkValue to realize one exact
+owned shard. A halo-padded field cannot satisfy that contract by selecting only its owned cells:
+the compiled kernel still reads the whole local buffer. Its neighbor replicas and physical-domain
+boundary cells need explicit provenance as well. This extends the current compiler vertical;
+it does not introduce another kernel ABI, quantization registry, or storage provider.
+
+## One local domain, several placements
+
+Keep the current `{ :value global-value :shard shard-id }` whole-shard spelling as a canonical
+single-owned placement. The new spelling describes the full local materialization:
+
+```clojure
+{:local-shape [4 7]
+ :placements
+ [{:kind :owned :value :u :shard :left :local-offsets [1 0]}
+  {:kind :replica :transfer :receive-right-face}
+  {:kind :boundary :region {:offsets [0 0] :shape [1 7]}
+   :producer :initialize-left-boundary}]}
+```
+
+The example's identifiers are schematic. Replica geometry comes from the referenced scheduled
+transfer, not from duplicated user-provided source/shard coordinates. Boundary producers must be
+verified executable writes or explicitly retained initialization evidence; a boundary-mode label
+such as `:nonperiodic` is not a numerical zero-fill operation.
+
+The first numerical implementation supports a single plain dense leaf. Check the declared
+`local-shape` against the entire LinkValue/leaf element count, preserve dtype and allocation, and
+construct an ordinary dense BufferView before selecting rectangles. Current heat LinkPlans carry
+flat `[n]` arrays: do not infer a two-dimensional domain from scalar parameter names, and do not
+confuse the acceptance test's separately constructed rectangular view with the compiled ABI view.
+Composite/packed layouts keep their existing whole-shard route until their physical layout has a
+certified region projection. Do not add per-quantization addressing knowledge to memory planning.
+
+For every local materialization:
+
+- Derive owned shape from ValueShard and check its local offsets.
+- Derive replica source/global and target-local regions from ScheduledHalo plus the owned anchor.
+- Project every region with `BufferView/rectangular-subview`; check disjoint logical coordinate
+  coverage of the whole local domain for any read/read-write ABI access.
+- Keep ABI-derived access on the whole LinkValue. Owned publication is the owned region only;
+  writes to ghost storage remain private unless an explicit combining operation publishes them.
+- Include private aliases in access/lifetime reasoning. The current fail-closed bound/private
+  overlap restriction must not be relaxed without replacement evidence.
+
+## Identity and endpoint resolution
+
+An owned realization remains keyed by `[device global-value shard-id]`. An incoming replica is
+keyed by `[target-device transfer-step-id]`, not by its source's owned-shard key. Source and target
+therefore may have different allocations, while repeated references to one materialization must
+agree on its actual views. Transfer identity also distinguishes refreshed replicas across unrolled
+time steps; the same backing allocation alone is not freshness evidence.
+
+Resolve transfer endpoints through these placement identities. Avoid a second handwritten list
+of ABI arguments or duplicate source/destination rectangle declarations. If the source owned
+realization cannot be identified uniquely, or the target replica is absent, lowering must refuse
+execution even when the topology-only plan remains useful for simulation.
+
+## Readiness is separate from geometry
+
+Before an executable plan can allocate resources, prove:
+
+1. Every compute step has a local executable binding, and every transfer has exact projected views.
+2. Every read has an initialized owned region, completed incoming transfer, or completed boundary
+   producer. Initial host data is evidence only until an intervening write invalidates it.
+3. Producers precede consumers through the DAG's actual dependencies/events. Vector order and
+   analytical duration estimates alone are not completion events.
+4. Writes and overlapping transfer ranges cannot race; refreshed replicas invalidate old readiness.
+5. Allocation sharing follows device-scoped materialization identities, with release after all
+   dependent operations complete. Existing separately instantiated owned LinkPlans do not do this.
+
+Lower dependencies to the existing ExecutionPlan logical queues/events and reuse the LinkPlan
+executable binder. Keep a synchronous executor as an explicit backend capability, not an implicit
+claim of asynchronous transport overlap. MPI/UCX/NCCL and storage/provider completions remain
+realizations of the scheduling boundary, not native handles inside the semantic IR.
+
+## Laptop acceptance and landing order
+
+The current DistributedPlan enforces one shard of a value per mesh device and requires distinct
+transfer endpoints with nonempty routes. A real co-located two-shard execution therefore needs an
+explicit local-copy lowering or a certified logical-to-runtime placement map. Do not silently map
+invented topology devices to the same `:ze:0` target. Local copies must occupy stated resources and
+have explicit cost/capability evidence; an empty route must not accidentally mean free transport.
+
+Land geometry/materialization normalization and validation first, then producer/freshness and
+transfer endpoint checks, then device-scoped allocation and event execution. Extend the existing
+unequal-shard heat and mapped-checkpoint acceptance to exercise that actual DAG. Only after this
+integration should numerical coarse/fine operators be counted as an AMR execution vertical.
+The full campaign still includes external model training validation and numerical AMR; none of
+these structural design requirements substitutes for those numerical workload gates.

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -1,6 +1,13 @@
 # Distributed materialization and execution boundary
 
-Status: reviewed implementation plan, not an implemented execution contract.
+Status: owned-domain normalization is implemented; replica/boundary coverage and execution below
+remain a reviewed implementation plan, not an implemented execution contract.
+
+The current `distributed-plan/compute-bindings` accepts an explicit `:local-shape` with one owned
+placement that covers the entire local domain. Its report retains the original ABI leaf views and
+adds a checked `:domain` with the reshaped view and owned placement. A flat `[6]` leaf can explicitly
+realize a `[2 3]` shard. Padding, replica placements, and boundary placements remain rejected until
+the corresponding coverage/provenance checks land; this is not yet the padded example below.
 
 The current whole-shard binding deliberately requires one local LinkValue to realize one exact
 owned shard. A halo-padded field cannot satisfy that contract by selecting only its owned cells:

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -3,6 +3,7 @@
    This namespace creates no runtime resources or distributed executor."
   (:require [clojure.set :as set]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.buffer-view :as view]
             [raster.compiler.ir.link-plan :as link]
             [raster.compiler.ir.validate :refer [fail!]]))
@@ -29,11 +30,54 @@
              :distributed-compute-entry-device {:device device :entry id}))
     {:link-plan plan :accesses accesses :required (required-values plan accesses)}))
 
+(defn- normalize-reference [reference]
+  (cond
+    (and (map? reference) (= #{:value :shard} (set (keys reference)))) reference
+
+    (and (map? reference) (= #{:local-shape :placements} (set (keys reference))))
+    (let [placements (:placements reference)
+          owned (when (vector? placements) (first placements))]
+      (when-not (and (vector? placements) (= 1 (count placements))
+                     (map? owned) (= :owned (:kind owned))
+                     (= #{:kind :value :shard :local-offsets} (set (keys owned))))
+        (fail! "this materialization requires one owned placement; replica/boundary proofs are not yet implemented"
+               :distributed-compute-placement-coverage {:reference reference}))
+      (assoc (select-keys owned [:value :shard])
+             :local-shape (:local-shape reference) :local-offsets (:local-offsets owned)
+             :explicit-domain? true))
+
+    :else
+    (fail! "binding must name a qualified shard or an explicit local materialization"
+           :distributed-compute-shard-reference {:reference reference})))
+
+(defn- project-domain [local leaves shape]
+  (let [abstract (:abstract local)
+        logical-shape (:shape abstract)
+        layout (:logical-layout abstract)
+        base (:view (first leaves))
+        concrete? #(and (vector? %) (seq %) (every? pos-int? %))]
+    (when-not (and (= :tensor (:kind abstract)) (concrete? shape) (concrete? logical-shape)
+                   (= 1 (count leaves))
+                   (= {:kind :plain} (:representation abstract))
+                   (= {:kind :dense} (:physical-layout local))
+                   (or (nil? layout) (= {:order :row-major} layout)
+                       (= {:strides (view/dense-strides logical-shape)} layout))
+                   (view/contiguous? base)
+                   (= (dtype/canon (:dtype abstract)) (:dtype base))
+                   (= (reduce *' 1 shape) (reduce *' 1 logical-shape)
+                      (reduce *' 1 (:shape base))))
+      (fail! "local coordinates require one plain dense leaf with a proven equal-volume layout"
+             :distributed-compute-local-domain
+             {:value (:id local) :local-shape shape :abstract abstract
+              :physical-layout (:physical-layout local)}))
+    (view/subview base {:shape shape})))
+
 (defn- bind-values [{plan :link-plan :keys [accesses required]} device globals shards bindings]
   (when-not (map? bindings)
     (fail! "compute bindings must map local values to qualified shard references"
            :distributed-compute-bindings {:bindings bindings}))
-  (let [supplied (set (keys bindings))
+  (let [bindings (update-vals bindings normalize-reference)
+        supplied (set (keys bindings))
         available (set/union (set (keys accesses)) (set (link/output-value-ids plan)))]
     (when-not (set/subset? required supplied)
       (fail! "compute binding omits a public local value"
@@ -41,7 +85,8 @@
     (when-not (set/subset? supplied available)
       (fail! "compute binding names an absent or unused local value"
              :distributed-compute-local-value {:unknown (set/difference supplied available)}))
-    (when-not (= (count bindings) (count (distinct (vals bindings))))
+    (when-not (= (count bindings)
+                 (count (distinct (map #(select-keys % [:value :shard]) (vals bindings)))))
       (fail! "one compute call gives one shard distinct local identities"
              :distributed-compute-duplicate-shard {:bindings bindings}))
     ;; LinkPlan validates declared aliases locally, but logical ABI access facts do not
@@ -57,9 +102,6 @@
                  {:bound-node bound-node :private-node private-node}))))
     (into {}
           (map (fn [[id reference]]
-                 (when-not (and (map? reference) (= #{:value :shard} (set (keys reference))))
-                   (fail! "shard identity must be qualified by its global value"
-                          :distributed-compute-shard-reference {:reference reference}))
                  (let [{:keys [value shard]} reference
                        global (get globals value)
                        candidate (first (filter #(= shard (:id %)) (get shards value)))
@@ -73,7 +115,9 @@
                    (when-not (= device (:device candidate))
                      (fail! "compute binding names a shard on another device"
                             :distributed-compute-shard-device {:device device :shard candidate}))
-                   (when-not (and (= (:shape candidate) (get-in local [:abstract :shape]))
+                   (when-not (and (= (:shape candidate) (if (:explicit-domain? reference)
+                                                        (:local-shape reference)
+                                                        (get-in local [:abstract :shape])))
                                   (av/storage-contract-compatible? global (:abstract local)))
                      (fail! "local value does not realize the shard's logical storage contract"
                             :distributed-compute-value-contract
@@ -84,9 +128,17 @@
                                               (get-in % [:view :allocation :memory-space])) leaves))
                      (fail! "local storage violates the global value's memory-space constraint"
                             :distributed-compute-memory-space {:reference reference}))
-                   [id {:value value :shard shard :access (get accesses id)
-                        :physical-layout (:physical-layout local)
-                        :leaves leaves}]))
+                   (let [domain (when (:explicit-domain? reference)
+                                  (project-domain local leaves (:local-shape reference)))
+                         owned (when domain
+                                 (view/rectangular-subview domain
+                                                          {:offsets (:local-offsets reference)
+                                                           :shape (:shape candidate)}))]
+                     [id (cond-> {:value value :shard shard :access (get accesses id)
+                                  :physical-layout (:physical-layout local) :leaves leaves}
+                           domain (assoc :domain {:shape (:local-shape reference) :view domain
+                                                  :placements [{:kind :owned :value value :shard shard
+                                                                :view owned}]}))])))
                bindings))))
 
 (defn bindings

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -864,7 +864,11 @@
 (defn compute-bindings
   "Validate and resolve named local compute entries and qualified shard bindings.
    Returns `{:bindings {step-id ...} :unbound [compute-step-id ...]}`. This is a
-   structural compiler contract, not a runtime executor or allocation/transfer proof."
+   structural compiler contract, not a runtime executor or allocation/transfer proof.
+   A binding is either `{:value id :shard id}` or an explicit `{:local-shape [...]
+   :placements [{:kind :owned :value id :shard id :local-offsets [...]}]}`. The latter
+   proves a dense equal-volume local coordinate domain and reports it under `:domain`.
+   Only complete owned-domain coverage is currently admitted, not padding/replicas."
   [plan]
   (compute/bindings (validate-structure! plan)))
 

--- a/src/raster/compiler/ir/invocation_link.clj
+++ b/src/raster/compiler/ir/invocation_link.clj
@@ -337,7 +337,12 @@
               storage)
         values
         (mapv (fn [[token {:keys [abstract]}]]
-                (link/value {:id token :abstract abstract
+                ;; The invocation already carries all shape scalars and extent bindings.
+                ;; Retain their resolved logical shape at the public LinkPlan boundary,
+                ;; rather than forcing composition to rediscover symbolic dimensions.
+                (link/value {:id token :abstract (assoc abstract :shape
+                                                       (concrete-shape token abstract shape-scalars
+                                                                       (:buffers realized) storage))
                              :leaves [{:name :value :node token}]}))
               storage)
         instance (link/program-instance

--- a/test/raster/compiler/distributed_numerical_test.clj
+++ b/test/raster/compiler/distributed_numerical_test.clj
@@ -293,6 +293,37 @@
                                               (double-array n) rows width dt])]
         (is (= 0 (get-in plan [:attributes :driver-allocations])))))))
 
+(deftest compiled-flat-heat-values-bind-through-explicit-local-domains
+  (let [plan (equation/lower @compiled-step [(double-array 56) (double-array 56)
+                                            (double-array 56) 8 width dt])
+        values (update-vals (:values plan)
+                            #(assoc (:abstract %) :shape [8 width]
+                                    :sharding {:kind :partitioned :axis 0 :devices [:ze:0]}))
+        shards (into {} (map (fn [id]
+                              [id [(distributed/shard {:id id :value id :device :ze:0
+                                                       :offsets [0 0] :shape [8 width]})]])
+                            (keys values)))
+        bindings (into {} (map (fn [id]
+                                [id {:local-shape [8 width]
+                                     :placements [{:kind :owned :value id :shard id
+                                                   :local-offsets [0 0]}]}]) (keys values)))
+        distributed (distributed/plan
+                     {:id :compiled-local-domains
+                      :mesh (distributed/mesh [{:name :local :size 1}] [:ze:0])
+                      :topology (distributed/topology
+                                 [(distributed/device {:id :ze:0 :memory-capacity-bytes 1048576})] [])
+                      :values values :shards shards
+                      :device-plans {:ze:0 {:entries {:heat {:link-plan plan}}
+                                           :steps {:step {:entry :heat :bindings bindings}}}}
+                      :steps [(distributed/compute-step {:id :step :device :ze:0 :duration-ns 1})]
+                      :outputs [:step]})
+        report (distributed/compute-bindings distributed)]
+    (is (every? #(= [56] (:shape (:abstract %))) (vals (:values plan))))
+    (is (empty? (:unbound report)))
+    (is (= 3 (count (get-in report [:bindings :step :values]))))
+    (is (every? #(= [8 width] (get-in % [:domain :shape]))
+                (vals (get-in report [:bindings :step :values]))))))
+
 (deftest compiled-two-worker-halos-use-resident-copies
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "compiled-two-worker-resident-halos")

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -132,6 +132,55 @@
 (defn- failure-reason [thunk]
   (:reason (ex-data (try (thunk) (catch clojure.lang.ExceptionInfo error error)))))
 
+(defn- explicit-domain [shape]
+  {:local-shape shape
+   :placements [{:kind :owned :value :x :shard :x-0 :local-offsets [0 0]}]})
+
+(deftest flat-local-storage-has-an-explicit-multidimensional-domain
+  (let [local (local-link-plan {:x-shape [6]})
+        plans (device-plans local {:local-x (explicit-domain [2 3])})
+        bound (get-in (distributed/compute-bindings (make-plan {:device-plans plans}))
+                      [:bindings :copy-0 :values :local-x])]
+    (is (= :read (:access bound)))
+    (is (= [6] (get-in bound [:leaves 0 :view :shape]))
+        "the compiled ABI leaf is retained, not silently rewritten")
+    (is (= [2 3] (get-in bound [:domain :view :shape])))
+    (is (= [3 1] (get-in bound [:domain :view :strides])))
+    (is (= (get-in bound [:leaves 0 :view :allocation])
+           (get-in bound [:domain :view :allocation])))
+    (is (= (get-in bound [:domain :view :byte-length])
+           (get-in bound [:domain :placements 0 :view :byte-length])))
+    (is (= :distributed-compute-value-contract
+           (failure-reason #(make-plan {:link-plan local})))
+        "without explicit coordinates the old exact-shape contract is unchanged")))
+
+(deftest local-domain-does-not-admit-unproven-layouts-or-padding
+  (let [local (local-link-plan {:x-shape [6]})
+        check (fn [plan reference]
+                (failure-reason #(make-plan {:device-plans
+                                            (device-plans plan {:local-x reference})})))]
+    (is (= :distributed-compute-value-contract (check local (explicit-domain [3 3])))))
+  (let [local (local-link-plan {:x-shape [6]})
+        plans (device-plans local {:local-x (explicit-domain [2 3])})]
+    (doseq [[changed expected]
+            [[(assoc-in local [:values :local-x :physical-layout] {:kind :packed})
+              :distributed-compute-local-domain]
+             [(-> local
+                  (assoc-in [:nodes :x-node :view :strides] [0])
+                  (assoc-in [:nodes :x-node :view :byte-length] 4))
+              :link-noncontiguous-binding]]]
+      (is (= expected
+             (failure-reason #(make-plan {:device-plans
+                                         (assoc-in plans [:gpu-0 :entries :copy :link-plan] changed)})))))
+    (is (= :buffer-view-region
+           (failure-reason #(make-plan {:device-plans
+                                       (assoc-in plans [:gpu-0 :steps :copy-0 :bindings :local-x
+                                                        :placements 0 :local-offsets] [1 0])}))))
+    (is (= :distributed-compute-placement-coverage
+           (failure-reason #(make-plan {:device-plans
+                                       (assoc-in plans [:gpu-0 :steps :copy-0 :bindings :local-x
+                                                        :placements] [{:kind :replica :transfer :missing}])}))))))
+
 (deftest compute-bindings-retain-exact-link-values-and-derived-accesses
   (let [plan (make-plan)
         report (distributed/compute-bindings plan)


### PR DESCRIPTION
## Summary

- Add explicit dense local coordinate domains to distributed compute bindings, retaining original ABI views and reporting checked domain/owned views separately.
- Keep the whole-shard spelling unchanged. Only a complete single owned-domain placement is admitted; padding, replicas and boundary placements remain fail-closed until their provenance/coverage checks land.
- Require one plain dense injective leaf, compatible dtype/layout, and equal logical/physical element volume. No parameter-name shape guessing or quantization registry.
- Fix the real equation-first integration gap: invocation-to-LinkPlan lowering now retains resolved logical shapes using its existing canonical resolver.
- Record the reviewed follow-up contract for replica/boundary regions and execution.

## Validation

- Distributed compute/plan plus LinkPlan, AMR and KV-transfer: 55 tests, 260 assertions, all passing.
- Numerical acceptance: 6 tests, 23 assertions, all passing, including actual GPU halo/checkpoint execution and a real compiled heat LinkPlan bound through explicit domains.
- Invocation materialization: 4 tests, 22 assertions, all passing.
- Adjacent CUDA/HIP heat source checks and compiled RK4 device parity pass.
- Full suite/source compilation gates delegated to CI.

This is the first local-domain slice, not padded distributed execution. Replica freshness, boundary producers, exact transfer endpoints, co-location and runtime event/allocation realization remain explicit in the design.
