### PR TITLE
Derive local copy-replica regions from scheduled halos

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -4,7 +4,7 @@ Status: owned-domain normalization and copy-replica geometry/coverage are implem
 boundary producers, freshness, endpoint realization and execution remain a reviewed plan.
 
 The current `distributed-plan/compute-bindings` accepts an explicit `:local-shape` with one owned
-placement that covers the entire local domain. Its report retains the original ABI leaf views and
+placement and optional copy replicas that together cover the entire local domain. Its report retains the original ABI leaf views and
 adds a checked `:domain` with the reshaped view and owned placement. A flat `[6]` leaf can explicitly
 realize a `[2 3]` shard. Copy replicas can now complete a padded domain: their destination rectangles
 are derived from validated ScheduledHalo steps, anchored at the owned region, and checked for exact

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -1,13 +1,18 @@
 # Distributed materialization and execution boundary
 
-Status: owned-domain normalization is implemented; replica/boundary coverage and execution below
-remain a reviewed implementation plan, not an implemented execution contract.
+Status: owned-domain normalization and copy-replica geometry/coverage are implemented;
+boundary producers, freshness, endpoint realization and execution remain a reviewed plan.
 
 The current `distributed-plan/compute-bindings` accepts an explicit `:local-shape` with one owned
 placement that covers the entire local domain. Its report retains the original ABI leaf views and
 adds a checked `:domain` with the reshaped view and owned placement. A flat `[6]` leaf can explicitly
-realize a `[2 3]` shard. Padding, replica placements, and boundary placements remain rejected until
-the corresponding coverage/provenance checks land; this is not yet the padded example below.
+realize a `[2 3]` shard. Copy replicas can now complete a padded domain: their destination rectangles
+are derived from validated ScheduledHalo steps, anchored at the owned region, and checked for exact
+coordinate-disjoint coverage. Each transfer must precede its consumer through the DAG, and repeated
+consumers must agree on its physical destination. Periodic halos have a complete structural example;
+boundary placements remain rejected, so the nonperiodic example below is not yet admitted.
+These checks do not prove initialization, freshness across intervening writes, or source endpoint
+availability. The report is still structural and must not be treated as execution authorization.
 Repeated owned realizations compare ordered physical regions: a contiguous ABI reshape preserves
 identity when allocation, dtype, byte range, and field packing agree. Explicit domains use their
 derived owned view; noncontiguous leaves retain their shape/stride mapping. Original ABI views

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -36,15 +36,19 @@
 
     (and (map? reference) (= #{:local-shape :placements} (set (keys reference))))
     (let [placements (:placements reference)
-          owned (when (vector? placements) (first placements))]
-      (when-not (and (vector? placements) (= 1 (count placements))
+          owners (when (vector? placements) (filter #(= :owned (:kind %)) placements))
+          owned (first owners)]
+      (when-not (and (vector? placements) (= 1 (count owners))
                      (map? owned) (= :owned (:kind owned))
-                     (= #{:kind :value :shard :local-offsets} (set (keys owned))))
-        (fail! "this materialization requires one owned placement; replica/boundary proofs are not yet implemented"
+                     (= #{:kind :value :shard :local-offsets} (set (keys owned)))
+                     (every? #(or (= % owned)
+                                  (and (map? %) (= :replica (:kind %))
+                                       (= #{:kind :transfer} (set (keys %))))) placements))
+        (fail! "materialization requires one owned placement and scheduled copy replicas; boundaries need producer proofs"
                :distributed-compute-placement-coverage {:reference reference}))
       (assoc (select-keys owned [:value :shard])
              :local-shape (:local-shape reference) :local-offsets (:local-offsets owned)
-             :explicit-domain? true))
+             :placements placements :explicit-domain? true))
 
     :else
     (fail! "binding must name a qualified shard or an explicit local materialization"
@@ -72,7 +76,57 @@
               :physical-layout (:physical-layout local)}))
     (view/subview base {:shape shape})))
 
-(defn- bind-values [{plan :link-plan :keys [accesses required]} device globals shards bindings]
+(defn- predecessor-ids [step-by-id id]
+  (loop [pending (seq (:dependencies (get step-by-id id))) seen #{}]
+    (if-let [id (first pending)]
+      (if (contains? seen id)
+        (recur (next pending) seen)
+        (recur (concat (next pending) (:dependencies (get step-by-id id))) (conj seen id)))
+      seen)))
+
+(defn- domain-placements [domain reference candidate device halo-steps predecessors]
+  (let [anchor (:local-offsets reference)
+        _ (view/rectangular-subview domain {:offsets anchor :shape (:shape candidate)})
+        placements
+        (mapv
+         (fn [placement]
+           (let [region
+                 (if (= :owned (:kind placement))
+                   {:offsets anchor :shape (:shape candidate)}
+                   (let [transfer (get halo-steps (:transfer placement))
+                         attrs (:attributes transfer)
+                         destination (:destination-region attrs)]
+                     (when-not (and transfer (= device (:target transfer))
+                                    (= (:value reference) (:value transfer))
+                                    (= (:shard reference) (:target-shard attrs))
+                                    (= :copy (:destination-mode attrs))
+                                    (= :target-local (:frame destination)))
+                       (fail! "replica must name a scheduled copy halo into this owned shard"
+                              :distributed-compute-replica-transfer {:placement placement}))
+                     (when-not (contains? predecessors (:id transfer))
+                       (fail! "replica transfer must precede its consumer through DAG dependencies"
+                              :distributed-compute-replica-dependency {:placement placement}))
+                     {:offsets (mapv +' anchor (:offsets destination))
+                      :shape (:shape destination)}))]
+             (assoc placement :region region :view (view/rectangular-subview domain region))))
+         (:placements reference))
+        regions (mapv :region placements)]
+    ;; Rectangular projection proves containment. Pairwise coordinate disjointness plus
+    ;; equal volume proves exact coverage, without confusing strided byte bounding spans.
+    (doseq [i (range (count regions)) j (range (inc i) (count regions))]
+      (let [a (nth regions i) b (nth regions j)]
+        (when (every? true? (map (fn [a n b m] (and (< a (+' b m)) (< b (+' a n))))
+                                 (:offsets a) (:shape a) (:offsets b) (:shape b)))
+          (fail! "local placements overlap in logical coordinates"
+                 :distributed-compute-placement-coverage {:left a :right b}))))
+    (when-not (= (reduce *' 1 (:shape domain))
+                 (reduce +' 0 (map #(reduce *' 1 (:shape %)) regions)))
+      (fail! "local placements do not cover the complete ABI domain"
+             :distributed-compute-placement-coverage {:shape (:shape domain) :regions regions}))
+    placements))
+
+(defn- bind-values [{plan :link-plan :keys [accesses required]} device globals shards bindings
+                   halo-steps predecessors]
   (when-not (map? bindings)
     (fail! "compute bindings must map local values to qualified shard references"
            :distributed-compute-bindings {:bindings bindings}))
@@ -115,9 +169,8 @@
                    (when-not (= device (:device candidate))
                      (fail! "compute binding names a shard on another device"
                             :distributed-compute-shard-device {:device device :shard candidate}))
-                   (when-not (and (= (:shape candidate) (if (:explicit-domain? reference)
-                                                        (:local-shape reference)
-                                                        (get-in local [:abstract :shape])))
+                   (when-not (and (or (:explicit-domain? reference)
+                                      (= (:shape candidate) (get-in local [:abstract :shape])))
                                   (av/storage-contract-compatible? global (:abstract local)))
                      (fail! "local value does not realize the shard's logical storage contract"
                             :distributed-compute-value-contract
@@ -130,15 +183,13 @@
                             :distributed-compute-memory-space {:reference reference}))
                    (let [domain (when (:explicit-domain? reference)
                                   (project-domain local leaves (:local-shape reference)))
-                         owned (when domain
-                                 (view/rectangular-subview domain
-                                                          {:offsets (:local-offsets reference)
-                                                           :shape (:shape candidate)}))]
+                         placements (when domain
+                                      (domain-placements domain reference candidate device
+                                                         halo-steps predecessors))]
                      [id (cond-> {:value value :shard shard :access (get accesses id)
                                   :physical-layout (:physical-layout local) :leaves leaves}
                            domain (assoc :domain {:shape (:local-shape reference) :view domain
-                                                  :placements [{:kind :owned :value value :shard shard
-                                                                :view owned}]}))])))
+                                                  :placements placements}))])))
                bindings))))
 
 (defn- owned-realization [{:keys [physical-layout leaves domain]}]
@@ -159,10 +210,12 @@
   "Derive bindings after the enclosing DistributedPlan validates its DAG and shards.
    Unbound analytical compute is explicit. Fully bound compute is not a distributed executor:
    device-scoped allocation, transfer realization, events and arena ownership remain runtime
-   obligations. Full owned-domain coverage is required, with optional explicit dense
-   reinterpretation; halo subregions still require coverage and provenance proofs."
-  [{:keys [device-plans steps values shards]}]
+   obligations. Explicit dense domains require exact owned/copy-replica coverage and
+   replica DAG predecessors. Initialization, intervening-write freshness, boundary providers,
+   and executable transfer endpoints remain additional execution-proof obligations."
+  [{:keys [device-plans steps values shards halos]}]
   (let [step-by-id (into {} (map (juxt :id identity)) steps)
+        halo-steps (into {} (map (juxt :id identity)) (mapcat :steps halos))
         bound
         (reduce-kv
          (fn [bound device local]
@@ -195,10 +248,12 @@
                            :distributed-compute-entry {:device device :entry entry}))
                   (assoc bound id {:entry entry :link-plan plan
                                    :values (bind-values (get entries entry) device values shards
-                                                        (:bindings call))})))
+                                                        (:bindings call) halo-steps
+                                                        (predecessor-ids step-by-id id))})))
               bound calls))))
          {} device-plans)
-        realized (volatile! {})]
+        realized (volatile! {})
+        replicas (volatile! {})]
     ;; Distinct entry points cannot silently assign one resident shard different storage.
     ;; IDs of views may differ; allocation identity, ranges and ordered field packing may not.
     (doseq [[id entry] bound
@@ -216,6 +271,16 @@
             (fail! "distinct distributed shards cannot alias physical storage without a relation"
                    :distributed-compute-shard-alias {:shard key :other other-key})))
         (vswap! realized assoc key {:realization realization :leaves leaves})))
+    (doseq [[id entry] bound
+            [_ binding] (:values entry)
+            placement (get-in binding [:domain :placements])
+            :when (= :replica (:kind placement))]
+      (let [key [(:device (get step-by-id id)) (:transfer placement)]
+            region (dissoc (:view placement) :id)]
+        (when (and (contains? @replicas key) (not= (get @replicas key) region))
+          (fail! "consumers disagree on a transfer's physical replica destination"
+                 :distributed-compute-replica-storage {:step id :replica key}))
+        (vswap! replicas assoc key region)))
     {:bindings bound
      :unbound (mapv :id (filter #(and (= :compute (:kind %))
                                      (not (contains? bound (:id %)))) steps))}))

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -868,7 +868,10 @@
    A binding is either `{:value id :shard id}` or an explicit `{:local-shape [...]
    :placements [{:kind :owned :value id :shard id :local-offsets [...]}]}`. The latter
    proves a dense equal-volume local coordinate domain and reports it under `:domain`.
-   Only complete owned-domain coverage is currently admitted, not padding/replicas."
+   Copy-halo replicas may complete the domain with `{:kind :replica :transfer step-id}`;
+   their geometry is derived from ScheduledHalo and their steps must precede the consumer.
+   Exact disjoint coverage is checked. This is not freshness/initialization or execution proof;
+   explicit boundary producers and combining transfers are not yet admitted as placements."
   [plan]
   (compute/bindings (validate-structure! plan)))
 

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -160,7 +160,7 @@
         check (fn [plan reference]
                 (failure-reason #(make-plan {:device-plans
                                             (device-plans plan {:local-x reference})})))]
-    (is (= :distributed-compute-value-contract (check local (explicit-domain [3 3])))))
+    (is (= :distributed-compute-local-domain (check local (explicit-domain [3 3])))))
   (let [local (local-link-plan {:x-shape [6]})
         plans (device-plans local {:local-x (explicit-domain [2 3])})]
     (doseq [[changed expected]
@@ -181,6 +181,71 @@
            (failure-reason #(make-plan {:device-plans
                                        (assoc-in plans [:gpu-0 :steps :copy-0 :bindings :local-x
                                                         :placements] [{:kind :replica :transfer :missing}])}))))))
+
+(defn- periodic-materialization-plan []
+  (let [global (assoc (global-value) :shape [2 2]
+                      :sharding {:kind :partitioned :axis 0 :devices [:gpu-0 :gpu-1]})
+        shards (mapv (fn [i]
+                       (distributed/shard {:id (keyword (str "x-" i)) :value :x
+                                           :device (keyword (str "gpu-" i))
+                                           :offsets [i 0] :shape [1 2] :ownership :owned}))
+                     (range 2))
+        halo (distributed/schedule-halo
+              (distributed/halo-exchange {:id :periodic :value :x :axis 0 :width 1
+                                          :boundary :periodic})
+              global shards {[:gpu-0 :gpu-1] [:forward] [:gpu-1 :gpu-0] [:backward]} [])
+        replicas (mapv (fn [step] {:kind :replica :transfer (:id step)})
+                       (filter #(= :gpu-0 (:target %)) (:steps halo)))
+        reference {:local-shape [3 2]
+                   :placements (into [{:kind :owned :value :x :shard :x-0 :local-offsets [1 0]}]
+                                     replicas)}
+        base (plan-map {:device-plans (device-plans (local-link-plan {:x-shape [6]})
+                                                    {:local-x reference})})]
+    (-> base
+        (assoc :halos [halo]
+               :topology (distributed/topology
+                           (vals (:devices (topology)))
+                           [(distributed/link {:id :forward :source :gpu-0 :target :gpu-1
+                                               :bandwidth-bytes-s 1.0e9 :latency-ns 100})
+                            (distributed/link {:id :backward :source :gpu-1 :target :gpu-0
+                                               :bandwidth-bytes-s 1.0e9 :latency-ns 100})]))
+        (assoc-in [:values :x] global)
+        (assoc-in [:shards :x] shards)
+        (update :steps (fn [steps]
+                         (into (:steps halo)
+                               (assoc-in steps [0 :dependencies] (:completions halo))))))))
+
+(deftest periodic-replicas-project-from-the-scheduled-halo
+  (let [plan (periodic-materialization-plan)
+        report (distributed/compute-bindings (distributed/plan plan))
+        placements (get-in report [:bindings :copy-0 :values :local-x :domain :placements])]
+    (is (= #{[0 0] [1 0] [2 0]} (set (map #(get-in % [:region :offsets]) placements))))
+    (is (= [[1 2] [1 2] [1 2]] (mapv #(get-in % [:view :shape]) placements)))
+    (is (= #{0 8 16} (set (map #(get-in % [:view :byte-offset]) placements))))
+    (is (= [:analytical-only] (:unbound report)))
+    (testing "a gap cannot be treated as an initialized boundary"
+      (is (= :distributed-compute-placement-coverage
+             (failure-reason #(distributed/plan
+                               (update-in plan [:device-plans :gpu-0 :steps :copy-0
+                                                :bindings :local-x :placements] pop))))))
+    (testing "repeated replicas do not prove coverage"
+      (is (= :distributed-compute-placement-coverage
+             (failure-reason #(distributed/plan
+                               (update-in plan [:device-plans :gpu-0 :steps :copy-0
+                                                :bindings :local-x :placements]
+                                          (fn [p] (assoc p 2 (nth p 1)))))))))
+    (testing "vector order is not a producer dependency"
+      (is (= :distributed-compute-replica-dependency
+             (failure-reason #(distributed/plan
+                               (update plan :steps
+                                       (fn [steps] (mapv (fn [s] (if (= :copy-0 (:id s))
+                                                                 (assoc s :dependencies []) s)) steps))))))))
+    (testing "a transfer to the other shard is not a local replica"
+      (is (= :distributed-compute-replica-transfer
+             (failure-reason #(distributed/plan
+                               (assoc-in plan [:device-plans :gpu-0 :steps :copy-0 :bindings
+                                               :local-x :placements 1 :transfer]
+                                         [:periodic :edge 0 :forward]))))))))
 
 (deftest compute-bindings-retain-exact-link-values-and-derived-accesses
   (let [plan (make-plan)

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -6,7 +6,8 @@
             [raster.compiler.ir.kernel-abi :as abi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.link-plan :as link]))
+            [raster.compiler.ir.link-plan :as link]
+            [raster.compiler.ir.scan :as scan]))
 
 (def ^:private copy-kernel
   (artifact/make
@@ -246,6 +247,24 @@
                                (assoc-in plan [:device-plans :gpu-0 :steps :copy-0 :bindings
                                                :local-x :placements 1 :transfer]
                                          [:periodic :edge 0 :forward]))))))))
+
+(deftest replica-transfers-are-transitive-predecessors-not-combining-writes
+  (let [plan (periodic-materialization-plan)
+        halo (first (:halos plan))
+        compute (filterv #(= :compute (:kind %)) (:steps plan))
+        relay (distributed/compute-step {:id :relay :device :gpu-0 :duration-ns 1
+                                         :dependencies (:completions halo)})
+        transitive (assoc plan :steps (into (conj (:steps halo) relay)
+                                            (assoc-in compute [0 :dependencies] [:relay])))]
+    (is (distributed/distributed-plan? (distributed/plan transitive)))
+    (let [combine (scan/certify {:acc 'acc :init 0.0 :lambda '(+ acc element)} :float)
+          combining (distributed/schedule-halo
+                     (assoc (:exchange halo) :combine combine)
+                     (get-in plan [:values :x]) (get-in plan [:shards :x]) (:routes halo) [])
+          changed (assoc plan :halos [combining] :steps (into (:steps combining) compute))]
+      (is (= :distributed-compute-replica-transfer
+             (failure-reason #(distributed/plan changed)))
+          "even a certified reduction cannot be silently implemented as a copy replica"))))
 
 (deftest compute-bindings-retain-exact-link-values-and-derived-accesses
   (let [plan (make-plan)


### PR DESCRIPTION
Continues #548 toward the distributed numerical execution vertical. Explicit dense domains may contain one owned placement and scheduled copy replicas. Derives target-local rectangles from validated ScheduledHalo transfers; checks exact disjoint coordinate coverage, transitive producer dependencies, and consistent replica destinations across consumers. Does not introduce ghost ValueShards or another kernel ABI. Boundary providers, initialization/freshness across writes, source endpoint realization, and runtime execution remain explicitly unimplemented obligations; this structural report is not execution authorization. Validation: 50 structural tests / 247 assertions plus existing numerical heat/halo/mmap-checkpoint tests (6 / 23), including real GPU execution, all passing in one capped REPL. Added periodic placement positive coverage and gap/overlap/wrong-target/missing-dependency negatives. Review is in progress; full gates run in CircleCI.