### PR TITLE
Project scheduled halo transfers to exact owned and replica endpoints

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -1,7 +1,8 @@
 # Distributed materialization and execution boundary
 
 Status: owned-domain normalization, copy-replica geometry/coverage and exact boundary
-provider bindings are implemented; initialization/freshness, endpoint realization and execution
+provider bindings and contiguous halo endpoint projection are implemented; initialization/freshness,
+runtime allocation/transport realization and execution
 remain a reviewed plan.
 
 The current `distributed-plan/compute-bindings` accepts an explicit `:local-shape` with one owned
@@ -88,12 +89,29 @@ Resolve transfer endpoints through these placement identities. Avoid a second ha
 of ABI arguments or duplicate source/destination rectangle declarations. If the source owned
 realization cannot be identified uniquely, or the target replica is absent, lowering must refuse
 execution even when the topology-only plan remains useful for simulation.
+`distributed-plan/transfer-bindings` now performs this strict geometric projection for every
+transfer in a plan. It indexes owned sources by device/value/shard and replica destinations by
+device/transfer, derives each source rectangle relative to its owned shard, and returns the existing
+BufferView records with exact shape/dtype/byte agreement. Analytical plans are still accepted by
+the ordinary planner when endpoints are absent; requesting strict projection rejects them.
+The current projector supports only contiguous plain ScheduledHalo copies. Generic transfers,
+combining transfers, and strided faces require additional lowerings and are rejected. This report
+is not an execution certificate: it does not establish source initialization/freshness, actual
+allocation sharing, event completion, or a usable transport implementation.
 Only copy-mode halos create replica placements. Combining halo transfers must use their certified
 reduction over the derived owned target face in global coordinates, not an absent ghost replica;
 they must never be silently implemented as a copy. The initial copy-mode vertical rejects these
 until its runtime can execute the stated reduction.
 
 ## Readiness is separate from geometry
+
+The next proof should reuse LinkPlan's ordered instance access facts and its existing
+`produced-views`/`partial-writes` accounting. `value-accesses` deliberately summarizes ABI access
+only; a `:write` entry is not an initialization postcondition. LinkPlan currently assumes caller
+input/constant/state nodes are initialized when checking the local program. Distributed lowering
+must discharge those caller preconditions using source leases and completed producers/transfers,
+not inherit the assumption as evidence. Expose the shared local pre/postcondition calculation
+from the existing validator rather than adding a second kernel-effect registry.
 
 Before an executable plan can allocate resources, prove:
 

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -347,3 +347,71 @@
     {:bindings bound
      :unbound (mapv :id (filter #(and (= :compute (:kind %))
                                      (not (contains? bound (:id %)))) steps))}))
+
+(defn- unique-endpoint-view! [views reason step]
+  (let [regions (distinct (map #(dissoc % :id) views))]
+    (when-not (= 1 (count regions))
+      (fail! "transfer requires one unambiguous physical endpoint"
+             reason {:step step :candidates (count regions)}))
+    (first views)))
+
+(defn transfer-bindings
+  "Strict physical endpoint projection after enclosing DistributedPlan structural validation.
+   Supports contiguous plain copy-halo regions only. Unlike the analytical planner, this fails
+   on absent/ambiguous endpoints and unsupported transfer kinds. No allocation is performed;
+   source initialization, freshness, and transport capability are NOT proven here."
+  [{:keys [steps shards halos] :as plan}]
+  (let [bound (:bindings (bindings plan))
+        step-by-id (into {} (map (juxt :id identity)) steps)
+        halo-ids (into #{} (map :id) (mapcat :steps halos))
+        shard-by-id (into {} (for [[value candidates] shards candidate candidates]
+                              [[value (:id candidate)] candidate]))
+        owned (reduce-kv
+               (fn [index step entry]
+                 (reduce-kv (fn [index local-id binding]
+                              (update index [(:device (get step-by-id step))
+                                             (:value binding) (:shard binding)]
+                                      (fnil conj []) {:entry entry :local-id local-id :binding binding}))
+                            index (:values entry))) {} bound)
+        replicas (reduce-kv
+                  (fn [index step entry]
+                    (reduce (fn [index placement]
+                              (update index [(:device (get step-by-id step)) (:transfer placement)]
+                                      (fnil conj []) (:view placement)))
+                            index (for [[_ binding] (:values entry)
+                                        placement (get-in binding [:domain :placements])
+                                        :when (= :replica (:kind placement))] placement))) {} bound)]
+    (into {}
+          (for [{:keys [id source target value bytes attributes] :as step} steps
+                :when (= :transfer (:kind step))]
+            (do
+              (when-not (and (contains? halo-ids id) (= :copy (:destination-mode attributes)))
+                (fail! "physical transfer projection requires a scheduled copy halo"
+                       :distributed-transfer-kind {:step id}))
+              (let [source-shard (:source-shard attributes)
+                    candidate (get shard-by-id [value source-shard])
+                    rectangle (:source-region attributes)
+                    relative {:offsets (mapv -' (:offsets rectangle) (:offsets candidate))
+                              :shape (:shape rectangle)}
+                    source-views
+                    (map (fn [{:keys [entry local-id binding]}]
+                           (let [owned-view (or (some #(when (= :owned (:kind %)) (:view %))
+                                                     (get-in binding [:domain :placements]))
+                                                (project-domain (get-in entry [:link-plan :values local-id])
+                                                                (:leaves binding) (:shape candidate)))]
+                             (view/rectangular-subview owned-view relative)))
+                         (get owned [source value source-shard]))
+                    from (unique-endpoint-view! source-views :distributed-transfer-source id)
+                    to (unique-endpoint-view! (get replicas [target id]) :distributed-transfer-target id)]
+                (when-not (and (view/contiguous? from) (view/contiguous? to))
+                  (fail! "strided halo endpoints require a certified pack/unpack lowering"
+                         :distributed-transfer-layout {:step id}))
+                (when-not (and (= (:dtype from) (:dtype to))
+                               (= (:shape from) (:shape to))
+                               (= bytes (:byte-length from) (:byte-length to)))
+                  (fail! "transfer endpoint extents disagree with scheduled payload"
+                         :distributed-transfer-extent {:step id :bytes bytes}))
+                [id {:source {:device source :value value :shard source-shard :view from}
+                     :target {:device target :value value :shard (:target-shard attributes)
+                              :replica id :view to}
+                     :bytes bytes}]))))))

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -878,6 +878,15 @@
   [plan]
   (compute/bindings (validate-structure! plan)))
 
+(defn transfer-bindings
+  "Validate and project every transfer to exact physical source/target BufferViews.
+   Currently requires contiguous plain ScheduledHalo copies with bound owned sources and
+   replica destinations. Unsupported or absent endpoints fail rather than acquiring guessed
+   storage. Returns a map keyed by transfer step ID. This does not authorize execution:
+   initialization/freshness, shared allocation and transport capabilities remain obligations."
+  [plan]
+  (compute/transfer-bindings (validate-structure! plan)))
+
 (defn plan
   [{:keys [id mesh topology values shards collective-groups collectives
            halos device-plans steps outputs attributes]

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -47,13 +47,13 @@
 (defn- local-link-plan
   ([] (local-link-plan {}))
   ([opts]
-   (let [{:keys [x-shape x-dtype target]
-          :or {x-shape [2 3] x-dtype :float target :gpu-0}} opts
+   (let [{:keys [x-shape x-dtype target elements tail-shape]
+          :or {x-shape [2 3] x-dtype :float target :gpu-0 elements 6 tail-shape [2 3]}} opts
          weights-source (if (contains? opts :weights-source)
                           (:weights-source opts)
-                          (float-array 6))
+                          (float-array elements))
          node (fn [id role source]
-                (link/node {:id id :dtype :float :shape [6] :device target :role role
+                (link/node {:id id :dtype :float :shape [elements] :device target :role role
                             :source source}))
          x (node :x-node :input nil)
          weights (node :weights-node :constant weights-source)
@@ -62,15 +62,15 @@
       {:id :local-copy :target target :nodes [x weights y]
        :values [(link/value {:id :local-x :abstract (local-abstract x-dtype x-shape)
                              :leaves [{:name :value :node :x-node}]})
-                (link/value {:id :local-weights :abstract (local-abstract [2 3])
+                (link/value {:id :local-weights :abstract (local-abstract tail-shape)
                              :leaves [{:name :value :node :weights-node}]})
-                (link/value {:id :local-y :abstract (local-abstract [2 3])
+                (link/value {:id :local-y :abstract (local-abstract tail-shape)
                              :leaves [{:name :value :node :y-node}]})]
        :instances [(link/instance {:id :copy :descriptor copy-descriptor
                                    :bindings {'x :local-x
                                               'weights :local-weights
                                               'y :local-y}
-                                   :scalars {'n 6}})]
+                                   :scalars {'n elements}})]
        :outputs [:y-node]}))))
 
 (defn- topology []
@@ -330,6 +330,98 @@
            (failure-reason #(distributed/plan
                              (assoc-in plan [:device-plans :gpu-0 :entries :boundary :link-plan
                                              :nodes :boundary-node :view :byte-offset] 8)))))))
+
+(defn- fully-bound-periodic-plan []
+  (let [base (periodic-materialization-plan)
+        incoming (filter #(= :gpu-1 (:target %)) (get-in base [:halos 0 :steps]))]
+    (assoc-in base [:device-plans :gpu-1]
+              {:entries {:copy {:link-plan (local-link-plan {:x-shape [6] :target :gpu-1})}}
+               :steps {:analytical-only
+                       {:entry :copy
+                        :bindings {:local-x {:local-shape [3 2]
+                                             :placements (into [{:kind :owned :value :x :shard :x-1
+                                                                 :local-offsets [1 0]}]
+                                                               (map (fn [s] {:kind :replica :transfer (:id s)}) incoming))}
+                                   :local-y {:value :y :shard :y-1}}}}})))
+
+(deftest copy-transfer-endpoints-come-from-owned-and-replica-views
+  (let [plan (distributed/plan (fully-bound-periodic-plan))
+        endpoints (distributed/transfer-bindings plan)]
+    (is (= 4 (count endpoints)))
+    (doseq [[id {:keys [source target bytes]}] endpoints]
+      (is (= 8 bytes))
+      (is (= 8 (get-in source [:view :byte-offset]))
+          "the source is the owned row, not the beginning of its padded allocation")
+      (is (contains? #{0 16} (get-in target [:view :byte-offset])))
+      (is (= id (:replica target)))
+      (is (not= (:device source) (:device target)))
+      (is (= [1 2] (get-in source [:view :shape]) (get-in target [:view :shape]))))
+    (is (= :distributed-transfer-target
+           (failure-reason #(distributed/transfer-bindings
+                             (distributed/plan (periodic-materialization-plan)))))
+        "an analytical plan may lack physical destinations, strict lowering may not")
+    (is (= :distributed-transfer-source
+           (failure-reason #(distributed/transfer-bindings
+                             (assoc-in plan [:device-plans :gpu-0] {})))))
+    (is (= {} (distributed/transfer-bindings (make-plan))))
+    (let [generic (distributed/transfer-step {:id :generic :source :gpu-0 :target :gpu-1
+                                              :route [:forward] :value :x :bytes 8})
+          analytical (distributed/plan (update plan :steps conj generic))]
+      (is (= :distributed-transfer-kind
+             (failure-reason #(distributed/transfer-bindings analytical)))
+          "an analytical transfer is not silently lowered as a halo copy"))))
+
+(deftest unequal-shard-upper-faces-use-owned-relative-coordinates
+  (let [base (fully-bound-periodic-plan)
+        global (assoc (get-in base [:values :x]) :shape [6 2])
+        shards [(assoc (get-in base [:shards :x 0]) :shape [2 2])
+                (assoc (get-in base [:shards :x 1]) :offsets [2 0] :shape [4 2])]
+        old (get-in base [:halos 0])
+        halo (distributed/schedule-halo (:exchange old) global shards (:routes old) [])
+        base (-> base (assoc-in [:values :x] global) (assoc-in [:shards :x] shards)
+                 (assoc :halos [halo] :steps (into (:steps halo) (filter #(= :compute (:kind %)) (:steps base)))))
+        plan (reduce
+              (fn [p [device step rows result]]
+                (let [n (* 2 (+ rows 2))
+                      local (local-link-plan {:x-shape [n] :tail-shape [n] :elements n :target device})
+                      value (assoc (global-value) :shape [n]
+                                   :sharding {:kind :replicated :devices [device]})]
+                  (-> p
+                      (assoc-in [:values result] value)
+                      (assoc-in [:shards result] [(distributed/shard {:id result :value result :device device
+                                                                      :offsets [0] :shape [n] :ownership :replica})])
+                      (assoc-in [:device-plans device :entries :copy :link-plan] local)
+                      (assoc-in [:device-plans device :steps step :bindings :local-y] {:value result :shard result})
+                      (assoc-in [:device-plans device :steps step :bindings :local-x :local-shape] [(+ rows 2) 2]))))
+              base [[:gpu-0 :copy-0 2 :left-result] [:gpu-1 :analytical-only 4 :right-result]])
+        endpoints (distributed/transfer-bindings (distributed/plan plan))]
+    (is (= 16 (get-in endpoints [[:periodic :edge 0 :forward] :source :view :byte-offset]))
+        "left upper face: one padding row plus one owned-relative row")
+    (is (= 8 (get-in endpoints [[:periodic :edge 0 :backward] :source :view :byte-offset]))
+        "right lower face: subtract global row two, then apply one padding row")
+    (is (= 32 (get-in endpoints [[:periodic :edge 1 :forward] :source :view :byte-offset]))
+        "right periodic upper face: padding plus three owned-relative rows")
+    (is (= 24 (get-in endpoints [[:periodic :edge 0 :backward] :target :view :byte-offset])))
+    (is (= 40 (get-in endpoints [[:periodic :edge 1 :backward] :target :view :byte-offset])))))
+
+(deftest strided-faces-require-pack-unpack-not-a-bounding-span-copy
+  (let [base (fully-bound-periodic-plan)
+        global (assoc-in (get-in base [:values :x]) [:sharding :axis] 1)
+        shards (mapv #(assoc % :shape [2 1] :offsets (vec (reverse (:offsets %))))
+                     (get-in base [:shards :x]))
+        old (get-in base [:halos 0])
+        halo (distributed/schedule-halo (assoc (:exchange old) :axis 1) global shards (:routes old) [])
+        plan (-> base (assoc-in [:values :x] global) (assoc-in [:shards :x] shards)
+                 (assoc :halos [halo] :steps (into (:steps halo) (filter #(= :compute (:kind %)) (:steps base)))))
+        plan (reduce (fn [p [device step]]
+                       (-> p
+                           (assoc-in [:device-plans device :steps step :bindings :local-x :local-shape] [2 3])
+                           (assoc-in [:device-plans device :steps step :bindings :local-x :placements 0
+                                      :local-offsets] [0 1])))
+                     plan [[:gpu-0 :copy-0] [:gpu-1 :analytical-only]])]
+    (is (distributed/distributed-plan? (distributed/plan plan)))
+    (is (= :distributed-transfer-layout
+           (failure-reason #(distributed/transfer-bindings (distributed/plan plan)))))))
 
 (deftest compute-bindings-retain-exact-link-values-and-derived-accesses
   (let [plan (make-plan)


### PR DESCRIPTION
Continues #550. Adds strict distributed-plan/transfer-bindings: derives source faces relative to certified owned shards and targets from existing replica placements, returning BufferViews with matching shape/dtype/bytes. Rejects absent/ambiguous endpoints, generic/combining transfers and strided faces requiring pack/unpack. Ordinary analytical planning remains independent of physical endpoint availability. No new kernel ABI, allocation, transport or execution-readiness claim. Review completed with no blocker; added unequal 2-row/4-row padded geometry regression to exercise nonzero upper-face offsets and global-to-owned coordinate translation. Validation: focused binding tests20/110; adjacent planning tests42/210 previously passing on same implementation; existing GPU numerical halo/checkpoint6/23 passing. Full suite and emitter gates delegated to CircleCI. Next readiness proof will reuse LinkPlan ordered access and partial-write/produced-view accounting rather than duplicate effect inference.