### PR TITLE
Preserve disjoint typed regions with device-scoped coverage algebra

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -139,6 +139,18 @@ Before an executable plan can allocate resources, prove:
 5. Allocation sharing follows device-scoped materialization identities, with release after all
    dependent operations complete. Existing separately instantiated owned LinkPlans do not do this.
 
+Physical interval operations for the initial contiguous readiness proof now live in BufferView:
+`subtract-contiguous` preserves unaffected typed fragments of an initialization fact after a write;
+`covered-contiguous?` checks whether several compatible views jointly cover a required range.
+They use device-scoped allocation identity, reject contradictory allocation contracts, and do not
+mistake strided bounding spans for dense coverage. Invalidation is independent of the writer's dtype
+when the cut is element-aligned; typed initialization coverage requires a matching dtype. A cut
+through part of an element is rejected until a byte-validity or outward-rounded invalidation
+policy exists. These helpers establish geometry only; the DAG checker must retain producer identity
+on each fragment and reject unordered conflicting effects and stale replicas.
+The existing `overlaps?` and `same-range?` predicates use the same device-scoped identity;
+zero-byte views never overlap a nonempty range, including when their offset lies inside it.
+
 Lower dependencies to the existing ExecutionPlan logical queues/events and reuse the LinkPlan
 executable binder. Keep a synchronous executor as an explicit backend capability, not an implicit
 claim of asynchronous transport overlap. MPI/UCX/NCCL and storage/provider completions remain

--- a/src/raster/compiler/ir/buffer_view.clj
+++ b/src/raster/compiler/ir/buffer_view.clj
@@ -131,7 +131,9 @@
 (defn byte-end [view]
   (+ (:byte-offset (validate-view! view)) (:byte-length view)))
 
-(defn- allocation-key [allocation]
+(defn- allocation-key
+  "A nil device is its own identity scope, never a wildcard for concrete devices."
+  [allocation]
   [(:device allocation) (:id allocation)])
 
 (defn overlaps?

--- a/src/raster/compiler/ir/buffer_view.clj
+++ b/src/raster/compiler/ir/buffer_view.clj
@@ -131,11 +131,15 @@
 (defn byte-end [view]
   (+ (:byte-offset (validate-view! view)) (:byte-length view)))
 
+(defn- allocation-key [allocation]
+  [(:device allocation) (:id allocation)])
+
 (defn overlaps?
-  "True when two views address at least one common byte of the same allocation."
+  "True when views address at least one common byte of the same device-scoped allocation."
   [a b]
   (let [a (validate-view! a) b (validate-view! b)]
-    (and (= (get-in a [:allocation :id]) (get-in b [:allocation :id]))
+    (and (= (allocation-key (:allocation a)) (allocation-key (:allocation b)))
+         (pos? (:byte-length a)) (pos? (:byte-length b))
          (< (:byte-offset a) (byte-end b))
          (< (:byte-offset b) (byte-end a)))))
 
@@ -144,7 +148,7 @@
 (defn same-range?
   [a b]
   (let [a (validate-view! a) b (validate-view! b)]
-    (and (= (get-in a [:allocation :id]) (get-in b [:allocation :id]))
+    (and (= (allocation-key (:allocation a)) (allocation-key (:allocation b)))
          (= (:byte-offset a) (:byte-offset b))
          (= (:byte-length a) (:byte-length b)))))
 
@@ -152,6 +156,74 @@
   [view]
   (let [{:keys [shape strides]} (validate-view! view)]
     (= strides (dense-strides shape))))
+
+(defn subtract-contiguous
+  "Return portions of base untouched by cut; split fragments are one-dimensional typed views.
+   An untouched base retains its original shape.
+   This is physical range subtraction, not a copy or a semantic reshape. Different allocations
+   do not intersect. Overlapping cuts must be contiguous and aligned to base's element size;
+   cut dtype does not matter for write invalidation. Partial-element cuts fail closed."
+  [base cut]
+  (let [base (validate-view! base) cut (validate-view! cut)
+        a (:allocation base) b (:allocation cut)]
+    (when-not (contiguous? base)
+      (throw (ex-info "range subtraction requires a contiguous base"
+                      {:reason :buffer-view-region-layout :view (:id base)})))
+    (if (not= (allocation-key a) (allocation-key b))
+      [base]
+      (do
+        (when-not (= a b)
+          (throw (ex-info "one allocation identity must preserve its storage contract"
+                          {:reason :buffer-view-region-allocation :left a :right b})))
+        (let [start (:byte-offset base) end (+' start (:byte-length base))
+              lo (max start (:byte-offset cut))
+              hi (min end (+' (:byte-offset cut) (:byte-length cut)))]
+          (if (>= lo hi)
+            [base]
+            (let [width (dtype/bytes-of (:dtype base))]
+              (when-not (contiguous? cut)
+                (throw (ex-info "a strided write needs a physical region projection"
+                                {:reason :buffer-view-region-layout :view (:id cut)})))
+              (when-not (and (zero? (mod (-' lo start) width))
+                             (zero? (mod (-' hi start) width)))
+                (throw (ex-info "cut intersects only part of a typed element"
+                                {:reason :buffer-view-region-alignment
+                                 :view (:id base) :cut (:id cut)})))
+              (mapv (fn [[begin finish]]
+                      (view a {:byte-offset begin :dtype (:dtype base)
+                               :shape [(quot (-' finish begin) width)]}))
+                    (filter (fn [[begin finish]] (< begin finish)) [[start lo] [hi end]])))))))))
+
+(defn covered-contiguous?
+  "Whether same-dtype physical views jointly cover the complete contiguous target.
+   Coverage may come from several disjoint producers. Unrelated allocations/dtypes do not
+   supply typed initialization evidence. This checks geometry only, not producer provenance."
+  [target covers]
+  (let [target (validate-view! target)
+        covers (mapv validate-view! covers)
+        allocation (:allocation target)
+        related (filterv #(= (allocation-key allocation) (allocation-key (:allocation %))) covers)]
+    (when-not (contiguous? target)
+      (throw (ex-info "coverage requires a contiguous target"
+                      {:reason :buffer-view-region-layout :view (:id target)})))
+    (doseq [cover related]
+      (when-not (= allocation (:allocation cover))
+        (throw (ex-info "one allocation identity must preserve its storage contract"
+                        {:reason :buffer-view-region-allocation
+                         :left allocation :right (:allocation cover)}))))
+    (let [typed (filterv #(and (= (:dtype target) (:dtype %)) (overlaps? target %)) related)]
+      (doseq [cover typed]
+        (when-not (contiguous? cover)
+          (throw (ex-info "strided initialization requires a physical region projection"
+                          {:reason :buffer-view-region-layout :view (:id cover)}))))
+      (loop [cursor (:byte-offset target)
+             pending (sort-by :byte-offset typed)]
+        (cond
+          (>= cursor (+' (:byte-offset target) (:byte-length target))) true
+          (empty? pending) false
+          (> (:byte-offset (first pending)) cursor) false
+          :else (let [cover (first pending)]
+                  (recur (max cursor (+' (:byte-offset cover) (:byte-length cover))) (next pending))))))))
 
 (defn contains-contiguous-view?
   "Whether base covers a dense, same-dtype view in the identical allocation contract."

--- a/test/raster/compiler/ir/buffer_view_test.clj
+++ b/test/raster/compiler/ir/buffer_view_test.clj
@@ -27,6 +27,8 @@
         empty (view/view allocation {:dtype :float :byte-offset 8 :shape [0]})]
     (is (not (view/overlaps? base remote)))
     (is (not (view/same-range? base remote)))
+    (is (not (view/same-range? base (assoc-in base [:allocation :device] nil)))
+        "nil placement is not a wildcard for a concrete device")
     (is (not (view/covered-contiguous? base [remote])))
     (is (not (view/overlaps? base empty)))
     (is (not (view/overlaps? empty base)))

--- a/test/raster/compiler/ir/buffer_view_test.clj
+++ b/test/raster/compiler/ir/buffer_view_test.clj
@@ -21,6 +21,62 @@
                           (view/view allocation {:id :other-name :dtype :float
                                                  :shape [1024]})))))
 
+(deftest physical-range-identity-is-device-scoped-and-empty-views-do-not-overlap
+  (let [base (view/view allocation {:dtype :float :shape [8]})
+        remote (assoc-in base [:allocation :device] :cuda:0)
+        empty (view/view allocation {:dtype :float :byte-offset 8 :shape [0]})]
+    (is (not (view/overlaps? base remote)))
+    (is (not (view/same-range? base remote)))
+    (is (not (view/covered-contiguous? base [remote])))
+    (is (not (view/overlaps? base empty)))
+    (is (not (view/overlaps? empty base)))
+    (is (view/disjoint? base empty))))
+
+(deftest regional-writes-preserve-untouched-initialization
+  (let [base (view/view allocation {:dtype :double :shape [8]})
+        cut (view/view allocation {:dtype :double :byte-offset 16 :shape [2]})
+        remaining (view/subtract-contiguous base cut)]
+    (is (= [[0 16] [32 32]] (mapv (juxt :byte-offset :byte-length) remaining)))
+    (is (every? view/buffer-view? remaining))
+    (is (every? #(= allocation (:allocation %)) remaining))
+    (is (not (view/covered-contiguous? base remaining)))
+    (is (view/covered-contiguous? base (conj remaining cut)))
+    (is (view/covered-contiguous? base (reverse (conj remaining cut))))
+    (is (= [] (view/subtract-contiguous base base)))
+    (is (= [base] (view/subtract-contiguous base (assoc-in cut [:allocation :device] :cuda:0))))
+    (is (= remaining
+           (view/subtract-contiguous base (view/view allocation {:dtype :byte :byte-offset 16 :shape [16]}))))
+    (is (not (view/covered-contiguous? base [(view/view allocation {:dtype :byte :shape [64]})])))
+    (is (view/covered-contiguous? (view/view allocation {:dtype :double :shape [0]}) []))
+    (is (= :buffer-view-region-alignment
+           (:reason (ex-data (try (view/subtract-contiguous base
+                                                           (view/view allocation {:dtype :byte :byte-offset 1 :shape [1]}))
+                                 (catch clojure.lang.ExceptionInfo e e))))))))
+
+(deftest region-coverage-does-not-hide-layout-or-allocation-conflicts
+  (let [base (view/view allocation {:dtype :float :shape [8]})
+        strided (view/view allocation {:dtype :float :shape [4] :strides [2]})
+        changed (assoc-in base [:allocation :ownership] :borrowed)
+        reason (fn [f] (:reason (ex-data (try (f) (catch clojure.lang.ExceptionInfo e e)))))]
+    (is (= :buffer-view-region-layout (reason #(view/subtract-contiguous base strided))))
+    (is (= :buffer-view-region-layout (reason #(view/covered-contiguous? base [base strided]))))
+    (is (view/covered-contiguous? base [base (assoc strided :byte-offset 128)])
+        "a disjoint strided view supplies no evidence and does not prevent valid coverage")
+    (doseq [covers [[base changed] [changed base]]]
+      (is (= :buffer-view-region-allocation (reason #(view/covered-contiguous? base covers)))))
+    (is (= :buffer-view-region-allocation (reason #(view/subtract-contiguous base changed))))))
+
+(deftest contiguous-subtraction-agrees-with-an-element-set-model
+  (let [base (view/view allocation {:dtype :float :byte-offset 8 :shape [8]})
+        cells (fn [v] (set (range (quot (:byte-offset v) 4)
+                                 (quot (+ (:byte-offset v) (:byte-length v)) 4))))]
+    (doseq [start (range 13) end (range start 13)]
+      (let [cut (view/view allocation {:dtype :float :byte-offset (* 4 start) :shape [(- end start)]})
+            remaining (view/subtract-contiguous base cut)
+            expected (into #{} (remove (cells cut)) (cells base))]
+        (is (= expected (into #{} (mapcat cells) remaining)))
+        (is (view/covered-contiguous? base (conj remaining cut)))))))
+
 (deftest prefix-views-require-the-same-allocation-and-typed-range
   (let [base (view/view allocation {:dtype :float :shape [16]})
         prefix (view/subview base {:shape [8]})


### PR DESCRIPTION
Continues #552 toward distributed readiness. Adds BufferView subtraction and union-coverage geometry so writes invalidate only intersecting regions and several producers may jointly satisfy a read. Split remnants are ordinary typed views; geometry alone proves no provenance/runtime readiness. Cut dtype may differ for invalidation but element boundaries must align; initialization evidence must match dtype. Rejects contradictory allocation contracts and overlapping strided evidence, while disjoint strided views do not obstruct coverage. Unifies overlaps?/same-range? with device-scoped allocation identity, makes nil a distinct non-wildcard scope, and fixes zero-length interior views falsely overlapping. Validation:10 focused view tests241 assertions including exhaustive small element-set oracle; adjacent compiler/planner74/569 passed before two final positive identity/strided assertions; actualGPU numerical6/23 passed. Read-only review and identity follow-up completed with no blocker. Full gates delegated to CircleCI. Next integrate producer identities, DAG ordering, initialization and stale-replica checks.