### PR TITLE
Normalize distributed owned-region identity across dense ABI reshapes

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -8,6 +8,10 @@ placement that covers the entire local domain. Its report retains the original A
 adds a checked `:domain` with the reshaped view and owned placement. A flat `[6]` leaf can explicitly
 realize a `[2 3]` shard. Padding, replica placements, and boundary placements remain rejected until
 the corresponding coverage/provenance checks land; this is not yet the padded example below.
+Repeated owned realizations compare ordered physical regions: a contiguous ABI reshape preserves
+identity when allocation, dtype, byte range, and field packing agree. Explicit domains use their
+derived owned view; noncontiguous leaves retain their shape/stride mapping. Original ABI views
+remain in the binding report and in the conservative cross-shard alias checks.
 
 The current whole-shard binding deliberately requires one local LinkValue to realize one exact
 owned shard. A halo-padded field cannot satisfy that contract by selecting only its owned cells:

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -141,11 +141,26 @@
                                                                 :view owned}]}))])))
                bindings))))
 
+(defn- owned-realization [{:keys [physical-layout leaves domain]}]
+  (let [owned (some #(when (= :owned (:kind %)) (:view %)) (:placements domain))
+        leaves (if owned [(assoc (first leaves) :view owned)] leaves)]
+    {:physical-layout physical-layout
+     :leaves (mapv (fn [leaf]
+                     (update leaf :view
+                             (fn [v]
+                               ;; Logical shape agreement is checked when binding the shard.
+                               ;; Dense ABI reshapes do not change its ordered physical cells.
+                               ;; Noncontiguous views must retain their coordinate mapping.
+                               (cond-> (dissoc v :id)
+                                 (view/contiguous? v) (dissoc :shape :strides)))))
+                   leaves)}))
+
 (defn bindings
   "Derive bindings after the enclosing DistributedPlan validates its DAG and shards.
    Unbound analytical compute is explicit. Fully bound compute is not a distributed executor:
    device-scoped allocation, transfer realization, events and arena ownership remain runtime
-   obligations. Whole-shard shapes are required; halo subregions need an explicit view relation."
+   obligations. Full owned-domain coverage is required, with optional explicit dense
+   reinterpretation; halo subregions still require coverage and provenance proofs."
   [{:keys [device-plans steps values shards]}]
   (let [step-by-id (into {} (map (juxt :id identity)) steps)
         bound
@@ -187,10 +202,9 @@
     ;; Distinct entry points cannot silently assign one resident shard different storage.
     ;; IDs of views may differ; allocation identity, ranges and ordered field packing may not.
     (doseq [[id entry] bound
-            [_ {:keys [value shard physical-layout leaves]}] (:values entry)]
+            [_ {:keys [value shard leaves] :as binding}] (:values entry)]
       (let [key [(:device (get step-by-id id)) value shard]
-            realization {:physical-layout physical-layout
-                         :leaves (mapv #(update % :view dissoc :id) leaves)}]
+            realization (owned-realization binding)]
         (when (and (contains? @realized key)
                    (not= (:realization (get @realized key)) realization))
           (fail! "compute entries disagree on a resident shard's physical realization"

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.ir.distributed-compute-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.buffer-view :as view]
             [raster.compiler.ir.distributed-plan :as distributed]
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-artifact :as artifact]
@@ -232,6 +233,45 @@
     (is (= :distributed-compute-entry-device
            (failure-reason
             #(make-plan {:device-plans (device-plans (local-link-plan {:target :gpu-1}))}))))))
+
+(deftest owned-identity-is-independent-of-dense-abi-reshape
+  (let [local (local-link-plan)
+        flat (local-link-plan {:x-shape [6]})
+        rectangular (update-in local [:nodes :x-node :view]
+                               #(view/subview % {:shape [2 3]}))
+        base (plan-map)
+        plans (-> (device-plans flat {:local-x (explicit-domain [2 3])})
+                  (assoc-in [:gpu-0 :entries :again] {:link-plan rectangular})
+                  (assoc-in [:gpu-0 :steps :analytical-only]
+                            (assoc (get-in (device-plans local) [:gpu-0 :steps :copy-0])
+                                   :entry :again)))
+        plan (assoc base :device-plans plans
+                    :steps (mapv #(assoc % :device :gpu-0) (:steps base)))
+        report (distributed/compute-bindings (distributed/plan plan))]
+    (is (empty? (:unbound report)))
+    (is (= [6] (get-in report [:bindings :copy-0 :values :local-x :leaves 0 :view :shape])))
+    (is (= [2 3] (get-in report [:bindings :analytical-only :values :local-x
+                                :leaves 0 :view :shape])))
+    (is (= [2 3] (get-in report [:bindings :copy-0 :values :local-x
+                                :domain :placements 0 :view :shape])))
+    (is (= 0 (get-in report [:bindings :copy-0 :values :local-x
+                             :domain :placements 0 :view :byte-offset])))
+    (testing "dense normalization cannot hide a different allocation"
+      (is (= :distributed-compute-shard-storage
+             (failure-reason
+              #(distributed/plan
+                (assoc-in plan [:device-plans :gpu-0 :entries :again :link-plan
+                                :nodes :x-node :view :allocation :id] :different))))))
+    (testing "nor a disjoint same-sized range in the same allocation"
+      (let [larger (-> plan
+                       (assoc-in [:device-plans :gpu-0 :entries :copy :link-plan
+                                  :nodes :x-node :view :allocation :byte-size] 48)
+                       (assoc-in [:device-plans :gpu-0 :entries :again :link-plan
+                                  :nodes :x-node :view :allocation :byte-size] 48)
+                       (assoc-in [:device-plans :gpu-0 :entries :again :link-plan
+                                  :nodes :x-node :view :byte-offset] 24))]
+        (is (= :distributed-compute-shard-storage
+               (failure-reason #(distributed/plan larger))))))))
 
 (deftest distinct-shards-cannot-alias-across-entries
   (let [local (assoc-in (local-link-plan)


### PR DESCRIPTION
Continues #547 toward shared distributed materializations. Compares derived owned views by their ordered physical cells while retaining original ABI views and conservative alias checks. Dense shape spelling no longer creates false storage disagreements; allocation, dtype, range, field packing and noncontiguous mapping remain significant. Halo padding and replica/boundary placement remain rejected pending coverage/provenance proofs. Validation: focused distributed-compute tests (14 tests, 57 assertions) and adjacent distributed-plan/LinkPlan/AMR/KV-transfer tests (42 tests, 210 assertions), all passing in the existing capped REPL. Full gates delegated to CircleCI.