### PR TITLE
Derive runtime input gates from shared local initialization analysis

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -112,11 +112,12 @@ alias requirements retain the actual requested subview. Declared source initiali
 from caller obligations and are not immutable snapshots or completed uploads. Produced storage
 does not imply retained semantic identity for private temporary values. These are conditional
 local facts; distributed lowering still needs to discharge them and establish freshness.
-The facts are conservative, not minimal across all aliases. The current `gpu.link` runtime also
-maintains `pending-inputs` for every owned, source-less input/constant/state node, including nodes
-that this analysis proves unused or written before reading. An executor must reconcile that gate
-with proven initialization and shared external bindings; it must not simply treat an empty
-`:requires` set as permission to bypass existing `run!` input checks.
+The facts are conservative, not minimal across all aliases. The `gpu.link` runtime now derives
+owned `pending-inputs` from this same `:requires` set, so unused inputs and state fully produced
+before reading do not demand redundant uploads. Pass-through outputs still require initialization.
+Borrowed/external buffers retain their existing caller-initialized contract; importing a buffer
+does not itself prove completion of a distributed producer. A distributed executor must discharge
+those external preconditions through actual completed events, not bypass `run!` input checks.
 
 The proof reuses LinkPlan's ordered instance access facts and its existing
 `produced-views`/`partial-writes` accounting. `value-accesses` deliberately summarizes ABI access

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -104,6 +104,7 @@
   ([plan {:keys [session external-buffers profile?] :or {external-buffers {} profile? false}}]
    ;; This is intentionally the first operation. Everything below may contact a backend.
    (let [plan (link-plan/validate! plan)
+         initialization (link-plan/initialization-contract plan)
          program-instances (filterv link-plan/program-link-instance? (:instances plan))
          _ (when (and (seq program-instances) (not= 1 (count (:instances plan))))
              (throw (ex-info
@@ -234,10 +235,9 @@
            (->LinkedExecutable plan session owns-session? @recorded-key @phases @prepared-program
                                @allocation-keys node-views
                                (atom (into #{}
-                                           (keep (fn [[node-id {:keys [role source view]}]]
-                                                   (when (and (contains? #{:input :constant :state}
-                                                                         role)
-                                                              (nil? source)
+                                           (keep (fn [[node-id {:keys [view]}]]
+                                                   (when (and (contains? (:requires initialization)
+                                                                         node-id)
                                                               (= :owned (get-in view
                                                                                 [:allocation
                                                                                  :ownership])))

--- a/test/raster/gpu/link_initialization_test.clj
+++ b/test/raster/gpu/link_initialization_test.clj
@@ -1,0 +1,59 @@
+(ns raster.gpu.link-initialization-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.kernel-abi :as abi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.link-plan :as link]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.link :as runtime]))
+
+(defn- copy-plan []
+  (let [kernel (artifact/make
+                {:kernel-name "copy" :source "__kernel void copy(__global const float* x, __global float* y) {}"
+                 :abi [(abi/slot 'x :input :float) (abi/slot 'y :output :float)]
+                 :arguments '[x y]
+                 :launch (launch/spec {:workgroup-size [1] :group-count [2]})
+                 :effects {:kind :map :reads '[x] :writes '[y]}})
+        descriptor {:dtype :float :all-params '[x] :array-params '[x] :scalar-params []
+                    :array-roles {'x :input}
+                    :allocs [{:sym 'y :dtype :float :size-fn (fn [_] 2)}]
+                    :steps [{:phase :copy :kernel-name "copy" :convention :map :artifact kernel
+                             :argument-specs [{:kind :input :sym 'x} {:kind :output :sym 'y}]}]
+                    :result-sym 'y}
+        node (fn [id role] (link/node {:id id :role role :device :ze:0 :dtype :float :shape [2]}))
+        instance (fn [id x y] (link/instance {:id id :descriptor descriptor
+                                             :bindings {'x x 'y y} :scalars {}}))]
+    (link/make {:id :initialization :target :ze:0
+                :nodes [(node :x :input) (node :unused :input)
+                        (node :scratch :state) (node :out :output)]
+                :instances [(instance :first :x :scratch) (instance :second :scratch :out)]
+                :outputs [:out]})))
+
+(deftest runtime-gates-use-local-preconditions-not-node-roles
+  (let [replays (atom 0)
+        uploads (atom 0)
+        session (atom {:device-id :ze:0})]
+    ;; Only backend operations are stubbed: real validation, instantiation, upload and run gates
+    ;; remain active. This is a hardware-free contract test, not numerical kernel validation.
+    (with-redefs [gpu/alloc! (fn [& _])
+                  gpu/buffer-view (fn [_ key opts] (assoc opts :buffer-key key))
+                  gpu/bind-step! (fn [& _])
+                  gpu/record-graph! (fn [& _])
+                  gpu/upload-range! (fn [& _] (swap! uploads inc))
+                  gpu/replay! (fn [& _] (swap! replays inc))]
+      (let [executable (runtime/instantiate! (copy-plan) {:session session})]
+        (is (= #{:x} @(:pending-inputs executable))
+            "unused input and locally produced state require no caller upload")
+        (is (= :link-pending-inputs
+               (try (runtime/run! executable) nil
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+        (is (zero? @replays))
+        (runtime/upload! executable :x (float-array [1 2]))
+        (runtime/run! executable)
+        (runtime/run! executable)
+        (is (= 1 @uploads))
+        (is (= 2 @replays)))
+      (let [plan (update (copy-plan) :outputs conj :unused)
+            executable (runtime/instantiate! plan {:session session})]
+        (is (= #{:x :unused} @(:pending-inputs executable))
+            "an exported pass-through input remains a real initialization requirement")))))


### PR DESCRIPTION
Shared LinkPlan initialization analysis now drives owned pending inputs. Real inputs and pass-through outputs remain gated; unused or locally produced buffers need no redundant upload. External caller obligations unchanged. Runtime and GPU numerical tests: 17 tests75 assertions pass. Reviewed with no blocker. Stacked on #554.