### PR TITLE
Execute co-located logical workers with explicit budgets and resident halo copies

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -199,9 +199,10 @@ staging (default 1 MiB) and synchronous download/upload chunks. This is not P2P,
 evidence that the topology's modeled link performance was achieved. The pool budget check covers
 the retained LinkPlan allocations, not all backend-private compilation/graph temporary memory.
 Source stability through initialization and constant immutability remain caller obligations.
-The new actual DAG acceptance is a single-device generated heat program. Bounded transfer tails,
+The actual DAG acceptance includes two logical workers on one physical GPU, with unequal owned
+regions and periodic halo copies over four generated heat epochs. Bounded transfer tails,
 allocation conflicts and failure cleanup have hardware-free tests; multi-device runtime execution
-and logical-worker co-location are not yet validated by that acceptance.
+is not yet validated by that acceptance.
 
 `link-plan/borrow-owned-storage` is the checked local ownership projection for an enclosing
 allocation owner. It preserves executable instances, roles, logical shapes and physical views,
@@ -217,11 +218,18 @@ session buffers. Closing the first removes only its borrowed registrations; the 
 resident state without reuploading the original source and matches four CPU reference steps.
 This validates the local storage seam, not DistributedPlan execution or cross-device transport.
 
-The current DistributedPlan enforces one shard of a value per mesh device and requires distinct
-transfer endpoints with nonempty routes. A real co-located two-shard execution therefore needs an
-explicit local-copy lowering or a certified logical-to-runtime placement map. Do not silently map
-invented topology devices to the same `:ze:0` target. Local copies must occupy stated resources and
-have explicit cost/capability evidence; an empty route must not accidentally mean free transport.
+DistributedPlan keeps shard identity on logical mesh workers. Each worker's device-plan may state
+an explicit `:target` shared with other workers; local LinkPlans must agree with that physical
+target. Remapped targets require an explicit aggregate `:device-capacities` runtime budget. Pool
+accounting deduplicates physical allocation identities rather than granting each worker a separate
+copy of the device's capacity. Cross-worker shard aliases are rejected, including immutable weight
+sharing until an explicit sharing relation exists. Ordered private scratch with the same physical
+allocation identity can be reused, subject to allocation-contract and readiness checks.
+
+`:transport :resident-copy` performs actual same-target buffer copies and rejects cross-target
+endpoints before device contact. Logical transfer routes and dependencies remain explicit; this
+synchronous executor does not claim modeled route costs, overlap, or free transport. The periodic
+heat acceptance checks 16 resident halo copies and six startup uploads with no later host uploads.
 
 Land geometry/materialization normalization and validation first, then producer/freshness and
 transfer endpoint checks, then device-scoped allocation and event execution. Extend the existing

--- a/src/raster/compiler/ir/distributed_compute.clj
+++ b/src/raster/compiler/ir/distributed_compute.clj
@@ -19,15 +19,15 @@
                     id))))
         (:values plan)))
 
-(defn- entry-facts [device id entry]
+(defn- entry-facts [device target id entry]
   (when-not (and (some? id) (map? entry) (= #{:link-plan} (set (keys entry))))
     (fail! "a named compute entry owns one LinkPlan"
            :distributed-compute-entry {:device device :entry id}))
   (let [plan (:link-plan entry)
         accesses (link/value-accesses plan)]
-    (when-not (= device (:target plan))
-      (fail! "compute entry target differs from its mesh device"
-             :distributed-compute-entry-device {:device device :entry id}))
+    (when-not (= target (:target plan))
+      (fail! "compute entry target differs from its explicit worker placement"
+             :distributed-compute-entry-device {:device device :target target :entry id}))
     {:link-plan plan :accesses accesses :required (required-values plan accesses)}))
 
 (defn- normalize-reference [reference]
@@ -264,10 +264,14 @@
         (reduce-kv
          (fn [bound device local]
            (when-not (set/subset? (set (keys local))
-                                  #{:entries :steps :link-plan :execution-plan :attributes})
+                                  #{:entries :steps :link-plan :execution-plan :attributes :target})
              (fail! "unknown device-local compute contract keys"
                     :distributed-compute-device-keys {:device device :keys (set (keys local))}))
-           (let [entries (get local :entries {}) calls (get local :steps {})]
+           (let [entries (get local :entries {}) calls (get local :steps {})
+                 target (get local :target device)]
+             (when-not (keyword? target)
+               (fail! "a worker placement requires a concrete target keyword"
+                      :distributed-compute-physical-target {:device device :target target}))
              (when-not (and (map? entries) (map? calls))
                (fail! "device compute entries and calls must be maps"
                       :distributed-compute-entries {:device device}))
@@ -276,7 +280,7 @@
                (fail! "analytical plans cannot also declare named compute entries"
                       :distributed-compute-mixed-plans {:device device}))
              (let [entries (into {} (map (fn [[id entry]]
-                                          [id (entry-facts device id entry)])) entries)]
+                                          [id (entry-facts device target id entry)])) entries)]
              (reduce-kv
               (fn [bound id call]
                 (when-not (and (map? call) (= #{:entry :bindings} (set (keys call))))
@@ -312,7 +316,7 @@
           (fail! "compute entries disagree on a resident shard's physical realization"
                  :distributed-compute-shard-storage {:step id :shard key}))
         (doseq [[other-key other] @realized
-                :when (and (not= key other-key) (= (first key) (first other-key)))
+                :when (not= key other-key)
                 left leaves right (:leaves other)]
           (when (view/overlaps? (:view left) (:view right))
             (fail! "distinct distributed shards cannot alias physical storage without a relation"

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -733,7 +733,7 @@
              :distributed-device-plan {:device device-id :plan local}))
     (when link-plan
       (link-plan/validate! link-plan)
-      (when-not (= device-id (:target link-plan))
+      (when-not (= (get local :target device-id) (:target link-plan))
         (fail! "shard-local LinkPlan target differs from its mesh device"
                :distributed-device-link-target
                {:device device-id :target (:target link-plan)})))

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -346,6 +346,34 @@
                                       values parameter-values))]
     (update parallel-program :values normalize-values)))
 
+(defn- refine-effect-result-shapes
+  "Refine the invocation boundary from the nested algorithm's storage/alias certificate.
+   The algorithm retains its symbolic values and explicit iteration extent; this does not
+   resize its operation or turn a physical destination capacity into a logical prefix extent."
+  [values equations]
+  (reduce
+   (fn [values equation]
+     (let [algorithm (:algorithm equation)
+           facts (soac/facts algorithm)]
+       (reduce
+        (fn [values inner]
+          (let [id (second inner)
+                aliases (get-in facts [:equations id :aliases])]
+            (reduce
+             (fn [values [result {:keys [destination access host-return]}]]
+               ;; A synthesized effect result represents the mutated destination, not a newly
+               ;; sized tensor. Never expand arbitrary alias/prefix views.
+               (if (and (= :effect host-return) (= :read-write access)
+                        (= destination (get aliases result))
+                        (get values result) (get values destination))
+                 (if-let [refined (av/merge-refinement (get values result) (get values destination))]
+                   (assoc values result refined)
+                   values)
+                 values))
+             values (map vector (nth inner 2) (soac/result-storage facts id)))))
+        values (soac/equations algorithm))))
+   values equations))
+
 (defn promote-soac-program
   "Promote one analyzed, loop-free TypedSOAC ParallelProgram into the common typed program union.
 
@@ -403,7 +431,8 @@
                                         (and (contains? shape-symbols symbol)
                                              (scalar-value? value))))
                            host-values)
-        program-values (merge shape-values program-values)
+        program-values (refine-effect-result-shapes (merge shape-values program-values)
+                                                   (:equations parallel-program))
         parallel-program (assoc parallel-program :values program-values)
         prefix (invocation-prefix parallel-program public-parameters host-values)
         binding-values

--- a/src/raster/gpu/distributed.clj
+++ b/src/raster/gpu/distributed.clj
@@ -1,6 +1,6 @@
 (ns raster.gpu.distributed
-  "Synchronous execution of checked DistributedPlans on their actual GPU device identities.
-   No logical-to-physical remapping or asynchronous overlap is implied."
+  "Synchronous execution of checked DistributedPlans with explicit worker target placement.
+   Logical workers have explicit physical targets; placement does not imply execution overlap."
   (:refer-clojure :exclude [run!])
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.buffer-view :as view]
@@ -61,26 +61,42 @@
 
 (defn instantiate!
   "Validate and initialize an owning, one-shot distributed execution.
-   Devices must be real runtime targets and all local allocations must be owned. Explicit
+   Local LinkPlans must target real devices and all local allocations must be owned. Explicit
    `{:transport :host-staged}` permits synchronous cross-device copies via a temporary native
    segment; it is not P2P/MPI or the topology's predicted transfer performance. Without that
    option, plans containing transfers are refused before contacting a device. Host staging is
    bounded by :max-staging-bytes (default 1 MiB), reused sequentially across transfer chunks.
+   Co-located workers declare :target in each device-plan, use :transport :resident-copy, and
+   supply an aggregate physical :device-capacities budget (bytes) for remapped targets. Local
+   copies still execute; logical topology predictions are not physical runtime cost evidence.
    Source objects must remain valid and stable through this synchronous initialization."
   ([plan] (instantiate! plan {}))
-  ([plan {:keys [transport max-staging-bytes] :or {max-staging-bytes 1048576}}]
+  ([plan {:keys [transport max-staging-bytes device-capacities]
+          :or {max-staging-bytes 1048576 device-capacities {}}}]
    (let [ready (distributed/check-readiness plan)
          {:keys [bindings]} (distributed/compute-bindings plan)
          schedule (schedule plan)
-         _ (when-not (contains? #{nil :host-staged} transport)
+         _ (when-not (contains? #{nil :host-staged :resident-copy} transport)
              (throw (ex-info "unsupported distributed transport"
                              {:reason :distributed-runtime-transport :transport transport})))
          _ (when-not (and (integer? max-staging-bytes) (<= 16 max-staging-bytes Long/MAX_VALUE))
              (throw (ex-info "host staging budget must be at least 16 bytes and fit a long"
                              {:reason :distributed-runtime-staging-size :bytes max-staging-bytes})))
-         _ (when (and (some #(= :transfer (:kind %)) (:steps plan)) (not= :host-staged transport))
+         _ (when (and (some #(= :transfer (:kind %)) (:steps plan)) (nil? transport))
              (throw (ex-info "distributed copies require an explicit supported transport"
                              {:reason :distributed-runtime-transport :transport transport})))
+         _ (when (= :resident-copy transport)
+             (doseq [action (:actions ready) :when (= :transfer (:kind action))]
+               (when-not (= (get-in action [:reads 0 :allocation :device])
+                            (get-in action [:writes 0 :allocation :device]))
+                 (throw (ex-info "resident-copy requires co-located physical endpoints"
+                                 {:reason :distributed-runtime-resident-copy :step (:id action)})))))
+         _ (when-not (map? device-capacities)
+             (throw (ex-info "physical device capacities must be a map"
+                             {:reason :distributed-runtime-physical-budget})))
+         remapped-targets (into #{} (keep (fn [[worker local]]
+                                            (let [target (get local :target worker)]
+                                              (when (not= worker target) target)))) (:device-plans plan))
          projections (update-vals bindings #(link-plan/borrow-owned-storage (:link-plan %)))
          specs (reduce
                 (fn [specs [_ {:keys [link-plan]}]]
@@ -101,8 +117,13 @@
                    specs (:nodes link-plan))) {} bindings)
          _ (doseq [[device entries] (group-by (comp first key) specs)]
              (let [bytes (reduce +' 0 (map (comp :byte-size :allocation val) entries))
-                   capacity (get-in plan [:topology :devices device :memory-capacity-bytes])]
-               (when (or (nil? capacity) (> bytes capacity))
+                   capacity (get device-capacities device
+                                 (when-not (contains? remapped-targets device)
+                                   (get-in plan [:topology :devices device :memory-capacity-bytes])))]
+               (when-not (and (integer? capacity) (<= 0 capacity Long/MAX_VALUE))
+                 (throw (ex-info "remapped devices require an explicit aggregate physical budget"
+                                 {:reason :distributed-runtime-physical-budget :device device :capacity capacity})))
+               (when (> bytes capacity)
                  (throw (ex-info "resident allocation pool exceeds the declared device budget"
                                  {:reason :distributed-runtime-memory :device device :bytes bytes :capacity capacity})))))
          _ (doseq [[index action] (map-indexed vector (:actions ready))
@@ -153,15 +174,21 @@
           (case (:kind operation)
             :compute
             (let [plan (get-in executable [:projections id :plan])
-                  session (get (:sessions executable) (:device operation))
+                  session (get (:sessions executable) (:target plan))
                   ids (set (map #(get-in % [:view :allocation :id]) (vals (:nodes plan))))
                   buffers (into {} (map (fn [id] [id (gpu/buffer session id)])) ids)]
               (with-open [local (link/instantiate! plan {:session session :external-buffers buffers})]
                 (link/run! local)))
             :transfer
             (let [action (actions id)]
-              (transfer-host-staged! (:sessions executable) (first (:reads action))
-                                     (first (:writes action)) (:staging-bytes executable))))
+              (if (= :resident-copy (:transport executable))
+                (let [source (first (:reads action)) target (first (:writes action))]
+                  (gpu/copy-range! (get (:sessions executable) (get-in source [:allocation :device]))
+                                   (physical-view (:sessions executable) source)
+                                   (physical-view (:sessions executable) target)
+                                   {:elements (reduce * 1 (:shape source))}))
+                (transfer-host-staged! (:sessions executable) (first (:reads action))
+                                       (first (:writes action)) (:staging-bytes executable)))))
           (vswap! completed conj (:id completion)))
         (reset! (:state executable) :complete)
         executable)

--- a/test/raster/compiler/distributed_numerical_test.clj
+++ b/test/raster/compiler/distributed_numerical_test.clj
@@ -3,6 +3,7 @@
    on one GPU; it proves compiled local updates and resident halo copies, not a multi-host runtime."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.core :refer [deftm]]
+            [raster.arrays :as arrays]
             [raster.numeric :as numeric]
             [raster.ode.pde :as pde]
             [raster.compiler.equation-first :as equation]
@@ -36,6 +37,9 @@
 
 (def ^:private compiled-step
   (delay (equation/compile #'heat-step! {:target :ze:0 :dtype :double})))
+
+(def ^:private compiled-copy
+  (delay (equation/compile #'arrays/acopy! {:target :ze:0 :dtype :double})))
 
 (defn- problem []
   (let [shards [(distributed/shard {:id :left :value :u :device :worker-0
@@ -448,6 +452,136 @@
                (try (gpu-distributed/run! executable) nil
                     (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
             "a second run needs new initialization/freshness evidence")))))
+
+(deftest generated-region-copy-keeps-the-whole-destination-and-untouched-regions
+  (let [source (double-array (range 9)) destination (double-array (repeat 13 -1.0))
+        expected (aclone destination)
+        plan (equation/lower @compiled-copy [source 2 destination 4 3])
+        output (first (:outputs plan))]
+    (System/arraycopy source 2 expected 4 3)
+    (is (= 2 (count (:nodes plan))) "an effect alias must not allocate a new result tensor")
+    (is (= [13] (get-in plan [:nodes output :view :shape]))
+        "the mutation result is the destination, not the copied three-element region")
+    (if-not @gp/gpu-available?
+      (gp/gpu-skip! "generated-region-copy-mutation-extent")
+      (with-open [executable (link/instantiate! plan)]
+        (link/run! executable)
+        (is (= (vec expected) (vec (link/download executable output))))))))
+
+(defn- colocated-periodic-heat-plan []
+  (let [p (problem)
+        workers (mapv :device (:shards p))
+        initial (local-inputs p)
+        locals (into {}
+                     (map (fn [{:keys [id device shape]}]
+                            (let [u (initial id) n (alength ^doubles u)
+                                  out (double-array n) rhs (double-array n)
+                                  fields {u :u out :out rhs :rhs}
+                                  place (fn [local]
+                                          (update local :nodes
+                                                  #(update-vals %
+                                                                (fn [node]
+                                                                  (update-in node [:view :allocation :id]
+                                                                             (fn [id] [device (or (fields (:source node)) id)]))))))]
+                              [device {:shape [(+ 2 (first shape)) width]
+                                       :heat (place (equation/lower @compiled-step [out u rhs (+ 2 (first shape)) width dt]))
+                                       :copy (place (equation/lower @compiled-copy [out 0 u 0 n]))
+                                       :fields fields :shard id}]))) (:shards p))
+        state-value (av/tensor {:dtype :double :shape [6 width]
+                                :sharding {:kind :partitioned :axis 0 :devices workers}})
+        globals (into {:u state-value}
+                      (for [[worker local] locals field [:out :rhs]]
+                        [[worker field] (av/tensor {:dtype :double :shape (:shape local)
+                                                   :sharding {:kind :replicated :devices [worker]}})]))
+        shards (into {:u (mapv #(assoc % :value :u) (:shards p))}
+                     (for [[worker local] locals field [:out :rhs]
+                           :let [id [worker field]]]
+                       [id [(distributed/shard {:id id :value id :device worker :offsets [0 0]
+                                                :shape (:shape local) :ownership :replica})]]))
+        routes {(vec workers) [:forward] (vec (reverse workers)) [:backward]}
+        epochs (mapv (fn [epoch]
+                       (let [previous (if (zero? epoch) [] (mapv #(vector :copy (dec epoch) %) workers))
+                             halo (distributed/schedule-halo
+                                    (distributed/halo-exchange {:id [:halo epoch] :value :u :axis 0 :width 1 :boundary :periodic})
+                                    state-value (:u shards) routes previous)]
+                         {:halo halo
+                          :steps (into (:steps halo)
+                                       (concat
+                                        (map (fn [worker] (distributed/compute-step
+                                                          {:id [:heat epoch worker] :device worker :duration-ns 1
+                                                           :dependencies (:completions halo)})) workers)
+                                        (map (fn [worker] (distributed/compute-step
+                                                          {:id [:copy epoch worker] :device worker :duration-ns 1
+                                                           :dependencies (mapv #(vector :heat epoch %) workers)})) workers)))}))
+                     (range iterations))
+        bindings (fn [worker local entry halo]
+                   (into {}
+                         (keep (fn [[id value]]
+                                 (when-let [field ((:fields local) (get-in entry [:nodes (get-in value [:leaves 0 :node]) :source]))]
+                                   [id (if (= :u field)
+                                         {:local-shape (:shape local)
+                                          :placements (into [{:kind :owned :value :u :shard (:shard local) :local-offsets [1 0]}]
+                                                            (map #(hash-map :kind :replica :transfer (:id %)))
+                                                            (filter #(= worker (:target %)) (:steps halo)))}
+                                         {:local-shape (:shape local)
+                                          :placements [{:kind :owned :value [worker field] :shard [worker field]
+                                                        :local-offsets [0 0]}]})]))) (:values entry)))]
+    (distributed/plan
+     {:id :colocated-periodic-heat
+      :mesh (distributed/mesh [{:name :workers :size 2}] workers)
+      :topology (distributed/topology
+                 (mapv #(distributed/device {:id % :memory-capacity-bytes 1048576}) workers)
+                 [(distributed/link {:id :forward :source (first workers) :target (second workers)
+                                     :bandwidth-bytes-s 1.0e9 :latency-ns 100})
+                  (distributed/link {:id :backward :source (second workers) :target (first workers)
+                                     :bandwidth-bytes-s 1.0e9 :latency-ns 100})])
+      :values globals :shards shards :halos (mapv :halo epochs)
+      :device-plans (into {}
+                          (map (fn [[worker local]]
+                                 [worker {:target :ze:0
+                                          :entries {:heat {:link-plan (:heat local)} :copy {:link-plan (:copy local)}}
+                                          :steps (into {} (for [[epoch {:keys [halo]}] (map-indexed vector epochs)
+                                                               kind [:heat :copy]]
+                                                           [[kind epoch worker]
+                                                            {:entry kind :bindings (bindings worker local (get local kind) halo)}]))}])) locals)
+      :steps (vec (mapcat :steps epochs))
+      :outputs (mapv #(vector :copy (dec iterations) %) workers)})))
+
+(deftest two-logical-workers-execute-periodic-halos-through-one-gpu-dag
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "colocated-periodic-heat-dag")
+    (let [plan (colocated-periodic-heat-plan)
+          expected (loop [u (aclone ^doubles (:initial (problem))) epoch 0]
+                     (if (= epoch iterations)
+                       (subvec (vec u) width (* 7 width))
+                       (do (System/arraycopy u (* 6 width) u 0 width)
+                           (System/arraycopy u width u (* 7 width) width)
+                           (recur (heat-step! (double-array 56) u (double-array 56) 8 width dt) (inc epoch)))))
+          copy-range! gpu/copy-range! upload-range! gpu/upload-range!
+          copies (atom 0) uploads (atom 0)]
+      (with-redefs [gpu/make-session (fn [& _] (throw (ex-info "unexpected driver contact" {})))]
+        (is (= :distributed-runtime-physical-budget
+               (try (gpu-distributed/instantiate! plan {:transport :resident-copy}) nil
+                    (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+      (with-redefs [gpu/copy-range! (fn [& args] (swap! copies inc) (apply copy-range! args))
+                    gpu/upload-range! (fn [& args] (swap! uploads inc) (apply upload-range! args))]
+       (with-open [executable (gpu-distributed/instantiate!
+                              plan {:transport :resident-copy :device-capacities {:ze:0 1048576}})]
+        (is (= #{:ze:0} (set (keys (:sessions executable)))))
+        (is (= 32 (count (get-in executable [:schedule :operations]))))
+        (is (= 6 @uploads) "each worker's three source buffers initialize exactly once")
+        (gpu-distributed/run! executable)
+        (is (= 16 @copies) "all four halo faces execute in each of four epochs")
+        (is (= 6 @uploads) "resident exchange and generated state copies add no host uploads")
+        (let [outputs (gpu-distributed/output-values executable)
+              actual (vec (mapcat (fn [{:keys [device shape]}]
+                                    (let [resident (first (vals (get outputs [:copy (dec iterations) device])))
+                                          values (double-array (* (+ 2 (first shape)) width))]
+                                      (gpu/download-range! (get (:sessions executable) :ze:0) resident values
+                                                           {:elements (alength values)})
+                                      (subvec (vec values) width (* (inc (first shape)) width))))
+                                  (:shards (problem))))]
+          (is (< (max-error expected actual) 1.0e-10))))))))
 
 (deftest compiled-two-worker-halos-use-resident-copies
   (if-not @gp/gpu-available?

--- a/test/raster/compiler/ir/distributed_compute_test.clj
+++ b/test/raster/compiler/ir/distributed_compute_test.clj
@@ -410,6 +410,35 @@
                       (float-array 6)))
           (fully-bound-periodic-plan) [:gpu-0 :gpu-1]))
 
+(deftest explicit-worker-placement-preserves-logical-shards-and-physical-alias-checks
+  (let [base (initialized-periodic-plan)
+        placed (reduce
+                (fn [plan device]
+                  (-> plan
+                      (assoc-in [:device-plans device :target] :ze:0)
+                      (update-in [:device-plans device :entries :copy :link-plan]
+                                 (fn [local]
+                                   (-> local (assoc :target :ze:0)
+                                       (update :nodes
+                                               #(update-vals %
+                                                             (fn [node]
+                                                               (-> node
+                                                                   (assoc-in [:view :allocation :device] :ze:0)
+                                                                   (update-in [:view :allocation :id] (fn [id] [device id])))))))))))
+                base [:gpu-0 :gpu-1])
+        ready (distributed/check-readiness (distributed/plan placed))]
+    (is (= 6 (count (:actions ready))))
+    (is (= #{:ze:0} (into #{} (map #(get-in % [:view :allocation :device])) (:initializers ready))))
+    (is (= #{:gpu-0 :gpu-1} (set (get-in placed [:mesh :devices]))))
+    (is (= :distributed-compute-entry-device
+           (failure-reason #(distributed/plan (update-in placed [:device-plans :gpu-0] dissoc :target)))))
+    (let [aliased (update-in placed [:device-plans :gpu-1 :entries :copy :link-plan :nodes]
+                            #(update-vals % (fn [node]
+                                              (assoc-in node [:view :allocation :id]
+                                                        [:gpu-0 (second (get-in node [:view :allocation :id]))]))))]
+      (is (= :distributed-compute-shard-alias (failure-reason #(distributed/plan aliased)))
+          "different logical workers cannot hide overlapping physical shard storage"))))
+
 (deftest readiness-composes-initializers-transfers-and-local-contracts
   (let [plan (distributed/plan (initialized-periodic-plan))
         ready (distributed/check-readiness plan)]

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -37,6 +37,33 @@
   (is (= 'xs (#'route/shape-projection-source '(clojure.core/long (alength xs)))))
   (is (nil? (#'route/shape-projection-source '(clojure.core/unchecked-int (alength xs))))))
 
+(deftest effect-result-refinement-uses-authoritative-inner-storage
+  (doseq [[host-return shape expected]
+          [[:effect '[(unknown-dimension result)] [13]]
+           [:buffer '[(unknown-dimension result)] '[(unknown-dimension result)]]
+           [:buffer [3] [3]]
+           [:effect [3] [3]]]]
+    (let [values {'dst (av/tensor {:dtype :double :shape [13]})
+                  'result (av/tensor {:dtype :double :shape shape})}
+          inner (list '= 'copy '[result] '(map {} [] [] nil))
+          ;; This unit isolates boundary refinement, not numerical map validation.
+          algorithm (list 'soac-program
+                     (soac/default-program-facts
+                      {:values values
+                       :equations {'copy (merge (soac/default-equation-facts)
+                                          {:aliases {'result 'dst}
+                                           :attributes {:result-storage
+                                                        [{:destination 'dst :access :read-write
+                                                          :host-return host-return}]}})}})
+                     [inner] '[result])
+          ;; Deliberately contradictory copied attributes must not become an authority.
+          outer {:algorithm algorithm :results '[result]
+                 :attributes {:result-storage [{:destination 'dst :access :read-write
+                                                :host-return (if (= :effect host-return)
+                                                               :buffer :effect)}]}}]
+      (is (= expected (:shape (get (#'route/refine-effect-result-shapes values [outer])
+                                   'result)))))))
+
 (defn- evaluate-test-scalar-expression [expression operands]
   (cond
     (number? expression) expression


### PR DESCRIPTION
## Summary

- Separate logical worker identity from explicit physical target placement, while checking cross-worker physical shard aliases.
- Require aggregate budgets for remapped physical targets and execute explicit resident-copy transfers.
- Refine synthesized mutation-result invocation shapes from authoritative nested TypedSOAC storage and alias facts; preserve logical prefixes.
- Validate four periodic heat epochs across unequal logical shards through one 32-operation GPU DAG, with 16 resident halo copies and exactly six startup uploads.

## Validation

Affected compiler, distributed compute and numerical namespaces: 66 tests, 356 assertions, zero failures/errors in the existing capped REPL, including real Intel GPU execution. Four-case shape regression covers conflicting copied metadata and prefix preservation. Independent review found no correctness blockers. Rebase onto current main preserved the tested tree exactly. Full suite delegated to CI.

## Boundaries

Synchronous single-physical-device acceptance, not multi-GPU performance evidence. Cross-shard immutable sharing remains rejected without an explicit sharing relation; ordered private scratch may be pooled. Resident pool budgets exclude backend-private graph/compiler temporaries. No topology-cost or SOTA performance claims.