### PR TITLE
Compile cell-centred coarse-fine numerical transfers through the shared pipeline

### DIFF
--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -254,3 +254,9 @@ executes their ordered DistributedPlan on one GPU. This full-domain cycle is an 
 not a general proof that a supplied local program implements a declared coarse/fine operator.
 Partial patch-region binding, executable numerical certification, refinement decisions, and
 coarse/fine PDE evolution with convergence and interface-flux oracles remain required.
+
+A separate smooth-field oracle uses exact cell averages of a bilinear polynomial on three
+rectangular resolutions. Averaging down recovers the coarse cell averages and both transfers
+preserve the analytic domain integral. The nonzero volume-weighted RMS error of constant
+prolongation decreases at first order. This measures transfer approximation, not PDE convergence
+or a general certified error bound; conservation alone must not be mistaken for accuracy.

--- a/design/distributed-materialization.md
+++ b/design/distributed-materialization.md
@@ -237,3 +237,20 @@ unequal-shard heat and mapped-checkpoint acceptance to exercise that actual DAG.
 integration should numerical coarse/fine operators be counted as an AMR execution vertical.
 The full campaign still includes external model training validation and numerical AMR; none of
 these structural design requirements substitutes for those numerical workload gates.
+
+## Generated coarse/fine numerical acceptance
+
+`raster.ode.multilevel` expresses dyadic, dense, cell-centred 2-D piecewise-constant prolongation
+and cell-average restriction as ordinary `deftm` programs. The existing TypedSOAC pipeline emits
+their kernels; there is no AMR emitter or privileged numerical operator lowering. Sources and
+destinations must be disjoint, and callers provide the stated coarse and doubled fine extents.
+Restriction uses FP64 arithmetic with the written summation order. These are first-order transfer
+operators, not higher-order interpolation, a PDE time integrator, subcycling or conservative reflux.
+
+The numerical acceptance checks rectangular CPU oracles, constant preservation and cell-volume
+weighted sum preservation, individual generated GPU execution, and a composed resident cycle.
+It also binds the two steps produced by `schedule-coarse-fine` to generated local LinkPlans and
+executes their ordered DistributedPlan on one GPU. This full-domain cycle is an executable witness,
+not a general proof that a supplied local program implements a declared coarse/fine operator.
+Partial patch-region binding, executable numerical certification, refinement decisions, and
+coarse/fine PDE evolution with convergence and interface-flux oracles remain required.

--- a/src/raster/ode/multilevel.clj
+++ b/src/raster/ode/multilevel.clj
@@ -1,0 +1,28 @@
+(ns raster.ode.multilevel
+  "Cell-centred numerical transfers expressed as ordinary typed programs.
+   These operators do not perform adaptation, subcycling or flux correction. Callers supply
+   disjoint dense row-major source/destination storage with the stated extents."
+  (:require [raster.core :refer [deftm]]
+            [raster.arrays :as arrays]))
+
+(deftm prolong-constant-2d!
+  [fine :- (Array double), coarse :- (Array double), nx :- Long, ny :- Long]
+  (let [fine-width (* 2 ny)]
+    (dotimes [i (* 2 nx)]
+      (dotimes [j fine-width]
+        (arrays/aset fine (+ (* i fine-width) j)
+                     (arrays/aget coarse (+ (* (quot i 2) ny) (quot j 2))))))
+    fine))
+
+(deftm restrict-average-2d!
+  [coarse :- (Array double), fine :- (Array double), nx :- Long, ny :- Long]
+  (let [fine-width (* 2 ny)]
+    (dotimes [i nx]
+      (dotimes [j ny]
+        (let [k (+ (* (* 2 i) fine-width) (* 2 j))]
+          (arrays/aset coarse (+ (* i ny) j)
+                       (* 0.25 (+ (arrays/aget fine k)
+                                  (arrays/aget fine (+ k 1))
+                                  (arrays/aget fine (+ k fine-width))
+                                  (arrays/aget fine (+ k fine-width 1))))))))
+    coarse))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -39,6 +39,7 @@
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.core :refer [deftm]]
+            [raster.ode.multilevel :as multilevel]
             [raster.dl.attention :as dl-attention]
             [raster.dl.array-ops :as dl-arrays]
             [raster.linalg.contract :as contract]
@@ -346,6 +347,10 @@
                  #'dl-arrays/sum-kv-heads {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-map {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'multilevel/prolong-constant-2d! {:target device-id :dtype :double}))
+      (:kernels (equation-first/compile
+                 #'multilevel/restrict-average-2d! {:target device-id :dtype :double}))
       (:kernels (equation-first/compile
                  #'public-c-family-scan {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -16,6 +16,7 @@
             [raster.dl.array-ops :as array-ops]
             [raster.numeric]
             [raster.ode.pde :as pde]
+            [raster.ode.multilevel :as multilevel]
             [raster.par]
             [raster.runtime.hardware :as hardware]))
 
@@ -412,6 +413,19 @@
           plan (equation-first/lower compilation
                                      [(double-array 35) (double-array 35)
                                       5 7 0.25 4.0 9.0])]
+      (is (seq (:kernels compilation)))
+      (is (every? #(= module-target (:target %)) (:kernels compilation)))
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 0 (get-in plan [:attributes :driver-allocations]))))))
+
+(deftest coarse-fine-operators-use-the-public-c-family-boundary
+  (doseq [[target module-target] [[cuda-target :cuda-c] [hip-target :hip-cpp]]
+          operator [#'multilevel/prolong-constant-2d! #'multilevel/restrict-average-2d!]]
+    (let [prolong? (= operator #'multilevel/prolong-constant-2d!)
+          compilation (equation-first/compile operator {:target target :dtype :double})
+          plan (equation-first/lower compilation
+                                     [(double-array (if prolong? 60 15))
+                                      (double-array (if prolong? 15 60)) 3 5])]
       (is (seq (:kernels compilation)))
       (is (every? #(= module-target (:target %)) (:kernels compilation)))
       (is (= :none (get-in compilation [:stats :fallback])))

--- a/test/raster/compiler/multilevel_numerical_test.clj
+++ b/test/raster/compiler/multilevel_numerical_test.clj
@@ -1,0 +1,148 @@
+(ns raster.compiler.multilevel-numerical-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.core :refer [deftm]]
+            [raster.ode.multilevel :as multilevel]
+            [raster.compiler.equation-first :as equation]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.amr-plan :as amr]
+            [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.distributed :as gpu-distributed]
+            [raster.gpu.link :as link]))
+
+(deftm transfer-cycle!
+  [out :- (Array double), fine :- (Array double), coarse :- (Array double),
+   nx :- Long, ny :- Long]
+  (multilevel/prolong-constant-2d! fine coarse nx ny)
+  (multilevel/restrict-average-2d! out fine nx ny))
+
+(deftest cell-centred-transfer-oracles
+  (doseq [[nx ny] [[1 1] [3 5] [4 2]]]
+    (let [coarse (double-array (map #(- (* 0.25 %) 2.0) (range (* nx ny))))
+          fine (double-array (* 4 nx ny))
+          restored (double-array (* nx ny))]
+      (multilevel/prolong-constant-2d! fine coarse nx ny)
+      (let [expected (vec (for [i (range (* 2 nx)) j (range (* 2 ny))]
+                            (aget coarse (+ (* (quot i 2) ny) (quot j 2)))))]
+        (is (= expected (vec fine))))
+      (multilevel/restrict-average-2d! restored fine nx ny)
+      (is (= (vec coarse) (vec restored)))
+      ;; Non-piecewise-constant fine data tests averaging independently of prolongation.
+      (let [fine (double-array (map #(* 0.125 %) (range (* 4 nx ny))))]
+        (multilevel/restrict-average-2d! restored fine nx ny)
+        (is (= (* 0.25 (reduce + (vec fine))) (reduce + (vec restored))))))
+    (let [constant (double-array (repeat (* 4 nx ny) 3.25))
+          coarse (double-array (* nx ny))]
+      (multilevel/restrict-average-2d! coarse constant nx ny)
+      (is (every? #(= 3.25 %) coarse)))))
+
+(deftest generated-coarse-fine-transfers-match-reference
+  (doseq [operator [#'multilevel/prolong-constant-2d! #'multilevel/restrict-average-2d!]]
+    (let [prolong? (= operator #'multilevel/prolong-constant-2d!)
+          source (double-array (map #(- (* 0.125 %) 1.0) (range (if prolong? 15 60))))
+          destination (double-array (repeat (if prolong? 60 15) -99.0))
+          expected (aclone destination)
+          _ (operator expected source 3 5)
+          compiled (equation/compile operator {:target :ze:0 :dtype :double})
+          plan (equation/lower compiled [destination source 3 5])]
+      (is (seq (:outputs plan)))
+      (if-not @gp/gpu-available?
+        (gp/gpu-skip! "generated-coarse-fine-transfer")
+        (with-open [executable (link/instantiate! plan)]
+          (link/run! executable)
+          (is (= (vec expected) (vec (link/download executable (first (:outputs plan)))))))))))
+
+(deftest composed-transfer-cycle-keeps-intermediate-resident
+  (let [coarse (double-array (map #(- (* 0.125 %) 1.0) (range 15)))
+        fine (double-array 60) out (double-array 15)
+        compiled (equation/compile #'transfer-cycle! {:target :ze:0 :dtype :double})
+        plan (equation/lower compiled [out fine coarse 3 5])]
+    (is (= 3 (count (:nodes plan))) "only the three caller buffers are materialized")
+    (if-not @gp/gpu-available?
+      (gp/gpu-skip! "generated-coarse-fine-cycle")
+      (with-open [executable (link/instantiate! plan)]
+        (link/run! executable)
+        (let [actual (link/download executable (first (:outputs plan)))]
+          (is (= (vec coarse) (vec actual))))))))
+
+(defn- scheduled-transfer-cycle [coarse fine]
+  (let [shapes {:coarse [3 5] :fine [6 10]}
+        fields {coarse :coarse fine :fine}
+        hierarchy (amr/hierarchy
+                   {:id :transfer-cycle :base-shape [3 5] :proper-nesting-width 0
+                    :levels (mapv (fn [[index field ratio]]
+                                    (amr/level
+                                     {:id index :index index :ratio-to-parent ratio
+                                      :patches [(amr/patch {:id field :level index :device :ze:0
+                                                           :offsets [0 0] :shape (shapes field)
+                                                           :field field})]}))
+                                  [[0 :coarse nil] [1 :fine [2 2]]])})
+        values (update-vals shapes #(av/tensor {:dtype :double :shape %
+                                               :sharding {:kind :partitioned :axis 0 :devices [:ze:0]}}))
+        scheduled (reduce (fn [result [kind source target method]]
+                            (conj result
+                                  (amr/schedule-coarse-fine
+                                   hierarchy values
+                                   (amr/coarse-fine-operation
+                                    {:id kind :kind kind :source-patch source :target-patch target
+                                     :source-region {:offsets [0 0] :shape (shapes source)}
+                                     :target-region {:offsets [0 0] :shape (shapes target)}
+                                     :operator {:method method :required-invariants #{:constant-preserving}}})
+                                   {:duration-ns 1 :dependencies (if (seq result)
+                                                                 [(:completion (peek result))] [])})))
+                          [] [[:prolongation :coarse :fine :piecewise-constant]
+                              [:restriction :fine :coarse :cell-average]])
+        entries (into {}
+                      (for [[kind operator args]
+                            [[:prolongation #'multilevel/prolong-constant-2d! [fine coarse 3 5]]
+                             [:restriction #'multilevel/restrict-average-2d! [coarse fine 3 5]]]
+                            :let [plan (equation/lower (equation/compile operator {:target :ze:0 :dtype :double}) args)
+                                  plan (update plan :nodes
+                                               #(update-vals % (fn [node]
+                                                                  (assoc-in node [:view :allocation :id]
+                                                                            (fields (:source node))))))]]
+                        [kind {:link-plan plan}]))
+        calls (into {}
+                    (for [scheduled scheduled
+                          :let [kind (get-in scheduled [:operation :kind])
+                                plan (get-in entries [kind :link-plan])]]
+                      [(:completion scheduled)
+                       {:entry kind
+                        :bindings (into {}
+                                        (for [[id value] (:values plan)
+                                              :let [node (get-in value [:leaves 0 :node])
+                                                    field (fields (get-in plan [:nodes node :source]))]
+                                              :when field]
+                                          [id {:local-shape (shapes field)
+                                               :placements [{:kind :owned :value field :shard field
+                                                             :local-offsets [0 0]}]}]))}]))]
+    (distributed/plan
+     {:id :generated-multilevel-cycle
+      :mesh (distributed/mesh [{:name :worker :size 1}] [:ze:0])
+      :topology (distributed/topology [(distributed/device {:id :ze:0 :memory-capacity-bytes 1048576})] [])
+      :values values
+      :shards (into {} (for [[field shape] shapes]
+                        [field [(distributed/shard {:id field :value field :device :ze:0
+                                                    :offsets [0 0] :shape shape})]]))
+      :device-plans {:ze:0 {:entries entries :steps calls}}
+      :steps (vec (mapcat :steps scheduled)) :outputs [(:completion (peek scheduled))]})))
+
+(deftest coarse-fine-schedule-executes-its-generated-local-entries
+  (let [coarse (double-array (map #(* 0.25 %) (range 15)))
+        fine (double-array 60)
+        plan (scheduled-transfer-cycle coarse fine)]
+    (is (= 2 (count (:actions (distributed/check-readiness plan)))))
+    (is (= :distributed-readiness-race
+           (try (distributed/check-readiness (assoc-in plan [:steps 1 :dependencies] []))
+                nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+        "the transfer cycle cannot observe a fine field without its producer dependency")
+    (if-not @gp/gpu-available?
+      (gp/gpu-skip! "scheduled-coarse-fine-cycle")
+      (with-open [executable (gpu-distributed/instantiate! plan)]
+        (gpu-distributed/run! executable)
+        (let [result (first (vals (get (gpu-distributed/output-values executable) [:restriction :apply])))
+              actual (double-array 15)]
+          (gpu/download-range! (get (:sessions executable) :ze:0) result actual {:elements 15})
+          (is (= (vec coarse) (vec actual))))))))

--- a/test/raster/compiler/multilevel_numerical_test.clj
+++ b/test/raster/compiler/multilevel_numerical_test.clj
@@ -31,6 +31,11 @@
       ;; Non-piecewise-constant fine data tests averaging independently of prolongation.
       (let [fine (double-array (map #(* 0.125 %) (range (* 4 nx ny))))]
         (multilevel/restrict-average-2d! restored fine nx ny)
+        (is (= (vec (for [i (range nx) j (range ny)]
+                      (/ (reduce + (for [di [0 1] dj [0 1]]
+                                     (aget fine (+ (* (+ (* 2 i) di) (* 2 ny))
+                                                   (* 2 j) dj)))) 4.0)))
+               (vec restored)))
         (is (= (* 0.25 (reduce + (vec fine))) (reduce + (vec restored))))))
     (let [constant (double-array (repeat (* 4 nx ny) 3.25))
           coarse (double-array (* nx ny))]

--- a/test/raster/compiler/multilevel_numerical_test.clj
+++ b/test/raster/compiler/multilevel_numerical_test.clj
@@ -58,6 +58,36 @@
           (link/run! executable)
           (is (= (vec expected) (vec (link/download executable (first (:outputs plan)))))))))))
 
+(defn- bilinear-cell-averages [nx ny]
+  ;; Exact unit-square cell averages of 1 + x + 2y + xy, not point samples of a
+  ;; general function. Its domain integral is 11/4 on every resolution.
+  (double-array (for [i (range nx) j (range ny)
+                      :let [x (/ (+ i 0.5) nx) y (/ (+ j 0.5) ny)]]
+                  (+ 1.0 x (* 2.0 y) (* x y)))))
+
+(deftest smooth-cell-averages-preserve-integrals-and-expose-transfer-error
+  (let [errors
+        (mapv (fn [nx]
+                (let [ny (* 2 nx)
+                      coarse (bilinear-cell-averages nx ny)
+                      exact-fine (bilinear-cell-averages (* 2 nx) (* 2 ny))
+                      prolonged (double-array (* 4 nx ny))
+                      restricted (double-array (* nx ny))]
+                  (multilevel/prolong-constant-2d! prolonged coarse nx ny)
+                  (multilevel/restrict-average-2d! restricted exact-fine nx ny)
+                  (is (< (reduce max 0.0 (map #(Math/abs (- %1 %2)) coarse restricted)) 1.0e-12))
+                  (is (< (Math/abs (- 2.75 (/ (reduce + (vec prolonged)) (* 4 nx ny)))) 1.0e-12))
+                  (is (< (Math/abs (- 2.75 (/ (reduce + (vec restricted)) (* nx ny)))) 1.0e-12))
+                  (Math/sqrt (/ (reduce + (map (fn [a b] (let [d (- a b)] (* d d)))
+                                              prolonged exact-fine))
+                                (* 4 nx ny)))))
+              [8 16 32])]
+    ;; Piecewise-constant prolongation is conservative, not an exact smooth-field
+    ;; refinement: its volume-weighted RMS discrepancy must decrease at first order.
+    (is (every? pos? errors))
+    (doseq [[coarser finer] (partition 2 1 errors)]
+      (is (< 1.95 (/ coarser finer) 2.05)))))
+
 (deftest composed-transfer-cycle-keeps-intermediate-resident
   (let [coarse (double-array (map #(- (* 0.125 %) 1.0) (range 15)))
         fine (double-array 60) out (double-array 15)


### PR DESCRIPTION
Replaces #560, which GitHub closed when its merged parent branch was deleted. Rebased onto merged #559 with exactly unchanged tree. Reviewed implementation and test evidence are preserved.

## Summary

Ordinary deftm dyadic 2D piecewise-constant prolongation and cell-average restriction, with no AMR-specific kernel emitter. Independent rectangular/per-cell CPU oracles, constant and volume-weighted conservation checks, generated GPU parity, resident composition and an executable full-patch distributed transfer cycle. Both numerical functions now enter CUDA/HIP vendor compile fixtures.

## Validation

4 numerical tests, 24 assertions pass on the existing capped REPL, including actual Intel GPU execution. Targeted public CUDA/HIP source/link test passes (16 assertions). Independent review found no blocker. Full suite and native vendor compilation are CI gates at this exact rebased head.

## Boundaries

This is not AMR operator semantic certification: methods/invariants/regions are not proven equivalent to arbitrary supplied LinkPlans. No adaptive refinement, partial-region general binding, PDE subcycling, reflux, convergence or multi-device claim. Dyadic dense FP64 operators require disjoint storage. The full compiler campaign remains active.