### PR TITLE
Bind nonperiodic boundaries to retained local compiler outputs

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -12,7 +12,8 @@ are derived from validated ScheduledHalo steps, anchored at the owned region, an
 coordinate-disjoint coverage. Each transfer must precede its consumer through the DAG, and repeated
 consumers must agree on its physical destination. Periodic and nonperiodic halos now have structural
 examples. A nonperiodic boundary names a bound preceding compute step and its ABI-written local
-value; the complete plain dense physical view must match the boundary region exactly. No implicit
+value declared as a public LinkPlan output; an internal/scratch write is not retained-output
+evidence. The complete plain dense physical view must match the boundary region exactly. No implicit
 fill is inferred from the boundary mode. Strided boundary outputs and selecting only part of a
 producer's larger value remain refused until their write-region projection is certified.
 An explicitly referenced boundary output is retained in the producing entry's `:boundary-outputs`

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -1,7 +1,8 @@
 # Distributed materialization and execution boundary
 
-Status: owned-domain normalization and copy-replica geometry/coverage are implemented;
-boundary producers, freshness, endpoint realization and execution remain a reviewed plan.
+Status: owned-domain normalization, copy-replica geometry/coverage and exact boundary
+provider bindings are implemented; initialization/freshness, endpoint realization and execution
+remain a reviewed plan.
 
 The current `distributed-plan/compute-bindings` accepts an explicit `:local-shape` with one owned
 placement and optional copy replicas that together cover the entire local domain. Its report retains the original ABI leaf views and
@@ -9,8 +10,15 @@ adds a checked `:domain` with the reshaped view and owned placement. A flat `[6]
 realize a `[2 3]` shard. Copy replicas can now complete a padded domain: their destination rectangles
 are derived from validated ScheduledHalo steps, anchored at the owned region, and checked for exact
 coordinate-disjoint coverage. Each transfer must precede its consumer through the DAG, and repeated
-consumers must agree on its physical destination. Periodic halos have a complete structural example;
-boundary placements remain rejected, so the nonperiodic example below is not yet admitted.
+consumers must agree on its physical destination. Periodic and nonperiodic halos now have structural
+examples. A nonperiodic boundary names a bound preceding compute step and its ABI-written local
+value; the complete plain dense physical view must match the boundary region exactly. No implicit
+fill is inferred from the boundary mode. Strided boundary outputs and selecting only part of a
+producer's larger value remain refused until their write-region projection is certified.
+An explicitly referenced boundary output is retained in the producing entry's `:boundary-outputs`
+report rather than requiring a synthetic global ValueShard. Other required public values still
+need global bindings. The boundary report records ABI write scope, not definite initialization of
+every cell; that stronger obligation belongs to the execution-readiness proof below.
 These checks do not prove initialization, freshness across intervening writes, or source endpoint
 availability. The report is still structural and must not be treated as execution authorization.
 Repeated owned realizations compare ordered physical regions: a contiguous ABI reshape preserves

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -332,7 +332,7 @@
                  :distributed-compute-boundary-provider {:step id :provider (:provider placement)}))
         (when-not (and (view/contiguous? target) (view/contiguous? source)
                        (= (dissoc source :id :shape :strides) (dissoc target :id :shape :strides)))
-          (fail! "boundary producer's complete written view must equal the boundary region"
+          (fail! "boundary producer's complete public output view must equal the boundary region"
                  :distributed-compute-boundary-storage {:step id :provider (:provider placement)}))))
     (doseq [[id entry] bound
             [_ binding] (:values entry)

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -43,8 +43,12 @@
                      (= #{:kind :value :shard :local-offsets} (set (keys owned)))
                      (every? #(or (= % owned)
                                   (and (map? %) (= :replica (:kind %))
-                                       (= #{:kind :transfer} (set (keys %))))) placements))
-        (fail! "materialization requires one owned placement and scheduled copy replicas; boundaries need producer proofs"
+                                       (= #{:kind :transfer} (set (keys %))))
+                                  (and (map? %) (= :boundary (:kind %))
+                                       (= #{:kind :region :provider} (set (keys %)))
+                                       (map? (:provider %))
+                                       (= #{:step :local-value} (set (keys (:provider %)))))) placements))
+        (fail! "materialization requires one owned placement and explicit replica/boundary evidence"
                :distributed-compute-placement-coverage {:reference reference}))
       (assoc (select-keys owned [:value :shard])
              :local-shape (:local-shape reference) :local-offsets (:local-offsets owned)
@@ -53,6 +57,10 @@
     :else
     (fail! "binding must name a qualified shard or an explicit local materialization"
            :distributed-compute-shard-reference {:reference reference})))
+
+(defn- local-leaves [plan local]
+  (mapv (fn [{:keys [name node]}]
+          {:name name :view (get-in plan [:nodes node :view])}) (:leaves local)))
 
 (defn- project-domain [local leaves shape]
   (let [abstract (:abstract local)
@@ -76,6 +84,23 @@
               :physical-layout (:physical-layout local)}))
     (view/subview base {:shape shape})))
 
+(defn- boundary-output-facts [{plan :link-plan :keys [accesses]} step local-ids]
+  (into {}
+        (map (fn [id]
+               (let [local (get-in plan [:values id])
+                     access (get accesses id)]
+                 (when-not (contains? #{:write :read-write} access)
+                   (fail! "boundary provider must name an ABI-written local value"
+                          :distributed-compute-boundary-write
+                          {:step step :local-value id :access access}))
+                 (when-not (contains? (set (link/output-value-ids plan)) id)
+                   (fail! "boundary provider must retain a public LinkPlan output"
+                          :distributed-compute-boundary-output {:step step :local-value id}))
+                 [id {:access access
+                      :view (project-domain local (local-leaves plan local)
+                                            (get-in local [:abstract :shape]))}]))
+             local-ids)))
+
 (defn- predecessor-ids [step-by-id id]
   (loop [pending (seq (:dependencies (get step-by-id id))) seen #{}]
     (if-let [id (first pending)]
@@ -91,8 +116,17 @@
         (mapv
          (fn [placement]
            (let [region
-                 (if (= :owned (:kind placement))
-                   {:offsets anchor :shape (:shape candidate)}
+                 (case (:kind placement)
+                   :owned {:offsets anchor :shape (:shape candidate)}
+                   :boundary (let [region (:region placement)]
+                               (when-not (and (map? region)
+                                              (= #{:offsets :shape} (set (keys region)))
+                                              (vector? (:shape region))
+                                              (every? pos-int? (:shape region)))
+                                 (fail! "boundary requires a positive exact local rectangle"
+                                        :distributed-compute-boundary-region {:placement placement}))
+                               region)
+                   :replica
                    (let [transfer (get halo-steps (:transfer placement))
                          attrs (:attributes transfer)
                          destination (:destination-region attrs)]
@@ -126,16 +160,17 @@
     placements))
 
 (defn- bind-values [{plan :link-plan :keys [accesses required]} device globals shards bindings
-                   halo-steps predecessors]
+                   halo-steps predecessors boundary-outputs]
   (when-not (map? bindings)
     (fail! "compute bindings must map local values to qualified shard references"
            :distributed-compute-bindings {:bindings bindings}))
   (let [bindings (update-vals bindings normalize-reference)
         supplied (set (keys bindings))
         available (set/union (set (keys accesses)) (set (link/output-value-ids plan)))]
-    (when-not (set/subset? required supplied)
+    (when-not (set/subset? required (set/union supplied boundary-outputs))
       (fail! "compute binding omits a public local value"
-             :distributed-compute-missing-values {:missing (set/difference required supplied)}))
+             :distributed-compute-missing-values
+             {:missing (set/difference required supplied boundary-outputs)}))
     (when-not (set/subset? supplied available)
       (fail! "compute binding names an absent or unused local value"
              :distributed-compute-local-value {:unknown (set/difference supplied available)}))
@@ -160,9 +195,7 @@
                        global (get globals value)
                        candidate (first (filter #(= shard (:id %)) (get shards value)))
                        local (get-in plan [:values id])
-                       leaves (mapv (fn [{:keys [name node]}]
-                                      {:name name :view (get-in plan [:nodes node :view])})
-                                    (:leaves local))]
+                       leaves (local-leaves plan local)]
                    (when-not (and global candidate)
                      (fail! "compute binding names an absent value shard"
                             :distributed-compute-shard {:reference reference}))
@@ -211,11 +244,22 @@
    Unbound analytical compute is explicit. Fully bound compute is not a distributed executor:
    device-scoped allocation, transfer realization, events and arena ownership remain runtime
    obligations. Explicit dense domains require exact owned/copy-replica coverage and
-   replica DAG predecessors. Initialization, intervening-write freshness, boundary providers,
-   and executable transfer endpoints remain additional execution-proof obligations."
+   replica DAG predecessors. Boundaries require an exact ABI-written provider view on a
+   preceding same-device compute step. Initialization, intervening-write freshness, and
+   executable transfer endpoints remain additional execution-proof obligations."
   [{:keys [device-plans steps values shards halos]}]
   (let [step-by-id (into {} (map (juxt :id identity)) steps)
         halo-steps (into {} (map (juxt :id identity)) (mapcat :steps halos))
+        ;; A boundary is local storage, not an extra globally partitioned value. Its
+        ;; exact producing LinkValue may be retained by this explicit use instead.
+        boundary-uses (for [[_ local] device-plans
+                            [_ call] (:steps local)
+                            [_ reference] (:bindings call)
+                            placement (:placements reference)
+                            :when (= :boundary (:kind placement))]
+                        (:provider placement))
+        boundary-outputs (reduce (fn [m {:keys [step local-value]}]
+                                   (update m step (fnil conj #{}) local-value)) {} boundary-uses)
         bound
         (reduce-kv
          (fn [bound device local]
@@ -247,9 +291,12 @@
                     (fail! "compute call names an absent local entry"
                            :distributed-compute-entry {:device device :entry entry}))
                   (assoc bound id {:entry entry :link-plan plan
+                                   :boundary-outputs
+                                   (boundary-output-facts (get entries entry) id (get boundary-outputs id))
                                    :values (bind-values (get entries entry) device values shards
                                                         (:bindings call) halo-steps
-                                                        (predecessor-ids step-by-id id))})))
+                                                        (predecessor-ids step-by-id id)
+                                                        (get boundary-outputs id #{}))})))
               bound calls))))
          {} device-plans)
         realized (volatile! {})
@@ -271,6 +318,22 @@
             (fail! "distinct distributed shards cannot alias physical storage without a relation"
                    :distributed-compute-shard-alias {:shard key :other other-key})))
         (vswap! realized assoc key {:realization realization :leaves leaves})))
+    (doseq [[id entry] bound
+            [_ binding] (:values entry)
+            placement (get-in binding [:domain :placements])
+            :when (= :boundary (:kind placement))]
+      (let [{producer :step local-value :local-value} (:provider placement)
+            source (get-in bound [producer :boundary-outputs local-value :view])
+            target (:view placement)
+            predecessors (predecessor-ids step-by-id id)]
+        (when-not (and source (= (:device (get step-by-id producer)) (:device (get step-by-id id)))
+                       (contains? predecessors producer))
+          (fail! "boundary must name a bound producer on this device preceding its consumer"
+                 :distributed-compute-boundary-provider {:step id :provider (:provider placement)}))
+        (when-not (and (view/contiguous? target) (view/contiguous? source)
+                       (= (dissoc source :id :shape :strides) (dissoc target :id :shape :strides)))
+          (fail! "boundary producer's complete written view must equal the boundary region"
+                 :distributed-compute-boundary-storage {:step id :provider (:provider placement)}))))
     (doseq [[id entry] bound
             [_ binding] (:values entry)
             placement (get-in binding [:domain :placements])

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -871,7 +871,10 @@
    Copy-halo replicas may complete the domain with `{:kind :replica :transfer step-id}`;
    their geometry is derived from ScheduledHalo and their steps must precede the consumer.
    Exact disjoint coverage is checked. This is not freshness/initialization or execution proof;
-   explicit boundary producers and combining transfers are not yet admitted as placements."
+   boundaries name an exact ABI-written local value of a preceding same-device compute step
+   via `{:kind :boundary :region {...} :provider {:step id :local-value id}}`. Such private
+   outputs are retained under the producer entry's `:boundary-outputs`, without a synthetic
+   global shard. Combining transfers are not admitted as copy-replica placements."
   [plan]
   (compute/bindings (validate-structure! plan)))
 

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -266,6 +266,71 @@
              (failure-reason #(distributed/plan changed)))
           "even a certified reduction cannot be silently implemented as a copy replica"))))
 
+(defn- boundary-fill-plan [physical-view]
+  (let [kernel (artifact/make
+                {:kernel-name "fill_boundary" :source "__kernel void fill_boundary(__global float* y) { y[get_global_id(0)] = 0; }"
+                 :abi [(abi/slot 'y :output :float)] :arguments '[y]
+                 :launch (launch/spec {:workgroup-size [1] :group-count [2]})
+                 :effects {:kind :map :reads [] :writes '[y]}})
+        descriptor {:dtype :float :all-params [] :array-params [] :scalar-params []
+                    :allocs [{:sym 'y :dtype :float :size-fn (fn [_] 2)}]
+                    :steps [{:phase :fill :kernel-name "fill_boundary" :convention :map
+                             :artifact kernel :argument-specs [{:kind :output :sym 'y}]}]
+                    :result-sym 'y}]
+    (link/make {:id :boundary-fill :target :gpu-0
+                :nodes [(link/node {:id :boundary-node :role :output :view physical-view})]
+                :values [(link/value {:id :boundary-output :abstract (local-abstract [2])
+                                      :leaves [{:name :value :node :boundary-node}]})]
+                :instances [(link/instance {:id :fill :descriptor descriptor
+                                            :bindings {'y :boundary-output} :scalars {}})]
+                :outputs [:boundary-node]})))
+
+(defn- boundary-materialization-plan []
+  (let [base (periodic-materialization-plan)
+        old (first (:halos base))
+        halo (distributed/schedule-halo (assoc (:exchange old) :boundary :nonperiodic)
+                                        (get-in base [:values :x]) (get-in base [:shards :x])
+                                        (:routes old) [])
+        consumer (get-in base [:device-plans :gpu-0 :entries :copy :link-plan])
+        boundary-view (view/subview (get-in consumer [:nodes :x-node :view]) {:shape [2]})
+        init (distributed/compute-step {:id :boundary-init :device :gpu-0 :duration-ns 1})
+        computes (filterv #(= :compute (:kind %)) (:steps base))]
+    (-> base
+        (assoc :halos [halo] :steps (into (into [init] (:steps halo))
+                                         (assoc-in computes [0 :dependencies]
+                                                   (conj (:completions halo) :boundary-init))))
+        (assoc-in [:device-plans :gpu-0 :entries :boundary] {:link-plan (boundary-fill-plan boundary-view)})
+        (assoc-in [:device-plans :gpu-0 :steps :boundary-init] {:entry :boundary :bindings {}})
+        (assoc-in [:device-plans :gpu-0 :steps :copy-0 :bindings :local-x :placements 2]
+                  {:kind :boundary :region {:offsets [0 0] :shape [1 2]}
+                   :provider {:step :boundary-init :local-value :boundary-output}}))))
+
+(deftest nonperiodic-boundary-has-an-exact-executable-producer
+  (let [plan (boundary-materialization-plan)
+        report (distributed/compute-bindings (distributed/plan plan))]
+    (is (= :write (get-in report [:bindings :boundary-init :boundary-outputs :boundary-output :access])))
+    (is (empty? (get-in report [:bindings :boundary-init :values]))
+        "a private boundary result is not a synthetic globally partitioned ValueShard")
+    (is (= [:analytical-only] (:unbound report)))
+    (is (= :distributed-compute-boundary-output
+           (failure-reason #(distributed/plan
+                             (assoc-in plan [:device-plans :gpu-0 :entries :boundary :link-plan
+                                             :outputs] []))))
+        "an internally written value is not a retained boundary output")
+    (is (= :distributed-compute-boundary-write
+           (failure-reason #(distributed/plan
+                             (assoc-in plan [:device-plans :gpu-0 :steps :copy-0 :bindings :local-x
+                                             :placements 2 :provider :local-value] :not-written)))))
+    (is (= :distributed-compute-boundary-provider
+           (failure-reason #(distributed/plan
+                             (update plan :steps (fn [steps]
+                                                   (mapv (fn [s] (if (= :copy-0 (:id s))
+                                                                   (update s :dependencies pop) s)) steps)))))))
+    (is (= :distributed-compute-boundary-storage
+           (failure-reason #(distributed/plan
+                             (assoc-in plan [:device-plans :gpu-0 :entries :boundary :link-plan
+                                             :nodes :boundary-node :view :byte-offset] 8)))))))
+
 (deftest compute-bindings-retain-exact-link-values-and-derived-accesses
   (let [plan (make-plan)
         report (distributed/compute-bindings plan)


### PR DESCRIPTION
Continues #549. A boundary placement names a preceding same-device compute step and a public ABI-written LinkPlan output. Its complete plain dense physical view must exactly equal the boundary region. Explicit local boundary use retains this output without inventing a global ValueShard; all other public binding requirements remain. Reuses LinkPlan output/access facts and BufferView projection, with no boundary numerical kernel special case. Review caught and fixed internal written values being mistaken for retained outputs; regression covers it. This certifies geometry/output scope/order only, not definite cell initialization, freshness across intervening writes, shared allocation realization, or runtime execution. Validation: 59 focused structural tests / 284 assertions plus existing real GPU numerical halo/checkpoint tests 6 / 23 pass in one capped REPL. Read-only review completed with no remaining blocker. Full gates delegated to CircleCI.