### PR TITLE
Keep late-upload constants behind runtime initialization gates

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -119,6 +119,13 @@ Borrowed/external buffers retain their existing caller-initialized contract; imp
 does not itself prove completion of a distributed producer. A distributed executor must discharge
 those external preconditions through actual completed events, not bypass `run!` input checks.
 
+Descriptor cacheable transforms can execute during graph recording. Runtime constant-role
+admission therefore also requires captured data (an owned source or caller-ready borrowed/external
+storage) with no overlapping local write. A late-uploaded owned constant is bound as a replay
+input instead: its initialization gate remains active and its transform is not run prematurely.
+Captured weights keep the existing one-time transform path. This does not authorize changing
+captured constant contents after instantiation without rebuilding their derived transforms.
+
 The proof reuses LinkPlan's ordered instance access facts and its existing
 `produced-views`/`partial-writes` accounting. `value-accesses` deliberately summarizes ABI access
 only; a `:write` entry is not an initialization postcondition. LinkPlan currently assumes caller

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -1068,7 +1068,9 @@
    the owner. Initialization requirements refer to the original plan, before sources are removed.
    No allocation, upload, ownership transfer or initialization proof occurs here. The owner must
    keep every supplied buffer alive through all local execution and release borrowed registrations
-   before freeing storage. Already external/borrowed allocations retain their original contracts."
+   before freeing storage. Already external/borrowed allocations retain their original contracts.
+   Projection fails closed if removing a source leaves an internal/output value without a valid
+   caller-input role or local producer; borrowed ownership alone is not initialization evidence."
   [plan]
   (let [plan (validate! plan)
         initialization (initialization-contract plan)

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -89,6 +89,24 @@
     (doseq [key (reverse allocation-keys)] (attempt! #(gpu/free-buffer! session key)))
     (when-let [error @failure] (throw error))))
 
+(defn- instance-runtime-roles
+  [plan instance initialization]
+  (let [writes (map #(get-in plan [:nodes % :view]) (:writes initialization))
+        captured? (fn [node]
+                    (and node
+                         (or (:source node)
+                             (contains? #{:borrowed :external}
+                                        (get-in node [:view :allocation :ownership])))
+                         (not-any? #(bview/overlaps? (:view node) %) writes)))]
+    (into {}
+          (map (fn [[symbol role]]
+                 (let [leaves (get-in plan [:values (get (:bindings instance) symbol) :leaves])]
+                   [symbol (if (and (= :constant role)
+                                    (not (and (seq leaves)
+                                              (every? #(captured? (get-in plan [:nodes (:node %)])) leaves))))
+                             :input role)])))
+          (link-plan/instance-roles plan instance))))
+
 (defn instantiate!
   "Instantiate a validated LinkPlan as one replayable LinkedExecutable.
 
@@ -227,7 +245,9 @@
                                                error))))))
                     {:schedule (or (:schedule instance)
                                    (get-in instance [:descriptor :schedule]))
-                     :roles (link-plan/instance-roles plan instance)})
+                     ;; Constant transforms may execute while recording, before run!'s input
+                     ;; gate. Only captured, locally unwritten values can enter that prologue.
+                     :roles (instance-runtime-roles plan instance initialization)})
                    (vswap! phases conj phase)))
                (let [gkey (graph-key execution-id)]
                  (gpu/record-graph! session @phases gkey {:profile? profile?})

--- a/test/raster/gpu/link_initialization_test.clj
+++ b/test/raster/gpu/link_initialization_test.clj
@@ -57,3 +57,29 @@
             executable (runtime/instantiate! plan {:session session})]
         (is (= #{:x :unused} @(:pending-inputs executable))
             "an exported pass-through input remains a real initialization requirement")))))
+
+(deftest constant-prologues-only-capture-initialized-locally-unwritten-values
+  (let [roles (atom [])
+        session (atom {:device-id :ze:0})
+        original (assoc-in (copy-plan) [:nodes :x :role] :constant)]
+    (with-redefs [gpu/alloc! (fn [& _])
+                  gpu/buffer-view (fn [_ key opts] (assoc opts :buffer-key key))
+                  gpu/bind-step! (fn [_ _ _ _ opts] (swap! roles conj (:roles opts)))
+                  gpu/record-graph! (fn [& _])
+                  gpu/upload-range! (fn [& _])]
+      (let [executable (runtime/instantiate! original {:session session})]
+        (is (= :input (get (first @roles) 'x))
+            "a late-upload constant must not be read by an instantiation-time prologue")
+        (is (= #{:x} @(:pending-inputs executable))))
+      (reset! roles [])
+      (runtime/instantiate! (assoc-in original [:nodes :x :source] (float-array [1 2])) {:session session})
+      (is (= :constant (get (first @roles) 'x))
+          "captured weights retain their one-time transform optimization")
+      (reset! roles [])
+      (is (= :link-role-mismatch
+             (try (runtime/instantiate! (assoc-in original [:instances 1 :roles 'x] :constant)
+                                        {:session session})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+          "the existing validator rejects relabeling writable state as a constant")
+      (is (empty? @roles)))))


### PR DESCRIPTION
Descriptor constant-transform admission now retains constant roles only for captured, locally unwritten storage. Late-uploaded owned constants remain replay inputs, preventing graph recording from consuming them before the pending-input gate. Source-backed weights preserve one-time conversion. Includes ownership projection wording clarification. Runtime/GPU composition/heat tests:19 tests84 assertions pass; independent review cleared. Stacked on compiler/link-storage-borrowing.