### PR TITLE
Expose local initialization requirements through shared LinkPlan effect analysis

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -112,6 +112,11 @@ alias requirements retain the actual requested subview. Declared source initiali
 from caller obligations and are not immutable snapshots or completed uploads. Produced storage
 does not imply retained semantic identity for private temporary values. These are conditional
 local facts; distributed lowering still needs to discharge them and establish freshness.
+The facts are conservative, not minimal across all aliases. The current `gpu.link` runtime also
+maintains `pending-inputs` for every owned, source-less input/constant/state node, including nodes
+that this analysis proves unused or written before reading. An executor must reconcile that gate
+with proven initialization and shared external bindings; it must not simply treat an empty
+`:requires` set as permission to bypass existing `run!` input checks.
 
 The proof reuses LinkPlan's ordered instance access facts and its existing
 `produced-views`/`partial-writes` accounting. `value-accesses` deliberately summarizes ABI access

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -105,13 +105,21 @@ until its runtime can execute the stated reduction.
 
 ## Readiness is separate from geometry
 
-The next proof should reuse LinkPlan's ordered instance access facts and its existing
+`link-plan/initialization-contract` now exposes the shared effect validator's node-level
+`:requires`, `:initializers`, `:produces`, `:reads`, `:writes`, and public `:outputs` sets.
+Caller requirements arise from reads or pass-through outputs before a proven local writer;
+alias requirements retain the actual requested subview. Declared source initializers are separate
+from caller obligations and are not immutable snapshots or completed uploads. Produced storage
+does not imply retained semantic identity for private temporary values. These are conditional
+local facts; distributed lowering still needs to discharge them and establish freshness.
+
+The proof reuses LinkPlan's ordered instance access facts and its existing
 `produced-views`/`partial-writes` accounting. `value-accesses` deliberately summarizes ABI access
 only; a `:write` entry is not an initialization postcondition. LinkPlan currently assumes caller
 input/constant/state nodes are initialized when checking the local program. Distributed lowering
 must discharge those caller preconditions using source leases and completed producers/transfers,
-not inherit the assumption as evidence. Expose the shared local pre/postcondition calculation
-from the existing validator rather than adding a second kernel-effect registry.
+not inherit the assumption as evidence. The shared calculation is in the existing validator,
+not a second kernel-effect registry.
 
 Before an executable plan can allocate resources, prove:
 

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -1018,7 +1018,7 @@
   (-> plan validate-plan-structure! validate-allocations-and-aliases! validate-effects!))
 
 (defn initialization-contract
-  "Validate and derive node-level initialization pre/postconditions from ordered ABI facts.
+  "Validate and derive conservative node-level initialization pre/postconditions from ordered ABI facts.
    :requires names caller-initialized nodes needed by reads or pass-through outputs;
    :initializers names nodes with declared host sources (not a content snapshot or upload event).
    :produces names nodes fully established by ordered writes, including certified produced
@@ -1026,7 +1026,8 @@
    retention or semantic-value preservation of private temporaries. :reads/:writes retain conservative
    effect scopes, and :outputs is the public output-node set. All sets contain LinkNode IDs.
    Postconditions assume caller requirements and initializers are realized and execution succeeds;
-   this is not proof of distributed readiness, source immutability, or runtime completion."
+   this is not proof of distributed readiness, source immutability, or runtime completion.
+   Requirements need not be minimal across aliases and do not replace a runtime's input gates."
   [plan]
   (analyze-effects! (-> plan validate-plan-structure! validate-allocations-and-aliases!)))
 

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -929,7 +929,7 @@
              (validate-program-instance-bindings! nodes values %))
           instances))
 
-(defn- validate-effects! [{:keys [target nodes values instances outputs aliases] :as plan}]
+(defn- analyze-effects! [{:keys [nodes outputs aliases] :as plan}]
   (let [step-facts (instance-access-facts plan)
         initialized (volatile! (into #{}
                                      (keep (fn [[id {:keys [role source]}]]
@@ -940,22 +940,37 @@
                                                        (contains? #{:input :constant :state} role))
                                                id)))
                                      nodes))
-        initially-initialized @initialized
+        initially-initialized (sort-by pr-str @initialized)
         written (volatile! #{})
+        required (volatile! #{})
+        reads (volatile! #{})
+        writes (volatile! #{})
+        caller-initialization!
+        (fn [node-id required-view-id]
+          (when (and (not (contains? @written node-id))
+                     (not (get-in nodes [node-id :source])))
+            (vswap! required conj required-view-id))
+          true)
         initialized-view?
         (fn [node-id]
-          (or (contains? @initialized node-id)
+          (or (when (contains? @initialized node-id)
+                (caller-initialization! node-id node-id))
               (let [view (get-in nodes [node-id :view])]
                 (and (bview/contiguous? view)
                      (some (fn [initialized-id]
                              (let [cover (get-in nodes [initialized-id :view])]
-                               (bview/contains-contiguous-view? cover view)))
+                               (when (bview/contains-contiguous-view? cover view)
+                                 (caller-initialization! initialized-id node-id))))
                            initially-initialized)))))]
     (doseq [{:keys [instance step phase facts produced-views partial-writes]} step-facts]
       (let [by-node (reduce (fn [m {:keys [node access]}]
                               (update m node merge-access access)) {} facts)]
         (doseq [[node-id access] by-node
                 :let [role (get-in nodes [node-id :role])]]
+          (when (contains? #{:read :read-write} access)
+            (vswap! reads conj node-id))
+          (when (contains? #{:write :read-write} access)
+            (vswap! writes conj node-id))
           (when (and (contains? #{:read :read-write} access)
                      (not (initialized-view? node-id)))
             (throw (ex-info "link plan reads an internal node before an ordered producer writes it"
@@ -988,12 +1003,32 @@
                     (initialized-view? node-id))
         (throw (ex-info "link plan exports a node with no value"
                         {:reason :link-unproduced-output :node node-id}))))
-    plan))
+    {:requires @required
+     :initializers (into #{} (keep (fn [[id node]] (when (:source node) id))) nodes)
+     :produces @written :reads @reads :writes @writes
+     :outputs (set outputs)}))
+
+(defn- validate-effects! [plan]
+  (analyze-effects! plan)
+  plan)
 
 (defn validate!
   "Validate a LinkPlan without allocating storage, registering kernels, or contacting a driver."
   [plan]
   (-> plan validate-plan-structure! validate-allocations-and-aliases! validate-effects!))
+
+(defn initialization-contract
+  "Validate and derive node-level initialization pre/postconditions from ordered ABI facts.
+   :requires names caller-initialized nodes needed by reads or pass-through outputs;
+   :initializers names nodes with declared host sources (not a content snapshot or upload event).
+   :produces names nodes fully established by ordered writes, including certified produced
+   subviews but excluding unproven tails of partial writes. This is initialized storage, not
+   retention or semantic-value preservation of private temporaries. :reads/:writes retain conservative
+   effect scopes, and :outputs is the public output-node set. All sets contain LinkNode IDs.
+   Postconditions assume caller requirements and initializers are realized and execution succeeds;
+   this is not proof of distributed readiness, source immutability, or runtime completion."
+  [plan]
+  (analyze-effects! (-> plan validate-plan-structure! validate-allocations-and-aliases!)))
 
 (defn value-accesses
   "Return conservative logical-value accesses from the validated executable ABI.

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -243,6 +243,13 @@
         "result views share storage without another allocation")
     (is (nil? (get-in linked [:nodes prefix :source])))
     (is (nil? (reason fresh)) "the contraction produces its entire logical prefix")
+    (let [contract (link-plan/initialization-contract fresh)]
+      (is (contains? (:produces contract) prefix))
+      (is (not (contains? (:produces contract) base)))
+      (is (not (contains? (:requires contract) base))
+          "a write-only prefix does not demand an initialized backing tail")
+      (is (contains? (:writes contract) base)
+          "the ABI pointer is written, but only the certified prefix is initialized"))
     (is (= :link-unproduced-output (reason (assoc fresh :outputs [base])))
         "writing a prefix cannot initialize or export the untouched tail")
     (is (= :program-link-result-view

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -77,6 +77,47 @@
                   (instance :layer-1 :hidden :w1 :out)]
       :outputs [:out]})))
 
+(deftest initialization-contract-separates-caller-data-from-ordered-producers
+  (let [initialized (valid-plan)
+        caller (update initialized :nodes
+                       #(update-vals % (fn [node] (assoc node :source nil))))]
+    (is (= {:requires #{} :initializers #{:x :w0 :w1} :produces #{:hidden :out}
+            :reads #{:x :w0 :w1 :hidden} :writes #{:hidden :out} :outputs #{:out}}
+           (link/initialization-contract initialized)))
+    (is (= #{:x :w0 :w1} (:requires (link/initialization-contract caller))))
+    (is (= #{} (:initializers (link/initialization-contract caller))))
+    (let [state (assoc-in caller [:nodes :hidden :role] :state)]
+      (is (not (contains? (:requires (link/initialization-contract state)) :hidden))
+          "a state role does not impose an initial value when an ordered producer writes first")
+      (is (contains? (:requires (link/initialization-contract
+                                (update state :instances #(vec (reverse %))))) :hidden)
+          "reading state before its writer creates a caller precondition"))
+    (let [with-unused (-> caller
+                          (assoc-in [:nodes :unused] (n :unused :input))
+                          (assoc-in [:values :unused] (link/value {:id :unused :abstract
+                                                                 (av/tensor {:dtype :float :shape [16]})
+                                                                 :leaves [{:name :value :node :unused}]})))]
+      (is (not (contains? (:requires (link/initialization-contract with-unused)) :unused)))
+      (is (contains? (:requires (link/initialization-contract (update with-unused :outputs conj :unused))) :unused)
+          "an unwritten pass-through output still requires caller data"))))
+
+(deftest initialization-contract-retains-the-required-alias-region
+  (let [base (link/node {:id :base :dtype :float :shape [4] :role :input :device :ze:0
+                         :allocation-id :shared :byte-size 16})
+        prefix (link/node {:id :prefix :dtype :float :shape [2] :role :internal :device :ze:0
+                           :allocation-id :shared :byte-size 16})
+        plan (link/make {:id :alias-precondition :target :ze:0
+                         :nodes [base prefix (n :x :input (float-array 16))
+                                 (n :w :constant (float-array 16)) (n :tmp :internal)]
+                         :aliases #{#{:base :prefix}}
+                         :instances [(instance :unrelated :x :w :tmp)] :outputs [:prefix]})
+        contract (link/initialization-contract plan)]
+    (is (= #{:prefix} (:requires contract))
+        "a subview requirement does not demand the untouched tail of its caller-owned base")
+    (is (= #{:tmp} (:produces contract)))
+    (is (= #{} (:requires (link/initialization-contract
+                           (assoc-in plan [:nodes :base :source] (float-array 4))))))))
+
 (deftest logical-value-accesses-come-from-bound-kernel-effects
   (let [plan (valid-plan)]
     (is (= {:x :read :w0 :read :w1 :read :hidden :read-write :out :write}


### PR DESCRIPTION
Continues #551 toward distributed readiness. Refactors the existing effect validator to also return node-level initialization requirements, declared source initializers, produced storage, conservative read/write scopes and public outputs. No independent effect registry or inference pass. Caller requirements are derived from reads/pass-through outputs before ordered producers, including exact alias subview requirements. Existing produced-view/partial-write evidence ensures writing a prefix does not initialize its backing tail. Facts are conditional on caller initialization and successful execution; they do not certify source snapshots, retained private semantic values, distributed freshness or event completion. Validation:64 structural tests330 assertions pass; targeted existing equation-first partial-prefix compiler test passes with four new contract assertions; actual GPU numerical halo/checkpoint6/23 pass. Read-only review in progress; full gates delegated to CircleCI.