### PR TITLE
Check distributed DAG initialization and producer freshness

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -1,9 +1,9 @@
 # Distributed materialization and execution boundary
 
 Status: owned-domain normalization, copy-replica geometry/coverage and exact boundary
-provider bindings and contiguous halo endpoint projection are implemented; initialization/freshness,
-runtime allocation/transport realization and execution
-remain a reviewed plan.
+provider bindings, contiguous halo endpoint projection and conditional DAG readiness are implemented.
+Source realization, resource ownership/lifetimes, runtime allocation/transport and execution remain
+a reviewed implementation plan.
 
 The current `distributed-plan/compute-bindings` accepts an explicit `:local-shape` with one owned
 placement and optional copy replicas that together cover the entire local domain. Its report retains the original ABI leaf views and
@@ -150,6 +150,23 @@ policy exists. These helpers establish geometry only; the DAG checker must retai
 on each fragment and reject unordered conflicting effects and stale replicas.
 The existing `overlaps?` and `same-range?` predicates use the same device-scoped identity;
 zero-byte views never overlap a nonempty range, including when their offset lies inside it.
+
+`distributed-plan/check-readiness` now combines the local contracts, strict copy endpoints and
+region operations into a conditional DAG check. Every compute must bind an executable local plan.
+The checker rejects unordered read/write conflicts (including private local effect scopes),
+requires complete typed coverage before a read, and checks that replica/boundary regions still
+originate from their declared transfer/provider. A later writer removes that provenance while
+preserving disjoint fragments. Being initialized is therefore not enough to satisfy a stale replica.
+
+The returned `:initializers` are explicit obligations: all declared host sources must be realized
+once before the DAG, with no implicit later reuploads. Overlapping initializers must identify the
+same source object and exact view; this is deliberately conservative and is not source snapshot
+certification. Initializer scopes are currently required at each local invocation conservatively.
+`:actions` records required/read/write/produced scopes, and `:final-regions` retains producer IDs.
+This is not a runnable distributed executable or a full ownership/semantic-equivalence certificate.
+Allocation sharing, private-storage lifetime isolation, runtime pending-input reconciliation and
+actual event/transport completion remain required. Unknown narrow write footprints retain whole-ABI
+invalidation; a produced prefix alone is not substituted for a certified write footprint.
 
 Lower dependencies to the existing ExecutionPlan logical queues/events and reuse the LinkPlan
 executable binder. Keep a synchronous executor as an explicit backend capability, not an implicit

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -13,6 +13,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.abstract-value :as abstract-value]
             [raster.compiler.ir.distributed-compute :as compute]
+            [raster.compiler.ir.distributed-readiness :as readiness]
             [raster.compiler.ir.execution-plan :as execution-plan]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.ir.scan :as scan]
@@ -886,6 +887,14 @@
    initialization/freshness, shared allocation and transport capabilities remain obligations."
   [plan]
   (compute/transfer-bindings (validate-structure! plan)))
+
+(defn check-readiness
+  "Check conditional physical initialization, DAG effect ordering and replica/boundary freshness.
+   Returns startup initializer obligations, action scopes and final initialized regions. Requires
+   bound compute and strict copy endpoints; no allocation or execution occurs. Source snapshots,
+   resource ownership, runtime input gates and event completion remain runtime obligations."
+  [plan]
+  (readiness/check (validate-structure! plan)))
 
 (defn plan
   [{:keys [id mesh topology values shards collective-groups collectives

--- a/src/raster/compiler/ir/distributed_readiness.clj
+++ b/src/raster/compiler/ir/distributed_readiness.clj
@@ -1,0 +1,131 @@
+(ns raster.compiler.ir.distributed-readiness
+  "Conditional physical initialization and producer freshness over a validated distributed DAG.
+   No runtime resources are created and declared sources are not treated as immutable snapshots."
+  (:require [raster.compiler.ir.buffer-view :as view]
+            [raster.compiler.ir.distributed-compute :as compute]
+            [raster.compiler.ir.link-plan :as link]
+            [raster.compiler.ir.validate :refer [fail!]]))
+
+(defn- allocation-key [v]
+  [(get-in v [:allocation :device]) (get-in v [:allocation :id])])
+
+(defn- dense! [v]
+  (when-not (view/contiguous? v)
+    (fail! "readiness needs a contiguous physical region projection"
+           :distributed-readiness-layout {:view (:id v)}))
+  v)
+
+(defn- node-views [plan ids]
+  (mapv #(dense! (get-in plan [:nodes % :view])) (sort-by pr-str ids)))
+
+(defn- compute-action [step entry]
+  (let [plan (:link-plan entry)
+        contract (link/initialization-contract plan)
+        ;; Declared initializers are conditional local preconditions too. Until local analysis
+        ;; distinguishes used initializer subregions, retain their complete scopes conservatively.
+        requires (node-views plan (into (:requires contract) (:initializers contract)))]
+    {:id (:id step) :kind :compute
+     :requires requires :reads (node-views plan (:reads contract))
+     :writes (node-views plan (:writes contract))
+     :produces (node-views plan (:produces contract))
+     :fresh (vec (for [[_ binding] (:values entry)
+                       placement (get-in binding [:domain :placements])
+                       :when (and (contains? #{:replica :boundary} (:kind placement))
+                                  (some #(view/overlaps? % (:view placement)) requires))]
+                   {:view (dense! (:view placement))
+                    :producer (case (:kind placement)
+                                :replica (:transfer placement)
+                                :boundary (get-in placement [:provider :step]))}))
+     :initializers (mapv (fn [id]
+                          {:id [(:device step) (:entry entry) id]
+                           :view (dense! (get-in plan [:nodes id :view]))
+                           :source (get-in plan [:nodes id :source])})
+                        (sort-by pr-str (:initializers contract)))}))
+
+(defn- initialization-facts [initializers]
+  (reduce
+   (fn [accepted {:keys [view source] :as candidate}]
+     (let [overlapping (filter #(view/overlaps? view (:view %)) accepted)]
+       (when (some #(not (and (= (dissoc view :id) (dissoc (:view %) :id))
+                              (identical? source (:source %)))) overlapping)
+         (fail! "overlapping startup initializers need one unambiguous source realization"
+                :distributed-readiness-initializers {:initializer (:id candidate)}))
+       (if (seq overlapping) accepted (conj accepted candidate)))) [] initializers))
+
+(defn- check-races [history ancestors action]
+  (reduce
+   (fn [history [v access]]
+     (let [key (allocation-key v)]
+       (doseq [{other :step previous :view previous-access :access} (get history key)
+               :when (and (not= other (:id action))
+                          (or (= :write access) (= :write previous-access))
+                          (view/overlaps? v previous)
+                          (not (contains? ancestors other)))]
+         (fail! "conflicting physical effects must be ordered by the distributed DAG"
+                :distributed-readiness-race {:step (:id action) :other other :allocation key}))
+       (update history key (fnil conj []) {:step (:id action) :view v :access access})))
+   ;; Preconditions also observe storage: pass-through outputs need no ABI load, but
+   ;; their producer must happen before this action, not merely earlier in this traversal.
+   history (concat (map #(vector % :read)
+                        (distinct (concat (:reads action) (:requires action)
+                                          (map :view (:fresh action)))))
+                   (map #(vector % :write) (:writes action)))))
+
+(defn- require-covered! [facts v producer step]
+  (let [covers (map :view (if (some? producer) (filter #(= producer (:producer %)) facts) facts))]
+    (when-not (view/covered-contiguous? v covers)
+      (fail! (if (some? producer) "required producer's region is absent or stale"
+                 "physical read has no complete initialization evidence")
+             (if (some? producer) :distributed-readiness-stale :distributed-readiness-uninitialized)
+             {:step step :view (:id v) :producer producer}))))
+
+(defn check
+  "Check a structurally validated plan, conditional on startup sources and successful events.
+   Every compute must bind a LinkPlan and every transfer must resolve exact copy endpoints.
+   All declared initializers must be realized once before the DAG, without later implicit
+   reuploads. Their source objects remain caller-owned mutable obligations, not certificates.
+   Returned actions and source requirements are not a runnable executable: allocation sharing,
+   ownership/lifetimes, runtime input gates and actual transport/event completion still need proof."
+  [{:keys [steps] :as plan}]
+  (let [{:keys [bindings unbound]} (compute/bindings plan)
+        _ (when (seq unbound)
+            (fail! "readiness requires all compute steps to be bound"
+                   :distributed-readiness-unbound {:steps unbound}))
+        endpoints (compute/transfer-bindings plan)
+        actions (mapv (fn [step]
+                        (case (:kind step)
+                          :compute (compute-action step (get bindings (:id step)))
+                          :transfer (let [{:keys [source target]} (get endpoints (:id step))]
+                                      {:id (:id step) :kind :transfer
+                                       :requires [(:view source)] :reads [(:view source)]
+                                       :writes [(:view target)] :produces [(:view target)]}))) steps)
+        views (mapcat #(concat (:requires %) (:reads %) (:writes %) (:produces %)
+                               (map :view (:initializers %))) actions)
+        _ (reduce (fn [seen v]
+                    (let [key (allocation-key v) a (:allocation v)]
+                      (when (and (contains? seen key) (not= (get seen key) a))
+                        (fail! "one physical allocation cannot have conflicting contracts"
+                               :distributed-readiness-allocation {:allocation key}))
+                      (assoc seen key a))) {} views)
+        initializers (initialization-facts (mapcat :initializers actions))
+        ancestors (reduce (fn [known step]
+                            (assoc known (:id step)
+                                   (into (set (:dependencies step))
+                                         (mapcat #(get known %) (:dependencies step))))) {} steps)]
+    (loop [remaining actions
+           facts (mapv #(hash-map :view (:view %) :initializer (:id %)) initializers)
+           history {}]
+      (if-let [action (first remaining)]
+        (let [history (check-races history (get ancestors (:id action)) action)]
+          (doseq [v (:requires action)] (require-covered! facts v nil (:id action)))
+          (doseq [{:keys [view producer]} (:fresh action)]
+            (require-covered! facts view producer (:id action)))
+          (let [facts (reduce (fn [facts write]
+                                (into [] (mapcat (fn [fact]
+                                                  (map #(assoc fact :view %)
+                                                       (view/subtract-contiguous (:view fact) write)))) facts))
+                              facts (:writes action))
+                facts (into facts (map #(hash-map :view % :producer (:id action)) (:produces action)))]
+            (recur (next remaining) facts history)))
+        {:initializers initializers :actions (mapv #(dissoc % :initializers) actions)
+         :final-regions facts}))))

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -277,7 +277,7 @@
                     :steps [{:phase :fill :kernel-name "fill_boundary" :convention :map
                              :artifact kernel :argument-specs [{:kind :output :sym 'y}]}]
                     :result-sym 'y}]
-    (link/make {:id :boundary-fill :target :gpu-0
+    (link/make {:id :boundary-fill :target (get-in physical-view [:allocation :device])
                 :nodes [(link/node {:id :boundary-node :role :output :view physical-view})]
                 :values [(link/value {:id :boundary-output :abstract (local-abstract [2])
                                       :leaves [{:name :value :node :boundary-node}]})]
@@ -403,6 +403,142 @@
         "right periodic upper face: padding plus three owned-relative rows")
     (is (= 24 (get-in endpoints [[:periodic :edge 0 :backward] :target :view :byte-offset])))
     (is (= 40 (get-in endpoints [[:periodic :edge 1 :backward] :target :view :byte-offset])))))
+
+(defn- initialized-periodic-plan []
+  (reduce (fn [plan device]
+            (assoc-in plan [:device-plans device :entries :copy :link-plan :nodes :x-node :source]
+                      (float-array 6)))
+          (fully-bound-periodic-plan) [:gpu-0 :gpu-1]))
+
+(deftest readiness-composes-initializers-transfers-and-local-contracts
+  (let [plan (distributed/plan (initialized-periodic-plan))
+        ready (distributed/check-readiness plan)]
+    (is (= 4 (count (:initializers ready))))
+    (is (= 6 (count (:actions ready))))
+    (is (= (mapv :id (:steps plan)) (mapv :id (:actions ready))))
+    (is (= #{[8 8]}
+           (into #{} (keep (fn [{:keys [view initializer]}]
+                             (when (and initializer (= :x-node (get-in view [:allocation :id])))
+                               [(:byte-offset view) (:byte-length view)]))) (:final-regions ready)))
+        "ghost writes preserve the independently initialized owned row")
+    (is (= :distributed-readiness-uninitialized
+           (failure-reason #(distributed/check-readiness
+                             (assoc-in plan [:device-plans :gpu-0 :entries :copy :link-plan
+                                             :nodes :x-node :source] nil)))))
+    (is (= :distributed-readiness-unbound
+           (failure-reason #(distributed/check-readiness (make-plan)))))))
+
+(deftest nonperiodic-readiness-requires-both-boundary-and-halo-producers
+  (let [base (initialized-periodic-plan)
+        old (get-in base [:halos 0])
+        halo (distributed/schedule-halo (assoc (:exchange old) :boundary :nonperiodic)
+                                        (get-in base [:values :x]) (get-in base [:shards :x]) (:routes old) [])
+        providers [(distributed/compute-step {:id :lower-boundary :device :gpu-0 :duration-ns 1})
+                   (distributed/compute-step {:id :upper-boundary :device :gpu-1 :duration-ns 1})]
+        computes (filterv #(= :compute (:kind %)) (:steps base))
+        base (assoc base :halos [halo]
+                    :steps (into (into providers (:steps halo))
+                                 (assoc-in computes [0 :dependencies]
+                                           (into (:completions halo) (map :id providers)))))
+        plan (reduce
+              (fn [plan [device step provider row]]
+                (let [base-view (get-in plan [:device-plans device :entries :copy :link-plan :nodes :x-node :view])
+                      incoming (first (filter #(= device (:target %)) (:steps halo)))
+                      owner (get-in plan [:device-plans device :steps step :bindings :local-x :placements 0])]
+                  (-> plan
+                      (assoc-in [:device-plans device :entries provider]
+                                {:link-plan (boundary-fill-plan (view/subview base-view {:byte-offset (* row 8) :shape [2]}))})
+                      (assoc-in [:device-plans device :steps provider] {:entry provider :bindings {}})
+                      (assoc-in [:device-plans device :steps step :bindings :local-x :placements]
+                                [owner {:kind :replica :transfer (:id incoming)}
+                                 {:kind :boundary :region {:offsets [row 0] :shape [1 2]}
+                                  :provider {:step provider :local-value :boundary-output}}]))))
+              base [[:gpu-0 :copy-0 :lower-boundary 0] [:gpu-1 :analytical-only :upper-boundary 2]])
+        report (distributed/check-readiness (distributed/plan plan))
+        producers (into #{} (mapcat #(map :producer (:fresh %))) (:actions report))]
+    (is (= 6 (count (:actions report))))
+    (is (contains? producers :lower-boundary))
+    (is (contains? producers :upper-boundary))))
+
+(deftest readiness-rejects-unordered-physical-writes
+  (let [plan (initialized-periodic-plan)
+        call (get-in plan [:device-plans :gpu-0 :steps :copy-0])
+        race (distributed/compute-step {:id :racing-copy :device :gpu-0 :duration-ns 1
+                                         :dependencies (get-in plan [:halos 0 :completions])})
+        plan (-> plan (update :steps conj race)
+                 (assoc-in [:device-plans :gpu-0 :steps :racing-copy] call))]
+    (is (distributed/distributed-plan? (distributed/plan plan)))
+    (is (= :distributed-readiness-race
+           (failure-reason #(distributed/check-readiness (distributed/plan plan)))))
+    (is (map? (distributed/check-readiness
+               (distributed/plan (update plan :steps
+                                         (fn [steps] (mapv #(if (= :racing-copy (:id %))
+                                                              (assoc % :dependencies [:copy-0]) %) steps)))))))))
+
+(deftest readiness-orders-pass-through-preconditions-without-abi-reads
+  (let [base (initialized-periodic-plan)
+        output-view (get-in base [:device-plans :gpu-0 :entries :copy :link-plan :nodes :y-node :view])
+        scratch (link/node {:id :unrelated :dtype :float :shape [2] :device :gpu-0 :role :internal})
+        passthrough (-> (boundary-fill-plan (:view scratch))
+                        (assoc-in [:nodes :pass] (link/node {:id :pass :role :input :view output-view}))
+                        (assoc-in [:values :pass]
+                                  (link/value {:id :pass :abstract (local-abstract [2 3])
+                                               :leaves [{:name :value :node :pass}]}))
+                        (assoc :outputs [:pass]))
+        plan (-> base
+                 (assoc-in [:device-plans :gpu-0 :entries :pass] {:link-plan passthrough})
+                 (assoc-in [:device-plans :gpu-0 :steps :pass]
+                           {:entry :pass :bindings {:pass {:value :y :shard :y-0}}})
+                 (update :steps conj (distributed/compute-step
+                                     {:id :pass :device :gpu-0 :duration-ns 1})))
+        contract (link/initialization-contract passthrough)]
+    (is (contains? (:requires contract) :pass))
+    (is (not (contains? (:reads contract) :pass)))
+    (is (= :distributed-readiness-race
+           (failure-reason #(distributed/check-readiness (distributed/plan plan))))
+        "vector order must not substitute for a producer dependency")
+    (is (map? (distributed/check-readiness
+               (distributed/plan (update plan :steps
+                                         (fn [steps] (mapv #(if (= :pass (:id %))
+                                                              (assoc % :dependencies [:copy-0]) %) steps)))))))))
+
+(deftest an-initialized-but-overwritten-replica-is-not-fresh
+  (let [plan (initialized-periodic-plan)
+        plan (-> plan
+                 (assoc-in [:device-plans :gpu-0 :entries :copy :link-plan :nodes :x-node :role] :state)
+                 (assoc-in [:device-plans :gpu-0 :entries :copy :link-plan :instances 0 :bindings 'y] :local-x)
+                 (assoc-in [:device-plans :gpu-0 :entries :copy :link-plan :outputs] [:x-node])
+                 (update-in [:device-plans :gpu-0 :steps :copy-0 :bindings] dissoc :local-y))
+        ;; The unused old y node is private storage, not an exported result.
+        plan (assoc-in plan [:device-plans :gpu-0 :entries :copy :link-plan :nodes :y-node :role] :internal)
+        call (get-in plan [:device-plans :gpu-0 :steps :copy-0])
+        again (distributed/compute-step {:id :again :device :gpu-0 :duration-ns 1 :dependencies [:copy-0]})
+        plan (-> plan (update :steps conj again)
+                 (assoc-in [:device-plans :gpu-0 :steps :again] call))]
+    (is (distributed/distributed-plan? (distributed/plan plan)))
+    (is (= :distributed-readiness-stale
+           (failure-reason #(distributed/check-readiness (distributed/plan plan))))
+        "a full state write initializes storage but invalidates the earlier transfer's provenance")
+    (let [old (get-in plan [:halos 0])
+          refresh (distributed/schedule-halo (assoc (:exchange old) :id :refresh)
+                                             (get-in plan [:values :x]) (get-in plan [:shards :x])
+                                             (:routes old) [:copy-0 :analytical-only])
+          retarget (fn [call]
+                     (update-in call [:bindings :local-x :placements]
+                                (fn [ps] (mapv #(if (= :replica (:kind %))
+                                                  (update % :transfer assoc 0 :refresh) %) ps))))
+          refreshed (-> plan
+                        (update :halos conj refresh)
+                        (assoc :steps (into (into (vec (remove #(= :again (:id %)) (:steps plan)))
+                                                  (:steps refresh))
+                                            [(assoc again :dependencies (:completions refresh))
+                                             (distributed/compute-step {:id :other-again :device :gpu-1
+                                                                        :duration-ns 1 :dependencies (:completions refresh)})]))
+                        (update-in [:device-plans :gpu-0 :steps :again] retarget)
+                        (assoc-in [:device-plans :gpu-1 :steps :other-again]
+                                  (retarget (get-in plan [:device-plans :gpu-1 :steps :analytical-only]))))]
+      (is (= 12 (count (:actions (distributed/check-readiness (distributed/plan refreshed)))))
+          "explicitly refreshed transfers establish the next iteration's replica provenance"))))
 
 (deftest strided-faces-require-pack-unpack-not-a-bounding-span-copy
   (let [base (fully-bound-periodic-plan)


### PR DESCRIPTION
## Summary
- Compose existing LinkPlan initialization contracts and exact halo endpoints into conditional physical-region readiness checks.
- Reject unordered overlapping effects, missing initialization, conflicting startup sources and stale replica/boundary producers; preserve disjoint initialized fragments.
- Treat pass-through requirements as read-like ordering obligations without changing ABI read reports.
- Keep source realization, ownership/lifetimes, shared runtime allocation, input gates and actual event completion explicit outstanding obligations. This is not yet a distributed executor.

## Validation
- Focused and adjacent region/LinkPlan/distributed tests: 63 tests, 529 assertions, zero failures/errors.
- Real GPU numerical halo and mapped checkpoint continuation: 6 tests, 23 assertions, zero failures/errors.
- Regression rejects vector-order-only pass-through production and accepts an explicit dependency.
- Full suites delegated to CircleCI.

Stacked on #553; independent review follow-up in progress.