### PR TITLE
Borrow local compiler storage from an enclosing allocation owner

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -176,6 +176,20 @@ realizations of the scheduling boundary, not native handles inside the semantic 
 
 ## Laptop acceptance and landing order
 
+`link-plan/borrow-owned-storage` is the checked local ownership projection for an enclosing
+allocation owner. It preserves executable instances, roles, logical shapes and physical views,
+changes owned physical/logical ownership to borrowed, and extracts the original allocation
+contracts and host initializers. The projected LinkPlan cannot silently reupload those sources.
+Already borrowed/external allocations retain their contracts. The returned initialization facts
+describe the original program's obligations; projection itself proves neither initialization nor
+lifetime. The enclosing owner must reconcile shared initializers, realize them once, retain buffers
+through completion, and release borrower registrations before freeing storage.
+
+A real GPU acceptance now runs two successive generated heat executables over the same owning
+session buffers. Closing the first removes only its borrowed registrations; the second continues
+resident state without reuploading the original source and matches four CPU reference steps.
+This validates the local storage seam, not DistributedPlan execution or cross-device transport.
+
 The current DistributedPlan enforces one shard of a value per mesh device and requires distinct
 transfer endpoints with nonempty routes. A real co-located two-shard execution therefore needs an
 explicit local-copy lowering or a certified logical-to-runtime placement map. Do not silently map

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -1062,6 +1062,39 @@
     (validate! (->LinkPlan id target nodes values (vec instances) (vec outputs) aliases
                            attributes))))
 
+(defn borrow-owned-storage
+  "Project a local plan's owned allocations into storage borrowed from an enclosing execution.
+   Returns the validated :plan plus original :allocations and :initializers to realize once in
+   the owner. Initialization requirements refer to the original plan, before sources are removed.
+   No allocation, upload, ownership transfer or initialization proof occurs here. The owner must
+   keep every supplied buffer alive through all local execution and release borrowed registrations
+   before freeing storage. Already external/borrowed allocations retain their original contracts."
+  [plan]
+  (let [plan (validate! plan)
+        initialization (initialization-contract plan)
+        owned? (fn [node] (= :owned (get-in node [:view :allocation :ownership])))
+        allocations (into {} (keep (fn [[_ node]]
+                                     (when (owned? node)
+                                       (let [a (get-in node [:view :allocation])]
+                                         [(:id a) a])))) (:nodes plan))
+        initializers (into {} (keep (fn [[id node]]
+                                     (when (:source node) [id {:view (:view node) :source (:source node)}])))
+                           (:nodes plan))
+        nodes (update-vals (:nodes plan)
+                           (fn [node]
+                             (if (owned? node)
+                               (-> node (assoc :source nil)
+                                   (assoc-in [:view :allocation :ownership] :borrowed))
+                               node)))
+        values (update-vals (:values plan)
+                            (fn [value]
+                              (if (owned? (get-in plan [:nodes (get-in value [:leaves 0 :node])]))
+                                (assoc-in value [:abstract :ownership] :borrowed)
+                                value)))]
+    {:plan (validate! (assoc plan :nodes nodes :values values))
+     :allocations allocations :initializers initializers
+     :initialization initialization}))
+
 (defn instance-roles
   "Resolve compiler-symbol roles for the runtime binder. Only `:constant` affects executable
    prologue hoisting today; the complete role map remains data for residency/lifetime policy."

--- a/test/raster/compiler/distributed_numerical_test.clj
+++ b/test/raster/compiler/distributed_numerical_test.clj
@@ -9,6 +9,7 @@
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.buffer-view :as view]
             [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.ir.numerical-state :as state]
             [raster.runtime.numerical-content :as content]
             [raster.dl.gpu-grad-parity :as gp]
@@ -211,6 +212,38 @@
       (gpu/copy-range! (:session executable) (link/node-view executable output)
                        (link/node-view executable input) {:elements (* 8 width)}))
     output))
+
+(deftest compiled-heat-executables-borrow-one-continuation-allocation-pool
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "shared-owned-heat-storage")
+    (let [initial (:initial (problem))
+          n (alength ^doubles initial)
+          original (equation/lower @compiled-step [(double-array n) initial (double-array n) 8 width dt])
+          input (first (keep (fn [[id node]] (when (identical? initial (:source node)) id)) (:nodes original)))
+          {:keys [plan allocations initializers]} (link-plan/borrow-owned-storage original)
+          session (gpu/make-session :ze:0)]
+      (try
+        ;; This fixture owns all heat storage in one session. Local executable registrations
+        ;; borrow it; the fixture, not either executable, owns the allocation lifetime.
+        (is (every? #(= :double (get-in % [:view :dtype])) (vals (:nodes original))))
+        (gpu/alloc! session (into {} (map (fn [[id a]] [id [:double (quot (:byte-size a) Double/BYTES) nil]])) allocations))
+        (doseq [[_ {:keys [view source]}] initializers]
+          (gpu/upload-range! session
+                             (gpu/buffer-view session (get-in view [:allocation :id])
+                                              (select-keys view [:id :byte-offset :dtype :shape :strides]))
+                             source {:elements (reduce * 1 (:shape view))}))
+        (let [external (into {} (map (fn [id] [id (gpu/buffer session id)])) (keys allocations))
+              opts {:session session :external-buffers external}]
+          (with-open [first-execution (link/instantiate! plan opts)]
+            (advance-device! first-execution input 2))
+          (is (= (set (keys allocations)) (set (keys (:buffers @session))))
+              "closing the first borrower removes registrations, not owner buffers")
+          ;; No source upload occurs during the second instantiation; it continues resident state.
+          (with-open [second-execution (link/instantiate! plan opts)]
+            (let [output (advance-device! second-execution input 2)]
+              (is (< (max-error (reference initial) (link/download second-execution output)) 1.0e-10))))
+          (is (= (set (keys allocations)) (set (keys (:buffers @session))))))
+        (finally (gpu/close-session! session))))))
 
 (deftest mapped-checkpoint-restores-into-a-new-compiled-device-session
   (if-not @gp/gpu-available?

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -77,6 +77,25 @@
                   (instance :layer-1 :hidden :w1 :out)]
       :outputs [:out]})))
 
+(deftest borrowing-storage-preserves-code-and-extracts-owner-obligations
+  (let [original (valid-plan)
+        {:keys [plan allocations initializers initialization]} (link/borrow-owned-storage original)]
+    (is (= #{:x :w0 :w1 :hidden :out} (set (keys allocations))))
+    (is (every? #(= :owned (:ownership %)) (vals allocations)))
+    (is (= #{:x :w0 :w1} (set (keys initializers))))
+    (is (identical? (get-in original [:nodes :x :source]) (get-in initializers [:x :source])))
+    (is (= (link/initialization-contract original) initialization))
+    (is (every? #(and (nil? (:source %))
+                     (= :borrowed (get-in % [:view :allocation :ownership]))) (vals (:nodes plan))))
+    (is (every? #(= :borrowed (get-in % [:abstract :ownership])) (vals (:values plan))))
+    (is (= (:instances original) (:instances plan)))
+    (is (= (:outputs original) (:outputs plan)))
+    (is (= (get-in original [:nodes :x :view]) (get-in initializers [:x :view])))
+    (let [again (link/borrow-owned-storage plan)]
+      (is (= plan (:plan again)))
+      (is (empty? (:allocations again)))
+      (is (empty? (:initializers again))))))
+
 (deftest initialization-contract-separates-caller-data-from-ordered-producers
   (let [initialized (valid-plan)
         caller (update initialized :nodes


### PR DESCRIPTION
Checked LinkPlan ownership projection preserves code, roles and geometry while extracting original sources and allocation contracts for an enclosing owner. Borrowers do not free owner buffers or reupload sources. GPU acceptance runs two generated heat executables successively over one resident pool and matches four CPU steps. Adjacent36 tests186 assertions and GPU7 tests27 assertions pass. Review cleared; exact runtime owner allocation realization and full DistributedPlan execution remain next. Stacked on #555.